### PR TITLE
fix: make bus departure timestamps smaller so they fit in the column

### DIFF
--- a/assets/css/departure_time.scss
+++ b/assets/css/departure_time.scss
@@ -60,7 +60,7 @@
 }
 
 .departure-time__timestamp--large {
-  font-size: 105px;
+  font-size: 72px;
   line-height: 144px;
 }
 
@@ -73,7 +73,7 @@
 }
 
 .departure-time__ampm--large {
-  font-size: 72px;
+  font-size: 52.5px;
   line-height: 144px;
 }
 


### PR DESCRIPTION
**Asana Task:** [Fix visual bug(s) with predictions >59m away](https://app.asana.com/0/1158428874739705/1162890718409619)

Changes the font sizes for departures to be the same as later departures. Line heights remain the same.