### PR TITLE
fix: text missing on some refreshes

### DIFF
--- a/assets/src/components/screen_container.tsx
+++ b/assets/src/components/screen_container.tsx
@@ -86,7 +86,7 @@ const ScreenContainer = ({ id }): JSX.Element => {
       window.location.reload(false);
     }
 
-    setSuccess(json.success_value);
+    setSuccess(json.success);
     setCurrentTimeString(json.current_time);
     setStopName(json.stop_name);
     setStopId(json.stop_id);

--- a/lib/screens/screen_data.ex
+++ b/lib/screens/screen_data.ex
@@ -5,7 +5,7 @@ defmodule Screens.ScreenData do
   alias Screens.Departures.Departure
   alias Screens.NearbyConnections
 
-  @version 10
+  @version 1
 
   def by_stop_id(stop_id) do
     # If we are unable to fetch alerts:
@@ -40,7 +40,7 @@ defmodule Screens.ScreenData do
       {:ok, departures} ->
         %{
           version: @version,
-          success_value: true,
+          success: true,
           current_time: format_current_time(DateTime.utc_now()),
           stop_name: stop_name,
           stop_id: stop_id,
@@ -52,7 +52,7 @@ defmodule Screens.ScreenData do
       :error ->
         %{
           version: @version,
-          success_value: false
+          success: false
         }
     end
   end


### PR DESCRIPTION
This seems (in a bunch of test deploys with breaking API changes with and without changing the version) to fix the observed issue with missing text.

I'm not entirely sure what caused the issue in the first place. It seems like something to do with full-page reloads (without cache) causing the fonts to be missing on the first render. If that's the case, it seems like we were also doing too many full-page reloads (which is perhaps what this PR fixes).

- Moving `version` inside of `ScreenContainer` seems to help stop doing as many full-page reloads (?)
- Switching to `window.location.reload(false)` seems to still load the new version, but without the fonts missing (?)

I think it would be good to follow up next week with a test where we change the GDS-set refresh rate of this screen to once per hour.