### PR TITLE
feat: add config option to exclude routes

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -353,9 +353,7 @@ config :screens,
           name: "Bus",
           arrow: :w,
           query: %{params: %{stop_ids: ["5740", "57400"]}, opts: %{}},
-          layout:
-            {:upcoming,
-             %{num_rows: 12, visible_rows: 8, paged: true, routes: {:exclude, [{"120", 1}]}}}
+          layout: {:upcoming, %{num_rows: 12, visible_rows: 8, paged: true}}
         }
       ],
       app_id: "solari"

--- a/lib/screens/solari_screen_data.ex
+++ b/lib/screens/solari_screen_data.ex
@@ -100,7 +100,7 @@ defmodule Screens.SolariScreenData do
   end
 
   defp filter_by_routes(query_data, %{routes: {action, routes}}) do
-    route_matchers = routes |> Enum.flat_map(&build_route_matcher/1) |> MapSet.new()
+    route_matchers = routes |> Enum.flat_map(&route_direction_tuple/1) |> MapSet.new()
 
     filter_fn =
       case action do
@@ -115,6 +115,6 @@ defmodule Screens.SolariScreenData do
 
   defp filter_by_routes(query_data, _), do: query_data
 
-  defp build_route_matcher({_, _} = route_id_and_direction), do: [route_id_and_direction]
-  defp build_route_matcher(route_id), do: [{route_id, 0}, {route_id, 1}]
+  defp route_direction_tuple({_, _} = route_id_and_direction), do: [route_id_and_direction]
+  defp route_direction_tuple(route_id), do: [{route_id, 0}, {route_id, 1}]
 end


### PR DESCRIPTION
**Asana task**: [Solari departures: Filter out terminal arrivals](https://app.asana.com/0/1158428874739705/1175251002338387/f)

I originally did the filtering immediately after fetching prediction data, but decided it made more sense to augment the existing filtering that happens in the code that handles layout options.

This also made it clearer in the config that you can either `include` or `exclude` specific routes in a section, but not both.