### PR TITLE
fix: update config to add more rows and make some additional tweaks

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -179,7 +179,7 @@ config :screens,
           name: "Busway",
           arrow: :s,
           query: %{params: %{stop_id: "334"}, opts: %{}},
-          layout: {:upcoming, %{num_rows: 12, visible_rows: 8, paged: true}}
+          layout: {:upcoming, %{num_rows: 14, visible_rows: 10, paged: true}}
         },
         %{
           name: "Red Line",
@@ -212,7 +212,7 @@ config :screens,
           query: %{params: %{stop_ids: ["72", "102", "1060", "1123"]}, opts: %{}},
           layout:
             {:upcoming,
-             %{num_rows: 12, visible_rows: 8, paged: true, routes: {:exclude, [{"70", 1}]}}}
+             %{num_rows: 14, visible_rows: 10, paged: true, routes: {:exclude, [{"70", 1}]}}}
         }
       ],
       app_id: "solari"
@@ -268,13 +268,13 @@ config :screens,
           name: "Upper Busway",
           arrow: :e,
           query: %{params: %{stop_id: "10642"}, opts: %{}},
-          layout: {:upcoming, %{num_rows: 8, visible_rows: 4, paged: true}}
+          layout: {:upcoming, %{num_rows: 10, visible_rows: 6, paged: true}}
         },
         %{
           name: "Lower Busway",
           arrow: :n,
           query: %{params: %{stop_id: "875"}, opts: %{}},
-          layout: {:upcoming, %{num_rows: 8, visible_rows: 4, paged: true}}
+          layout: {:upcoming, %{num_rows: 10, visible_rows: 6, paged: true}}
         }
       ],
       app_id: "solari"
@@ -287,7 +287,7 @@ config :screens,
           name: "Upper Busway",
           arrow: :e,
           query: %{params: %{stop_id: "10642"}, opts: %{}},
-          layout: {:upcoming, %{num_rows: 12, visible_rows: 8, paged: true}}
+          layout: {:upcoming, %{num_rows: 14, visible_rows: 10, paged: true}}
         },
         %{
           name: "Commuter Rail",
@@ -333,8 +333,8 @@ config :screens,
           layout:
             {:upcoming,
              %{
-               num_rows: 11,
-               visible_rows: 7,
+               num_rows: 12,
+               visible_rows: 8,
                paged: true,
                routes: {:exclude, [{"92", 1}, {"93", 1}]}
              }}
@@ -343,7 +343,7 @@ config :screens,
           name: "Congress St @ Haymarket Sta",
           arrow: :n,
           query: %{params: %{stop_id: "117"}, opts: %{}},
-          layout: {:upcoming, %{num_rows: 7, visible_rows: 3, paged: true}}
+          layout: {:upcoming, %{num_rows: 8, visible_rows: 4, paged: true}}
         }
       ],
       app_id: "solari"
@@ -362,7 +362,7 @@ config :screens,
           name: "Bus",
           arrow: :w,
           query: %{params: %{stop_ids: ["5740", "57400"]}, opts: %{}},
-          layout: {:upcoming, %{num_rows: 12, visible_rows: 8, paged: true}}
+          layout: {:upcoming, %{num_rows: 14, visible_rows: 10, paged: true}}
         }
       ],
       app_id: "solari"
@@ -375,7 +375,7 @@ config :screens,
           name: "Lower Busway",
           arrow: :e,
           query: %{params: %{stop_ids: ["17862", "17863"]}, opts: %{}},
-          layout: {:upcoming, %{num_rows: 12, visible_rows: 8, paged: true}}
+          layout: {:upcoming, %{num_rows: 14, visible_rows: 10, paged: true}}
         },
         %{
           name: "Commuter Rail",
@@ -398,7 +398,7 @@ config :screens,
             opts: %{}
           },
           layout:
-            {:upcoming, %{num_rows: 9, visible_rows: 5, paged: true, routes: {:exclude, ["90"]}}}
+            {:upcoming, %{num_rows: 10, visible_rows: 6, paged: true, routes: {:exclude, ["90"]}}}
         },
         %{
           name: "Lower Busway",
@@ -409,7 +409,7 @@ config :screens,
             },
             opts: %{}
           },
-          layout: {:upcoming, %{num_rows: 9, visible_rows: 5, paged: true}}
+          layout: {:upcoming, %{num_rows: 10, visible_rows: 6, paged: true}}
         }
       ],
       app_id: "solari"
@@ -428,7 +428,7 @@ config :screens,
           name: "Bus",
           arrow: :w,
           query: %{params: %{stop_id: "15795"}, opts: %{}},
-          layout: {:upcoming, %{num_rows: 12, visible_rows: 8, paged: true}}
+          layout: {:upcoming, %{num_rows: 14, visible_rows: 10, paged: true}}
         }
       ],
       app_id: "solari"
@@ -447,7 +447,7 @@ config :screens,
           name: "Tufts Medical Center",
           arrow: :nw,
           query: %{params: %{stop_ids: ["70016", "70017", "49002", "6565"]}, opts: %{}},
-          layout: {:upcoming, %{num_rows: 5}}
+          layout: {:upcoming, %{num_rows: 5, routes: {:exclude, ["11"]}}}
         },
         %{
           name: "Bus",


### PR DESCRIPTION
**Asana tasks**:
- [Solari: further config tweaks](https://app.asana.com/0/1158428874739705/1177618166395311)
- [Solari: Increase number of rows in config](https://app.asana.com/0/1158428874739705/1177535756643107)

Changes:
- At Haymarket busway, hide routes 92 and 93 in direction_id 1.
- At 10PP Back Bay CR, don't show trips towards South Station.
- Add more rows to sections to fill available vertical space.