### PR TITLE
fix: don't show nearby departures with nil departure times

### DIFF
--- a/lib/screens/nearby_departures.ex
+++ b/lib/screens/nearby_departures.ex
@@ -17,7 +17,12 @@ defmodule Screens.NearbyDepartures do
         predictions
         |> Enum.group_by(& &1.stop.id)
         |> Enum.map(fn {stop_id, prediction_list} ->
-          {stop_id, Enum.min_by(prediction_list, & &1.departure_time)}
+          {
+            stop_id,
+            prediction_list
+            |> Enum.reject(&is_nil(&1.departure_time))
+            |> Enum.min_by(& &1.departure_time)
+          }
         end)
         |> Enum.map(fn {_stop_id, prediction} -> format_prediction(prediction) end)
 


### PR DESCRIPTION
**Asana Task:** [fix: Invalid date on nearby departures](https://app.asana.com/0/1158428874739705/1172777557515257)

Elixir thinks nil is less than any datetime:
```
iex(1)> t = ~U[2018-07-16 10:00:00Z]
~U[2018-07-16 10:00:00Z]
iex(2)> [nil, t] |> Enum.min
nil
iex(3)> nil < t
true
```