### PR TITLE
feat: basic NormalHeader and NormalFooter widget instances

### DIFF
--- a/lib/screens/v2/widget_instance/normal_footer.ex
+++ b/lib/screens/v2/widget_instance/normal_footer.ex
@@ -1,0 +1,24 @@
+defmodule Screens.V2.WidgetInstance.NormalFooter do
+  @moduledoc false
+
+  alias Screens.V2.WidgetInstance.NormalFooter
+
+  defstruct screen: nil,
+            url: nil
+
+  @type config :: :ok
+  @type t :: %__MODULE__{
+          screen: config(),
+          url: String.t()
+        }
+
+  defimpl Screens.V2.WidgetInstance do
+    def priority(_instance), do: [2]
+
+    def serialize(%NormalFooter{url: url}) do
+      %{url: url}
+    end
+
+    def slot_names(_instance), do: [:footer]
+  end
+end

--- a/lib/screens/v2/widget_instance/normal_header.ex
+++ b/lib/screens/v2/widget_instance/normal_header.ex
@@ -1,0 +1,26 @@
+defmodule Screens.V2.WidgetInstance.NormalHeader do
+  @moduledoc false
+
+  alias Screens.V2.WidgetInstance.NormalHeader
+
+  defstruct screen: nil,
+            station_name: nil,
+            time: nil
+
+  @type config :: :ok
+  @type t :: %__MODULE__{
+          screen: config(),
+          station_name: String.t(),
+          time: DateTime.t()
+        }
+
+  defimpl Screens.V2.WidgetInstance do
+    def priority(_instance), do: [2]
+
+    def serialize(%NormalHeader{station_name: station_name, time: time}) do
+      %{station_name: station_name, time: DateTime.to_iso8601(time)}
+    end
+
+    def slot_names(_instance), do: [:header]
+  end
+end

--- a/test/screens/v2/widget_instance/departures_test.exs
+++ b/test/screens/v2/widget_instance/departures_test.exs
@@ -6,7 +6,7 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
   alias Screens.Trips.Trip
   alias Screens.V2.WidgetInstance
 
-  setup_all do
+  setup do
     trip_headsign = "Ruggles"
     trip = %Trip{headsign: trip_headsign}
 

--- a/test/screens/v2/widget_instance/normal_footer_test.exs
+++ b/test/screens/v2/widget_instance/normal_footer_test.exs
@@ -1,0 +1,33 @@
+defmodule Screens.V2.WidgetInstance.NormalFooterTest do
+  use ExUnit.Case, async: true
+
+  alias Screens.V2.WidgetInstance
+
+  setup do
+    %{
+      instance: %WidgetInstance.NormalFooter{
+        url: "mbta.com/stops/1722"
+      }
+    }
+  end
+
+  describe "priority/1" do
+    test "returns 2", %{instance: instance} do
+      assert [2] == WidgetInstance.priority(instance)
+    end
+  end
+
+  describe "serialize/1" do
+    test "returns serialized url", %{instance: instance} do
+      assert %{
+               url: "mbta.com/stops/1722"
+             } == WidgetInstance.serialize(instance)
+    end
+  end
+
+  describe "slot_names/1" do
+    test "returns footer", %{instance: instance} do
+      assert [:footer] == WidgetInstance.slot_names(instance)
+    end
+  end
+end

--- a/test/screens/v2/widget_instance/normal_header_test.exs
+++ b/test/screens/v2/widget_instance/normal_header_test.exs
@@ -1,0 +1,35 @@
+defmodule Screens.V2.WidgetInstance.NormalHeaderTest do
+  use ExUnit.Case, async: true
+
+  alias Screens.V2.WidgetInstance
+
+  setup do
+    %{
+      instance: %WidgetInstance.NormalHeader{
+        station_name: "Ruggles",
+        time: ~U[2021-03-04 11:00:00Z]
+      }
+    }
+  end
+
+  describe "priority/1" do
+    test "returns 2", %{instance: instance} do
+      assert [2] == WidgetInstance.priority(instance)
+    end
+  end
+
+  describe "serialize/1" do
+    test "returns serialized name and time", %{instance: instance} do
+      assert %{
+               station_name: "Ruggles",
+               time: "2021-03-04T11:00:00Z"
+             } == WidgetInstance.serialize(instance)
+    end
+  end
+
+  describe "slot_names/1" do
+    test "returns header", %{instance: instance} do
+      assert [:header] == WidgetInstance.slot_names(instance)
+    end
+  end
+end

--- a/test/screens/v2/widget_instance/static_image_test.exs
+++ b/test/screens/v2/widget_instance/static_image_test.exs
@@ -3,7 +3,7 @@ defmodule Screens.V2.WidgetInstance.StaticImageTest do
   alias Screens.V2.WidgetInstance
   alias Screens.V2.WidgetInstance.StaticImage
 
-  setup_all do
+  setup do
     priority = [2]
 
     image_url =


### PR DESCRIPTION
**Asana task**: ad hoc

When looking over the Asana tasks for the front-end, I noticed that we never filed a task to create the corresponding Widget instances for `NormalHeader` and `NormalFooter` on the backend. We'll need to return these from the candidate generator's `candidate_instances`.