### PR TITLE
fix: vertical spacing around departure rows with parens in headsign

### DIFF
--- a/assets/src/components/solari/departure.tsx
+++ b/assets/src/components/solari/departure.tsx
@@ -26,8 +26,14 @@ const Departure = ({
   groupStart,
   groupEnd,
 }): JSX.Element => {
+  const viaPattern = /(.+) (via .+)/;
+  const parenPattern = /(.+) (\(.+)/;
+
   const viaModifier =
-    destination && destination.includes(" via ") ? "with-via" : "no-via";
+    destination &&
+    (viaPattern.test(destination) || parenPattern.test(destination))
+      ? "with-via"
+      : "no-via";
 
   const timeRepresentation = standardTimeRepresentation(
     time,


### PR DESCRIPTION
**Asana task**: [Fix vertical spacing around departures whose headsigns contain parentheses](https://app.asana.com/0/1185117109217413/1197392913089129)



- [x] Needs version bump?
