### PR TITLE
fix: retry building erlang if it fails

### DIFF
--- a/semaphore/setup.sh
+++ b/semaphore/setup.sh
@@ -5,6 +5,9 @@ ELIXIR_VERSION=1.9.4
 ERLANG_VERSION=22.3.2
 NODE_JS_VERSION=13.6
 
+MAX_ERLANG_INSTALL_ATTEMPTS=3
+erlang_install_attempt=1
+
 change-phantomjs-version 2.1.1
 
 nvm install $NODE_JS_VERSION --latest-npm
@@ -13,7 +16,12 @@ export ERL_HOME="${SEMAPHORE_CACHE_DIR}/.kerl/installs/${ERLANG_VERSION}"
 
 if [ ! -d "${ERL_HOME}" ]; then
     mkdir -p "${ERL_HOME}"
-    KERL_BUILD_BACKEND=git kerl build $ERLANG_VERSION $ERLANG_VERSION
+    until KERL_BUILD_BACKEND=git kerl build $ERLANG_VERSION $ERLANG_VERSION || (( erlang_install_attempt == MAX_ERLANG_INSTALL_ATTEMPTS ))
+    do
+    	echo "Failed to build erlang, trying again in 5 seconds..."
+    	erlang_install_attempt++
+    	sleep 5
+    done
     kerl install $ERLANG_VERSION $ERL_HOME
 fi
 


### PR DESCRIPTION
**Asana task**: ["X is not a valid Erlang/OTP release" causing random failures in CI](https://app.asana.com/0/1158428874739705/1183016380513841)