### PR TITLE
refactor: some cleanup in Departure module

### DIFF
--- a/lib/screens/bus_screen_data.ex
+++ b/lib/screens/bus_screen_data.ex
@@ -82,7 +82,7 @@ defmodule Screens.BusScreenData do
   end
 
   defp format_departure_rows(departures) do
-    Enum.map(departures, &Departure.to_map/1)
+    Enum.map(departures, &Map.from_struct/1)
   end
 
   def format_global_alert(alert) do

--- a/lib/screens/gl_screen_data.ex
+++ b/lib/screens/gl_screen_data.ex
@@ -86,7 +86,7 @@ defmodule Screens.GLScreenData do
   end
 
   defp format_departure_rows(departures) do
-    Enum.map(departures, &Departure.to_map/1)
+    Enum.map(departures, &Map.from_struct/1)
   end
 
   def format_global_alert(alert) do

--- a/lib/screens/solari_screen_data.ex
+++ b/lib/screens/solari_screen_data.ex
@@ -87,7 +87,7 @@ defmodule Screens.SolariScreenData do
     query_data
     |> filter_by_routes(layout_opts)
     |> Enum.take(num_rows)
-    |> Enum.map(&Departure.to_map/1)
+    |> Enum.map(&Map.from_struct/1)
   end
 
   defp do_layout(query_data, :bidirectional) do
@@ -96,7 +96,7 @@ defmodule Screens.SolariScreenData do
     |> Tuple.to_list()
     |> Enum.flat_map(&Enum.slice(&1, 0, 1))
     |> Enum.sort_by(& &1.time)
-    |> Enum.map(&Departure.to_map/1)
+    |> Enum.map(&Map.from_struct/1)
   end
 
   defp filter_by_routes(query_data, %{routes: routes}) do


### PR DESCRIPTION
**Asana task**: ad hoc

- Remove `Departure.to_map/1` and use `Map.from_struct/1` instead, after renaming the one field that differed.
- Simplify `Departure.deduplicate_combined_routes/1`.
