### PR TITLE
feat: Normal header widget

### DIFF
--- a/assets/css/v2.scss
+++ b/assets/css/v2.scss
@@ -1,3 +1,5 @@
+@import "v2/header/normal";
+
 body {
   margin: 0px;
 }

--- a/assets/css/v2/header/normal.scss
+++ b/assets/css/v2/header/normal.scss
@@ -1,0 +1,12 @@
+.header-normal {
+  width: 1080px;
+  height: 272px;
+}
+
+.header-normal__station-name {
+  display: inline-block;
+}
+
+.header-normal__time {
+  display: inline-block;
+}

--- a/assets/src/components/v2/flex/one_large.tsx
+++ b/assets/src/components/v2/flex/one_large.tsx
@@ -1,8 +1,12 @@
 import React from "react";
 
-import Widget from "Components/v2/widget";
+import Widget, { WidgetData } from "Components/v2/widget";
 
-const OneLarge = ({ large }) => {
+interface Props {
+  large: WidgetData;
+}
+
+const OneLarge: React.ComponentType<Props> = ({ large }) => {
   return (
     <div className="flex-one-large">
       <div className="flex-one-large__large">

--- a/assets/src/components/v2/flex/one_medium_two_small.tsx
+++ b/assets/src/components/v2/flex/one_medium_two_small.tsx
@@ -1,8 +1,14 @@
 import React from "react";
 
-import Widget from "Components/v2/widget";
+import Widget, { WidgetData } from "Components/v2/widget";
 
-const OneMediumTwoSmall = ({
+interface Props {
+  medium_left: WidgetData;
+  small_upper_right: WidgetData;
+  small_lower_right: WidgetData;
+}
+
+const OneMediumTwoSmall: React.ComponentType<Props> = ({
   medium_left: mediumLeft,
   small_upper_right: smallUpperRight,
   small_lower_right: smallLowerRight,

--- a/assets/src/components/v2/flex/two_medium.tsx
+++ b/assets/src/components/v2/flex/two_medium.tsx
@@ -7,7 +7,10 @@ interface Props {
   medium_right: WidgetData;
 }
 
-const TwoMedium: React.ComponentType<Props> = ({ medium_left: mediumLeft, medium_right: mediumRight }) => {
+const TwoMedium: React.ComponentType<Props> = ({
+  medium_left: mediumLeft,
+  medium_right: mediumRight,
+}) => {
   return (
     <div className="flex-two-medium">
       <div className="flex-two-medium__left">

--- a/assets/src/components/v2/flex/two_medium.tsx
+++ b/assets/src/components/v2/flex/two_medium.tsx
@@ -1,8 +1,13 @@
 import React from "react";
 
-import Widget from "Components/v2/widget";
+import Widget, { WidgetData } from "Components/v2/widget";
 
-const TwoMedium = ({ medium_left: mediumLeft, medium_right: mediumRight }) => {
+interface Props {
+  medium_left: WidgetData;
+  medium_right: WidgetData;
+}
+
+const TwoMedium: React.ComponentType<Props> = ({ medium_left: mediumLeft, medium_right: mediumRight }) => {
   return (
     <div className="flex-two-medium">
       <div className="flex-two-medium__left">

--- a/assets/src/components/v2/header/normal.tsx
+++ b/assets/src/components/v2/header/normal.tsx
@@ -5,10 +5,10 @@ interface Props {
   time: string;
 }
 
-const NormalHeader = ({
+const NormalHeader: React.ComponentType<Props> = ({
   station_name: stationName,
   time,
-}: Props): JSX.Element => {
+}) => {
   return (
     <div className="header-normal">
       <div className="header-normal__station-name">{stationName}</div>

--- a/assets/src/components/v2/header/normal.tsx
+++ b/assets/src/components/v2/header/normal.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+
+interface Props {
+  station_name: string;
+  time: string;
+}
+
+const NormalHeader = ({
+  station_name: stationName,
+  time,
+}: Props): JSX.Element => {
+  return (
+    <div className="header-normal">
+      <div className="header-normal__station-name">{stationName}</div>
+      <div className="header-normal__time">{time}</div>
+    </div>
+  );
+};
+
+export default NormalHeader;

--- a/assets/src/components/v2/screen/normal.tsx
+++ b/assets/src/components/v2/screen/normal.tsx
@@ -1,8 +1,15 @@
 import React from "react";
 
-import Widget from "Components/v2/widget";
+import Widget, { WidgetData } from "Components/v2/widget";
 
-const Normal = ({
+interface Props {
+  header: WidgetData;
+  main_content: WidgetData;
+  flex_zone: WidgetData;
+  footer: WidgetData;
+}
+
+const Normal: React.ComponentType<Props> = ({
   header,
   main_content: mainContent,
   flex_zone: flexZone,

--- a/assets/src/components/v2/screen/takeover.tsx
+++ b/assets/src/components/v2/screen/takeover.tsx
@@ -1,8 +1,12 @@
 import React from "react";
 
-import Widget from "Components/v2/widget";
+import Widget, { WidgetData } from "Components/v2/widget";
 
-const Takeover = ({ fullscreen }) => {
+interface Props {
+  fullscreen: WidgetData;
+}
+
+const Takeover: React.ComponentType<Props> = ({ fullscreen }) => {
   return (
     <div className="screen-takeover">
       <div className="screen-takeover__fullscreen">

--- a/assets/src/components/v2/widget.tsx
+++ b/assets/src/components/v2/widget.tsx
@@ -7,7 +7,6 @@ import OneLarge from "Components/v2/flex/one_large";
 import TwoMedium from "Components/v2/flex/two_medium";
 import OneMediumTwoSmall from "Components/v2/flex/one_medium_two_small";
 
-
 type WidgetData = { type: string } & Record<string, any>;
 
 const TYPE_TO_COMPONENT: Record<string, React.ComponentType<any>> = {
@@ -35,4 +34,4 @@ const Widget: React.ComponentType<Props> = ({ data }) => {
 };
 
 export default Widget;
-export { WidgetData }
+export { WidgetData };

--- a/assets/src/components/v2/widget.tsx
+++ b/assets/src/components/v2/widget.tsx
@@ -1,6 +1,10 @@
 import React from "react";
 
-const TYPE_TO_COMPONENT = {};
+import NormalHeader from "Components/v2/header/normal";
+
+const TYPE_TO_COMPONENT: Record<string, React.ComponentType<any>> = {
+  normal_header: NormalHeader,
+};
 
 const Widget = ({ data }) => {
   const { type, ...props } = data;


### PR DESCRIPTION
**Asana task**: [normal header](https://app.asana.com/0/1185117109217413/1199987812749015/f)

Basic normal header widget with expected props matching the fields of the `NormalHeader` widget instance struct on the backend. It displays the ISO8601 timestamp directly for now rather than formatting it in a human-readable way.
