### PR TITLE
chore: add LastImage and LastData fields to mercury logging

### DIFF
--- a/lib/screens/mercury_data/fetch.ex
+++ b/lib/screens/mercury_data/fetch.ex
@@ -43,7 +43,9 @@ defmodule Screens.MercuryData.Fetch do
       external_battery: "ExternalBattery",
       uptime: "Uptime",
       connect_reason: "ConnectReason",
-      connectivity_used: "ConnectivityUsed"
+      connectivity_used: "ConnectivityUsed",
+      last_image_time: "LastImage",
+      last_data_time: "LastData"
     }
     |> Enum.map(fn {name, status_key} -> {name, Map.get(status, status_key)} end)
     |> Enum.into(%{})


### PR DESCRIPTION
**Asana task**: [Mercury E-Ink signs' online/uptime is set in Splunk](https://app.asana.com/0/1185117109217413/1186489874194555)

This PR logs the new fields which Mercury added to support uptime monitoring. The Mercury API is currently being slow, so I tested by locally increasing the timeout to 1 minute.