### PR TITLE
fix: small widget backend fixes

### DIFF
--- a/lib/screens/v2/candidate_generator.ex
+++ b/lib/screens/v2/candidate_generator.ex
@@ -3,7 +3,7 @@ defmodule Screens.V2.CandidateGenerator do
 
   alias Screens.V2.ScreenData
 
-  @callback candidate_template() :: Screens.V2.Template.template()
+  @callback screen_template() :: Screens.V2.Template.template()
 
   @callback candidate_instances(ScreenData.config()) :: ScreenData.candidate_instances()
 end

--- a/lib/screens/v2/candidate_generator.ex
+++ b/lib/screens/v2/candidate_generator.ex
@@ -3,7 +3,7 @@ defmodule Screens.V2.CandidateGenerator do
 
   alias Screens.V2.ScreenData
 
-  @callback candidate_templates() :: Screens.V2.Template.template()
+  @callback candidate_template() :: Screens.V2.Template.template()
 
   @callback candidate_instances(ScreenData.config()) :: ScreenData.candidate_instances()
 end

--- a/lib/screens/v2/candidate_generator/bus_shelter.ex
+++ b/lib/screens/v2/candidate_generator/bus_shelter.ex
@@ -5,19 +5,41 @@ defmodule Screens.V2.CandidateGenerator.BusShelter do
   alias Screens.Predictions.Prediction
   alias Screens.V2.CandidateGenerator
   alias Screens.V2.WidgetInstance.Alert, as: AlertWidget
-  alias Screens.V2.WidgetInstance.{Departures, DeparturesNoData, StaticImage}
+
+  alias Screens.V2.WidgetInstance.{
+    Departures,
+    DeparturesNoData,
+    NormalFooter,
+    NormalHeader,
+    StaticImage
+  }
 
   @behaviour CandidateGenerator
 
   # Using Columbus Ave @ Walnut Ave until we have real config
   @dummy_stop_id "1743"
+  @dummy_station_name "Columbus Ave @ Walnut Ave"
 
   @dummy_psa_priority [5]
   @dummy_psa_size :small
 
   @impl CandidateGenerator
-  def candidate_templates do
-    :ok
+  def candidate_template do
+    {:screen,
+     %{
+       normal: [
+         :header,
+         :main_content,
+         {:flex_zone,
+          %{
+            one_large: [:large],
+            one_medium_two_small: [:medium_left, :small_upper_right, :small_lower_right],
+            two_medium: [:medium_left, :medium_right]
+          }},
+         :footer
+       ],
+       takeover: [:fullscreen]
+     }}
   end
 
   @impl CandidateGenerator
@@ -41,7 +63,10 @@ defmodule Screens.V2.CandidateGenerator.BusShelter do
       |> fetch_psas()
       |> generate_static_image_widgets(config)
 
-    [departures_widget] ++ alert_widgets ++ psa_widgets
+    header_widget = %NormalHeader{station_name: @dummy_station_name, time: DateTime.utc_now()}
+    footer_widget = %NormalFooter{url: "mbta.com/stops/#{@dummy_stop_id}"}
+
+    [departures_widget] ++ alert_widgets ++ psa_widgets ++ [header_widget] ++ [footer_widget]
   end
 
   defp fetch_predictions(stop_id, prediction_fetcher) do

--- a/lib/screens/v2/candidate_generator/bus_shelter.ex
+++ b/lib/screens/v2/candidate_generator/bus_shelter.ex
@@ -24,7 +24,7 @@ defmodule Screens.V2.CandidateGenerator.BusShelter do
   @dummy_psa_size :small
 
   @impl CandidateGenerator
