### PR TITLE
Get API V3 url from its own env var

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -22,8 +22,8 @@ config :screens, ScreensWeb.Endpoint,
   ]
 
 config :screens,
-  default_api_v3_url: System.get_env("API_V3_URL", "https://api-v3.mbta.com/"),
   api_v3_key: System.get_env("API_V3_KEY"),
+  api_v3_url: System.get_env("API_V3_URL", "https://api-v3.mbta.com/"),
   gds_dms_password: System.get_env("GDS_DMS_PASSWORD"),
   mercury_api_key: System.get_env("MERCURY_API_KEY"),
   config_fetcher: Screens.Config.State.LocalFetch,

--- a/lib/screens/v3_api.ex
+++ b/lib/screens/v3_api.ex
@@ -49,18 +49,7 @@ defmodule Screens.V3Api do
   end
 
   defp base_url do
-    :screens
-    |> Application.get_env(:environment_name)
-    |> base_url_for_environment()
-  end
-
-  defp base_url_for_environment(environment_name) do
-    case environment_name do
-      "screens-prod" -> "https://api-v3.mbta.com/"
-      "screens-dev" -> "https://dev.api.mbtace.com/"
-      "screens-dev-green" -> "https://green.dev.api.mbtace.com/"
-      _ -> Application.get_env(:screens, :default_api_v3_url)
-    end
+    Application.get_env(:screens, :api_v3_url)
   end
 
   defp api_key_headers(nil), do: []


### PR DESCRIPTION
**Asana task**: ad hoc

We have a separate env var for the V3 API url now, so we can get it directly from that rather than mapping the environment name value to a url.

- [ ] Needs version bump?
