### PR TITLE
feat: choose api v3 environment based on screens environment

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -61,7 +61,7 @@ config :screens,
   audio_psa_s3_directory: "/screens/audio_assets/psa/",
   signs_ui_s3_path: "config.json",
   signs_ui_config_fetcher: Screens.SignsUiConfig.State.S3Fetch,
-  api_v3_url: "https://api-v3.mbta.com/"
+  default_api_v3_url: "https://api-v3.mbta.com/"
 
 config :screens,
   # Maps alert informed entity contents to the appropriate headsign to show for that alert.

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -22,6 +22,7 @@ config :screens, ScreensWeb.Endpoint,
   ]
 
 config :screens,
+  default_api_v3_url: System.get_env("API_V3_URL", "https://api-v3.mbta.com/"),
   api_v3_key: System.get_env("API_V3_KEY"),
   gds_dms_password: System.get_env("GDS_DMS_PASSWORD"),
   mercury_api_key: System.get_env("MERCURY_API_KEY"),

--- a/lib/screens/v3_api.ex
+++ b/lib/screens/v3_api.ex
@@ -4,7 +4,6 @@ defmodule Screens.V3Api do
   require Logger
 
   @default_opts [timeout: 2000, recv_timeout: 2000, hackney: [pool: :api_v3_pool]]
-  @base_url Application.get_env(:screens, :api_v3_url)
 
   def get_json(route, params \\ %{}, extra_headers \\ [], opts \\ []) do
     headers = extra_headers ++ api_key_headers(Application.get_env(:screens, :api_v3_key))
@@ -42,11 +41,26 @@ defmodule Screens.V3Api do
   end
 
   defp build_url(route, params) when map_size(params) == 0 do
-    @base_url <> route
+    base_url() <> route
   end
 
   defp build_url(route, params) do
-    "#{@base_url}#{route}?#{URI.encode_query(params)}"
+    "#{base_url()}#{route}?#{URI.encode_query(params)}"
+  end
+
+  defp base_url do
+    :screens
+    |> Application.get_env(:environment_name)
+    |> base_url_for_environment()
+  end
+
+  defp base_url_for_environment(environment_name) do
+    case environment_name do
+      "screens-prod" -> "https://api-v3.mbta.com/"
+      "screens-dev" -> "https://dev.api.mbtace.com/"
+      "screens-dev-green" -> "https://green.dev.api.mbtace.com/"
+      _ -> Application.get_env(:screens, :default_api_v3_url)
+    end
   end
 
   defp api_key_headers(nil), do: []


### PR DESCRIPTION
**Asana task**: [Make screens environments use corresponding API environment](https://app.asana.com/0/1185117109217413/1199551908917601)

- Use the existing environment name to automatically match API environment to screens environment.
- Configurable default environment name; locally you could run something like `API_V3_URL="https://green.dev.api.mbtace.com/" API_V3_KEY=<your-key-here> iex -S mix phx.server`