### PR TITLE
chore: remove Python from tool versions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,3 @@
 elixir 1.9.4-otp-22
 erlang 22.3.2
 nodejs 13.6.0
-python 3.6.8


### PR DESCRIPTION
We don't actually use Python, I must have copied this from another project. Ran into this again recently when getting Tyler set up.