### PR TITLE
fix: use schedule rather than prediction with departure_time nil

### DIFF
--- a/lib/screens/departures/departure.ex
+++ b/lib/screens/departures/departure.ex
@@ -96,6 +96,7 @@ defmodule Screens.Departures.Departure do
     predicted_trip_ids =
       predictions
       |> Enum.reject(&is_nil(&1.trip))
+      |> Enum.reject(&is_nil(&1.departure_time))
       |> Enum.map(& &1.trip.id)
       |> Enum.into(MapSet.new())
 


### PR DESCRIPTION
**Asana task**: [Solari: Investigate commuter rail departures from South Station and Back Bay](https://app.asana.com/0/1158428874739705/1177535756643109)

For commuter rail, we combine predictions and schedules. Currently, we do this by merging on trip id, preferring predictions over schedules if we have both for the same trip id. This means that if we have a prediction with nil `departure_time`, we'll choose that (and later filter it out) rather than showing a scheduled departure time, which was causing us to miss a lot of upcoming departures. This PR should resolve the issue.