### PR TITLE
feat: messaging for level 4 COVID-19 service

### DIFF
--- a/lib/screens/headways.ex
+++ b/lib/screens/headways.ex
@@ -79,9 +79,11 @@ defmodule Screens.Headways do
 
   defp schedule_with_override(time, service_level) do
     # Level 3 turns weekday into Saturday schedule
+    # Level 4 is always Sunday schedule
     # Otherwise, use normal schedule
     case {service_level, schedule(time)} do
       {3, :weekday} -> :saturday
+      {4, _} -> :sunday
       {_, schedule} -> schedule
     end
   end


### PR DESCRIPTION
**Asana Task:** [COVID Level 4 feature](https://app.asana.com/0/1158428874739705/1166954201865362)

Per discussion at standup today, this is actually the same as level 3, but with a different schedule (level 4 will be Sunday schedule for all days).

For now, this just changes headways; in the future, it will also change the next scheduled departure. The flex zone / global alert is the same as for Level 3.