### PR TITLE
fix: environment name for production is screens-prod, not prod

### DIFF
--- a/lib/screens/override/fetch.ex
+++ b/lib/screens/override/fetch.ex
@@ -24,7 +24,7 @@ defmodule Screens.Override.Fetch do
 
   defp config_path_for_environment do
     case Application.get_env(:screens, :environment_name) do
-      "prod" -> "prod.json"
+      "screens-prod" -> "prod.json"
       _ -> "dev.json"
     end
   end


### PR DESCRIPTION
**Asana Task:** ad hoc

The possible values of environment name are `screens-{prod, dev, etc.}`.