### PR TITLE
Add "special" free-text type to config spec

### DIFF
--- a/lib/screens/config/dup/override/free_text.ex
+++ b/lib/screens/config/dup/override/free_text.ex
@@ -6,10 +6,12 @@ defmodule Screens.Config.Dup.Override.FreeText do
           | %{format: format, text: String.t()}
           | %{route: route_pill}
           | %{color: color, text: String.t()}
+          | %{special: special}
 
   @type format :: :bold
   @type route_pill :: :red | :blue | :orange | :green | :silver
   @type color :: :red | :blue | :orange | :green | :silver | :purple
+  @type special :: :break
 
   def from_json(text) when is_binary(text) do
     text
@@ -36,6 +38,14 @@ defmodule Screens.Config.Dup.Override.FreeText do
 
     def from_json(%{"color" => unquote(color_string), "text" => text}) do
       %{color: unquote(color), text: text}
+    end
+  end
+
+  for special <- ~w[break]a do
+    special_string = Atom.to_string(special)
+
+    def from_json(%{"special" => unquote(special_string)}) do
+      %{special: unquote(special)}
     end
   end
 


### PR DESCRIPTION
**Asana task**: ad hoc

This lets us use line breaks in override alert free-text.
