### PR TITLE
fix: Alerts.Parser.parse_result expects {:ok, result} or :error

### DIFF
--- a/lib/screens/alerts/parser.ex
+++ b/lib/screens/alerts/parser.ex
@@ -8,7 +8,7 @@ defmodule Screens.Alerts.Parser do
     |> Enum.reject(&is_nil/1)
   end
 
-  def parse_result(:error) do
+  def parse_result(_) do
     []
   end
 


### PR DESCRIPTION
**Asana task**: [Prevent Screens/Warnings errors from occurring](https://app.asana.com/0/1185117109217413/1199961093406630)

The error was caused by failing to parse unsuccessful API requests. `Screens.Alerts.Parser.parse_result` only has cases for `{:ok, result}` and `:error`, so passing through specific v3 API error causes didn't match.