### PR TITLE
fix: correct name for Solari screen at Nubian Platform C

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -291,7 +291,7 @@ config :screens,
         }
       ],
       app_id: "solari",
-      name: "Nubian Platform C SOL"
+      name: "Nubian Platform C SOL04"
     },
     "305" => %{
       station_name: "Forest Hills",


### PR DESCRIPTION
**Asana task**: ad hoc