### PR TITLE
fix: don't change behavior for sections with no associated signs

### DIFF
--- a/lib/screens/signs_ui_config/state.ex
+++ b/lib/screens/signs_ui_config/state.ex
@@ -37,6 +37,8 @@ defmodule Screens.SignsUiConfig.State do
     all_signs_in_modes?(pid, sign_ids, [:off, :static_text])
   end
 
+  defp all_signs_in_modes?(_pid, [], _modes), do: false
+
   defp all_signs_in_modes?(pid, sign_ids, modes) do
     GenServer.call(pid, {:all_signs_in_modes, sign_ids, modes})
   end


### PR DESCRIPTION
**Asana task**: ad hoc

Currently, `all_signs_in_modes?` is returning the result of an `Enum.all?` which is `true` for empty lists. If we've configured a section so that there aren't any associated LED countdown signs, we don't want to say that that section should be turned off or set to headway mode, so we want the empty list case to return `false` instead.