### PR TITLE
Fix antialiasing weirdness on Solari background

### DIFF
--- a/assets/css/solari/screen_container.scss
+++ b/assets/css/solari/screen_container.scss
@@ -4,10 +4,11 @@
   width: 1080px;
   height: 1920px;
 
-  background-image: repeating-linear-gradient(
+  background: repeating-linear-gradient(
     -45deg,
-    #f5f4f1 0px,
-    #f5f4f1 12px,
-    rgba(199, 199, 199, 0.58) 12px 17px
+    #f5f4f1 0,
+    #f5f4f1 40%,
+    rgba(199, 199, 199, 0.58) 40% 50%
   );
+  background-size: 15px 15px;
 }


### PR DESCRIPTION
**Asana task**: ad hoc

Based on advice from the end of [this guide](https://css-tricks.com/stripes-css/), I used percentages instead of pixel counts, as well as smaller, repeating tiled images instead of a single image for the whole 1920x1080 container. This fixed the antialiasing problems and allowed for thinner stripes that are closer to what's in Tyler's designs.

**Old** ![Screen Shot 2020-05-19 at 3 43 51 PM](https://user-images.githubusercontent.com/63608771/82371072-95539780-99e7-11ea-9e22-46fab9a92de6.png)

**New** ![Screen Shot 2020-05-19 at 3 38 07 PM](https://user-images.githubusercontent.com/63608771/82370925-59203700-99e7-11ea-8c97-a20e84742e84.png)

