### PR TITLE
fix: Send 404 response for non-cognito auth requests

### DIFF
--- a/lib/screens_web/controllers/auth_controller.ex
+++ b/lib/screens_web/controllers/auth_controller.ex
@@ -6,6 +6,10 @@ defmodule ScreensWeb.AuthController do
     send_resp(conn, 404, "Not Found")
   end
 
+  def callback(conn, %{"provider" => provider}) when provider != "cognito" do
+    send_resp(conn, 404, "Not Found")
+  end
+
   def callback(%{assigns: %{ueberauth_auth: auth}} = conn, _params) do
     username = auth.uid
     expiration = auth.credentials.expires_at


### PR DESCRIPTION
**Asana task**: [Prevent Screens Warnings/Errors from occurring](https://app.asana.com/0/1164574158255689/1192815705596985/f) (first sub-task)

I tried changing the route to explicitly accept only /auth/cognito and /auth/cognito/callback, but the param still needs to be passed through for Ueberauth to work, and I couldn't find a way to create a route that says "Accept /auth/:provider but only when :provider is 'cognito'".

- [ ] Needs version bump?
