### PR TITLE
fix: new options format for CopyWebpackPlugin

### DIFF
--- a/assets/webpack.config.js
+++ b/assets/webpack.config.js
@@ -78,7 +78,7 @@ module.exports = (env, options) => ({
   },
   plugins: [
     new MiniCssExtractPlugin({ filename: "../css/[name].css" }),
-    new CopyWebpackPlugin([{ from: "static/", to: "../" }])
+    new CopyWebpackPlugin({patterns: [{ from: "static/", to: "../" }]})
   ],
   devtool: "source-map",
   optimization: {


### PR DESCRIPTION
**Asana task**: ad hoc

The new version of CopyWebpackPlugin as of #202 changed the format of the options.