### PR TITLE
fix: parse STOP_MOVE alert effect

### DIFF
--- a/lib/screens/alerts/parser.ex
+++ b/lib/screens/alerts/parser.ex
@@ -81,6 +81,7 @@ defmodule Screens.Alerts.Parser do
   defp parse_effect("STOP_CLOSURE"), do: :stop_closure
   defp parse_effect("DOCK_CLOSURE"), do: :dock_closure
   defp parse_effect("STATION_CLOSURE"), do: :station_closure
+  defp parse_effect("STOP_MOVE"), do: :stop_moved
   defp parse_effect("STOP_MOVED"), do: :stop_moved
   defp parse_effect("EXTRA_SERVICE"), do: :extra_service
   defp parse_effect("SCHEDULE_CHANGE"), do: :schedule_change


### PR DESCRIPTION
**Asana Task:** ad hoc

As seen in the attached image, we're not handling the stop move alerts correctly -- the effect is `STOP_MOVE` and we're currently only parsing `STOP_MOVED`. (It's unclear whether `STOP_MOVED` also exists.) This PR fixes the parsing of that effect so we don't default to `Unknown`.

![image](https://user-images.githubusercontent.com/4276843/76115957-0e317e80-5fb7-11ea-9f9f-1a9370b32b8f.png)
