### PR TITLE
fix: Make the app work on both GDS and Mercury signs

### DIFF
--- a/lib/screens_web/router.ex
+++ b/lib/screens_web/router.ex
@@ -6,7 +6,6 @@ defmodule ScreensWeb.Router do
     plug :fetch_session
     plug :fetch_flash
     plug :protect_from_forgery
-    plug :put_secure_browser_headers
   end
 
   pipeline :api do


### PR DESCRIPTION
It seems that including (at least one of) the headers added by `:put_secure_browser_headers` causes the app not to work on the Mercury screens. This change makes the app work on both Mercury and GDS.

Note that it may be possible to manually add back individual headers which `:put_secure_browser_headers` would have added. But since the app isn't interactive, it should be OK to omit these.