### PR TITLE
feat: Add Solari local storage watchdog

### DIFF
--- a/assets/src/components/solari/screen_container.tsx
+++ b/assets/src/components/solari/screen_container.tsx
@@ -58,7 +58,7 @@ const ScreenContainer = ({ id }): JSX.Element => {
   const query = new URLSearchParams(useLocation().search);
   const datetime = query.get("datetime");
 
-  const apiResponse = useApiResponse(id, SOLARI_REFRESH_MS, datetime);
+  const apiResponse = useApiResponse(id, SOLARI_REFRESH_MS, datetime, true);
   return <ScreenLayout apiResponse={apiResponse} />;
 };
 

--- a/assets/src/hooks/use_api_response.tsx
+++ b/assets/src/hooks/use_api_response.tsx
@@ -1,6 +1,11 @@
 import { useEffect, useState } from "react";
 
-const useApiResponse = (id, refreshMs, datetime) => {
+const useApiResponse = (
+  id,
+  refreshMs,
+  datetime = null,
+  withWatchdog = false
+) => {
   const [apiResponse, setApiResponse] = useState(null);
   const apiVersion = document.getElementById("app").dataset.apiVersion;
 
@@ -20,6 +25,7 @@ const useApiResponse = (id, refreshMs, datetime) => {
       if (json.force_reload === true) {
         window.location.reload(false);
       }
+      if (withWatchdog) updateSolariWatchdog();
       setApiResponse(json);
     } catch (err) {
       setApiResponse({ success: false });
@@ -37,6 +43,12 @@ const useApiResponse = (id, refreshMs, datetime) => {
   }, []);
 
   return apiResponse;
+};
+
+const updateSolariWatchdog = () => {
+  const now = new Date().toISOString();
+  localStorage.clear();
+  localStorage.setItem("mainWatch", now);
 };
 
 export default useApiResponse;


### PR DESCRIPTION
**Asana task**: [Solari: trigger watchdog to prevent screen resets](https://app.asana.com/0/1158428874739705/1180649348335905/f)

Confirmed that local storage 'mainWatch' value is getting updated every 15 seconds on Solari screens and not on other screens.