### PR TITLE
fix: use DateTime.compare in Alert.in_active_period

### DIFF
--- a/lib/screens/alerts/alert.ex
+++ b/lib/screens/alerts/alert.ex
@@ -316,15 +316,15 @@ defmodule Screens.Alerts.Alert do
   end
 
   def in_active_period({nil, end_t}, t) do
-    t <= end_t
+    DateTime.compare(t, end_t) in [:lt, :eq]
   end
 
   def in_active_period({start_t, nil}, t) do
-    t >= start_t
+    DateTime.compare(t, start_t) in [:gt, :eq]
   end
 
   def in_active_period({start_t, end_t}, t) do
-    t >= start_t && t <= end_t
+    DateTime.compare(t, start_t) in [:gt, :eq] && DateTime.compare(t, end_t) in [:lt, :eq]
   end
 
   def within_two_weeks(time_1, time_2) do


### PR DESCRIPTION
**Asana task**: ad hoc

This is causing the alert version of the screen to appear early. Comparing `DateTime` values with `<=` and `>=` isn't semantically meaningful; in particular, 8pm is `>=` 8:45pm, which is why the alert treatment started too early at Kenmore.