### PR TITLE
chore: don't include or use neue haas grotesk on DUPs

### DIFF
--- a/assets/css/dup/departure_route.scss
+++ b/assets/css/dup/departure_route.scss
@@ -9,7 +9,7 @@
   padding-bottom: 32px;
 
   .base-route-pill__route-text {
-    font-family: Helvetica, neue-haas-grotesk-text, sans serif;
+    font-family: Helvetica, sans serif;
     line-height: 144px;
   }
 }

--- a/assets/css/dup/free_text.scss
+++ b/assets/css/dup/free_text.scss
@@ -32,7 +32,7 @@
 
 .free-text__route-pill {
   display: inline-block;
-  font-family: Helvetica, neue-haas-grotesk-text, sans-serif;
+  font-family: Helvetica, sans-serif;
   font-weight: 700;
   text-align: center;
 
@@ -63,7 +63,7 @@
 
 .free-text__text-pill {
   display: inline-block;
-  font-family: Helvetica, neue-haas-grotesk-text, sans-serif;
+  font-family: Helvetica, sans-serif;
   font-weight: 700;
 
   &--green {

--- a/assets/css/dup/header.scss
+++ b/assets/css/dup/header.scss
@@ -24,7 +24,7 @@
 }
 
 .header__time {
-  font-family: Helvetica, neue-haas-grotesk-display, sans-serif;
+  font-family: Helvetica, sans-serif;
   font-size: 96px;
   position: absolute;
   top: 66px;
@@ -51,7 +51,7 @@
 }
 
 .header__text {
-  font-family: Helvetica, neue-haas-grotesk-display, sans-serif;
+  font-family: Helvetica, sans-serif;
   font-weight: 700;
   font-size: 144px;
 }

--- a/assets/css/dup/screen_container.scss
+++ b/assets/css/dup/screen_container.scss
@@ -24,7 +24,7 @@
 
 .disabled__time {
   color: #ffffff;
-  font-family: Helvetica, neue-haas-grotesk-text, sans-serif;
+  font-family: Helvetica, sans-serif;
   font-size: 138px;
   line-height: 138px;
   position: absolute;

--- a/lib/screens_web/templates/layout/app.html.eex
+++ b/lib/screens_web/templates/layout/app.html.eex
@@ -5,7 +5,9 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>Screens</title>
+    <%= if @app_id != :dup do %>
     <link rel="stylesheet" href="https://use.typekit.net/emd6vhv.css">
+    <% end %>
     <link rel="stylesheet" href="<%= Routes.static_path(@conn, "/css/#{@app_id}.css") %>"/>
   </head>
   <body class="<%= @body_class %>">


### PR DESCRIPTION
**Asana task**: ad hoc

On real DUPs, we'll bundle Helvetica and won't have access to Typekit. In Chrome (when debugging), we'll have local copies of Helvetica we can use; showing Neue Haas Grotesk would be misleading, since it can't appear on the real screens.