### PR TITLE
feat: use env var instead of secrets manager

### DIFF
--- a/config/releases.exs
+++ b/config/releases.exs
@@ -4,15 +4,8 @@
 # remember to add this file to your .gitignore.
 import Config
 
-secret_key_base =
-  "screens-dev-secret-key-base"
-  |> ExAws.SecretsManager.get_secret_value()
-  |> ExAws.request!()
-  |> Map.fetch!("SecretString")
-
 config :screens, ScreensWeb.Endpoint,
-  http: [:inet6, port: String.to_integer(System.get_env("PORT") || "4000")],
-  secret_key_base: secret_key_base
+  http: [:inet6, port: String.to_integer(System.get_env("PORT") || "4000")]
 
 # ## Using releases (Elixir v1.9+)
 #

--- a/lib/screens_web/endpoint.ex
+++ b/lib/screens_web/endpoint.ex
@@ -43,4 +43,19 @@ defmodule ScreensWeb.Endpoint do
     signing_salt: "g3bAaGvf"
 
   plug ScreensWeb.Router
+
+  # callback for runtime configuration
+  def init(:supervisor, config) do
+    secret_key_base = System.get_env("SECRET_KEY_BASE")
+
+    config =
+      if secret_key_base do
+        Keyword.put(config, :secret_key_base, secret_key_base)
+      else
+        config[:secret_key_base] || raise "No SECRET_KEY_BASE ENV var!"
+        config
+      end
+
+    {:ok, config}
+  end
 end


### PR DESCRIPTION
We'd like to use secrets manager, but we can temporarily use this branch if we're having issues getting secrets manager to work.