### PR TITLE
feat: if no predictions, show connection error during service day

### DIFF
--- a/assets/src/components/eink/bus/screen_container.tsx
+++ b/assets/src/components/eink/bus/screen_container.tsx
@@ -123,6 +123,8 @@ const NoConnectionScreenLayout = (): JSX.Element => {
 };
 
 const ScreenLayout = ({ apiResponse }): JSX.Element => {
+  const noDepartures = (apiResponse?.departures?.length ?? 0) === 0;
+
   switch (true) {
     case !apiResponse || apiResponse.success === false:
       return <NoConnectionScreenLayout />;
@@ -130,11 +132,9 @@ const ScreenLayout = ({ apiResponse }): JSX.Element => {
       return <TakeoverScreenLayout apiResponse={apiResponse} />;
     case apiResponse.service_level === 5:
       return <NoServiceScreenLayout />;
-    case (!apiResponse.departures || apiResponse.departures.length === 0) &&
-      apiResponse.in_service_day:
+    case noDepartures && apiResponse.in_service_day:
       return <NoConnectionScreenLayout />;
-    case (!apiResponse.departures || apiResponse.departures.length === 0) &&
-      !apiResponse.in_service_day:
+    case noDepartures && !apiResponse.in_service_day:
       return <NoDeparturesScreenLayout apiResponse={apiResponse} />;
     default:
       return (

--- a/lib/screens/bus_screen_data.ex
+++ b/lib/screens/bus_screen_data.ex
@@ -87,7 +87,7 @@ defmodule Screens.BusScreenData do
   defp in_service_day_at_stop?(stop_id, current_time) do
     with {:ok, schedules} <- Schedule.fetch(%{stop_ids: [stop_id]}),
          {first_arrival_time, last_arrival_time} <- get_service_day_from_schedules(schedules) do
-      DateTime.compare(first_arrival_time, current_time) in [:lt, :eq] &&
+      DateTime.compare(first_arrival_time, current_time) in [:lt, :eq] and
         DateTime.compare(last_arrival_time, current_time) == :gt
     else
       _ -> true
@@ -95,14 +95,11 @@ defmodule Screens.BusScreenData do
   end
 
   defp get_service_day_from_schedules(schedules) do
-    departure_times =
-      schedules
-      |> Enum.map(& &1.departure_time)
-      |> Enum.reject(&is_nil/1)
-
-    case departure_times do
+    schedules
+    |> Enum.map(& &1.departure_time)
+    |> case do
       [] -> nil
-      _ -> {Enum.min(departure_times), Enum.max(departure_times)}
+      departure_times -> {Enum.min(departure_times), Enum.max(departure_times)}
     end
   end
 


### PR DESCRIPTION
**Asana task**: [Handle missing bus data on bus e-Ink](https://app.asana.com/0/1185117109217413/1198304125039167)

Get the scheduled first and last stop time at the stop, then include whether the current time is between them as a part of the api response. When there are no predictions, show a good night screen if the current time is not between the first and last scheduled stop time, but show a connection error screen if it is.