### PR TITLE
chore: factor out screen data override and version code

### DIFF
--- a/lib/screens/bus_screen_data.ex
+++ b/lib/screens/bus_screen_data.ex
@@ -7,33 +7,12 @@ defmodule Screens.BusScreenData do
   alias Screens.LogScreenData
   alias Screens.NearbyConnections
 
-  def by_stop_id_with_override_and_version(stop_id, screen_id, client_version, is_screen) do
-    if Screens.Override.State.disabled?(String.to_integer(screen_id)) do
-      LogScreenData.log_api_response(screen_id, client_version, is_screen, %{
-        force_reload: false,
-        success: false
-      })
-    else
-      LogScreenData.log_api_response(
-        screen_id,
-        client_version,
-        is_screen,
-        by_stop_id_with_version(stop_id, client_version, screen_id, is_screen)
-      )
-    end
-  end
+  def by_screen_id(screen_id, is_screen) do
+    %{stop_id: stop_id} =
+      :screens
+      |> Application.get_env(:screen_data)
+      |> Map.get(screen_id)
 
-  defp by_stop_id_with_version(stop_id, client_version, screen_id, is_screen) do
-    api_version = Application.get_env(:screens, :api_version)
-
-    if api_version == client_version do
-      by_stop_id(stop_id, screen_id, is_screen)
-    else
-      %{force_reload: true}
-    end
-  end
-
-  defp by_stop_id(stop_id, screen_id, is_screen) do
     # If we are unable to fetch alerts:
     # - inline_alerts will be an empty list
     # - global_alert will be nil

--- a/lib/screens/gl_screen_data.ex
+++ b/lib/screens/gl_screen_data.ex
@@ -6,68 +6,12 @@ defmodule Screens.GLScreenData do
   alias Screens.Departures.Departure
   alias Screens.LogScreenData
 
-  def by_stop_id_with_override_and_version(stop_id, screen_id, client_version, is_screen) do
-    %{route_id: route_id, direction_id: direction_id, platform_id: platform_id} =
+  def by_screen_id(screen_id, is_screen) do
+    %{stop_id: stop_id, route_id: route_id, direction_id: direction_id, platform_id: platform_id} =
       :screens
       |> Application.get_env(:screen_data)
       |> Map.get(screen_id)
 
-    if Screens.Override.State.disabled?(String.to_integer(screen_id)) do
-      LogScreenData.log_api_response(screen_id, client_version, is_screen, %{
-        force_reload: false,
-        success: false
-      })
-    else
-      LogScreenData.log_api_response(
-        screen_id,
-        client_version,
-        is_screen,
-        by_stop_id_with_version(
-          stop_id,
-          client_version,
-          route_id,
-          direction_id,
-          platform_id,
-          screen_id,
-          is_screen
-        )
-      )
-    end
-  end
-
-  defp by_stop_id_with_version(
-         stop_id,
-         client_version,
-         route_id,
-         direction_id,
-         platform_id,
-         screen_id,
-         is_screen
-       ) do
-    api_version = Application.get_env(:screens, :api_version)
-
-    if api_version == client_version do
-      by_stop_id(
-        stop_id,
-        route_id,
-        direction_id,
-        platform_id,
-        screen_id,
-        is_screen
-      )
-    else
-      %{force_reload: true}
-    end
-  end
-
-  defp by_stop_id(
-         stop_id,
-         route_id,
-         direction_id,
-         platform_id,
-         screen_id,
-         is_screen
-       ) do
     # If we are unable to fetch alerts:
     # - inline_alerts will be an empty list
     # - global_alert will be nil

