### PR TITLE
feat: config option to filter departures by time

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -434,7 +434,7 @@ config :screens,
           name: "Commuter Rail (South Station)",
           arrow: :w,
           query: %{params: %{stop_id: "South Station"}, opts: %{include_schedules: true}},
-          layout: {:upcoming, %{num_rows: 7, visible_rows: 3, paged: true}}
+          layout: {:upcoming, %{num_rows: 7, visible_rows: 3, paged: true, max_minutes: 60}}
         },
         %{
           name: "Tufts Medical Center",
@@ -459,7 +459,7 @@ config :screens,
           name: "Commuter Rail (Back Bay)",
           arrow: :nw,
           query: %{params: %{stop_id: "Back Bay"}, opts: %{include_schedules: true}},
-          layout: {:upcoming, %{num_rows: 9, visible_rows: 5, paged: true}}
+          layout: {:upcoming, %{num_rows: 9, visible_rows: 5, paged: true, max_minutes: 60}}
         },
         %{
           name: "Bus",

--- a/lib/screens/solari_screen_data.ex
+++ b/lib/screens/solari_screen_data.ex
@@ -86,6 +86,7 @@ defmodule Screens.SolariScreenData do
   defp do_layout(query_data, {:upcoming, %{num_rows: num_rows} = layout_opts}) do
     query_data
     |> filter_by_routes(layout_opts)
+    |> filter_by_minutes(layout_opts)
     |> Enum.take(num_rows)
     |> Enum.map(&Map.from_struct/1)
   end
@@ -98,6 +99,17 @@ defmodule Screens.SolariScreenData do
     |> Enum.sort_by(& &1.time)
     |> Enum.map(&Map.from_struct/1)
   end
+
+  defp filter_by_minutes(query_data, %{max_minutes: max_minutes}) do
+    max_departure_time = DateTime.add(DateTime.utc_now(), 60 * max_minutes)
+
+    Enum.reject(query_data, fn %{time: time_str} ->
+      {:ok, departure_time, _} = DateTime.from_iso8601(time_str)
+      DateTime.compare(departure_time, max_departure_time) == :gt
+    end)
+  end
+
+  defp filter_by_minutes(query_data, _), do: query_data
 
   defp filter_by_routes(query_data, %{routes: {action, routes}}) do
     route_matchers = routes |> Enum.flat_map(&route_direction_tuple/1) |> MapSet.new()


### PR DESCRIPTION
**Asana task**: [Solari: add max_minutes option to config](https://app.asana.com/0/1158428874739705/1177618166395305)

This functions similarly to a routes: `num_rows` is still required (and will be used for dynamic row counts), but we also filter out departures which are greater than `max_minutes` away.