### PR TITLE
fix: crowding doesn't cause later departures to wrap

### DIFF
--- a/assets/css/departure_destination.scss
+++ b/assets/css/departure_destination.scss
@@ -9,6 +9,6 @@
 }
 
 .departure-destination--small {
-  width: 646px;
+  width: 491px;
   font-size: 54px;
 }


### PR DESCRIPTION
**Asana task**: ad hoc

Later Departures on bus e-ink aren't currently visible (because they're covered by PSAs), but they're currently broken because the addition of crowding icons caused the lines to wrap.