### PR TITLE
chore: use Helvetica before neue haas grotesk on DUPs

### DIFF
--- a/assets/css/dup/departure_route.scss
+++ b/assets/css/dup/departure_route.scss
@@ -9,7 +9,7 @@
   padding-bottom: 32px;
 
   .base-route-pill__route-text {
-    font-family: neue-haas-grotesk-text, sans serif;
+    font-family: Helvetica, neue-haas-grotesk-text, sans serif;
     line-height: 144px;
   }
 }

--- a/assets/css/dup/free_text.scss
+++ b/assets/css/dup/free_text.scss
@@ -32,7 +32,7 @@
 
 .free-text__route-pill {
   display: inline-block;
-  font-family: neue-haas-grotesk-text;
+  font-family: Helvetica, neue-haas-grotesk-text, sans-serif;
   font-weight: 700;
   text-align: center;
 
@@ -63,7 +63,7 @@
 
 .free-text__text-pill {
   display: inline-block;
-  font-family: neue-haas-grotesk-text;
+  font-family: Helvetica, neue-haas-grotesk-text, sans-serif;
   font-weight: 700;
 
   &--green {

--- a/assets/css/dup/header.scss
+++ b/assets/css/dup/header.scss
@@ -24,7 +24,7 @@
 }
 
 .header__time {
-  font-family: neue-haas-grotesk-display, sans-serif;
+  font-family: Helvetica, neue-haas-grotesk-display, sans-serif;
   font-size: 96px;
   position: absolute;
   top: 66px;
@@ -51,7 +51,7 @@
 }
 
 .header__text {
-  font-family: neue-haas-grotesk-display, sans-serif;
+  font-family: Helvetica, neue-haas-grotesk-display, sans-serif;
   font-weight: 700;
   font-size: 144px;
 }

--- a/assets/css/dup/screen_container.scss
+++ b/assets/css/dup/screen_container.scss
@@ -24,7 +24,7 @@
 
 .disabled__time {
   color: #ffffff;
-  font-family: neue-haas-grotesk-display, sans-serif;
+  font-family: Helvetica, neue-haas-grotesk-text, sans-serif;
   font-size: 138px;
   line-height: 138px;
   position: absolute;


### PR DESCRIPTION
**Asana task**: ad hoc

We don't have the ability to include Neue Haas Grotesk except as a web font. We'll bundle Helvetica and Inter with the DUP apps.