### PR TITLE
fix: don't render departures list when departures is undefined

### DIFF
--- a/assets/src/components/solari/section.tsx
+++ b/assets/src/components/solari/section.tsx
@@ -26,20 +26,21 @@ const Section = ({
     <div className="section">
       <SectionHeader name={name} arrow={arrow} />
       <div className="departure-container">
-        {departures.map((departure) => {
-          const { id, route, destination, time } = departure;
-          const routeId = departure.route_id;
-          return (
-            <Departure
-              route={route}
-              routeId={routeId}
-              destination={destination}
-              time={time}
-              currentTimeString={currentTimeString}
-              key={id}
-            />
-          );
-        })}
+        {departures &&
+          departures.map((departure) => {
+            const { id, route, destination, time } = departure;
+            const routeId = departure.route_id;
+            return (
+              <Departure
+                route={route}
+                routeId={routeId}
+                destination={destination}
+                time={time}
+                currentTimeString={currentTimeString}
+                key={id}
+              />
+            );
+          })}
       </div>
     </div>
   );


### PR DESCRIPTION
**Asana task**: ad hoc

Leaving the Solari app page open currently results in JS errors. I believe they're due to departures being undefined, and this PR should resolve the issue.