### PR TITLE
fix: check ENVIRONMENT_NAME env var at runtime

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -25,7 +25,7 @@ config :phoenix, :json_library, Jason
 config :screens, :redirect_http?, true
 
 config :screens,
-  environment_name: System.get_env("ENVIRONMENT_NAME"),
+  environment_name: {:system, "ENVIRONMENT_NAME"},
   api_version: "1",
   screen_data: %{
     "1" => %{stop_id: "1722", app_id: "bus_eink"},

--- a/lib/screens/application.ex
+++ b/lib/screens/application.ex
@@ -8,6 +8,8 @@ defmodule Screens.Application do
   def start(_type, _args) do
     import Supervisor.Spec, warn: false
 
+    load_runtime_config()
+
     # List all child processes to be supervised
     children = [
       # Start the endpoint when the application starts
@@ -28,5 +30,21 @@ defmodule Screens.Application do
   def config_change(changed, _new, removed) do
     ScreensWeb.Endpoint.config_change(changed, removed)
     :ok
+  end
+
+  def load_runtime_config do
+    Application.put_env(
+      :screens,
+      :environment_name,
+      runtime_config(Application.get_env(:screens, :environment_name))
+    )
+  end
+
+  defp runtime_config({:system, environment_variable}) do
+    System.get_env(environment_variable)
+  end
+
+  defp runtime_config(value) do
+    value
   end
 end


### PR DESCRIPTION
The change from [Make it visually obvious that dev is dev](https://app.asana.com/0/1158428874739705/1158451159995212) isn't working since we're not checking `ENVIRONMENT_NAME` at runtime. This PR should fix that issue.