### PR TITLE
fix: default return value when fetching psa lists should be a tuple

### DIFF
--- a/lib/screens/override/state.ex
+++ b/lib/screens/override/state.ex
@@ -80,7 +80,7 @@ defmodule Screens.Override.State do
   end
 
   def handle_call({:psa_list, screen_id}, _from, state) do
-    {:reply, Map.get(state.psa_lists_by_screen_id, screen_id, []), state}
+    {:reply, Map.get(state.psa_lists_by_screen_id, screen_id, {nil, []}), state}
   end
 
   @impl true


### PR DESCRIPTION
**Asana task**: ad hoc

`Screens.Psa.current_psa_for/1` expects `State.psa_list` to return a tuple now:

```
16 {psa_type, psa_list} = State.psa_list(screen_id)
```

This seems to be causing errors, likely when we fail to fetch the config from S3.