### PR TITLE
fix: test out setting transpileOnly to check whether the build succeeds

### DIFF
--- a/assets/webpack.config.js
+++ b/assets/webpack.config.js
@@ -23,7 +23,8 @@ module.exports = (env, options) => ({
         exclude: /node_modules/,
         use: [
           {
-            loader: "ts-loader"
+            loader: "ts-loader",
+            options: { transpileOnly: true }
           }
         ]
       },


### PR DESCRIPTION
IMPORTANT: This hides type errors and should be removed soon when we want to start checking types! But for now, the higher priority is getting something on the sample e-ink screen, and we don't yet have types to check.