### PR TITLE
feat: option to show an individual section without a header

### DIFF
--- a/assets/src/components/solari/section.tsx
+++ b/assets/src/components/solari/section.tsx
@@ -212,7 +212,7 @@ class PagedSection extends React.Component {
 
     return (
       <div className="section">
-        {this.props.showSectionHeaders && (
+        {this.props.showSectionHeaders && this.props.name !== null && (
           <SectionHeader name={this.props.name} arrow={this.props.arrow} />
         )}
         <div className="departure-container">
@@ -248,7 +248,9 @@ const Section = ({
 
   return (
     <div className="section">
-      {showSectionHeaders && <SectionHeader name={name} arrow={arrow} />}
+      {showSectionHeaders && name !== null && (
+        <SectionHeader name={name} arrow={arrow} />
+      )}
       <div className="departure-container">
         {departureGroups.map((group) => (
           <DepartureGroup

--- a/config/config.exs
+++ b/config/config.exs
@@ -446,8 +446,14 @@ config :screens,
         %{
           name: "Tufts Medical Center",
           arrow: :nw,
-          query: %{params: %{stop_ids: ["70016", "70017", "49002", "6565"]}, opts: %{}},
-          layout: {:upcoming, %{num_rows: 5, routes: {:exclude, ["11"]}}}
+          query: %{params: %{stop_ids: ["70016", "70017"]}, opts: %{}},
+          layout: :bidirectional
+        },
+        %{
+          name: nil,
+          arrow: nil,
+          query: %{params: %{stop_ids: ["49002", "6565"]}, opts: %{}},
+          layout: {:bidirectional, %{routes: {:exclude, ["11"]}}}
         },
         %{
           name: "Bus",

--- a/lib/screens/solari_screen_data.ex
+++ b/lib/screens/solari_screen_data.ex
@@ -87,17 +87,25 @@ defmodule Screens.SolariScreenData do
     query_data
     |> filter_by_routes(layout_opts)
     |> filter_by_minutes(layout_opts)
+    |> Enum.sort_by(& &1.time)
     |> Enum.take(num_rows)
     |> Enum.map(&Map.from_struct/1)
   end
 
-  defp do_layout(query_data, :bidirectional) do
+  defp do_layout(query_data, {:bidirectional, layout_opts}) do
     query_data
+    |> filter_by_routes(layout_opts)
+    |> filter_by_minutes(layout_opts)
+    |> Enum.sort_by(& &1.time)
     |> Enum.split_with(fn %{direction_id: direction_id} -> direction_id == 0 end)
     |> Tuple.to_list()
     |> Enum.flat_map(&Enum.slice(&1, 0, 1))
     |> Enum.sort_by(& &1.time)
     |> Enum.map(&Map.from_struct/1)
+  end
+
+  defp do_layout(query_data, :bidirectional) do
+    do_layout(query_data, {:bidirectional, %{}})
   end
 
   defp filter_by_minutes(query_data, %{max_minutes: max_minutes}) do


### PR DESCRIPTION
**Asana tasks**:
- [Solari: Option for individual sections to not have headers](https://app.asana.com/0/1158428874739705/1177618166395321)
- [Solari: Address issues with Tufts Medical Center](https://app.asana.com/0/1158428874739705/1177535756643111)

This PR splits Tufts Medical Center into two bidirectional sections, one for OL and one for SL. It also adds the ability to filter by routes and max_minutes in bidirectional layouts (in this case so that we can exclude the inbound 11 at Tufts Medical).