### PR TITLE
fix: deduplicate predictions at central

### DIFF
--- a/lib/screens/nearby_departures.ex
+++ b/lib/screens/nearby_departures.ex
@@ -14,19 +14,12 @@ defmodule Screens.NearbyDepartures do
         predictions
         |> Enum.group_by(& &1.stop.id)
         |> Enum.map(fn {stop_id, prediction_list} ->
-          {stop_id, select_earliest_prediction(prediction_list)}
+          {stop_id, Enum.min_by(prediction_list, & &1.departure_time, fn -> nil end)}
         end)
         |> Enum.map(fn {_stop_id, prediction} -> format_prediction(prediction) end)
 
       :error ->
         []
-    end
-  end
-
-  defp select_earliest_prediction(prediction_list) do
-    case Enum.reject(prediction_list, &is_nil(&1.departure_time)) do
-      [] -> nil
-      predictions -> Enum.min_by(predictions, & &1.departure_time)
     end
   end
 

--- a/lib/screens/predictions/prediction.ex
+++ b/lib/screens/predictions/prediction.ex
@@ -27,11 +27,17 @@ defmodule Screens.Predictions.Prediction do
 
   @spec fetch(Departure.query_params()) :: {:ok, list(t())} | :error
   def fetch(%{} = query_params) do
-    Departure.do_query_and_parse(
-      query_params,
-      "predictions",
-      Screens.Predictions.Parser,
-      %{include: ~w[route stop trip trip.stops vehicle alerts]}
-    )
+    predictions =
+      Departure.do_query_and_parse(
+        query_params,
+        "predictions",
+        Screens.Predictions.Parser,
+        %{include: ~w[route stop trip trip.stops vehicle alerts]}
+      )
+
+    case predictions do
+      {:ok, result} -> {:ok, Enum.reject(result, &is_nil(&1.departure_time))}
+      :error -> :error
+    end
   end
 end

--- a/lib/screens/schedules/schedule.ex
+++ b/lib/screens/schedules/schedule.ex
@@ -25,11 +25,17 @@ defmodule Screens.Schedules.Schedule do
   def fetch(%{} = query_params, date \\ nil) do
     extra_params = if is_nil(date), do: %{}, else: %{date: date}
 
-    Departure.do_query_and_parse(
-      query_params,
-      "schedules",
-      Screens.Schedules.Parser,
-      extra_params
-    )
+    schedules =
+      Departure.do_query_and_parse(
+        query_params,
+        "schedules",
+        Screens.Schedules.Parser,
+        extra_params
+      )
+
+    case schedules do
+      {:ok, result} -> {:ok, Enum.reject(result, &is_nil(&1.departure_time))}
+      :error -> :error
+    end
   end
 end


### PR DESCRIPTION
**Asana task**: [Trips that serve multiple stop IDs included on a screen only appear once](https://app.asana.com/0/1185117109217413/1187043084646514)

This PR narrowly fixes the issue at Central. (We don't believe it happens anywhere else.) When there are multiple predictions for the same `trip_id`, we take the earliest. We log if this happens and it's not on route 64.