### PR TITLE
feat: first pass at 10PP screen config

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -425,6 +425,50 @@ config :screens,
       ],
       app_id: "solari"
     },
+    "313" => %{
+      station_name: "10 Park Plaza",
+      show_section_headers: true,
+      sections: [
+        %{
+          name: "Commuter Rail (South Station)",
+          arrow: :w,
+          query: %{params: %{stop_id: "South Station"}, opts: %{include_schedules: true}},
+          layout: {:upcoming, %{num_rows: 7, visible_rows: 3, paged: true}}
+        },
+        %{
+          name: "Tufts Medical Center",
+          arrow: :nw,
+          query: %{params: %{stop_ids: ["70016", "70017", "49002", "6565"]}, opts: %{}},
+          layout: {:upcoming, %{num_rows: 5}}
+        },
+        %{
+          name: "Bus",
+          arrow: :e,
+          query: %{params: %{stop_id: "9983"}, opts: %{}},
+          layout: {:upcoming, %{num_rows: 1}}
+        }
+      ],
+      app_id: "solari"
+    },
+    "314" => %{
+      station_name: "10 Park Plaza",
+      show_section_headers: true,
+      sections: [
+        %{
+          name: "Commuter Rail (Back Bay)",
+          arrow: :nw,
+          query: %{params: %{stop_id: "Back Bay"}, opts: %{include_schedules: true}},
+          layout: {:upcoming, %{num_rows: 9, visible_rows: 5, paged: true}}
+        },
+        %{
+          name: "Bus",
+          arrow: nil,
+          query: %{params: %{stop_ids: ["145", "9983"]}, opts: %{}},
+          layout: {:upcoming, %{num_rows: 5}}
+        }
+      ],
+      app_id: "solari"
+    },
     "320" => %{
       station_name: "Summer Street",
       show_section_headers: true,


### PR DESCRIPTION
**Asana task**: [Solari: Configure 10PP screens](https://app.asana.com/0/1158428874739705/1176512175485628)

I say "first pass" because these have actually raised a number of new issues. I expect they'll be resolved by a mixture of changing this config and better supporting this config. I'd like to get this out to dev so that everyone can see the new screens, then we can talk about how to resolve the various issues.