### PR TITLE
feat: allow for secondary departures to be empty (show primary again)

### DIFF
--- a/lib/screens/dup_screen_data.ex
+++ b/lib/screens/dup_screen_data.ex
@@ -29,8 +29,14 @@ defmodule Screens.DupScreenData do
   def by_screen_id(screen_id, "2") do
     %Dup{secondary: secondary_departures} = State.app_params(screen_id)
 
-    current_time = DateTime.utc_now()
-    fetch_departures_response(secondary_departures, current_time)
+    case secondary_departures do
+      %Dup.Departures{sections: []} ->
+        by_screen_id(screen_id, "0")
+
+      _ ->
+        current_time = DateTime.utc_now()
+        fetch_departures_response(secondary_departures, current_time)
+    end
   end
 
   defp disabled_response do


### PR DESCRIPTION
**Asana task**: ad hoc

Some of the DUPs in the [Airtable](https://airtable.com/tblsBncVeywAyGHDF/viwEOxVMtv4p0uCP2?blocks=hide) don't have anything for the secondary screen. In these cases, we can just replace screen 2 with another copy of screen 0.