### PR TITLE
fix: add screen_sn back to GDS logs

### DIFF
--- a/lib/screens/gds_data/fetch.ex
+++ b/lib/screens/gds_data/fetch.ex
@@ -206,6 +206,7 @@ defmodule Screens.GdsData.Fetch do
         devices_data
         |> Map.get(sn)
         |> Map.put(:ping_count, ping_count)
+        |> Map.put(:screen_sn, sn)
       end)
 
     {:ok, merged_data}


### PR DESCRIPTION
**Asana task**: ad hoc

This field was inadvertently removed in #185 when switching to the new `GetDevicesList` API call for GDS.