### PR TITLE
fix: parse empty schedules API response

### DIFF
--- a/lib/screens/schedules/parser.ex
+++ b/lib/screens/schedules/parser.ex
@@ -6,6 +6,10 @@ defmodule Screens.Schedules.Parser do
     parse_data(data, included_data)
   end
 
+  def parse_result(%{"data" => []}) do
+    []
+  end
+
   defp parse_included_data(data) do
     data
     |> Enum.map(fn item ->


### PR DESCRIPTION
**Asana task**: ad hoc

When there's nothing to include (because there are no schedules), the API response doesn't have `"included"` as a key.