### PR TITLE
chore: set new dialyxer version to runtime: false

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -63,7 +63,7 @@ defmodule Screens.MixProject do
       {:httpoison, "~> 1.6"},
       {:tzdata, "~> 1.0.3"},
       {:credo, "~> 1.3.2", only: [:dev, :test]},
-      {:dialyxir, "~> 1.0.0", only: [:dev, :test]},
+      {:dialyxir, "~> 1.0.0", only: [:dev, :test], runtime: false},
       {:excoveralls, "~> 0.12.3", only: :test},
       {:ex_aws, "~> 2.1", only: :prod},
       {:ex_aws_secretsmanager, "~> 2.0", only: :prod},


### PR DESCRIPTION
#95 updated dialyxir to version 1.0.0, after which we started getting a warning message suggesting that we add `runtime: false` to `mix.exs`:

> Warning: the `dialyxir` application's start function was called, which likely means you did not add the dependency with the `runtime: false` flag. This is not recommended because it will mean that unnecessary applications are started, and unnecessary applications are most likely being added to your PLT file, increasing build time. Please add `runtime: false` in your `mix.exs` dependency section e.g.: {:dialyxir, "~> 0.5", only: [:dev], runtime: false}