### PR TITLE
Fix wording for "westbound" headsign in alert content

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -76,7 +76,7 @@ config :screens,
       {~w[70149 70211], ~w[70153 70187], "BC/Clev. Circ."},
       {~w[70149 70187], ~w[70153 70211], "BC/Riverside"},
       {~w[70211 70187], ~w[70153 70149], "Clev. Circ./Riverside"},
-      {~w[70149 70211 70187], "70153", "Westbound"},
+      {~w[70149 70211 70187], "70153", {:adj, "westbound"}},
       {"70152", ~w[70148 70212 70186], "Park Street"}
     ],
     # Prudential

--- a/lib/screens/dup_screen_data/response.ex
+++ b/lib/screens/dup_screen_data/response.ex
@@ -52,6 +52,10 @@ defmodule Screens.DupScreenData.Response do
     end
   end
 
+  defp partial_alert_specifier(%{headsign: {:adj, headsign}}) do
+    {headsign, "trains"}
+  end
+
   defp partial_alert_specifier(%{headsign: headsign}) do
     {headsign, "trains"}
   end
@@ -128,7 +132,7 @@ defmodule Screens.DupScreenData.Response do
       icon: :warning,
       text: [
         %{format: :bold, text: "No #{@pill_to_specifier[pill]}"},
-        "service to #{headsign}"
+        service_to_headsign(headsign)
       ]
     }
   end
@@ -165,6 +169,9 @@ defmodule Screens.DupScreenData.Response do
       unquote(icon)
     end
   end
+
+  defp service_to_headsign({:adj, headsign}), do: "#{headsign} service"
+  defp service_to_headsign(headsign), do: "service to #{headsign}"
 
   defp line_color(:mattapan), do: :red
   defp line_color(pill), do: pill


### PR DESCRIPTION
**Asana task**: [Fix destinations ("to westbound")](https://app.asana.com/0/1185117109217413/1199713421250175/f)

(Should this say "No westbound Green Line service" or is this wording ok?)

![image](https://user-images.githubusercontent.com/63608771/106516303-d8d23100-64a4-11eb-88bf-a62cf46aef56.png)