### PR TITLE
fix: fullscreen alert content for suspension at multi-line stop

### DIFF
--- a/lib/screens/dup_screen_data.ex
+++ b/lib/screens/dup_screen_data.ex
@@ -223,7 +223,7 @@ defmodule Screens.DupScreenData do
       header: header,
       pattern: Response.pattern(alert.region, alert.effect, line_count),
       color: Response.color(alert.pill, alert.effect, line_count, 1),
-      issue: Response.alert_issue(alert),
+      issue: Response.alert_issue(alert, line_count),
       remedy: Response.alert_remedy(alert)
     }
   end
@@ -236,7 +236,7 @@ defmodule Screens.DupScreenData do
       header: header,
       pattern: :x,
       color: :yellow,
-      issue: Response.alert_issue(alert),
+      issue: Response.alert_issue(alert, 2),
       remedy: Response.alert_remedy(alert)
     }
   end

--- a/lib/screens/dup_screen_data/response.ex
+++ b/lib/screens/dup_screen_data/response.ex
@@ -114,25 +114,27 @@ defmodule Screens.DupScreenData.Response do
     ""
   end
 
-  def alert_issue(%{effect: :delay, cause: cause}) do
+  def alert_issue(alert, line_count)
+
+  def alert_issue(%{effect: :delay, cause: cause}, _) do
     %{
       icon: :warning,
       text: [%{format: :bold, text: "SERVICE DISRUPTION"}, render_alert_cause(cause)]
     }
   end
 
-  def alert_issue(%{effect: :suspension, region: :inside, pill: pill}) do
+  def alert_issue(%{region: :inside, cause: cause}, 1) do
+    %{icon: :x, text: [%{format: :bold, text: "STATION CLOSED"}, render_alert_cause(cause)]}
+  end
+
+  def alert_issue(%{region: :inside, pill: pill}, 2) do
     %{
       icon: :warning,
       text: [%{format: :bold, text: "No #{@pill_to_specifier[pill]}"}, "service"]
     }
   end
 
-  def alert_issue(%{region: :inside, cause: cause}) do
-    %{icon: :x, text: [%{format: :bold, text: "STATION CLOSED"}, render_alert_cause(cause)]}
-  end
-
-  def alert_issue(%{region: :boundary, pill: pill, headsign: headsign}) do
+  def alert_issue(%{region: :boundary, pill: pill, headsign: headsign}, 1) do
     %{
       icon: :warning,
       text: [


### PR DESCRIPTION
**Asana task**: [Haymarket w/ no GL should say "no green line service" not "station closed" (and similar)](https://app.asana.com/0/1185117109217413/1199713421250177/f)

![image](https://user-images.githubusercontent.com/63608771/106511797-bd642780-649e-11eb-801a-e98b1c3f6c70.png)

(Also add function heads for `pattern` and `color` to document their params)