### PR TITLE
fix: fetch environment name in releases.exs

### DIFF
--- a/assets/src/components/header.tsx
+++ b/assets/src/components/header.tsx
@@ -27,7 +27,9 @@ const Header = ({ stopName, currentTimeString }): JSX.Element => {
   return (
     <div className="header">
       <div className="header__environment">
-        {["dev", "dev-green"].includes(environmentName) ? environmentName : ""}
+        {["screens-dev", "screens-dev-green"].includes(environmentName)
+          ? environmentName
+          : ""}
       </div>
       <div className="header__time">{currentTime}</div>
       <div className="header__realtime-indicator">

--- a/config/config.exs
+++ b/config/config.exs
@@ -25,7 +25,6 @@ config :phoenix, :json_library, Jason
 config :screens, :redirect_http?, true
 
 config :screens,
-  environment_name: {:system, "ENVIRONMENT_NAME"},
   api_version: "1",
   screen_data: %{
     "1" => %{stop_id: "1722", app_id: "bus_eink"},

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -30,6 +30,8 @@ config :screens, ScreensWeb.Endpoint,
 
 config :screens, api_v3_key: api_v3_key
 
+config :screens, environment_name: eb_env_name
+
 # ## Using releases (Elixir v1.9+)
 #
 # If you are doing OTP releases, you need to instruct Phoenix

--- a/lib/screens/application.ex
+++ b/lib/screens/application.ex
@@ -8,8 +8,6 @@ defmodule Screens.Application do
   def start(_type, _args) do
     import Supervisor.Spec, warn: false
 
-    load_runtime_config()
-
     # List all child processes to be supervised
     children = [
       # Start the endpoint when the application starts
@@ -30,21 +28,5 @@ defmodule Screens.Application do
   def config_change(changed, _new, removed) do
     ScreensWeb.Endpoint.config_change(changed, removed)
     :ok
-  end
-
-  def load_runtime_config do
-    Application.put_env(
-      :screens,
-      :environment_name,
-      runtime_config(Application.get_env(:screens, :environment_name))
-    )
-  end
-
-  defp runtime_config({:system, environment_variable}) do
-    System.get_env(environment_variable)
-  end
-
-  defp runtime_config(value) do
-    value
   end
 end


### PR DESCRIPTION
- Set application config `:environment_name` in releases.exs, where we already use the `ENVIRONMENT_NAME` env var to fetch secrets.
- Possible values of `ENVIRONMENT_NAME` are `screens-dev`, `screens-prod`, etc.