### PR TITLE
fix: exclude route 90 from upper busway at Sullivan

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -390,7 +390,8 @@ config :screens,
             params: %{stop_ids: ["29001", "29002", "29003", "29004", "29005", "29006"]},
             opts: %{}
           },
-          layout: {:upcoming, %{num_rows: 9, visible_rows: 5, paged: true}}
+          layout:
+            {:upcoming, %{num_rows: 9, visible_rows: 5, paged: true, routes: {:exclude, ["90"]}}}
         },
         %{
           name: "Lower Busway",


### PR DESCRIPTION
**Asana task**: ad hoc

Currently route 90 (in both directions) appears in both busways. Per Dan S, `29001` in the upper busway is where all routes drop off, and the pickup is in the lower busway.