### PR TITLE
fix: only show stops which entirely fit in the visible area

### DIFF
--- a/assets/src/components/eink/green_line/line_map.tsx
+++ b/assets/src/components/eink/green_line/line_map.tsx
@@ -411,10 +411,10 @@ const LineMapOriginStop = (): JSX.Element => {
   );
 };
 
-const LineMapStops = ({}): JSX.Element => {
+const LineMapStops = (): JSX.Element => {
   const {
     showOriginStop,
-    originStopIndex,
+    lastVisibleStopIndex,
     stopNames,
     radius,
     dy,
@@ -423,15 +423,9 @@ const LineMapStops = ({}): JSX.Element => {
   } = useContext(LineMapContext);
   return (
     <g>
-      {[...Array(originStopIndex + 1)].map((_, i) => {
-        if (stopMarginTop + radius + i * dy < height) {
-          return (
-            <LineMapStop i={i} stopName={stopNames[i]} key={"stop-" + i} />
-          );
-        } else {
-          return null;
-        }
-      })}
+      {[...Array(lastVisibleStopIndex + 1)].map((_, i) => (
+        <LineMapStop i={i} stopName={stopNames[i]} key={"stop-" + i} />
+      ))}
       <LineMapCurrentStop />
       {showOriginStop && <LineMapOriginStop />}
     </g>
@@ -480,7 +474,7 @@ const LineMapContainer = ({
 
   // The last stop which fits in the alloted vertical space
   const lastVisibleStopIndex = Math.floor(
-    (height - constants.stopMarginTop + constants.radius) / constants.dy
+    (height - constants.stopMarginTop - 2 * constants.radius) / constants.dy
   );
 
   // Compute the y-position of the current stop
@@ -531,6 +525,7 @@ const LineMapContainer = ({
     showOriginStop,
     stopNames,
     showScheduledDeparture,
+    lastVisibleStopIndex,
   };
 
   const params = { ...constants, ...props };

--- a/assets/src/components/eink/green_line/single/screen_container.tsx
+++ b/assets/src/components/eink/green_line/single/screen_container.tsx
@@ -33,7 +33,7 @@ const TopScreenLayout = ({
       />
       <LineMap
         data={lineMapData}
-        height={1140}
+        height={1134}
         currentTimeString={currentTimeString}
         showVehicles={!isHeadwayMode}
       />


### PR DESCRIPTION
**Asana Task:** [Heath Street is cut off on GL single line map](https://app.asana.com/0/1158428874739705/1174167275848881)

I think this may be a combination of the Line Map refactor and the change to make GL single (Mercury) screens 1594 rather than 1600px tall? In any case, this PR should compute whether there's actually room to show a stop and only show those stops which actually fit.