### PR TITLE
feat: separate json configs for local and dev-green

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ npm-debug.log
 # this depending on your deployment strategy.
 /priv/static/
 
+# Local config file
+/priv/local.json
+
 /assets/coverage
 
 # Ignore the directory created by the ElixirLS VSCode plugin

--- a/config/config.exs
+++ b/config/config.exs
@@ -29,6 +29,7 @@ config :screens, :redirect_http?, true
 config :screens,
   gds_dms_username: "mbtadata@gmail.com",
   api_version: "6",
+  override_fetcher: Screens.Override.Fetch,
   screen_data: %{
     "1" => %{stop_id: "1722", app_id: "bus_eink"},
     "2" => %{stop_id: "383", app_id: "bus_eink"},

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -24,7 +24,8 @@ config :screens, ScreensWeb.Endpoint,
 config :screens,
   api_v3_key: System.get_env("API_V3_KEY"),
   gds_dms_password: System.get_env("GDS_DMS_PASSWORD"),
-  mercury_api_key: System.get_env("MERCURY_API_KEY")
+  mercury_api_key: System.get_env("MERCURY_API_KEY"),
+  override_fetcher: Screens.Override.LocalFetch
 
 # ## SSL Support
 #

--- a/lib/screens/override/fetch.ex
+++ b/lib/screens/override/fetch.ex
@@ -3,7 +3,7 @@ defmodule Screens.Override.Fetch do
 
   @default_opts [timeout: 2000, recv_timeout: 2000]
 
-  def fetch_config_from_s3(opts \\ []) do
+  def fetch_config(opts \\ []) do
     url = "https://mbta-dotcom.s3.amazonaws.com/screens/config/" <> config_path_for_environment()
     headers = []
 
@@ -19,7 +19,8 @@ defmodule Screens.Override.Fetch do
   defp config_path_for_environment do
     case Application.get_env(:screens, :environment_name) do
       "screens-prod" -> "prod.json"
-      _ -> "dev.json"
+      "screens-dev" -> "dev.json"
+      "screens-dev-green" -> "dev-green.json"
     end
   end
 end

--- a/lib/screens/override/local_fetch.ex
+++ b/lib/screens/override/local_fetch.ex
@@ -1,0 +1,12 @@
+defmodule Screens.Override.LocalFetch do
+  @moduledoc false
+
+  def fetch_config do
+    with {:ok, file_contents} <- File.read(Path.join(:code.priv_dir(:screens), "local.json")),
+         {:ok, parsed} <- Jason.decode(file_contents, keys: :atoms!) do
+      {:ok, Screens.Override.from_json(parsed)}
+    else
+      _ -> :error
+    end
+  end
+end

--- a/lib/screens/override/state.ex
+++ b/lib/screens/override/state.ex
@@ -85,8 +85,10 @@ defmodule Screens.Override.State do
 
   @impl true
   def handle_info(:refresh, _state) do
+    override_fetcher = Application.get_env(:screens, :override_fetcher)
+
     new_state =
-      case Screens.Override.Fetch.fetch_config_from_s3() do
+      case override_fetcher.fetch_config() do
         {:ok, config} -> config
         :error -> @default_config
       end


### PR DESCRIPTION
Pros:
- Create your own `local.json` config file for local development, you can change this without having to mess around with S3 / it won't affect anyone else.
- dev-green is running different code and so it should have its own config (e.g. so it doesn't break when we add a new key)

Cons:
- We need to add creating `local.json` to the setup process
- Your individual `local.json` could get out-of-sync with the "real" ones on S3 so that what you're seeing locally is substantively different from what's on the real screens