### PR TITLE
feat: StaticImage widget

### DIFF
--- a/assets/src/components/v2/static_image.tsx
+++ b/assets/src/components/v2/static_image.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+
+interface Props {
+  url: string;
+}
+
+const StaticImage: React.ComponentType<Props> = ({ url }) => {
+  return (
+    <div className="static-image">
+      <img src={url} />
+    </div>
+  );
+};
+
+export default StaticImage;

--- a/assets/src/components/v2/widget.tsx
+++ b/assets/src/components/v2/widget.tsx
@@ -6,6 +6,7 @@ import Takeover from "Components/v2/screen/takeover";
 import OneLarge from "Components/v2/flex/one_large";
 import TwoMedium from "Components/v2/flex/two_medium";
 import OneMediumTwoSmall from "Components/v2/flex/one_medium_two_small";
+import StaticImage from "Components/v2/static_image";
 
 type WidgetData = { type: string } & Record<string, any>;
 
@@ -16,6 +17,7 @@ const TYPE_TO_COMPONENT: Record<string, React.ComponentType<any>> = {
   one_large: OneLarge,
   two_medium: TwoMedium,
   one_medium_two_small: OneMediumTwoSmall,
+  static_image: StaticImage,
 };
 
 interface Props {

--- a/lib/screens/v2/candidate_generator/bus_shelter.ex
+++ b/lib/screens/v2/candidate_generator/bus_shelter.ex
@@ -20,7 +20,7 @@ defmodule Screens.V2.CandidateGenerator.BusShelter do
   @dummy_stop_id "1743"
   @dummy_station_name "Columbus Ave @ Walnut Ave"
 
-  @dummy_psa_priority [5]
+  @dummy_psa_priority [1]
   @dummy_psa_size :small
 
   @impl CandidateGenerator


### PR DESCRIPTION
**Asana task**: [static image (small, medium, large, takeover)](https://app.asana.com/0/1185117109217413/1199987812749027)

Defines a single `StaticImage` component.

Currently the component doesn't do anything to account for the size; the position is determined by the parent, and the size is just determined by the size of the image. When we implement the real templates, we should standardize where the position and size of each widget are defined. Maybe the widget specifies its size and the parent just specifies the positions of its children?