### PR TITLE
fix: screens can have fewer than five rows

### DIFF
--- a/assets/src/components/solari/section_list_sizer.tsx
+++ b/assets/src/components/solari/section_list_sizer.tsx
@@ -107,6 +107,7 @@ interface State {
 
 const NORMAL_DEPARTURES_HEIGHT = 1565;
 const OVERHEAD_DEPARTURES_HEIGHT = 1464;
+const MIN_NUM_ROWS = 3;
 
 class SectionListSizer extends React.Component<Props, State> {
   ref: React.RefObject<HTMLDivElement>;
@@ -170,7 +171,8 @@ class SectionListSizer extends React.Component<Props, State> {
   shouldAdjustSectionSizes() {
     const departuresHeight = this.ref?.current?.clientHeight ?? 0;
     return (
-      departuresHeight > this.maxDeparturesHeight && this.state.numRows > 5
+      departuresHeight > this.maxDeparturesHeight &&
+      this.state.numRows > MIN_NUM_ROWS
     );
   }
 


### PR DESCRIPTION
**Asana task**: [Change min number of rows on Solari](https://app.asana.com/0/1158428874739705/1181531255937151)

5 rows with delays don't fit on overhead display. This PR changes the minimum total number of rows to three instead.