### PR TITLE
feat: Change PSA config to be per-screen

### DIFF
--- a/lib/screens/bus_screen_data.ex
+++ b/lib/screens/bus_screen_data.ex
@@ -44,7 +44,7 @@ defmodule Screens.BusScreenData do
 
     _ = LogScreenData.log_departures(screen_id, is_screen, departures)
 
-    psa_name = Screens.Psa.current_bus_psa()
+    psa_name = Screens.Psa.current_psa_for(screen_id)
 
     case departures do
       {:ok, departures} ->

--- a/lib/screens/gl_screen_data.ex
+++ b/lib/screens/gl_screen_data.ex
@@ -55,7 +55,7 @@ defmodule Screens.GLScreenData do
 
     _ = LogScreenData.log_departures(screen_id, is_screen, departures)
 
-    psa_name = Screens.Psa.current_green_line_psa()
+    psa_name = Screens.Psa.current_psa_for(screen_id)
 
     case departures do
       {:ok, departures} ->

--- a/lib/screens/override.ex
+++ b/lib/screens/override.ex
@@ -11,9 +11,7 @@ defmodule Screens.Override do
           bus_service: pos_integer(),
           green_line_service: pos_integer(),
           headway_mode_screen_ids: MapSet.t(pos_integer()),
-          bus_psa_list: list(String.t()),
-          green_line_psa_list: list(String.t()),
-          solari_psa_list: list(String.t())
+          psa_lists_by_screen_id: %{String.t() => list(String.t())}
         }
 
   defstruct api_version: 1,
@@ -22,9 +20,7 @@ defmodule Screens.Override do
             bus_service: 1,
             green_line_service: 1,
             headway_mode_screen_ids: MapSet.new(),
-            bus_psa_list: [],
-            green_line_psa_list: [],
-            solari_psa_list: []
+            psa_lists_by_screen_id: %{}
 
   @spec new :: __MODULE__.t()
   def new, do: %__MODULE__{}
@@ -36,9 +32,7 @@ defmodule Screens.Override do
           optional(:bus_service) => pos_integer(),
           optional(:green_line_service) => pos_integer(),
           optional(:headway_mode_screen_ids) => list(pos_integer()),
-          optional(:bus_psa_list) => list(String.t()),
-          optional(:green_line_psa_list) => list(String.t()),
-          optional(:solari_psa_list) => list(String.t())
+          optional(:psa_lists_by_screen_id) => %{String.t() => list(String.t())}
         }
 
   @doc """
@@ -51,7 +45,8 @@ defmodule Screens.Override do
         disabled_screen_ids: #MapSet<[1, 2]>,
         globally_disabled: false,
         green_line_service: 1,
-        headway_mode_screen_ids: #MapSet<[]>
+        headway_mode_screen_ids: #MapSet<[]>,
+        ... more values added after this comment was written
       }
   """
   @spec from_json(json_map()) :: __MODULE__.t()
@@ -60,6 +55,7 @@ defmodule Screens.Override do
       override_map
       |> disabled_map_set()
       |> headway_mode_map_set()
+      |> psa_lists_map()
 
     struct(__MODULE__, converted)
   end
@@ -77,4 +73,14 @@ defmodule Screens.Override do
   end
 
   defp headway_mode_map_set(%{} = override_map), do: override_map
+
+  # Converts the keyword-list-like psa_lists_by_screen_id to a map, if it exists
+  defp psa_lists_map(%{psa_lists_by_screen_id: psa_lists_by_screen_id} = override_map) do
+    psa_lists_map =
+      for [screen_id, psa_list] <- psa_lists_by_screen_id, into: %{}, do: {screen_id, psa_list}
+
+    Map.put(override_map, :psa_lists_by_screen_id, psa_lists_map)
+  end
+
+  defp psa_lists_map(%{} = override_map), do: override_map
 end

--- a/lib/screens/override/state.ex
+++ b/lib/screens/override/state.ex
@@ -33,16 +33,8 @@ defmodule Screens.Override.State do
     GenServer.call(pid, {:headway_mode?, screen_id})
   end
 
