### PR TITLE
fix: specify America/New_York instead of relying on device timezone

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -6810,6 +6810,14 @@
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
       "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
     },
+    "moment-timezone": {
+      "version": "0.5.27",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.27.tgz",
+      "integrity": "sha512-EIKQs7h5sAsjhPCqN6ggx6cEbs94GK050254TIJySD1bzoM5JTYDwAU1IoVOeTOL6Gm27kYJ51/uuvq1kIlrbw==",
+      "requires": {
+        "moment": ">= 2.9.0"
+      }
+    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",

--- a/assets/package.json
+++ b/assets/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "core-js": "^3.6.4",
     "moment": "^2.24.0",
+    "moment-timezone": "^0.5.27",
     "phoenix": "file:../deps/phoenix",
     "phoenix_html": "file:../deps/phoenix_html",
     "qrcode.react": "^1.0.0",

--- a/assets/src/app.tsx
+++ b/assets/src/app.tsx
@@ -21,6 +21,7 @@ import {
 } from "react-router-dom";
 
 import moment from "moment";
+import "moment-timezone";
 
 const HomePage = (): JSX.Element => {
   return (
@@ -362,8 +363,8 @@ const LaterDepartureTime = ({ time, currentTimeString }): JSX.Element => {
       </div>
     );
   } else {
-    const timestamp = departureTime.format("h:mm");
-    const ampm = departureTime.format("A");
+    const timestamp = departureTime.tz("America/New_York").format("h:mm");
+    const ampm = departureTime.tz("America/New_York").format("A");
 
     return (
       <div className="later-departure-time-container">
@@ -403,7 +404,7 @@ const FlexZoneAlert = ({ alert }): JSX.Element => {
         </div>
         <div className="alert-header-timestamp">
           Updated <br />
-          {updatedTime.format("M/D/Y · h:mm A")}
+          {updatedTime.tz("America/New_York").format("M/D/Y · h:mm A")}
         </div>
       </div>
 
@@ -505,7 +506,9 @@ const TopScreenContainer = forwardRef(
 const Header = ({ stopName, currentTimeString }): JSX.Element => {
   const ref = useRef(null);
   const [stopSize, setStopSize] = useState(2);
-  const currentTime = moment(currentTimeString).format("h:mm");
+  const currentTime = moment(currentTimeString)
+    .tz("America/New_York")
+    .format("h:mm");
 
   useLayoutEffect(() => {
     const height = ref.current.clientHeight;


### PR DESCRIPTION
The test screen we have in the office appears to be in UTC +1 (which is Italy's time zone); in any case, we shouldn't rely on the local timezone on each e-ink screen.