### PR TITLE
feat: is_screen detects solari audio button presses

### DIFF
--- a/lib/screens_web/user_agent.ex
+++ b/lib/screens_web/user_agent.ex
@@ -24,6 +24,14 @@ defmodule ScreensWeb.UserAgent do
   end
 
   defp is_solari?(user_agent) do
+    is_solari_audio?(user_agent) or is_solari_browser?(user_agent)
+  end
+
+  defp is_solari_audio?(user_agent) do
+    String.contains?(user_agent, "MPlayer")
+  end
+
+  defp is_solari_browser?(user_agent) do
     String.contains?(user_agent, "(X11; Ubuntu; Linux i686; rv:22.0)") and
       String.contains?(user_agent, "Firefox/22.0")
   end


### PR DESCRIPTION
**Asana task**: [Solari: make is_screen detect audio button user agent](https://app.asana.com/0/1158428874739705/1182316709686689)

Testing determined that the user agent at Ruggles was `MPlayer svn r34540 (Ubuntu), built with gcc-4.6`.