### PR TITLE
fix: Use arrow-only icon in vertical header when section contains ≤ 1 row

### DIFF
--- a/assets/css/solari/section.scss
+++ b/assets/css/solari/section.scss
@@ -15,7 +15,7 @@
 
   .section-header__icon {
     display: block;
-    margin: 20px auto 0 auto;
+    margin: 24px auto 0 auto;
   }
 
   .later-departure__header-title {

--- a/assets/src/components/solari/section.tsx
+++ b/assets/src/components/solari/section.tsx
@@ -47,6 +47,21 @@ const isArrivingOrBoarding = (
   );
 };
 
+const verticalHeaderIconSrc = (name, departuresLength) => {
+  switch (true) {
+    case departuresLength <= 1 && name === "Upper Busway":
+      return "/images/icon-upper-busway-arrow-only.svg";
+    case departuresLength <= 1 && name === "Lower Busway":
+      return "/images/icon-lower-busway-arrow-only.svg";
+    case name === "Upper Busway":
+      return "/images/icon-upper-busway.svg";
+    case name === "Lower Busway":
+      return "/images/icon-lower-busway.svg";
+    case name === "Commuter Rail":
+      return "/images/icon-commuter-rail.svg";
+  }
+};
+
 const SectionHeader = ({ name, arrow }): JSX.Element => {
   return (
     <div className="section-header">
@@ -65,6 +80,7 @@ const SectionFrame = ({
   name,
   arrow,
   overhead,
+  departuresLength,
   children,
 }): JSX.Element => {
   const sectionModifier = sectionHeaders === "vertical" ? "vertical" : "normal";
@@ -73,13 +89,9 @@ const SectionFrame = ({
     sectionHeaders !== null && name !== null && !overhead;
 
   if (sectionHeaders === "vertical") {
-    const iconSrcByName = {
-      "Upper Busway": "/images/icon-upper-busway.svg",
-      "Lower Busway": "/images/icon-lower-busway.svg",
-      "Commuter Rail": "/images/icon-commuter-rail.svg",
-    };
+    const iconSrc = verticalHeaderIconSrc(name, departuresLength);
 
-    name = <img className="section-header__icon" src={iconSrcByName[name]} />;
+    name = <img className="section-header__icon" src={iconSrc} />;
   }
 
   return (
@@ -404,6 +416,7 @@ const PagedSection = ({
     name,
     arrow: sectionHeaders === "normal" ? arrow : null,
     overhead,
+    departuresLength: staticDepartures.length,
   };
 
   if (staticDepartures.length === 0) {
@@ -451,7 +464,13 @@ const Section = ({
     arrow = null;
   }
 
-  const frameProps = { sectionHeaders, name, arrow, overhead };
+  const frameProps = {
+    sectionHeaders,
+    name,
+    arrow,
+    overhead,
+    departuresLength: departures.length,
+  };
 
   if (departures.length === 0) {
     return (

--- a/assets/static/images/icon-lower-busway-arrow-only.svg
+++ b/assets/static/images/icon-lower-busway-arrow-only.svg
@@ -1,0 +1,4 @@
+<svg width="52" height="52" viewBox="0 0 52 52" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M14 21L26 33L38 21" stroke="#171F26" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M26 50C39.25 50 50 39.25 50 26C50 12.75 39.25 2 26 2C12.75 2 2 12.75 2 26C2 39.25 12.75 50 26 50Z" stroke="#171F26" stroke-width="4" stroke-miterlimit="10"/>
+</svg>

--- a/assets/static/images/icon-upper-busway-arrow-only.svg
+++ b/assets/static/images/icon-upper-busway-arrow-only.svg
@@ -1,0 +1,4 @@
+<svg width="52" height="52" viewBox="0 0 52 52" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M38 31L26 19L14 31" stroke="#171F26" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M26 2C12.75 2 2 12.75 2 26C2 39.25 12.75 50 26 50C39.25 50 50 39.25 50 26C50 12.75 39.25 2 26 2Z" stroke="#171F26" stroke-width="4" stroke-miterlimit="10"/>
+</svg>


### PR DESCRIPTION
**Asana task**: [Solari: Prevent vertical header icons from getting cut off when there are no departures](https://app.asana.com/0/1185117109217413/1190151787758963/f)

![Screen Shot 2020-09-01 at 2 35 52 PM](https://user-images.githubusercontent.com/63608771/91892748-3138a480-ec61-11ea-9686-28789c3fbec6.png)
