### PR TITLE
fix: use arrival time when not null

### DIFF
--- a/lib/screens/predictions/parser.ex
+++ b/lib/screens/predictions/parser.ex
@@ -40,8 +40,17 @@ defmodule Screens.Predictions.Parser do
         %{"id" => id, "attributes" => attributes, "relationships" => relationships},
         included_data
       ) do
-    %{"departure_time" => time_string} = attributes
-    time = parse_time(time_string)
+    %{"arrival_time" => arrival_time_string, "departure_time" => departure_time_string} =
+      attributes
+
+    arrival_time = parse_time(arrival_time_string)
+    departure_time = parse_time(departure_time_string)
+
+    time =
+      case arrival_time do
+        nil -> departure_time
+        t -> t
+      end
 
     %{
       "route" => %{"data" => %{"id" => route_id}},


### PR DESCRIPTION
**Asana Task:** [Use arrival_time vs departure_time in line with best practices](https://app.asana.com/0/1158428874739705/1167343203779683)

Per the [best practices](https://www.mbta.com/developers/v3-api/best-practices), if both arrival time and departure time are present, the arrival time should be used. If arrival time is nil, then we're at the start of a route, and we should use departure time instead.