### PR TITLE
fix: don't let screen containers exceed 1600px in height

### DIFF
--- a/assets/css/departures_row.scss
+++ b/assets/css/departures_row.scss
@@ -5,13 +5,13 @@
 }
 
 .departures-row__container--large {
-  margin-top: 40px;
-  margin-bottom: 40px;
+  padding-top: 40px;
+  padding-bottom: 40px;
 }
 
 .departures-row__container--small {
-  margin-top: 20px;
-  margin-bottom: 20px;
+  padding-top: 20px;
+  padding-bottom: 20px;
 }
 
 .departures-row__hairline {


### PR DESCRIPTION
**Asana Task:** [ad hoc]

The margin on Later Departures was forcing the total page size to be 1200x3220 rather than 1200x3200 (which would likely result in the bottom 20 pixels being cut off). Replacing the margin by padding should fix the issue.