### PR TITLE
fix: define widget_type/1 for NormalHeader and NormalFooter

### DIFF
--- a/lib/screens/v2/widget_instance/normal_footer.ex
+++ b/lib/screens/v2/widget_instance/normal_footer.ex
@@ -20,5 +20,7 @@ defmodule Screens.V2.WidgetInstance.NormalFooter do
     end
 
     def slot_names(_instance), do: [:footer]
+
+    def widget_type(_instance), do: :normal_footer
   end
 end

--- a/lib/screens/v2/widget_instance/normal_header.ex
+++ b/lib/screens/v2/widget_instance/normal_header.ex
@@ -22,5 +22,7 @@ defmodule Screens.V2.WidgetInstance.NormalHeader do
     end
 
     def slot_names(_instance), do: [:header]
+
+    def widget_type(_instance), do: :normal_header
   end
 end

--- a/test/screens/v2/widget_instance/normal_footer_test.exs
+++ b/test/screens/v2/widget_instance/normal_footer_test.exs
@@ -30,4 +30,10 @@ defmodule Screens.V2.WidgetInstance.NormalFooterTest do
       assert [:footer] == WidgetInstance.slot_names(instance)
     end
   end
+
+  describe "widget_type/1" do
+    test "returns normal_footer", %{instance: instance} do
+      assert :normal_footer == WidgetInstance.widget_type(instance)
+    end
+  end
 end

--- a/test/screens/v2/widget_instance/normal_header_test.exs
+++ b/test/screens/v2/widget_instance/normal_header_test.exs
@@ -32,4 +32,10 @@ defmodule Screens.V2.WidgetInstance.NormalHeaderTest do
       assert [:header] == WidgetInstance.slot_names(instance)
     end
   end
+
+  describe "widget_type/1" do
+    test "returns normal_header", %{instance: instance} do
+      assert :normal_header == WidgetInstance.widget_type(instance)
+    end
+  end
 end


### PR DESCRIPTION
**Asana task**: ad hoc

Doing a quick merge since this is causing failures on master. `widget_type/1` wasn't defined in `NormalHeader` and `NormalFooter` in #716 but was required by #717.