### PR TITLE
feat: configure new screens to avoid using the same id for two screens

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -55,7 +55,21 @@ config :screens,
       direction_id: 1,
       app_id: "gl_eink_single"
     },
+    "111" => %{
+      stop_id: "place-bland",
+      platform_id: "70148",
+      route_id: "Green-B",
+      direction_id: 1,
+      app_id: "gl_eink_single"
+    },
     "102" => %{
+      stop_id: "place-bland",
+      platform_id: "70149",
+      route_id: "Green-B",
+      direction_id: 0,
+      app_id: "gl_eink_single"
+    },
+    "112" => %{
       stop_id: "place-bland",
       platform_id: "70149",
       route_id: "Green-B",
@@ -111,6 +125,13 @@ config :screens,
       direction_id: 1,
       app_id: "gl_eink_double"
     },
+    "213" => %{
+      stop_id: "place-bcnwa",
+      platform_id: "70230",
+      route_id: "Green-C",
+      direction_id: 1,
+      app_id: "gl_eink_double"
+    },
     "204" => %{
       stop_id: "place-bcnwa",
       platform_id: "70229",
@@ -126,6 +147,13 @@ config :screens,
       app_id: "gl_eink_double"
     },
     "206" => %{
+      stop_id: "place-mfa",
+      platform_id: "70245",
+      route_id: "Green-E",
+      direction_id: 0,
+      app_id: "gl_eink_double"
+    },
+    "216" => %{
       stop_id: "place-mfa",
       platform_id: "70245",
       route_id: "Green-E",


### PR DESCRIPTION
**Asana Task:** [Make all URLs screen-specific (i.e., one-to-one relationship)](https://app.asana.com/0/1158428874739705/1167563928363452)

This PR creates new screen IDs for the screens which we have more than one of: 111, 112, 213, 216 are the same as the current 101, 102, 203 and 206, respectively.