### PR TITLE
fix: remove top and bottom borders on later departures

### DIFF
--- a/assets/css/solari/section.scss
+++ b/assets/css/solari/section.scss
@@ -63,9 +63,6 @@
   margin: 33px 0 33px;
 }
 
-.later-departure {
-}
-
 .later-departure__header {
   position: relative;
   margin-left: 42px;


### PR DESCRIPTION
**Asana task**: [Solari: Fix duplicate dividers around Later Departures](https://app.asana.com/0/1158428874739705/1177535756643099)

Per Adam, we can just remove the top and bottom dividers on the Later Departures component.