### PR TITLE
fix: Only display delay alerts for delays of at least 30 minutes

### DIFF
--- a/lib/screens/alerts/alert.ex
+++ b/lib/screens/alerts/alert.ex
@@ -297,6 +297,10 @@ defmodule Screens.Alerts.Alert do
 
   def high_severity(_), do: 0
 
+  def high_severity?(alert) do
+    high_severity(alert) > 0
+  end
+
   # HAPPENING NOW
   # defined as: some active period contains the current time
   defp happening_now(%{active_period: aps}) do

--- a/lib/screens/dup_screen_data/request.ex
+++ b/lib/screens/dup_screen_data/request.ex
@@ -21,9 +21,7 @@ defmodule Screens.DupScreenData.Request do
 
     opts
     |> Alert.fetch()
-    |> Enum.filter(fn a ->
-      Alert.happening_now?(a) and a.effect in @alert_effects
-    end)
+    |> Enum.filter(&relevant?/1)
   end
 
   def fetch_sections_data([_, _] = sections_with_alerts, current_time) do
@@ -116,4 +114,16 @@ defmodule Screens.DupScreenData.Request do
         :error
     end
   end
+
+  defp relevant?(alert) do
+    Alert.happening_now?(alert) and
+      alert.effect in @alert_effects and
+      effect_specific_conditions?(alert)
+  end
+
+  defp effect_specific_conditions?(%Alert{effect: :delay} = alert) do
+    Alert.high_severity?(alert)
+  end
+
+  defp effect_specific_conditions?(_), do: true
 end


### PR DESCRIPTION
**Asana task**: [Fix: Only show Line Suspension View when delays are above some severity threshold](https://app.asana.com/0/1185117109217413/1199566341123906/f)

Alert severity level 7 corresponds to delays of up to 30 minutes.

- [ ] Needs version bump?
