### PR TITLE
fix: replace headsigns which cause partial alerts to overflow

### DIFF
--- a/lib/screens/dup_screen_data/response.ex
+++ b/lib/screens/dup_screen_data/response.ex
@@ -9,6 +9,11 @@ defmodule Screens.DupScreenData.Response do
     mattapan: "Mattapan Line"
   }
 
+  @headsign_overrides %{
+    "Boston College" => "Boston Coll",
+    "Cleveland Circle" => "Cleveland Cir"
+  }
+
   def render_headway_lines(pill, {lo, hi}, num_rows) do
     case num_rows do
       2 ->
@@ -53,7 +58,8 @@ defmodule Screens.DupScreenData.Response do
   end
 
   defp partial_alert_specifier(%{headsign: headsign}) do
-    {headsign, "trains"}
+    overridden_headsign = Map.get(@headsign_overrides, headsign, headsign)
+    {overridden_headsign, "trains"}
   end
 
   def pattern(_, :delay, _), do: :hatched


### PR DESCRIPTION
**Asana task**: [Fix "No Boston College Trains", "No Cleveland Circle Trains"](https://app.asana.com/0/1185117109217413/1199715498628938)

Boston College -> Boston Coll
Cleveland Circle -> Cleveland Cir