### PR TITLE
fix: Handle failure to fetch destination for GL e-ink screens

### DIFF
--- a/lib/screens/gl_screen_data.ex
+++ b/lib/screens/gl_screen_data.ex
@@ -15,14 +15,51 @@ defmodule Screens.GLScreenData do
       platform_id: platform_id
     } = State.app_params(screen_id)
 
-    # If we are unable to fetch alerts:
-    # - inline_alerts will be an empty list
-    # - global_alert will be nil
-    #
-    # We do this because we still want to return an API response with departures,
-    # even if the other API requests fail.
-    {inline_alerts, global_alert} = Alert.by_route_id(route_id, stop_id)
+    {line_map_data, departures} =
+      get_line_map_data_and_departures(route_id, stop_id, direction_id, platform_id)
 
+    destination = get_destination(route_id, direction_id)
+
+    _ = LogScreenData.log_departures(screen_id, is_screen, departures)
+
+    # If we are unable to fetch departures or destination, we want to show an error message on the screen.
+    with {:ok, departures} <- departures,
+         {:ok, destination} <- destination do
+      {inline_alerts, global_alert} = Alert.by_route_id(route_id, stop_id)
+      {psa_type, psa_name} = Screens.Psa.current_psa_for(screen_id)
+
+      %{
+        force_reload: false,
+        success: true,
+        current_time: Screens.Util.format_time(DateTime.utc_now()),
+        stop_name: destination,
+        stop_id: stop_id,
+        route_id: route_id,
+        departures: format_departure_rows(departures),
+        global_alert: format_global_alert(global_alert),
+        inline_alert: format_inline_alert(inline_alerts),
+        nearby_departures: Screens.NearbyDepartures.by_stop_id(stop_id),
+        line_map: line_map_data,
+        headway: Screens.Headways.by_route_id(route_id, stop_id, direction_id),
+        service_level: State.green_line_service(),
+        is_headway_mode: headway_mode?,
+        psa_type: psa_type,
+        psa_name: psa_name
+      }
+    else
+      :error ->
+        %{
+          force_reload: false,
+          success: false
+        }
+    end
+  end
+
+  @typep line_map_data :: map() | nil
+  @typep departures :: {:ok, list()} | :error
+  @spec get_line_map_data_and_departures(String.t(), String.t(), 0 | 1, String.t()) ::
+          {line_map_data(), departures()}
+  defp get_line_map_data_and_departures(route_id, stop_id, direction_id, platform_id) do
     predictions =
       Screens.Predictions.Prediction.fetch(%{
         direction_id: direction_id,
@@ -30,63 +67,26 @@ defmodule Screens.GLScreenData do
         stop_ids: [stop_id]
       })
 
-    {line_map_data, predictions} =
-      case predictions do
-        {:ok, predictions} ->
+    case predictions do
+      {:ok, predictions} ->
+        {line_map_data, filtered_predictions} =
           Screens.LineMap.by_stop_id(platform_id, route_id, direction_id, predictions)
 
-        :error ->
-          # handle case where vehicle request fails
-          {nil, :error}
-      end
+        departures = Departure.from_predictions(filtered_predictions)
 
-    # If we are unable to fetch departures, we want to show an error message on the screen.
-    departures =
-      case Departure.from_predictions(predictions) do
-        {:ok, result} -> {:ok, result}
-        :error -> :error
-      end
-
-    nearby_departures = Screens.NearbyDepartures.by_stop_id(stop_id)
-
-    # Move this and make it less brittle
-    {:ok, %{direction_destinations: destinations}} = Screens.Routes.Route.by_id(route_id)
-    destination = Enum.at(destinations, direction_id)
-
-    service_level = State.green_line_service()
-
-    headway_data = Screens.Headways.by_route_id(route_id, stop_id, direction_id, service_level)
-
-    _ = LogScreenData.log_departures(screen_id, is_screen, departures)
-
-    {psa_type, psa_name} = Screens.Psa.current_psa_for(screen_id)
-
-    case departures do
-      {:ok, departures} ->
-        %{
-          force_reload: false,
-          success: true,
-          current_time: Screens.Util.format_time(DateTime.utc_now()),
-          stop_name: destination,
-          stop_id: stop_id,
-          route_id: route_id,
-          departures: format_departure_rows(departures),
-          global_alert: format_global_alert(global_alert),
-          inline_alert: format_inline_alert(inline_alerts),
-          nearby_departures: nearby_departures,
-          line_map: line_map_data,
-          headway: headway_data,
-          service_level: service_level,
-          is_headway_mode: headway_mode?,
-          psa_type: psa_type,
-          psa_name: psa_name
-        }
+        {line_map_data, departures}
 
       :error ->
-        %{
-          force_reload: false,
-          success: false
-        }
+        # handle case where vehicle request fails
+        {nil, :error}
+    end
+  end
+
+  @spec get_destination(String.t(), 0 | 1) :: {:ok, String.t()} | :error
+  defp get_destination(route_id, direction_id) do
+    case Screens.Routes.Route.by_id(route_id) do
+      {:ok, %{direction_destinations: destinations}} -> {:ok, Enum.at(destinations, direction_id)}
+      :error -> :error
     end
   end
 

--- a/lib/screens/headways.ex
+++ b/lib/screens/headways.ex
@@ -1,6 +1,8 @@
 defmodule Screens.Headways do
   @moduledoc false
 
+  alias Screens.Config.State
+
   @dayparts [
     {:late_night, ~T[00:00:00], :close},
     {:early_morning, :open, ~T[06:30:00]},
@@ -11,8 +13,8 @@ defmodule Screens.Headways do
     {:late_night, ~T[20:00:00], :midnight}
   ]
 
-  def by_route_id(route_id, stop_id, direction_id, service_level, time \\ DateTime.utc_now()) do
-    current_schedule = schedule_with_override(time, service_level)
+  def by_route_id(route_id, stop_id, direction_id, time \\ DateTime.utc_now()) do
+    current_schedule = schedule_with_override(time)
     current_daypart = daypart(time, stop_id, direction_id, current_schedule)
     headway(route_id, current_schedule, current_daypart)
   end
@@ -77,7 +79,8 @@ defmodule Screens.Headways do
   defp headway("Green-E", :sunday, :early_morning), do: 15
   defp headway("Green-E", :sunday, _), do: 12
 
-  defp schedule_with_override(time, service_level) do
+  defp schedule_with_override(time) do
+    service_level = State.green_line_service()
     # Level 3 turns weekday into Saturday schedule
     # Level 4 is always Sunday schedule
     # Otherwise, use normal schedule


### PR DESCRIPTION
**Asana task**: [Prevent unsuccessful APIv3 route calls from causing crashes](https://app.asana.com/0/1164574158255689/1189108614365497/f)

I did my best to disentangle the variables in `GLScreenData.by_screen_id`, so that any intermediate logic within the function was broken out into helper functions.

I also moved all of the function calls that don't affect the shape of the return value so that they are called after we first check whether departures and destination were fetched successfully.

Specific refactoring changes:
- service level is now fetched from config state directly in `Headways.schedule_with_override` instead of being passed down to it from `GLScreenData.by_screen_id`
- predictions are fetched in a helper function and transformed to departures before being returned to `GLScreenData.by_screen_id`
- line map data and departures are fetched together in a helper function since departures depend on predictions that have been filtered during the process of fetching line map data
- destination is fetched in a helper function
