### PR TITLE
fix: handle leaked :ssl_closed messages from Hackney

### DIFF
--- a/lib/screens/override/state.ex
+++ b/lib/screens/override/state.ex
@@ -104,4 +104,10 @@ defmodule Screens.Override.State do
     schedule_refresh(self())
     {:noreply, new_state}
   end
+
+  # Handle leaked :ssl_closed messages from Hackney.
+  # Workaround for this issue: https://github.com/benoitc/hackney/issues/464
+  def handle_info({:ssl_closed, _}, state) do
+    {:noreply, state}
+  end
 end


### PR DESCRIPTION
**Asana task**: [Splunk Alert: Screens Warnings/Errors triggered](https://app.asana.com/0/1158428874739705/1178678170537265)

These are being leaked by one our of our dependencies, per https://github.com/benoitc/hackney/issues/464.