### PR TITLE
feat: only log successful api responses

### DIFF
--- a/lib/screens/log_screen_data.ex
+++ b/lib/screens/log_screen_data.ex
@@ -33,16 +33,31 @@ defmodule Screens.LogScreenData do
     end
   end
 
-  def log_api_response(screen_id, client_version, is_screen) do
-    if is_screen do
-      data = %{
-        screen_id: screen_id,
-        screen_name: screen_name_for_id(screen_id),
-        version: client_version
-      }
+  def log_api_response(%{force_reload: true}, screen_id, client_version, is_screen) do
+    log_api_response_success(screen_id, client_version, is_screen)
+  end
 
-      log_message("[screen api response]", data)
-    end
+  def log_api_response(%{success: true}, screen_id, client_version, is_screen) do
+    log_api_response_success(screen_id, client_version, is_screen)
+  end
+
+  def log_api_response(_response, _screen_id, _client_version, _is_screen) do
+    :ok
+  end
+
+  defp log_api_response_success(screen_id, client_version, is_screen) do
+    _ =
+      if is_screen do
+        data = %{
+          screen_id: screen_id,
+          screen_name: screen_name_for_id(screen_id),
+          version: client_version
+        }
+
+        log_message("[screen api response success]", data)
+      end
+
+    :ok
   end
 
   def log_departures(_screen_id, false, _), do: nil

--- a/lib/screens/screen_data.ex
+++ b/lib/screens/screen_data.ex
@@ -28,7 +28,7 @@ defmodule Screens.ScreenData do
         true -> fetch_data(screen_id, is_screen)
       end
 
-    _ = LogScreenData.log_api_response(screen_id, client_version, is_screen)
+    _ = LogScreenData.log_api_response(response, screen_id, client_version, is_screen)
 
     response
   end


### PR DESCRIPTION
**Asana task**: [Log in Splunk whether API responses are successful](https://app.asana.com/0/1185117109217413/1179747271353409)

Currently:
- We log a `[screen data request]` each time we get an API request.
- We log a `[screen api response]` each time we send something back (no matter what it is).

Problems:
- We don’t know whether the api response actually included data or was just an error.
- If our code causes a crash, we’ll send back a HTTP 500 error, but we won’t log anything here.

This PR's change:
Each time we send something back to the client, we check whether it’s either:
a) `%{success: true}` with data, or
b) `%{force_reload: true}` when we do a version change.

If so, we log a `[screen api response success]`.

Then, for a given time range and screen, we can look at:
(# of `[screen data request]`) / (# of `[screen api response success]`) to get our “uptime”.