### PR TITLE
feat: detect solari screens by user agent

### DIFF
--- a/lib/screens_web/user_agent.ex
+++ b/lib/screens_web/user_agent.ex
@@ -11,7 +11,7 @@ defmodule ScreensWeb.UserAgent do
   def is_screen?(nil), do: false
 
   def is_screen?(user_agent) do
-    is_mercury?(user_agent) or is_gds?(user_agent)
+    is_mercury?(user_agent) or is_gds?(user_agent) or is_solari?(user_agent)
   end
 
   defp is_mercury?(user_agent) do
@@ -21,5 +21,10 @@ defmodule ScreensWeb.UserAgent do
 
   defp is_gds?(user_agent) do
     String.contains?(user_agent, "einkapp-qt")
+  end
+
+  defp is_solari?(user_agent) do
+    String.contains?(user_agent, "(X11; Ubuntu; Linux i686; rv:22.0)") and
+      String.contains?(user_agent, "Firefox/22.0")
   end
 end


### PR DESCRIPTION
**Asana task**: [Update is_screen to detect Solari screens](https://app.asana.com/0/1158428874739705/1180634597971873)

User agent was determined to be: `Mozilla/5.0 (X11; Ubuntu; Linux i686; rv:22.0) Gecko/20100101 Firefox/22.0`.