### PR TITLE
feat (blocked for now): Add route_type query param for V3 API predictions/schedules requests

### DIFF
--- a/lib/screens/config/query/params.ex
+++ b/lib/screens/config/query/params.ex
@@ -6,12 +6,16 @@ defmodule Screens.Config.Query.Params do
   @type t :: %__MODULE__{
           stop_ids: list(String.t()),
           route_ids: list(String.t()),
-          direction_id: 0 | 1 | :both
+          direction_id: 0 | 1 | :both,
+          route_type: route_type
         }
+
+  @type route_type :: :light_rail | :subway | :rail | :bus | :ferry | :all
 
   defstruct stop_ids: [],
             route_ids: [],
-            direction_id: :both
+            direction_id: :both,
+            route_type: :all
 
   @spec from_json(map() | :default) :: t()
   def from_json(%{} = json) do
@@ -35,6 +39,18 @@ defmodule Screens.Config.Query.Params do
   end
 
   defp value_from_json("direction_id", "both"), do: :both
+
+  for route_type <- ~w[light_rail subway rail bus ferry all]a do
+    route_type_string = Atom.to_string(route_type)
+
+    defp value_from_json("route_type", unquote(route_type_string)) do
+      unquote(route_type)
+    end
+
+    defp value_to_json(:route_type, unquote(route_type)) do
+      unquote(route_type_string)
+    end
+  end
 
   defp value_from_json(_, value), do: value
 

--- a/lib/screens/departures/departure.ex
+++ b/lib/screens/departures/departure.ex
@@ -44,8 +44,11 @@ defmodule Screens.Departures.Departure do
           optional(:direction_id) => 0 | 1 | :both,
           optional(:sort) => String.t(),
           optional(:include) => list(String.t()),
-          optional(:date) => String.t()
+          optional(:date) => String.t(),
+          optional(:route_type) => Screens.Config.Query.Params.route_type()
         }
+
+  @route_type_mapping light_rail: 0, subway: 1, rail: 2, bus: 3, ferry: 4
 
   @spec fetch(query_params(), boolean()) :: {:ok, list()} | :error
   def fetch(%{} = query_params, include_schedules \\ false) do
@@ -334,6 +337,16 @@ defmodule Screens.Departures.Departure do
 
   defp format_query_param({:date, date}) do
     {"date", date}
+  end
+
+  for {route_type, number} <- @route_type_mapping do
+    defp format_query_param({:route_type, unquote(route_type)}) do
+      {"filter[route_type]", unquote(number)}
+    end
+  end
+
+  defp format_query_param({:route_type, _}) do
+    nil
   end
 
   defp log_unexpected_groups(groups) do


### PR DESCRIPTION
**Asana task**: [Use route_type filter in V3 API requests once it's available for both predictions and schedules](https://app.asana.com/0/1185117109217422/1198147537218987/f)

This adds support for setting a `route_type` filter in the query params for a Solari section.

We'll need to wait until [this task](https://app.asana.com/0/1170755226288827/1198173974731337) to allow passing a `filter[route_type]` param to the /schedules GET resource is completed, but I had already written the code for our side of things and figure it could go in a PR until then.

- [ ] Needs version bump?
