### PR TITLE
chore: remove line map hack

### DIFF
--- a/assets/src/components/eink/green_line/header.tsx
+++ b/assets/src/components/eink/green_line/header.tsx
@@ -57,8 +57,16 @@ const Header = ({ stopName, routeId, currentTimeString }): JSX.Element => {
     }
   });
 
+  const environmentName = document.getElementById("app").dataset
+    .environmentName;
+
   return (
     <div className="header">
+      <div className="header__environment">
+        {["screens-dev", "screens-dev-green"].includes(environmentName)
+          ? environmentName
+          : ""}
+      </div>
       <div className="header__time">{currentTime}</div>
       <div className="header__realtime-indicator">
         <img


### PR DESCRIPTION
**Asana Task:** [Cleanup: Remove line map hack](https://app.asana.com/0/1158428874739705/1174156599988097)

Since we replaced the SVG COVID graphics with PNGs, this should no longer be necessary either. I deployed to dev-green and displayed on the Mercury sign at MFA to confirm that this still looked OK.