### PR TITLE
feat: make it visually obvious when we're on dev

### DIFF
--- a/assets/css/header.scss
+++ b/assets/css/header.scss
@@ -5,6 +5,18 @@
   position: relative;
 }
 
+.header__environment {
+  position: absolute;
+  top: 12px;
+  left: 40px;
+  font-family: neue-haas-grotesk-text;
+  font-size: 48px;
+  color: #ffffff;
+  letter-spacing: 0;
+  line-height: 48px;
+  font-weight: 700;
+}
+
 .header__time {
   position: absolute;
   top: 28px;

--- a/assets/src/components/header.tsx
+++ b/assets/src/components/header.tsx
@@ -21,8 +21,14 @@ const Header = ({ stopName, currentTimeString }): JSX.Element => {
     }
   });
 
+  const environmentName = document.getElementById("app").dataset
+    .environmentName;
+
   return (
     <div className="header">
+      <div className="header__environment">
+        {["dev", "dev-green"].includes(environmentName) ? environmentName : ""}
+      </div>
       <div className="header__time">{currentTime}</div>
       <div className="header__realtime-indicator">
         <img

--- a/config/config.exs
+++ b/config/config.exs
@@ -25,6 +25,7 @@ config :phoenix, :json_library, Jason
 config :screens, :redirect_http?, true
 
 config :screens,
+  environment_name: System.get_env("ENVIRONMENT_NAME"),
   api_version: "1",
   screen_data: %{
     "1" => %{stop_id: "1722", app_id: "bus_eink"},

--- a/lib/screens_web/controllers/screen_controller.ex
+++ b/lib/screens_web/controllers/screen_controller.ex
@@ -2,10 +2,16 @@ defmodule ScreensWeb.ScreenController do
   use ScreensWeb, :controller
 
   plug(:api_version)
+  plug(:environment_name)
 
   defp api_version(conn, _) do
     api_version = Application.get_env(:screens, :api_version)
     assign(conn, :api_version, api_version)
+  end
+
+  defp environment_name(conn, _) do
+    environment_name = Application.get_env(:screens, :environment_name)
+    assign(conn, :environment_name, environment_name)
   end
 
   defp screen_ids(target_app_id) do

--- a/lib/screens_web/templates/screen/index.html.eex
+++ b/lib/screens_web/templates/screen/index.html.eex
@@ -1,1 +1,1 @@
-<div id="app" data-api-version="<%= @api_version %>" %>"></div>
+<div id="app" data-api-version="<%= @api_version %>" data-environment-name="<%= @environment_name %>"></div>

--- a/lib/screens_web/templates/screen/index_multi.html.eex
+++ b/lib/screens_web/templates/screen/index_multi.html.eex
@@ -1,1 +1,1 @@
-<div id="app" data-api-version="<%= @api_version %>" data-screen-ids="<%= Jason.encode!(@screen_ids) %>"></div>
+<div id="app" data-api-version="<%= @api_version %>" data-environment-name="<%= @environment_name %>" data-screen-ids="<%= Jason.encode!(@screen_ids) %>"></div>


### PR DESCRIPTION
**Asana Task:** [Make it visually obvious that dev is dev](https://app.asana.com/0/1158428874739705/1158451159995212)

This PR adds the text `dev` or `dev-green` in the upper-left corner when we're on those environments. Otherwise, we don't show anything.