### PR TITLE
fix: replace station tags without the correct rider-facing names

### DIFF
--- a/assets/src/components/dup/screen_container.tsx
+++ b/assets/src/components/dup/screen_container.tsx
@@ -58,8 +58,15 @@ const LinkArrow = ({ width, color }) => {
   );
 };
 
+// Fix station name tags without rider-facing names
+const REPLACEMENTS = {
+  WTC: "World Trade Center",
+  Malden: "Malden Center",
+};
+
 const NoDataLayout = ({ code }: { code?: string }): JSX.Element => {
-  const stationName = useOutfrontStation() || "Transit information";
+  let stationName = useOutfrontStation() || "Transit information";
+  stationName = REPLACEMENTS[stationName] || stationName;
 
   return (
     <div className={classWithModifier("screen-container", "no-data")}>


### PR DESCRIPTION
**Asana task**: [Make sure that our configured DUP IDs match up with the Outfront Station tags](https://app.asana.com/0/1185117109217413/1199642437884330)

Some station tags have names which aren't how riders would recognize the station (e.g. WTC instead of World Trade Center), so we want to replace them in the no-data state.