### PR TITLE
fix: use "none" instead of null for no section headers

### DIFF
--- a/assets/src/components/solari/section.tsx
+++ b/assets/src/components/solari/section.tsx
@@ -86,7 +86,7 @@ const SectionFrame = ({
   const sectionModifier = sectionHeaders === "vertical" ? "vertical" : "normal";
   const sectionClass = classWithModifier("section", sectionModifier);
   const shouldShowHeader =
-    sectionHeaders !== null && name !== null && !overhead;
+    sectionHeaders !== "none" && name !== null && !overhead;
 
   if (sectionHeaders === "vertical") {
     const iconSrc = verticalHeaderIconSrc(name, departuresLength);
@@ -384,7 +384,7 @@ interface PagedSectionProps {
   departures: object[];
   numRows: number;
   arrow: Direction | null;
-  sectionHeaders: "normal" | "vertical" | null;
+  sectionHeaders: "normal" | "vertical" | "none";
   name: string | null;
   pill: string;
   overhead: boolean;

--- a/lib/screens/config/solari.ex
+++ b/lib/screens/config/solari.ex
@@ -7,7 +7,7 @@ defmodule Screens.Config.Solari do
   @type t :: %__MODULE__{
           station_name: String.t(),
           overhead: boolean(),
-          section_headers: :normal | :vertical | nil,
+          section_headers: :normal | :vertical | :none,
           sections: list(Section.t()),
           psa_config: PsaConfig.t(),
           audio_psa: AudioPsa.t()
@@ -38,7 +38,7 @@ defmodule Screens.Config.Solari do
     |> Enum.into(%{}, fn {k, v} -> {k, value_to_json(k, v)} end)
   end
 
-  for headers <- ~w[normal vertical]a do
+  for headers <- ~w[normal vertical none]a do
     headers_string = Atom.to_string(headers)
 
     defp value_from_json("section_headers", unquote(headers_string)) do


### PR DESCRIPTION
**Asana task**: [Replace null section headers with actual value](https://app.asana.com/0/1185117109217413/1192137237077451)

Note that the default value for `section_headers` is `:normal`, so I'll have to be a bit careful when updating the config to use the new shape.