-  def bus_psa_list(pid \\ __MODULE__) do
-    GenServer.call(pid, :bus_psa_list)
-  end
-
-  def green_line_psa_list(pid \\ __MODULE__) do
-    GenServer.call(pid, :green_line_psa_list)
-  end
-
-  def solari_psa_list(pid \\ __MODULE__) do
-    GenServer.call(pid, :solari_psa_list)
+  def psa_list(pid \\ __MODULE__, screen_id) do
+    GenServer.call(pid, {:psa_list, screen_id})
   end
 
   def schedule_refresh(pid, ms \\ @refresh_ms) do
@@ -87,16 +79,8 @@ defmodule Screens.Override.State do
     {:reply, MapSet.member?(state.headway_mode_screen_ids, screen_id), state}
   end
 
-  def handle_call(:bus_psa_list, _from, state) do
-    {:reply, state.bus_psa_list, state}
-  end
-
-  def handle_call(:green_line_psa_list, _from, state) do
-    {:reply, state.green_line_psa_list, state}
-  end
-
-  def handle_call(:solari_psa_list, _from, state) do
-    {:reply, state.solari_psa_list, state}
+  def handle_call({:psa_list, screen_id}, _from, state) do
+    {:reply, Map.get(state.psa_lists_by_screen_id, screen_id, []), state}
   end
 
   @impl true

--- a/lib/screens/psa.ex
+++ b/lib/screens/psa.ex
@@ -7,24 +7,31 @@ defmodule Screens.Psa do
 
   alias Screens.Override.State
 
-  def current_bus_psa do
-    choose_from_rotating_list(State.bus_psa_list(), @eink_refresh_seconds)
+  def current_psa_for(screen_id) do
+    app_id =
+      :screens
+      |> Application.get_env(:screen_data)
+      |> get_in([screen_id, :app_id])
+
+    psa_list = State.psa_list(screen_id)
+
+    choose_psa(psa_list, app_id)
   end
 
-  def current_green_line_psa do
-    choose_from_rotating_list(State.green_line_psa_list(), @eink_refresh_seconds)
-  end
-
-  def current_solari_psa do
+  defp choose_psa(psa_list, "solari") do
     # How often to change the selected PSA
     solari_psa_refresh_seconds = @solari_refresh_seconds * @solari_psa_period
 
     # Choose which PSA to show, if we're showing one this refresh
-    solari_psa = choose_from_rotating_list(State.solari_psa_list(), solari_psa_refresh_seconds)
+    solari_psa = choose_from_rotating_list(psa_list, solari_psa_refresh_seconds)
 
     # Return either the current PSA or nil
     solari_list = [solari_psa] ++ List.duplicate(nil, @solari_psa_period - 1)
     choose_from_rotating_list(solari_list, @solari_refresh_seconds)
+  end
+
+  defp choose_psa(psa_list, app_id) when app_id in ~w[bus_eink gl_eink_single gl_eink_double] do
+    choose_from_rotating_list(psa_list, @eink_refresh_seconds)
   end
 
   defp choose_from_rotating_list([], _), do: nil

--- a/lib/screens/solari_screen_data.ex
+++ b/lib/screens/solari_screen_data.ex
@@ -16,7 +16,7 @@ defmodule Screens.SolariScreenData do
         dt -> dt
       end
 
-    psa_name = Screens.Psa.current_solari_psa()
+    psa_name = Screens.Psa.current_psa_for(screen_id)
 
     case fetch_sections_data(sections, datetime) do
       {:ok, data} ->


### PR DESCRIPTION
**Asana task**: [Ability to target PSAs to individual screen ids (not just apps)](https://app.asana.com/0/1158428874739705/1178933953782188/f)

For future reference: the screen ID -> PSA list mapping needed to be entered as a list of two-element lists because:
- `:1`, `:2`, etc are not valid atom names
- `Jason.decode!(string, keys: :atoms!)` doesn't let you specify which objects in the JSON blob should have their keys converted to atoms
- We didn't want to revert to manually converting all the other keys in the config from strings to atoms.

- [x] Needs version bump?