### PR TITLE
fix: widget instance serialize function should include type

### DIFF
--- a/lib/screens/v2/widget_instance.ex
+++ b/lib/screens/v2/widget_instance.ex
@@ -1,6 +1,7 @@
 defprotocol Screens.V2.WidgetInstance do
   @type priority :: list(integer)
   @type slot_id :: atom()
+  @type widget_type :: atom()
 
   @spec priority(t) :: priority()
   def priority(instance)
@@ -10,4 +11,7 @@ defprotocol Screens.V2.WidgetInstance do
 
   @spec slot_names(t) :: list(slot_id)
   def slot_names(instance)
+
+  @spec widget_type(t) :: widget_type()
+  def widget_type(instance)
 end

--- a/lib/screens/v2/widget_instance/alert.ex
+++ b/lib/screens/v2/widget_instance/alert.ex
@@ -38,7 +38,6 @@ defmodule Screens.V2.WidgetInstance.Alert do
 
   def serialize(%T{} = t, alert_active? \\ &Alert.happening_now?/1) do
     %{
-      type: :alert,
       pill: :bus,
       icon: :warning,
       active_status: if(alert_active?.(t.alert), do: :active, else: :upcoming),
@@ -48,6 +47,8 @@ defmodule Screens.V2.WidgetInstance.Alert do
   end
 
   def slot_names(%T{}), do: ~w[medium_left medium_right]a
+
+  def widget_type(%T{}), do: :alert
 
   defp active_priority(%T{alert: alert}, alert_active?) do
     if alert_active?.(alert), do: 0, else: 1
@@ -80,5 +81,6 @@ defmodule Screens.V2.WidgetInstance.Alert do
     def priority(t), do: T.priority(t)
     def serialize(t), do: T.serialize(t)
     def slot_names(t), do: T.slot_names(t)
+    def widget_type(t), do: T.widget_type(t)
   end
 end

--- a/lib/screens/v2/widget_instance/departures.ex
+++ b/lib/screens/v2/widget_instance/departures.ex
@@ -22,7 +22,7 @@ defmodule Screens.V2.WidgetInstance.Departures do
         |> Enum.sort_by(& &1.departure_time)
         |> Enum.map(&serialize_prediction/1)
 
-      %{type: :departures, departures: departures}
+      %{departures: departures}
     end
 
     defp serialize_prediction(%Prediction{
@@ -34,5 +34,7 @@ defmodule Screens.V2.WidgetInstance.Departures do
     end
 
     def slot_names(_instance), do: [:main_content]
+
+    def widget_type(_instance), do: :departures
   end
 end

--- a/lib/screens/v2/widget_instance/departures_no_data.ex
+++ b/lib/screens/v2/widget_instance/departures_no_data.ex
@@ -11,7 +11,8 @@ defmodule Screens.V2.WidgetInstance.DeparturesNoData do
 
   defimpl Screens.V2.WidgetInstance do
     def priority(_instance), do: [2]
-    def serialize(_instance), do: %{type: :departures_no_data}
+    def serialize(_instance), do: %{}
     def slot_names(_instance), do: [:main_content]
+    def widget_type(_instance), do: :departures_no_data
   end
 end

--- a/lib/screens/v2/widget_instance/static_image.ex
+++ b/lib/screens/v2/widget_instance/static_image.ex
@@ -20,7 +20,7 @@ defmodule Screens.V2.WidgetInstance.StaticImage do
 
   defimpl Screens.V2.WidgetInstance do
     def priority(%StaticImage{priority: priority}), do: priority
-    def serialize(%StaticImage{image_url: image_url}), do: %{type: :static_image, url: image_url}
+    def serialize(%StaticImage{image_url: image_url}), do: %{url: image_url}
 
     def slot_names(%StaticImage{screen: _screen, size: size}) do
       case size do
@@ -30,5 +30,7 @@ defmodule Screens.V2.WidgetInstance.StaticImage do
         :small -> [:small_upper_right, :small_lower_right]
       end
     end
+
+    def widget_type(_instance), do: :static_image
   end
 end

--- a/test/screens/v2/widget_instance/alert_test.exs
+++ b/test/screens/v2/widget_instance/alert_test.exs
@@ -56,7 +56,6 @@ defmodule Screens.V2.WidgetInstance.AlertTest do
       alert_active? = fn _ -> true end
 
       expected = %{
-        type: :alert,
         pill: :bus,
         icon: :warning,
         active_status: :active,
@@ -73,6 +72,14 @@ defmodule Screens.V2.WidgetInstance.AlertTest do
       widget = alert_widget_with_effect(:delay)
 
       assert ~w[medium_left medium_right]a == AlertWidget.slot_names(widget)
+    end
+  end
+
+  describe "widget_type/1" do
+    test "returns alert widget type" do
+      widget = alert_widget_with_effect(:delay)
+
+      assert :alert == AlertWidget.widget_type(widget)
     end
   end
 

--- a/test/screens/v2/widget_instance/departures_no_data_test.exs
+++ b/test/screens/v2/widget_instance/departures_no_data_test.exs
@@ -12,13 +12,19 @@ defmodule Screens.V2.WidgetInstance.DeparturesNoDataTest do
 
   describe "serialize/1" do
     test "returns empty map" do
-      assert %{type: :departures_no_data} == WidgetInstance.serialize(@instance)
+      assert %{} == WidgetInstance.serialize(@instance)
     end
   end
 
   describe "slot_names/1" do
     test "returns main_content" do
       assert [:main_content] == WidgetInstance.slot_names(@instance)
+    end
+  end
+
+  describe "widget_type/1" do
+    test "returns departures no data" do
+      assert :departures_no_data == WidgetInstance.widget_type(@instance)
     end
   end
 end

--- a/test/screens/v2/widget_instance/departures_test.exs
+++ b/test/screens/v2/widget_instance/departures_test.exs
@@ -40,7 +40,6 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
       departure_time: departure_time
     } do
       assert %{
-               type: :departures,
                departures: [
                  %{destination: trip_headsign, route: route_name, time: departure_time}
                ]
@@ -51,6 +50,12 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
   describe "slot_names/1" do
     test "returns main_content", %{instance: instance} do
       assert [:main_content] == WidgetInstance.slot_names(instance)
+    end
+  end
+
+  describe "widget_type/1" do
+    test "returns departures", %{instance: instance} do
+      assert :departures == WidgetInstance.widget_type(instance)
     end
   end
 end

--- a/test/screens/v2/widget_instance/static_image_test.exs
+++ b/test/screens/v2/widget_instance/static_image_test.exs
@@ -22,7 +22,6 @@ defmodule Screens.V2.WidgetInstance.StaticImageTest do
   describe "serialize/1" do
     test "returns instance url", %{instance: instance} do
       assert %{
-               type: :static_image,
                url:
                  "https://mbta-screens.s3.amazonaws.com/screens-prod/images/psa/e-ink-face-covering-psa.png"
              } == WidgetInstance.serialize(instance)
@@ -52,6 +51,12 @@ defmodule Screens.V2.WidgetInstance.StaticImageTest do
 
       assert MapSet.new([:small_upper_right, :small_lower_right]) ==
                MapSet.new(WidgetInstance.slot_names(instance))
+    end
+  end
+
+  describe "widget_type/1" do
+    test "returns static image", %{instance: instance} do
+      assert :static_image == WidgetInstance.widget_type(instance)
     end
   end
 end


### PR DESCRIPTION
**Asana task**: ad hoc

We want the new API to include type alongside the rest of the serialized data; this will tell the front-end which component to use. The natural place to provide these types is in `WidgetInstance.serialize`.