### PR TITLE
feat: only show later departures section when it has 3+ entries

### DIFF
--- a/assets/src/components/solari/section.tsx
+++ b/assets/src/components/solari/section.tsx
@@ -171,6 +171,7 @@ class PagedSection extends React.Component {
     super(props);
     this.state = { currentPageNumber: 0 };
     this.MAX_PAGE_COUNT = 5;
+    this.MIN_PAGE_COUNT = 3;
   }
 
   componentDidMount() {
@@ -225,10 +226,11 @@ class PagedSection extends React.Component {
   }
 
   render() {
-    const staticDepartures = this.props.departures.slice(
-      0,
-      this.props.numRows - 1
-    );
+    const numPages = this.pageCount(this.props);
+    const showPagedDeparture = numPages >= this.MIN_PAGE_COUNT;
+    const staticDepartures = showPagedDeparture
+      ? this.props.departures.slice(0, this.props.numRows - 1)
+      : this.props.departures;
     const staticDepartureGroups = buildDepartureGroups(staticDepartures);
 
     let arrow = this.props.arrow;
@@ -259,11 +261,13 @@ class PagedSection extends React.Component {
             key={group[0].id}
           />
         ))}
-        <PagedDeparture
-          departures={this.pagedDepartures()}
-          currentPageNumber={this.state.currentPageNumber}
-          currentTimeString={this.props.currentTimeString}
-        />
+        {showPagedDeparture && (
+          <PagedDeparture
+            departures={this.pagedDepartures()}
+            currentPageNumber={this.state.currentPageNumber}
+            currentTimeString={this.props.currentTimeString}
+          />
+        )}
       </SectionFrame>
     );
   }


### PR DESCRIPTION
**Asana task**: [Solari: don't use later departure component when there's only one later departure](https://app.asana.com/0/1158428874739705/1177618166395307)

When there would only be 1 or 2 rows in the Later Departures section, just show them as a normal section.