### PR TITLE
fix: add docker hub login to build-push script

### DIFF
--- a/semaphore/build_push.sh
+++ b/semaphore/build_push.sh
@@ -7,6 +7,11 @@ set -e -x -u
 # * DOCKER_REPO
 awsenv=$1
 
+# log into docker hub if credentials are in the environment
+if [ -n "$DOCKER_USERNAME" ]; then
+  echo $DOCKER_PASSWORD | docker login -u $DOCKER_USERNAME --password-stdin
+fi
+
 # build docker image and tag it with git hash and aws environment
 githash=$(git rev-parse --short HEAD)
 docker build -t $APP:latest .


### PR DESCRIPTION
**Asana task**: ad hoc

Docker added rate limits for unauthenticated build pulls, so now we have to log in to avoid failures like this one: https://semaphoreci.com/mbta/screens/servers/screens-dev/deploys/549.