### PR TITLE
fix: fix and re-enable log_unexpected_groups

### DIFF
--- a/lib/screens/gl_screen_data.ex
+++ b/lib/screens/gl_screen_data.ex
@@ -73,7 +73,7 @@ defmodule Screens.GLScreenData do
         {line_map_data, filtered_predictions} =
           Screens.LineMap.by_stop_id(platform_id, route_id, direction_id, predictions)
 
-        departures = Departure.from_predictions(filtered_predictions)
+        departures = Departure.from_predictions_or_schedules(filtered_predictions)
 
         {line_map_data, departures}
 


### PR DESCRIPTION
**Asana task**: [Fix log_unexpected_groups for slashed routes](https://app.asana.com/0/1185117109217413/1198300804470237)

This PR fixes the issue by calling `deduplicate_slashed_routes` before `deduplicate_repeated_trips` (which does the logging). This required some code reorganization; `from_schedules` and `from_predictions` no longer do any filtering on the predictions/schedules which are passed to them.