### PR TITLE
feat: Minimal alert instance

### DIFF
--- a/lib/screens/v2/widget_instance/alert.ex
+++ b/lib/screens/v2/widget_instance/alert.ex
@@ -27,17 +27,12 @@ defmodule Screens.V2.WidgetInstance.Alert do
                      stop_closure: 0,
                      stop_moved: 0
 
-  def priority(
-        %T{} = t,
-        active_priority_fn \\ &active_priority/1,
-        informed_entity_priority_fn \\ &informed_entity_priority/1,
-        effect_priority_fn \\ &effect_priority/1
-      ) do
+  def priority(%T{} = t, alert_active? \\ &Alert.happening_now?/1) do
     [
       @base_alert_priority,
-      active_priority_fn.(t),
-      informed_entity_priority_fn.(t),
-      effect_priority_fn.(t)
+      active_priority(t, alert_active?),
+      informed_entity_priority(t),
+      effect_priority(t)
     ]
   end
 
@@ -53,24 +48,24 @@ defmodule Screens.V2.WidgetInstance.Alert do
 
   def slot_names(%T{}), do: ~w[medium_left medium_right]a
 
-  def active_priority(%T{alert: alert}, alert_active? \\ &Alert.happening_now?/1) do
+  defp active_priority(%T{alert: alert}, alert_active?) do
     if alert_active?.(alert), do: 0, else: 1
   end
 
-  def informed_entity_priority(%T{
-        screen: :ok,
-        alert: %Alert{informed_entities: _informed_entities}
-      }) do
+  defp informed_entity_priority(%T{
+         screen: :ok,
+         alert: %Alert{informed_entities: _informed_entities}
+       }) do
     0
   end
 
   for {effect, priority} <- @effect_priorities do
-    def effect_priority(%T{alert: %Alert{effect: unquote(effect)}}) do
+    defp effect_priority(%T{alert: %Alert{effect: unquote(effect)}}) do
       unquote(priority)
     end
   end
 
-  def effect_priority(_), do: 100
+  defp effect_priority(_), do: 100
 
   defp serialize_text(%T{alert: _alert}) do
     ["Dummy alert text"]
@@ -81,16 +76,8 @@ defmodule Screens.V2.WidgetInstance.Alert do
   end
 
   defimpl Screens.V2.WidgetInstance do
-    def priority(%T{} = t) do
-      T.priority(t)
-    end
-
-    def serialize(%T{} = t) do
-      T.serialize(t)
-    end
-
-    def slot_names(%T{} = t) do
-      T.slot_names(t)
-    end
+    def priority(t), do: T.priority(t)
+    def serialize(t), do: T.serialize(t)
+    def slot_names(t), do: T.slot_names(t)
   end
 end


### PR DESCRIPTION
**Asana task**: [Minimal alert instance implementation](https://app.asana.com/0/1185117109217413/1199912001957327/f)

Minimal alert instance, with tests. Since we don't have a screen config yet, things like priority based on the screen's location relative to an alert's informed entities are stubbed out for now.