-  def candidate_template do
+  def screen_template do
     {:screen,
      %{
        normal: [

--- a/lib/screens/v2/screen_data.ex
+++ b/lib/screens/v2/screen_data.ex
@@ -17,10 +17,10 @@ defmodule Screens.V2.ScreenData do
   def by_screen_id(screen_id) do
     config = get_config(screen_id)
     candidate_generator = get_candidate_generator(config)
-    candidate_template = candidate_generator.candidate_template()
+    screen_template = candidate_generator.screen_template()
     candidate_instances = candidate_generator.candidate_instances(config)
 
-    candidate_template
+    screen_template
     |> pick_instances(candidate_instances)
     |> serialize()
   end
@@ -37,13 +37,13 @@ defmodule Screens.V2.ScreenData do
 
   @spec pick_instances(Template.template(), candidate_instances()) ::
           {Template.layout(), selected_instances_map()}
-  def pick_instances(candidate_template, candidate_instances) do
+  def pick_instances(screen_template, candidate_instances) do
     prioritized_instances = Enum.sort_by(candidate_instances, &WidgetInstance.priority/1)
 
     # N.B. Each template can place each instance it contains in a different place, so we need to
     # store a mapping from slot_id to instance for each template.
     candidate_placements =
-      candidate_template
+      screen_template
       |> Template.slot_combinations()
       |> Enum.map(fn t -> {t, %{}} end)
       |> Enum.into(%{})

--- a/lib/screens/v2/screen_data.ex
+++ b/lib/screens/v2/screen_data.ex
@@ -9,21 +9,18 @@ defmodule Screens.V2.ScreenData do
   @type screen_id :: String.t()
   @type config :: :ok
   @type candidate_generator :: module()
-  @type candidate_templates :: :ok
   @type candidate_instances :: list(WidgetInstance.t())
-  @type selected_template :: :ok
-  @type selected_widgets :: :ok
-  @type selected :: {selected_template, selected_widgets}
+  @type selected_instances_map :: %{atom() => WidgetInstance.t()}
   @type serializable_map :: %{type: atom()}
 
   @spec by_screen_id(screen_id()) :: serializable_map()
   def by_screen_id(screen_id) do
     config = get_config(screen_id)
     candidate_generator = get_candidate_generator(config)
-    candidate_templates = candidate_generator.candidate_templates()
+    candidate_template = candidate_generator.candidate_template()
     candidate_instances = candidate_generator.candidate_instances(config)
 
-    candidate_templates
+    candidate_template
     |> pick_instances(candidate_instances)
     |> serialize()
   end
@@ -39,14 +36,15 @@ defmodule Screens.V2.ScreenData do
   end
 
   @spec pick_instances(Template.template(), candidate_instances()) ::
-          {Template.layout(), %{atom() => WidgetInstance.t()}}
-  def pick_instances(candidate_templates, candidate_instances) do
+          {Template.layout(), selected_instances_map()}
+  def pick_instances(candidate_template, candidate_instances) do
     prioritized_instances = Enum.sort_by(candidate_instances, &WidgetInstance.priority/1)
 
     # N.B. Each template can place each instance it contains in a different place, so we need to
     # store a mapping from slot_id to instance for each template.
     candidate_placements =
-      candidate_templates
+      candidate_template
+      |> Template.slot_combinations()
       |> Enum.map(fn t -> {t, %{}} end)
       |> Enum.into(%{})
 
@@ -125,7 +123,7 @@ defmodule Screens.V2.ScreenData do
     length(matching_slots) > 0
   end
 
-  @spec serialize({Template.layout(), %{atom() => WidgetInstance.t()}}) :: map()
+  @spec serialize({Template.layout(), selected_instances_map()}) :: serializable_map()
   def serialize({layout, instance_map}) do
     serialized_instance_map =
       instance_map

--- a/test/screens/v2/candidate_generator/bus_shelter_test.exs
+++ b/test/screens/v2/candidate_generator/bus_shelter_test.exs
@@ -5,11 +5,32 @@ defmodule Screens.V2.CandidateGenerator.BusShelterTest do
   alias Screens.Predictions.Prediction
   alias Screens.V2.CandidateGenerator.BusShelter
   alias Screens.V2.WidgetInstance.Alert, as: AlertWidget
-  alias Screens.V2.WidgetInstance.{Departures, DeparturesNoData, StaticImage}
 
-  describe "candidate_templates/0" do
-    test "returns ok" do
-      assert :ok == BusShelter.candidate_templates()
+  alias Screens.V2.WidgetInstance.{
+    Departures,
+    DeparturesNoData,
+    NormalFooter,
+    NormalHeader,
+    StaticImage
+  }
+
+  describe "candidate_template/0" do
+    test "returns template" do
+      assert {:screen,
+              %{
+                normal: [
+                  :header,
+                  :main_content,
+                  {:flex_zone,
+                   %{
+                     one_large: [:large],
+                     one_medium_two_small: [:medium_left, :small_upper_right, :small_lower_right],
+                     two_medium: [:medium_left, :medium_right]
+                   }},
+                  :footer
+                ],
+                takeover: [:fullscreen]
+              }} == BusShelter.candidate_template()
     end
   end
 
@@ -18,16 +39,30 @@ defmodule Screens.V2.CandidateGenerator.BusShelterTest do
       prediction_fetcher = fn _params -> {:ok, List.duplicate(%Prediction{}, 3)} end
       alert_fetcher = fn _params -> List.duplicate(%Alert{}, 2) end
 
-      assert [%Departures{}, %AlertWidget{}, %AlertWidget{}, %StaticImage{}, %StaticImage{}] =
-               BusShelter.candidate_instances(:ok, prediction_fetcher, alert_fetcher)
+      assert [
+               %Departures{},
+               %AlertWidget{},
+               %AlertWidget{},
+               %StaticImage{},
+               %StaticImage{},
+               %NormalHeader{},
+               %NormalFooter{}
+             ] = BusShelter.candidate_instances(:ok, prediction_fetcher, alert_fetcher)
     end
 
     test "returns a DeparturesNoData widget if prediction fetcher returns :error" do
       prediction_fetcher = fn _params -> :error end
       alert_fetcher = fn _params -> List.duplicate(%Alert{}, 2) end
 
-      assert [%DeparturesNoData{}, %AlertWidget{}, %AlertWidget{}, %StaticImage{}, %StaticImage{}] =
-               BusShelter.candidate_instances(:ok, prediction_fetcher, alert_fetcher)
+      assert [
+               %DeparturesNoData{},
+               %AlertWidget{},
+               %AlertWidget{},
+               %StaticImage{},
+               %StaticImage{},
+               %NormalHeader{},
+               %NormalFooter{}
+             ] = BusShelter.candidate_instances(:ok, prediction_fetcher, alert_fetcher)
     end
   end
 end

--- a/test/screens/v2/candidate_generator/bus_shelter_test.exs
+++ b/test/screens/v2/candidate_generator/bus_shelter_test.exs
@@ -14,7 +14,7 @@ defmodule Screens.V2.CandidateGenerator.BusShelterTest do
     StaticImage
   }
 
-  describe "candidate_template/0" do
+  describe "screen_template/0" do
     test "returns template" do
       assert {:screen,
               %{
@@ -30,7 +30,7 @@ defmodule Screens.V2.CandidateGenerator.BusShelterTest do
                   :footer
                 ],
                 takeover: [:fullscreen]
-              }} == BusShelter.candidate_template()
+              }} == BusShelter.screen_template()
     end
   end
 

