### PR TITLE
fix: handle prediction API responses with empty data better

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -45,22 +45,9 @@ config :screens,
     "16" => %{stop_id: "407"},
     "17" => %{stop_id: "5605"},
     "18" => %{stop_id: "637"},
-    "19" => %{stop_id: "8178"},
-    # detour
-    "100" => %{stop_id: "2166"},
-    # stop move
-    "101" => %{stop_id: "150"},
-    # stop closure
-    "102" => %{stop_id: "1921"},
-    # service change
-    "103" => %{stop_id: "2085"},
-    # station issue
-    "104" => %{stop_id: "38671"}
+    "19" => %{stop_id: "8178"}
   },
-  # api_v3_key: "ba359ac2ed5b41a5b05bfae67321766a",
   api_v3_url: "https://api-v3.mbta.com/",
-  # api_v3_key: "b982dde8f59047da860575f09f7fae4b",
-  # api_v3_url: "https://green.dev.api.mbtace.com/",
   nearby_connections: %{
     "1722" => ["place-matt", "place-DB-2222"],
     "383" => ["2923", "568"],

--- a/lib/screens/predictions/parser.ex
+++ b/lib/screens/predictions/parser.ex
@@ -1,15 +1,13 @@
 defmodule Screens.Predictions.Parser do
   @moduledoc false
 
-  def parse_result(result) do
-    included_data =
-      result
-      |> Map.get("included")
-      |> parse_included_data()
+  def parse_result(%{"data" => data, "included" => included}) do
+    included_data = parse_included_data(included)
+    parse_data(data, included_data)
+  end
 
-    result
-    |> Map.get("data")
-    |> parse_data(included_data)
+  def parse_result(%{"data" => []}) do
+    []
   end
 
   defp parse_data(data, included_data) do


### PR DESCRIPTION
If we query the v3 API for predictions at a stop with no predictions, we get an empty response. 

Our current parser assumes that we'll always have `"included"` as a key in the response, which isn't valid. This PR resolves the issue by handling the empty response case.