### PR TITLE
fix: failing to fetch nearby departures returns empty list, not error

### DIFF
--- a/lib/screens/nearby_departures.ex
+++ b/lib/screens/nearby_departures.ex
@@ -7,17 +7,23 @@ defmodule Screens.NearbyDepartures do
       |> Application.get_env(:nearby_departures)
       |> Map.get(stop_id)
 
-    {:ok, predictions} =
+    prediction_result =
       nearby_departure_stop_ids
       |> Enum.join(",")
       |> Screens.Predictions.Prediction.by_stop_id()
 
-    predictions
-    |> Enum.group_by(& &1.stop.id)
-    |> Enum.map(fn {stop_id, prediction_list} ->
-      {stop_id, Enum.min_by(prediction_list, & &1.time)}
-    end)
-    |> Enum.map(fn {_stop_id, prediction} -> format_prediction(prediction) end)
+    case prediction_result do
+      {:ok, predictions} ->
+        predictions
+        |> Enum.group_by(& &1.stop.id)
+        |> Enum.map(fn {stop_id, prediction_list} ->
+          {stop_id, Enum.min_by(prediction_list, & &1.time)}
+        end)
+        |> Enum.map(fn {_stop_id, prediction} -> format_prediction(prediction) end)
+
+      :error ->
+        []
+    end
   end
 
   defp format_prediction(%{


### PR DESCRIPTION
**Asana Task:** ad hoc

If we get an error when fetching predictions for Nearby Departures, we want to return an empty list (which will cause Nearby Departures to not be shown) rather than erroring (which will cause a 500 error on the server and will in turn show a Connection Error screen).