### PR TITLE
fix(solari): make parenthesized destinations secondary

### DIFF
--- a/assets/src/components/eink/base_departure_destination.tsx
+++ b/assets/src/components/eink/base_departure_destination.tsx
@@ -1,16 +1,13 @@
 import React from "react";
 
 const splitDestination = (destination) => {
-  if (destination.includes("via")) {
-    const parts = destination.split(" via ");
-    const primaryDestination = parts[0];
-    const secondaryDestination = "via " + parts[1];
-    return [primaryDestination, secondaryDestination];
-  } else if (destination.includes("(")) {
-    const parts = destination.split(" (");
-    const primaryDestination = parts[0].trim();
-    const secondaryDestination = "(" + parts[1];
-    return [primaryDestination, secondaryDestination];
+  const viaPattern = /(.+) (via .+)/;
+  const parenPattern = /(.+) (\(.+)/;
+
+  if (viaPattern.test(destination)) {
+    return viaPattern.exec(destination).slice(1);
+  } else if (parenPattern.test(destination)) {
+    return parenPattern.exec(destination).slice(1);
   } else {
     return [destination];
   }
@@ -25,24 +22,18 @@ const BaseDepartureDestination = ({ destination }): JSX.Element => {
     destination
   );
 
-  if (secondaryDestination) {
-    return (
-      <div className="base-departure-destination__container">
-        <div className="base-departure-destination__primary">
-          {primaryDestination}
-        </div>
+  return (
+    <div className="base-departure-destination__container">
+      <div className="base-departure-destination__primary">
+        {primaryDestination}
+      </div>
+      {secondaryDestination && (
         <div className="base-departure-destination__secondary">
           {secondaryDestination}
         </div>
-      </div>
-    );
-  } else {
-    return (
-      <div className="base-departure-destination__container">
-        <div className="base-departure-destination__primary">{destination}</div>
-      </div>
-    );
-  }
+      )}
+    </div>
+  );
 };
 
 export default BaseDepartureDestination;


### PR DESCRIPTION
**Asana task**: ad hoc

Some long headsigns which don't contain "via" have an additional description in parentheses, and are wrapping to a second line in Solari (with crowding added). Moving these to the secondary destination (smaller second row) addresses this issue.

![Screen Shot 2020-09-23 at 2 47 43 PM](https://user-images.githubusercontent.com/4276843/94071707-6482d500-fdc2-11ea-8d1f-1998c5aafeeb.png)

![Screen Shot 2020-09-23 at 2 38 24 PM](https://user-images.githubusercontent.com/4276843/94071731-6c427980-fdc2-11ea-916f-cb3bc31a9c38.png)