### PR TITLE
fix: Get environment correctly for PSA image paths

### DIFF
--- a/lib/screens/psa.ex
+++ b/lib/screens/psa.ex
@@ -103,6 +103,6 @@ defmodule Screens.Psa do
   defp get_s3_url(filename), do: @s3_base_url <> psa_images_prefix() <> filename
 
   defp psa_images_prefix do
-    Application.get_env(:screens, :environment_name, "screeens-prod") <> "/images/psa/"
+    Application.get_env(:screens, :environment_name, "screens-prod") <> "/images/psa/"
   end
 end


### PR DESCRIPTION
**Asana task**: ad hoc

Previously we were calling `Application.get_env` to set a module attribute (which happens at compile time) and thus not getting the correct env name for PSA image paths.

This gets it correctly now, but we will also need to rename/replace the S3 directories with ones named "screens-dev" etc.