### PR TITLE
fix: make time line heights consistent

### DIFF
--- a/assets/css/base/base_departure_time.scss
+++ b/assets/css/base/base_departure_time.scss
@@ -7,6 +7,7 @@
 .base-departure-time__text {
   @include font--text--75bold;
   font-size: 1em;
+  line-height: 1.185em;
 }
 
 .base-departure-time__minutes {

--- a/assets/css/eink/green_line/departures.scss
+++ b/assets/css/eink/green_line/departures.scss
@@ -45,6 +45,10 @@
   padding-bottom: 72px;
 }
 
+.departures__departure .base-departure-time__text {
+  line-height: 1em;
+}
+
 .departures__departure .base-departure-time__minutes {
   line-height: 1em;
 }


### PR DESCRIPTION
**Asana task**: [ARR/BRD rows are slightly shorter than normal rows on overhead layout](https://app.asana.com/0/1158428874739705/1181800343653473)

The text line height should typically be `1.185em` to be consistent with minute predictions. Green Line e-ink screens override this value to be `1em` for both minutes and text.