--- a/lib/screens/screen_data.ex
+++ b/lib/screens/screen_data.ex
@@ -1,0 +1,52 @@
+defmodule Screens.ScreenData do
+  @moduledoc false
+
+  alias Screens.LogScreenData
+
+  @modules_by_app_id %{
+    "bus_eink" => Screens.BusScreenData,
+    "gl_eink_single" => Screens.GLScreenData,
+    "gl_eink_double" => Screens.GLScreenData,
+    "solari" => Screens.SolariScreenData
+  }
+
+  def by_screen_id_with_override_and_version(screen_id, client_version, is_screen) do
+    if Screens.Override.State.disabled?(String.to_integer(screen_id)) do
+      LogScreenData.log_api_response(screen_id, client_version, is_screen, %{
+        force_reload: false,
+        success: false
+      })
+    else
+      LogScreenData.log_api_response(
+        screen_id,
+        client_version,
+        is_screen,
+        by_screen_id_with_version(
+          screen_id,
+          client_version,
+          is_screen
+        )
+      )
+    end
+  end
+
+  defp by_screen_id_with_version(screen_id, client_version, is_screen) do
+    api_version = Application.get_env(:screens, :api_version)
+
+    if api_version == client_version do
+      by_screen_id(screen_id, is_screen)
+    else
+      %{force_reload: true}
+    end
+  end
+
+  defp by_screen_id(screen_id, is_screen) do
+    %{app_id: app_id} =
+      :screens
+      |> Application.get_env(:screen_data)
+      |> Map.get(screen_id)
+
+    screen_data_module = Map.get(@modules_by_app_id, app_id)
+    screen_data_module.by_screen_id(screen_id, is_screen)
+  end
+end

--- a/lib/screens/solari_screen_data.ex
+++ b/lib/screens/solari_screen_data.ex
@@ -1,39 +1,7 @@
 defmodule Screens.SolariScreenData do
   @moduledoc false
 
-  alias Screens.LogScreenData
-
-  def by_screen_id_with_override_and_version(screen_id, client_version, is_screen) do
-    if Screens.Override.State.disabled?(String.to_integer(screen_id)) do
-      LogScreenData.log_api_response(screen_id, client_version, is_screen, %{
-        force_reload: false,
-        success: false
-      })
-    else
-      LogScreenData.log_api_response(
-        screen_id,
-        client_version,
-        is_screen,
-        by_screen_id_with_version(
-          screen_id,
-          client_version,
-          is_screen
-        )
-      )
-    end
-  end
-
-  defp by_screen_id_with_version(screen_id, client_version, is_screen) do
-    api_version = Application.get_env(:screens, :api_version)
-
-    if api_version == client_version do
-      by_screen_id(screen_id, is_screen)
-    else
-      %{force_reload: true}
-    end
-  end
-
-  defp by_screen_id(screen_id, _is_screen) do
+  def by_screen_id(screen_id, _is_screen) do
     %{station_name: station_name, sections: sections} =
       :screens
       |> Application.get_env(:screen_data)

--- a/lib/screens_web/controllers/screen_api_controller.ex
+++ b/lib/screens_web/controllers/screen_api_controller.ex
@@ -3,14 +3,6 @@ defmodule ScreensWeb.ScreenApiController do
   require Logger
 
   def show(conn, %{"id" => screen_id, "version" => version}) do
-    config_data =
-      :screens
-      |> Application.get_env(:screen_data)
-      |> Map.get(screen_id)
-
-    app_id = Map.get(config_data, :app_id)
-    stop_id = Map.get(config_data, :stop_id)
-
     is_screen = ScreensWeb.UserAgent.is_screen_conn?(conn)
 
     _ =
@@ -19,38 +11,7 @@ defmodule ScreensWeb.ScreenApiController do
       end
 
     data =
-      case app_id do
-        "bus_eink" ->
-          Screens.BusScreenData.by_stop_id_with_override_and_version(
-            stop_id,
-            screen_id,
-            version,
-            is_screen
-          )
-
-        "gl_eink_single" ->
-          Screens.GLScreenData.by_stop_id_with_override_and_version(
-            stop_id,
-            screen_id,
-            version,
-            is_screen
-          )
-
-        "gl_eink_double" ->
-          Screens.GLScreenData.by_stop_id_with_override_and_version(
-            stop_id,
-            screen_id,
-            version,
-            is_screen
-          )
-
-        "solari" ->
-          Screens.SolariScreenData.by_screen_id_with_override_and_version(
-            screen_id,
-            version,
-            is_screen
-          )
-      end
+      Screens.ScreenData.by_screen_id_with_override_and_version(screen_id, version, is_screen)
 
     json(conn, data)
   end


### PR DESCRIPTION
**Asana task**: [Screen Data for Bus and Green Line should be by_screen_id, not by_stop_id](https://app.asana.com/0/1158428874739705/1173512029504777)

- We should be fetching data by screen id, not stop id.
- Given the above change, the code to handle overrides and version bumps is identical and can be factored out.