### PR TITLE
feat: Use BRD instead of ARR for first stop on route

### DIFF
--- a/assets/src/components/solari/departure.tsx
+++ b/assets/src/components/solari/departure.tsx
@@ -44,6 +44,7 @@ const Departure = ({
   time,
   currentTimeString,
   vehicleStatus,
+  stopType,
   alerts,
 }): JSX.Element => {
   const { routeName, routePillColor } = routeToPill(route, routeId);
@@ -61,7 +62,8 @@ const Departure = ({
           time={standardTimeRepresentation(
             time,
             currentTimeString,
-            vehicleStatus
+            vehicleStatus,
+            stopType
           )}
         />
       </div>

--- a/assets/src/components/solari/section.tsx
+++ b/assets/src/components/solari/section.tsx
@@ -67,6 +67,7 @@ class PagedSection extends React.Component {
                 route_id: routeId,
                 vehicle_status: vehicleStatus,
                 alerts: alerts,
+                stop_type: stopType,
               }) => {
                 return (
                   <Departure
@@ -77,6 +78,7 @@ class PagedSection extends React.Component {
                     currentTimeString={this.props.currentTimeString}
                     vehicleStatus={vehicleStatus}
                     alerts={alerts}
+                    stopType={stopType}
                     key={id}
                   />
                 );
@@ -96,6 +98,7 @@ class PagedSection extends React.Component {
                 currentTimeString={this.props.currentTimeString}
                 vehicleStatus={currentPagedDeparture.vehicle_status}
                 alerts={currentPagedDeparture.alerts}
+                stopType={currentPagedDeparture.stopType}
               />
             </>
           )}
@@ -126,6 +129,7 @@ const Section = ({
             route_id: routeId,
             vehicle_status: vehicleStatus,
             alerts,
+            stop_type: stopType,
           }) => {
             return (
               <Departure
@@ -136,6 +140,7 @@ const Section = ({
                 currentTimeString={currentTimeString}
                 vehicleStatus={vehicleStatus}
                 alerts={alerts}
+                stopType={stopType}
                 key={id}
               />
             );

--- a/assets/src/util/time_representation.tsx
+++ b/assets/src/util/time_representation.tsx
@@ -11,7 +11,8 @@ export type TimeRepresentation =
 export const standardTimeRepresentation = (
   departureTimeString: string,
   currentTimeString: string,
-  vehicleStatus: string
+  vehicleStatus: string,
+  stopType: string
 ): TimeRepresentation => {
   const departureTime = moment(departureTimeString);
   const currentTime = moment(currentTimeString);
@@ -23,6 +24,9 @@ export const standardTimeRepresentation = (
   }
 
   if (secondDifference <= 30) {
+    if (stopType === "first_stop") {
+      return { type: "TEXT", text: "BRD" };
+    }
     return { type: "TEXT", text: "ARR" };
   }
 

--- a/lib/screens/departures/departure.ex
+++ b/lib/screens/departures/departure.ex
@@ -12,6 +12,7 @@ defmodule Screens.Departures.Departure do
             direction_id: nil,
             vehicle_status: nil,
             alerts: [],
+            stop_type: nil,
             time: nil,
             inline_badges: nil
 
@@ -24,6 +25,7 @@ defmodule Screens.Departures.Departure do
           direction_id: 0 | 1 | nil,
           vehicle_status: String.t(),
           alerts: list(:delay | :snow_route | :last_trip),
+          stop_type: :first_stop | :last_stop | :mid_route_stop,
           time: DateTime.t(),
           inline_badges: list(map())
         }
@@ -155,6 +157,7 @@ defmodule Screens.Departures.Departure do
       route: route_short_name,
       route_id: route_id,
       time: DateTime.to_iso8601(time),
+      stop_type: stop_type(arrival_time, departure_time),
       inline_badges: []
     }
 
@@ -189,6 +192,14 @@ defmodule Screens.Departures.Departure do
       {nil, t} -> t
       {_, nil} -> nil
       {t, _} -> t
+    end
+  end
+
+  def stop_type(arrival_time, departure_time) do
+    case {arrival_time, departure_time} do
+      {nil, _} -> :first_stop
+      {_, nil} -> :last_stop
+      {_, _} -> :mid_route_stop
     end
   end
 


### PR DESCRIPTION
**Asana task**: [Solari: Buses never say BRD](https://app.asana.com/0/1158428874739705/1176512175485622/f)

This adds a `stop_type` field to departures indicating whether it's the first stop, last stop, or a mid-route stop. `standardTimeRepresentation` now uses this info to follow "Arrival and Departure Times" >  "Else" in the [best practices](https://www.mbta.com/developers/v3-api/best-practices).
