### PR TITLE
feat: Make hatched background compatible with FF 22

### DIFF
--- a/assets/css/solari/screen_container.scss
+++ b/assets/css/solari/screen_container.scss
@@ -6,7 +6,7 @@
 
   background: repeating-linear-gradient(
     -45deg,
-    #f5f4f1 0px,
+    #f5f4f1 0%,
     #f5f4f1 40%,
     rgba(199, 199, 199, 0.58) 40%,
     rgba(199, 199, 199, 0.58) 50%


### PR DESCRIPTION
**Asana task**: ad hoc

Use single-position color stops because double-position stops aren't supported by FF 22.

Tested on FF 22.
