### PR TITLE
temp fix: Create atoms at runtime when parsing JSON config

### DIFF
--- a/lib/screens/override/fetch.ex
+++ b/lib/screens/override/fetch.ex
@@ -9,7 +9,7 @@ defmodule Screens.Override.Fetch do
 
     with {:ok, response} <- HTTPoison.get(url, headers, Keyword.merge(@default_opts, opts)),
          %{status_code: 200, body: body} <- response,
-         {:ok, parsed} <- Jason.decode(body, keys: :atoms!) do
+         {:ok, parsed} <- Jason.decode(body, keys: :atoms) do
       {:ok, Screens.Override.from_json(parsed)}
     else
       _ -> :error

--- a/lib/screens/override/local_fetch.ex
+++ b/lib/screens/override/local_fetch.ex
@@ -3,7 +3,7 @@ defmodule Screens.Override.LocalFetch do
 
   def fetch_config do
     with {:ok, file_contents} <- File.read(Path.join(:code.priv_dir(:screens), "local.json")),
-         {:ok, parsed} <- Jason.decode(file_contents, keys: :atoms!) do
+         {:ok, parsed} <- Jason.decode(file_contents, keys: :atoms) do
       {:ok, Screens.Override.from_json(parsed)}
     else
       _ -> :error


### PR DESCRIPTION
**Asana task**: ad hoc

This prevents unexpected keys from breaking the app, which makes deploys that involve config changes less of a hassle.

This is a **temporary fix**, as creating new atoms at runtime from data received over the network is a Bad Idea™️. The long-term fix to do our own config parsing is still in the works.