### PR TITLE
feat: make solari PSA configurable

### DIFF
--- a/assets/src/components/solari/psa.tsx
+++ b/assets/src/components/solari/psa.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+
+const Psa = ({ psaName, currentTimeString }): JSX.Element => {
+  const imageSrc = `https://mbta-dotcom.s3.amazonaws.com/screens/images/psa/${psaName}.png`;
+  return (
+    <div className="screen-container__flex-space" key={currentTimeString}>
+      <img src={imageSrc} />
+    </div>
+  );
+};
+
+export default Psa;

--- a/assets/src/components/solari/screen_container.tsx
+++ b/assets/src/components/solari/screen_container.tsx
@@ -2,6 +2,7 @@ import React from "react";
 
 import Header from "Components/solari/header";
 import SectionList from "Components/solari/section_list";
+import Psa from "Components/solari/psa";
 
 import useApiResponse from "Hooks/use_api_response";
 
@@ -20,13 +21,11 @@ const DefaultScreenLayout = ({ apiResponse }): JSX.Element => {
         sectionHeaders={apiResponse.section_headers}
         currentTimeString={apiResponse.current_time}
       />
-      {apiResponse.show_psa && (
-        <div
-          className="screen-container__flex-space"
-          key={"flex-" + apiResponse.current_time}
-        >
-          <img src="/images/feedback-psa.png" />
-        </div>
+      {apiResponse.psa_name && (
+        <Psa
+          psaName={apiResponse.psa_name}
+          currentTimeString={apiResponse.current_time}
+        />
       )}
     </div>
   );

--- a/lib/screens/override.ex
+++ b/lib/screens/override.ex
@@ -12,7 +12,8 @@ defmodule Screens.Override do
           green_line_service: pos_integer(),
           headway_mode_screen_ids: MapSet.t(pos_integer()),
           bus_psa_list: list(String.t()),
-          green_line_psa_list: list(String.t())
+          green_line_psa_list: list(String.t()),
+          solari_psa_list: list(String.t())
         }
 
   defstruct api_version: 1,
@@ -22,7 +23,8 @@ defmodule Screens.Override do
             green_line_service: 1,
             headway_mode_screen_ids: MapSet.new(),
             bus_psa_list: [],
-            green_line_psa_list: []
+            green_line_psa_list: [],
+            solari_psa_list: []
 
   @spec new :: __MODULE__.t()
   def new, do: %__MODULE__{}
@@ -35,7 +37,8 @@ defmodule Screens.Override do
           optional(:green_line_service) => pos_integer(),
           optional(:headway_mode_screen_ids) => list(pos_integer()),
           optional(:bus_psa_list) => list(String.t()),
-          optional(:green_line_psa_list) => list(String.t())
+          optional(:green_line_psa_list) => list(String.t()),
+          optional(:solari_psa_list) => list(String.t())
         }
 
   @doc """

--- a/lib/screens/override/state.ex
+++ b/lib/screens/override/state.ex
@@ -41,6 +41,10 @@ defmodule Screens.Override.State do
     GenServer.call(pid, :green_line_psa_list)
   end
 
+  def solari_psa_list(pid \\ __MODULE__) do
+    GenServer.call(pid, :solari_psa_list)
+  end
+
   def schedule_refresh(pid, ms \\ @refresh_ms) do
     Process.send_after(pid, :refresh, ms)
     :ok
@@ -89,6 +93,10 @@ defmodule Screens.Override.State do
 
   def handle_call(:green_line_psa_list, _from, state) do
     {:reply, state.green_line_psa_list, state}
+  end
+
+  def handle_call(:solari_psa_list, _from, state) do
+    {:reply, state.solari_psa_list, state}
   end
 
   @impl true

--- a/lib/screens/psa.ex
+++ b/lib/screens/psa.ex
@@ -3,6 +3,7 @@ defmodule Screens.Psa do
 
   @eink_refresh_seconds 30
   @solari_refresh_seconds 15
+  @solari_psa_period 3
 
   alias Screens.Override.State
 
@@ -14,8 +15,16 @@ defmodule Screens.Psa do
     choose_from_rotating_list(State.green_line_psa_list(), @eink_refresh_seconds)
   end
 
-  def show_solari_psa do
-    choose_from_rotating_list([true, false, false], @solari_refresh_seconds)
+  def current_solari_psa do
+    # How often to change the selected PSA
+    solari_psa_refresh_seconds = @solari_refresh_seconds * @solari_psa_period
+
+    # Choose which PSA to show, if we're showing one this refresh
+    solari_psa = choose_from_rotating_list(State.solari_psa_list(), solari_psa_refresh_seconds)
+
+    # Return either the current PSA or nil
+    solari_list = [solari_psa] ++ List.duplicate(nil, @solari_psa_period - 1)
+    choose_from_rotating_list(solari_list, @solari_refresh_seconds)
   end
 
   defp choose_from_rotating_list([], _), do: nil

--- a/lib/screens/solari_screen_data.ex
+++ b/lib/screens/solari_screen_data.ex
@@ -16,7 +16,7 @@ defmodule Screens.SolariScreenData do
         dt -> dt
       end
 
-    show_psa = Screens.Psa.show_solari_psa()
+    psa_name = Screens.Psa.current_solari_psa()
 
     case fetch_sections_data(sections, datetime) do
       {:ok, data} ->
@@ -27,7 +27,7 @@ defmodule Screens.SolariScreenData do
           station_name: station_name,
           sections: data,
           section_headers: section_headers,
-          show_psa: show_psa
+          psa_name: psa_name
         }
 
       :error ->


### PR DESCRIPTION
**Asana task**: [Solari PSA: Config option to choose which PSA image(s) to show](https://app.asana.com/0/1158428874739705/1179749118368738)

- Add `solari_psa_list` to config state.
- Look up S3 image url in `solari_psa_list`.
- Rather than cycling every data refresh (as on e-ink), the PSA is only shown every `@solari_psa_period` data refreshes (currently set to 3).