### PR TITLE
fix: use wider mini-pill for route 441/442

### DIFF
--- a/assets/css/solari/section.scss
+++ b/assets/css/solari/section.scss
@@ -86,7 +86,7 @@
 
   &--size-normal {
     .later-departure__route-pill--size-small {
-      top: -4.5px;
+      transform: translateY(-4.5px);
     }
   }
 }
@@ -121,7 +121,17 @@
 
   &--selected {
     height: 46px;
-    width: 89px;
+
+    // Width depends on the route
+    &.later-departure__route-pill {
+      &--width-wide {
+        width: 158px;
+      }
+
+      &--width-normal {
+        width: 89px;
+      }
+    }
 
     // Different selected pill colors by mode
     &.later-departure__route-pill {
@@ -141,7 +151,17 @@
     color: rgba(23, 31, 38, 0.8);
     border: 3px solid rgba(23, 31, 38, 0.8);
     height: 40px;
-    width: 83px;
+
+    // Width depends on the route
+    &.later-departure__route-pill {
+      &--width-wide {
+        width: 152px;
+      }
+
+      &--width-normal {
+        width: 83px;
+      }
+    }
   }
 }
 

--- a/assets/src/components/solari/route_pill.tsx
+++ b/assets/src/components/solari/route_pill.tsx
@@ -2,6 +2,7 @@ import React from "react";
 
 import { classWithModifier, classWithModifiers } from "Util/util";
 import BaseRoutePill from "Components/eink/base_route_pill";
+import { WIDE_MINI_PILL_ROUTES } from "Components/solari/section";
 
 interface PillType {
   routeName: string | null;
@@ -110,12 +111,19 @@ const routeIdMapping: Record<string, string> = {
 const PagedDepartureRoutePill = ({ route, routeId, selected }): JSX.Element => {
   const isCommuterRail = routeId.startsWith("CR-");
   const isSlashRoute = route.includes("/");
+  const isWideRoute = WIDE_MINI_PILL_ROUTES.includes(route);
 
   const selectedModifier = selected ? "selected" : "unselected";
   const sizeModifier =
     isCommuterRail || isSlashRoute ? "size-small" : "size-normal";
   const modeModifier = isCommuterRail ? "commuter-rail" : "bus";
-  const modifiers = [selectedModifier, sizeModifier, modeModifier];
+  const widthModifier = isWideRoute ? "width-wide" : "width-normal";
+  const modifiers = [
+    selectedModifier,
+    sizeModifier,
+    modeModifier,
+    widthModifier,
+  ];
   const pillClass = classWithModifiers(
     "later-departure__route-pill",
     modifiers


### PR DESCRIPTION
**Asana task**: [441/442 doesn't fit in mini-pill](https://app.asana.com/0/1185117109217413/1197171015038497)

- Reduce the number of departures shown in a paged departure by 1 for each departure on route 441/442 in order to make room for the wider pills.
- Add a class to make the mini-pills for route 441/442 wider.
- Update the calculation which positions the caret to account for the wider pills.