### PR TITLE
fix: make paged section last when there are no headers, if possible

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -176,13 +176,6 @@ config :screens,
       section_headers: nil,
       sections: [
         %{
-          name: "Busway",
-          arrow: :s,
-          query: %{params: %{stop_id: "334"}, opts: %{}},
-          layout: {:upcoming, %{num_rows: 14, visible_rows: 10, paged: true}},
-          pill: :bus
-        },
-        %{
           name: "Red Line",
           arrow: :e,
           query: %{params: %{stop_id: "70094"}, opts: %{}},
@@ -195,6 +188,13 @@ config :screens,
           query: %{params: %{stop_id: "70261"}, opts: %{}},
           layout: {:upcoming, %{num_rows: 1}},
           pill: :mattapan
+        },
+        %{
+          name: "Busway",
+          arrow: :s,
+          query: %{params: %{stop_id: "334"}, opts: %{}},
+          layout: {:upcoming, %{num_rows: 14, visible_rows: 10, paged: true}},
+          pill: :bus
         }
       ],
       app_id: "solari"
@@ -293,18 +293,18 @@ config :screens,
       section_headers: nil,
       sections: [
         %{
-          name: "Upper Busway",
-          arrow: :e,
-          query: %{params: %{stop_id: "10642"}, opts: %{}},
-          layout: {:upcoming, %{num_rows: 14, visible_rows: 10, paged: true}},
-          pill: :bus
-        },
-        %{
           name: "Commuter Rail",
           arrow: :w,
           query: %{params: %{stop_id: "Forest Hills"}, opts: %{include_schedules: true}},
           layout: :bidirectional,
           pill: :cr
+        },
+        %{
+          name: "Upper Busway",
+          arrow: :e,
+          query: %{params: %{stop_id: "10642"}, opts: %{}},
+          layout: {:upcoming, %{num_rows: 14, visible_rows: 10, paged: true}},
+          pill: :bus
         }
       ],
       app_id: "solari"


### PR DESCRIPTION
**Asana task**: ad hoc

Tyler pointed out that it can be confusing if the Later Departures section isn't last when there are no section headers: for instance, you can't really tell whether the Later Departures header describes everything below it. This PR moves rail above paged bus sections in a couple of cases where there are no section headers.