### PR TITLE
feat: temporarily log user agent for DUP API requests

### DIFF
--- a/lib/screens_web/controllers/screen_api_controller.ex
+++ b/lib/screens_web/controllers/screen_api_controller.ex
@@ -40,9 +40,21 @@ defmodule ScreensWeb.ScreenApiController do
     is_screen = ScreensWeb.UserAgent.is_screen_conn?(conn)
 
     _ = Screens.LogScreenData.log_data_request(screen_id, nil, is_screen)
+    _ = log_user_agent(conn)
 
     data = Screens.DupScreenData.by_screen_id(screen_id, rotation_index)
 
     json(conn, data)
+  end
+
+  defp log_user_agent(conn) do
+    user_agent =
+      conn.req_headers
+      |> Enum.into(%{})
+      |> Map.get("user-agent")
+
+    if !is_nil(user_agent) do
+      Logger.info("[dup user agent] #{user_agent}")
+    end
   end
 end


### PR DESCRIPTION
**Asana task**: [Log DUP screen requests](https://app.asana.com/0/1185117109217413/1199947129013698)

This change will log all user agents for DUP requests. Once we know what the real DUP user agents are, we can update `ScreensWeb.UserAgent.is_screen?` to detect DUPs.