--- a/test/screens/v2/screen_data_test.exs
+++ b/test/screens/v2/screen_data_test.exs
@@ -5,14 +5,13 @@ defmodule Screens.V2.ScreenDataTest do
 
   describe "pick_instances/2" do
     test "chooses the expected template and instance placement" do
-      candidate_templates = [
-        {[:large], {:flex_zone, {:one_large, [:large]}}},
-        {[:medium_left, :small_upper_right, :small_lower_right],
-         {:flex_zone,
-          {:one_medium_two_small, [:medium_left, :small_upper_right, :small_lower_right]}}},
-        {[:medium_left, :medium_right],
-         {:flex_zone, {:two_medium, [:medium_left, :medium_right]}}}
-      ]
+      candidate_template =
+        {:flex_zone,
+         %{
+           one_large: [:large],
+           two_medium: [:medium_left, :medium_right],
+           one_medium_two_small: [:medium_left, :small_upper_right, :small_lower_right]
+         }}
 
       candidate_instances = [
         %StaticImage{size: :small, priority: [4], image_url: "4"},
@@ -22,7 +21,7 @@ defmodule Screens.V2.ScreenDataTest do
       ]
 
       {actual_layout, actual_instance_placement} =
-        Screens.V2.ScreenData.pick_instances(candidate_templates, candidate_instances)
+        Screens.V2.ScreenData.pick_instances(candidate_template, candidate_instances)
 
       assert {:flex_zone,
               {:one_medium_two_small, [:medium_left, :small_upper_right, :small_lower_right]}} ==


### PR DESCRIPTION
**Asana task**: [Verify backend](https://app.asana.com/0/1185117109217413/1200038952107753)

- Clean up some types in `Screens.V2.ScreenData`
- Rename candidate generator `candidate_templates` -> `candidate_template`
- Define `candidate_template` for `Screens.V2.CandidateGenerator.BusShelter`
- Add header and footer widget instances to `BusShelter.candidate_instances`
- Add missing `Template.slot_combinations` call to `pick_instances`