### PR TITLE
feat(e-ink): Support for GL single departure PSA

### DIFF
--- a/assets/src/components/eink/green_line/departures.tsx
+++ b/assets/src/components/eink/green_line/departures.tsx
@@ -88,12 +88,55 @@ const DepartureList = ({
     ...renderedDepartures.slice(1, 2),
   ];
 };
+
 interface DepartureListProps {
   departures: { time: string }[];
   currentTimeString: string;
   destination: string;
   headway: number;
 }
+
+const DeparturesListPsa = ({ psaName }): JSX.Element => {
+  const srcPath = `https://mbta-dotcom.s3.amazonaws.com/screens/images/psa/${psaName}.png`;
+  return (
+    <div>
+      <img src={srcPath} />
+    </div>
+  );
+};
+
+const DepartureWithPsa = ({
+  departures,
+  currentTimeString,
+  destination,
+  headway,
+  psaName,
+}): JSX.Element[] => {
+  let firstDepartureOrHeadway;
+
+  if (departures.length > 0) {
+    firstDepartureOrHeadway = (
+      <Departure
+        time={departures[0].time}
+        currentTimeString={currentTimeString}
+        key={departures[0].id}
+      />
+    );
+  } else {
+    firstDepartureOrHeadway = (
+      <HeadwayMessage
+        destination={destination}
+        headway={headway}
+        variant={HeadwayMessageVariant.Sub}
+        key={"departures-list-headway"}
+      />
+    );
+  }
+
+  const psa = <DeparturesListPsa psaName={psaName} />;
+
+  return [firstDepartureOrHeadway, psa];
+};
 
 const Departures = ({
   departures,
@@ -103,24 +146,43 @@ const Departures = ({
   currentTimeString,
   serviceLevel,
   isHeadwayMode,
+  psaName,
 }): JSX.Element => {
+  let departuresComponent;
+
+  if (psaName) {
+    departuresComponent = (
+      <DepartureWithPsa
+        departures={departures}
+        currentTimeString={currentTimeString}
+        destination={destination}
+        headway={headway}
+        psaName={psaName}
+      />
+    );
+  } else if (isHeadwayMode) {
+    departuresComponent = (
+      <HeadwayMessage
+        destination={destination}
+        headway={headway}
+        variant={HeadwayMessageVariant.Main}
+      />
+    );
+  } else {
+    departuresComponent = (
+      <DepartureList
+        departures={departures}
+        currentTimeString={currentTimeString}
+        destination={destination}
+        headway={headway}
+      />
+    );
+  }
+
   return (
     <div className="departures">
       <div className="departures__container">
-        {isHeadwayMode ? (
-          <HeadwayMessage
-            destination={destination}
-            headway={headway}
-            variant={HeadwayMessageVariant.Main}
-          />
-        ) : (
-          <DepartureList
-            departures={departures}
-            currentTimeString={currentTimeString}
-            destination={destination}
-            headway={headway}
-          />
-        )}
+        {departuresComponent}
         <div className="departures__delay-badge">
           {serviceLevel > 1 ? (
             <TakeoverInlineAlert />

--- a/assets/src/components/eink/green_line/single/screen_container.tsx
+++ b/assets/src/components/eink/green_line/single/screen_container.tsx
@@ -24,6 +24,7 @@ const TopScreenLayout = ({
   inlineAlert,
   serviceLevel,
   isHeadwayMode,
+  psaName,
 }): JSX.Element => {
   return (
     <div className="single-screen-container single-screen-container--gl-mercury">
@@ -46,6 +47,7 @@ const TopScreenLayout = ({
         currentTimeString={currentTimeString}
         serviceLevel={serviceLevel}
         isHeadwayMode={isHeadwayMode}
+        psaName={psaName}
       />
       <DigitalBridge stopId={stopId} />
     </div>
@@ -65,6 +67,9 @@ const DefaultScreenLayout = ({ apiResponse }): JSX.Element => {
       inlineAlert={apiResponse.inline_alert}
       serviceLevel={apiResponse.service_level}
       isHeadwayMode={apiResponse.is_headway_mode}
+      psaName={
+        apiResponse.psa_type === "departure" ? apiResponse.psa_name : null
+      }
     />
   );
 };

--- a/lib/screens/config/psa_list.ex
+++ b/lib/screens/config/psa_list.ex
@@ -11,7 +11,7 @@ defmodule Screens.Config.PsaList do
   @type psa_type :: bus_psa_type | gl_psa_type | solari_psa_type | nil
 
   @type bus_psa_type :: :double | :takeover
-  @type gl_psa_type :: :double | :takeover
+  @type gl_psa_type :: :double | :takeover | :departure
   @type solari_psa_type :: :psa | :takeover
 
   @spec from_json(map() | :default) :: t()
@@ -35,7 +35,7 @@ defmodule Screens.Config.PsaList do
     }
   end
 
-  for psa_type <- ~w[psa double takeover]a do
+  for psa_type <- ~w[psa double takeover departure]a do
     psa_type_string = Atom.to_string(psa_type)
 
     defp type_from_json(unquote(psa_type_string)) do


### PR DESCRIPTION
**Asana task**: [Blandford E-Ink screens are configured for Mon. 8/10 B branch shutdown](https://app.asana.com/0/1185117109217413/1187705902975601)

New PSA type replaces the bottom departure on GL e-ink single.