### PR TITLE
Revert "Merge pull request #401 from mbta/dependabot/npm_and_yarn/assets/terser-webpack-plugin-4.0.0"

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -10442,12 +10442,11 @@
       }
     },
     "jest-worker": {
-      "version": "26.2.1",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.2.1.tgz",
-      "integrity": "sha512-+XcGMMJDTeEGncRb5M5Zq9P7K4sQ1sirhjdOxsN1462h6lFo9w59bl2LVQmdGEEeU3m+maZCkS2Tcc9SfCHO4A==",
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.1.0.tgz",
+      "integrity": "sha512-Z9P5pZ6UC+kakMbNJn+tA2RdVdNX5WH1x+5UCBZ9MxIK24pjYtFt96fK+UwBTrjLYm232g1xz0L3eTh51OW+yQ==",
       "dev": true,
       "requires": {
-        "@types/node": "*",
         "merge-stream": "^2.0.0",
         "supports-color": "^7.0.0"
       },
@@ -14059,19 +14058,19 @@
       }
     },
     "terser-webpack-plugin": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-4.0.0.tgz",
-      "integrity": "sha512-Gb/bmPMavJsDTYiIocakp9OJhrIBnYrWa5VM0Bb2RngWmszeQUN1xFNh2E8Re+9Cj3/sPrA50Jj/q0nzgLAUuw==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-3.0.8.tgz",
+      "integrity": "sha512-ygwK8TYMRTYtSyLB2Mhnt90guQh989CIq/mL/2apwi6rA15Xys4ydNUiH4ah6EZCfQxSk26ZFQilZ4IQ6IZw6A==",
       "dev": true,
       "requires": {
         "cacache": "^15.0.5",
         "find-cache-dir": "^3.3.1",
-        "jest-worker": "^26.2.1",
+        "jest-worker": "^26.1.0",
         "p-limit": "^3.0.2",
         "schema-utils": "^2.6.6",
         "serialize-javascript": "^4.0.0",
         "source-map": "^0.6.1",
-        "terser": "^5.0.0",
+        "terser": "^4.8.0",
         "webpack-sources": "^1.4.3"
       },
       "dependencies": {
@@ -14281,9 +14280,9 @@
           }
         },
         "terser": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/terser/-/terser-5.0.0.tgz",
-          "integrity": "sha512-olH2DwGINoSuEpSGd+BsPuAQaA3OrHnHnFL/rDB2TVNc3srUbz/rq/j2BlF4zDXI+JqAvGr86bIm1R2cJgZ3FA==",
+          "version": "4.8.0",
+          "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.0.tgz",
+          "integrity": "sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==",
           "dev": true,
           "requires": {
             "commander": "^2.20.0",

--- a/assets/package.json
+++ b/assets/package.json
@@ -50,7 +50,7 @@
     "prettier": "^2.0.5",
     "sass-loader": "^9.0.2",
     "source-map-loader": "^1.0.1",
-    "terser-webpack-plugin": "^4.0.0",
+    "terser-webpack-plugin": "^3.0.8",
     "ts-jest": "^25.5.1",
     "ts-loader": "^8.0.2",
     "tslint": "^6.1.3",


### PR DESCRIPTION
This version bump caused issues. We can either upgrade our version of Node JS (which doesn't seem so straightforward, so I don't want to take it up at the moment) or else wait for the dependencies to be updated to work with our version of node.

This reverts commit 55482b94b9d940ed6d5f4effc932ca7f013bd5ed, reversing
changes made to 2d25215e09808b4c2577e33459ed8d96cbc36e69.