### PR TITLE
fix: recreate layouts when data refreshes

### DIFF
--- a/assets/src/components/eink/bus/screen_container.tsx
+++ b/assets/src/components/eink/bus/screen_container.tsx
@@ -81,6 +81,7 @@ const DefaultScreenLayout = ({ apiResponse }): JSX.Element => {
         stopName={apiResponse.stop_name}
         departures={departuresData}
         ref={departuresRef}
+        key={`top-${apiResponse.current_time}`}
       />
       <BottomScreenLayout
         currentTimeString={apiResponse.current_time}
@@ -90,6 +91,7 @@ const DefaultScreenLayout = ({ apiResponse }): JSX.Element => {
         nearbyConnections={apiResponse.nearby_connections}
         psaName={apiResponse.psa_name}
         ref={laterDeparturesRef}
+        key={`bottom-${apiResponse.current_time}`}
       />
     </div>
   );


### PR DESCRIPTION
**Asana task**: [Problem with bus e-ink row count](https://app.asana.com/0/1158428874739705/1178276607652580)

The hook which sets the number of rows (`useFitDepartures`) lives in `DefaultScreenLayout` since both `TopScreenLayout` and `BottomScreenLayout` depend on how many rows fit on the top screen, so we have to re-render both the top and bottom screens on each data refresh.