### PR TITLE
chore: update is_screen to recognize DUP user agent

### DIFF
--- a/lib/screens_web/controllers/screen_api_controller.ex
+++ b/lib/screens_web/controllers/screen_api_controller.ex
@@ -40,21 +40,9 @@ defmodule ScreensWeb.ScreenApiController do
     is_screen = ScreensWeb.UserAgent.is_screen_conn?(conn)
 
     _ = Screens.LogScreenData.log_data_request(screen_id, nil, is_screen)
-    _ = log_user_agent(conn)
 
     data = Screens.DupScreenData.by_screen_id(screen_id, rotation_index)
 
     json(conn, data)
-  end
-
-  defp log_user_agent(conn) do
-    user_agent =
-      conn.req_headers
-      |> Enum.into(%{})
-      |> Map.get("user-agent")
-
-    if !is_nil(user_agent) do
-      Logger.info("[dup user agent] #{user_agent}")
-    end
   end
 end

--- a/lib/screens_web/user_agent.ex
+++ b/lib/screens_web/user_agent.ex
@@ -11,7 +11,8 @@ defmodule ScreensWeb.UserAgent do
   def is_screen?(nil), do: false
 
   def is_screen?(user_agent) do
-    is_mercury?(user_agent) or is_gds?(user_agent) or is_solari?(user_agent)
+    is_mercury?(user_agent) or is_gds?(user_agent) or is_solari?(user_agent) or
+      is_dup?(user_agent)
   end
 
   defp is_mercury?(user_agent) do
@@ -34,5 +35,9 @@ defmodule ScreensWeb.UserAgent do
   defp is_solari_browser?(user_agent) do
     String.contains?(user_agent, "(X11; Ubuntu; Linux i686; rv:22.0)") and
       String.contains?(user_agent, "Firefox/22.0")
+  end
+
+  defp is_dup?(user_agent) do
+    user_agent == "okhttp/3.8.0"
   end
 end


### PR DESCRIPTION
**Asana task**: [Log DUP screen requests](https://app.asana.com/0/1185117109217413/1199947129013698)

Follow-up to #714. Removes the logging of the DUP user agent, and instead updates `ScreensWeb.UserAgent.is_screen?` to recognize DUP user agents. The logging from #714 found that the DUPs have user agent `"okhttp/3.8.0"`.