### PR TITLE
feat: define screen_template in candidate generators for real screen types

### DIFF
--- a/lib/screens/v2/candidate_generator/bus_eink.ex
+++ b/lib/screens/v2/candidate_generator/bus_eink.ex
@@ -1,0 +1,37 @@
+defmodule Screens.V2.CandidateGenerator.BusEink do
+  @moduledoc false
+
+  alias Screens.V2.CandidateGenerator
+  alias Screens.V2.WidgetInstance.Placeholder
+
+  @behaviour CandidateGenerator
+
+  @impl CandidateGenerator
+  def screen_template do
+    {:screen,
+     %{
+       normal: [
+         :header,
+         :main_content,
+         :medium_flex,
+         :footer
+       ],
+       bottom_takeover: [
+         :header,
+         :main_content,
+         :bottom_screen
+       ],
+       full_takeover: [:full_screen]
+     }}
+  end
+
+  @impl CandidateGenerator
+  def candidate_instances(_config) do
+    [
+      %Placeholder{color: :blue, slot_names: [:header]},
+      %Placeholder{color: :blue, slot_names: [:footer]},
+      %Placeholder{color: :green, slot_names: [:main_content]},
+      %Placeholder{color: :red, slot_names: [:medium_flex]}
+    ]
+  end
+end

--- a/lib/screens/v2/candidate_generator/bus_shelter.ex
+++ b/lib/screens/v2/candidate_generator/bus_shelter.ex
@@ -38,13 +38,13 @@ defmodule Screens.V2.CandidateGenerator.BusShelter do
           }},
          :footer
        ],
-       takeover: [:fullscreen]
+       takeover: [:full_screen]
      }}
   end
 
   @impl CandidateGenerator
   def candidate_instances(
-        :ok = config,
+        config,
         prediction_fetcher \\ &Prediction.fetch/1,
         alert_fetcher \\ &Alert.fetch/1
       ) do
@@ -89,7 +89,7 @@ defmodule Screens.V2.CandidateGenerator.BusShelter do
     Enum.map(alerts, &%AlertWidget{screen: config, alert: &1})
   end
 
-  defp fetch_psas(:ok) do
+  defp fetch_psas(_config) do
     [
       %{
         image_url:

--- a/lib/screens/v2/candidate_generator/dup.ex
+++ b/lib/screens/v2/candidate_generator/dup.ex
@@ -1,0 +1,25 @@
+defmodule Screens.V2.CandidateGenerator.Dup do
+  @moduledoc false
+
+  alias Screens.V2.CandidateGenerator
+  alias Screens.V2.WidgetInstance.Placeholder
+
+  @behaviour CandidateGenerator
+
+  @impl CandidateGenerator
+  def screen_template do
+    {:screen,
+     %{
+       normal: [:header, :main_content],
+       full_takeover: [:full_screen]
+     }}
+  end
+
+  @impl CandidateGenerator
+  def candidate_instances(_config) do
+    [
+      %Placeholder{color: :grey, slot_names: [:header]},
+      %Placeholder{color: :red, slot_names: [:main_content]}
+    ]
+  end
+end

--- a/lib/screens/v2/candidate_generator/gl_eink_double.ex
+++ b/lib/screens/v2/candidate_generator/gl_eink_double.ex
@@ -1,0 +1,37 @@
+defmodule Screens.V2.CandidateGenerator.GlEinkDouble do
+  @moduledoc false
+
+  alias Screens.V2.CandidateGenerator
+  alias Screens.V2.WidgetInstance.Placeholder
+
+  @behaviour CandidateGenerator
+
+  @impl CandidateGenerator
+  def screen_template do
+    {:screen,
+     %{
+       normal: [
+         :header,
+         :main_content,
+         :medium_flex,
+         :footer
+       ],
+       bottom_takeover: [
+         :header,
+         :main_content,
+         :bottom_screen
+       ],
+       full_takeover: [:full_screen]
+     }}
+  end
+
+  @impl CandidateGenerator
+  def candidate_instances(_config) do
+    [
+      %Placeholder{color: :red, slot_names: [:header]},
+      %Placeholder{color: :red, slot_names: [:footer]},
+      %Placeholder{color: :blue, slot_names: [:main_content]},
+      %Placeholder{color: :green, slot_names: [:medium_flex]}
+    ]
+  end
+end

--- a/lib/screens/v2/candidate_generator/gl_eink_single.ex
+++ b/lib/screens/v2/candidate_generator/gl_eink_single.ex
@@ -1,0 +1,30 @@
+defmodule Screens.V2.CandidateGenerator.GlEinkSingle do
+  @moduledoc false
+
+  alias Screens.V2.CandidateGenerator
+  alias Screens.V2.WidgetInstance.Placeholder
+
+  @behaviour CandidateGenerator
+
+  @impl CandidateGenerator
+  def screen_template do
+    {:screen,
+     %{
+       normal: [
+         :header,
+         :main_content,
+         :footer
+       ],
+       full_takeover: [:full_screen]
+     }}
+  end
+
+  @impl CandidateGenerator
+  def candidate_instances(_config) do
+    [
+      %Placeholder{color: :blue, slot_names: [:header]},
+      %Placeholder{color: :blue, slot_names: [:footer]},
+      %Placeholder{color: :green, slot_names: [:main_content]}
+    ]
+  end
+end

--- a/lib/screens/v2/candidate_generator/solari.ex
+++ b/lib/screens/v2/candidate_generator/solari.ex
@@ -1,0 +1,26 @@
+defmodule Screens.V2.CandidateGenerator.Solari do
+  @moduledoc false
+
+  alias Screens.V2.CandidateGenerator
+  alias Screens.V2.WidgetInstance.Placeholder
+
+  @behaviour CandidateGenerator
+
+  @impl CandidateGenerator
+  def screen_template do
+    {:screen,
+     %{
+       normal: [:header_normal, :main_content_normal],
+       overhead: [:header_overhead, :main_content_overhead],
+       takeover: [:full_screen]
+     }}
+  end
+
+  @impl CandidateGenerator
+  def candidate_instances(_config) do
+    [
+      %Placeholder{color: :green, slot_names: [:header_normal]},
+      %Placeholder{color: :blue, slot_names: [:main_content_normal]}
+    ]
+  end
+end

--- a/lib/screens/v2/screen_data.ex
+++ b/lib/screens/v2/screen_data.ex
@@ -3,15 +3,25 @@ defmodule Screens.V2.ScreenData do
 
   require Logger
 
+  alias Screens.V2.CandidateGenerator
   alias Screens.V2.Template
   alias Screens.V2.WidgetInstance
 
   @type screen_id :: String.t()
-  @type config :: :ok
+  @type config :: Screens.Config.Screen.t()
   @type candidate_generator :: module()
   @type candidate_instances :: list(WidgetInstance.t())
   @type selected_instances_map :: %{atom() => WidgetInstance.t()}
   @type serializable_map :: %{type: atom()}
+
+  @app_id_to_candidate_generator %{
+    bus_eink: CandidateGenerator.BusEink,
+    gl_eink_double: CandidateGenerator.GlEinkDouble,
+    gl_eink_single: CandidateGenerator.GlEinkSingle,
+    solari: CandidateGenerator.Solari,
+    dup: CandidateGenerator.Dup,
+    bus_shelter: CandidateGenerator.BusShelter
+  }
 
   @spec by_screen_id(screen_id()) :: serializable_map()
   def by_screen_id(screen_id) do
@@ -26,13 +36,13 @@ defmodule Screens.V2.ScreenData do
   end
 
   @spec get_config(screen_id()) :: config()
-  def get_config(_screen_id) do
-    :ok
+  def get_config(screen_id) do
+    Screens.Config.State.screen(screen_id)
   end
 
   @spec get_candidate_generator(config()) :: candidate_generator()
-  def get_candidate_generator(:ok) do
-    Screens.V2.CandidateGenerator.BusShelter
+  def get_candidate_generator(%Screens.Config.Screen{app_id: app_id}) do
+    Map.get(@app_id_to_candidate_generator, app_id)
   end
 
   @spec pick_instances(Template.template(), candidate_instances()) ::

--- a/lib/screens/v2/widget_instance/placeholder.ex
+++ b/lib/screens/v2/widget_instance/placeholder.ex
@@ -1,0 +1,21 @@
+defmodule Screens.V2.WidgetInstance.Placeholder do
+  @moduledoc false
+
+  alias Screens.V2.WidgetInstance.Placeholder
+
+  defstruct color: nil,
+            slot_names: []
+
+  @type color :: :grey | :blue | :green | :red
+  @type t :: %__MODULE__{
+          color: color(),
+          slot_names: list(atom())
+        }
+
+  defimpl Screens.V2.WidgetInstance do
+    def priority(_), do: [2]
+    def serialize(%Placeholder{color: color}), do: %{color: color}
+    def slot_names(%Placeholder{slot_names: slot_names}), do: slot_names
+    def widget_type(_), do: :placeholder
+  end
+end

--- a/test/screens/v2/candidate_generator/bus_eink_test.exs
+++ b/test/screens/v2/candidate_generator/bus_eink_test.exs
@@ -1,0 +1,25 @@
+defmodule Screens.V2.CandidateGenerator.BusEinkTest do
+  use ExUnit.Case, async: true
+
+  alias Screens.V2.CandidateGenerator.BusEink
+
+  describe "screen_template/0" do
+    test "returns correct template" do
+      assert {:screen,
+              %{
+                normal: [
+                  :header,
+                  :main_content,
+                  :medium_flex,
+                  :footer
+                ],
+                bottom_takeover: [
+                  :header,
+                  :main_content,
+                  :bottom_screen
+                ],
+                full_takeover: [:full_screen]
+              }} == BusEink.screen_template()
+    end
+  end
+end

--- a/test/screens/v2/candidate_generator/bus_shelter_test.exs
+++ b/test/screens/v2/candidate_generator/bus_shelter_test.exs
@@ -29,7 +29,7 @@ defmodule Screens.V2.CandidateGenerator.BusShelterTest do
                    }},
                   :footer
                 ],
-                takeover: [:fullscreen]
+                takeover: [:full_screen]
               }} == BusShelter.screen_template()
     end
   end

--- a/test/screens/v2/candidate_generator/dup_test.exs
+++ b/test/screens/v2/candidate_generator/dup_test.exs
@@ -1,0 +1,15 @@
+defmodule Screens.V2.CandidateGenerator.DupTest do
+  use ExUnit.Case, async: true
+
+  alias Screens.V2.CandidateGenerator.Dup
+
+  describe "screen_template/0" do
+    test "returns correct template" do
+      assert {:screen,
+              %{
+                normal: [:header, :main_content],
+                full_takeover: [:full_screen]
+              }} == Dup.screen_template()
+    end
+  end
+end

--- a/test/screens/v2/candidate_generator/gl_eink_double_test.exs
+++ b/test/screens/v2/candidate_generator/gl_eink_double_test.exs
@@ -1,0 +1,25 @@
+defmodule Screens.V2.CandidateGenerator.GlEinkDoubleTest do
+  use ExUnit.Case, async: true
+
+  alias Screens.V2.CandidateGenerator.GlEinkDouble
+
+  describe "screen_template/0" do
+    test "returns correct template" do
+      assert {:screen,
+              %{
+                normal: [
+                  :header,
+                  :main_content,
+                  :medium_flex,
+                  :footer
+                ],
+                bottom_takeover: [
+                  :header,
+                  :main_content,
+                  :bottom_screen
+                ],
+                full_takeover: [:full_screen]
+              }} == GlEinkDouble.screen_template()
+    end
+  end
+end

--- a/test/screens/v2/candidate_generator/gl_eink_single_test.exs
+++ b/test/screens/v2/candidate_generator/gl_eink_single_test.exs
@@ -1,0 +1,19 @@
+defmodule Screens.V2.CandidateGenerator.GlEinkSingleTest do
+  use ExUnit.Case, async: true
+
+  alias Screens.V2.CandidateGenerator.GlEinkSingle
+
+  describe "screen_template/0" do
+    test "returns correct template" do
+      assert {:screen,
+              %{
+                normal: [
+                  :header,
+                  :main_content,
+                  :footer
+                ],
+                full_takeover: [:full_screen]
+              }} == GlEinkSingle.screen_template()
+    end
+  end
+end

--- a/test/screens/v2/candidate_generator/solari_test.exs
+++ b/test/screens/v2/candidate_generator/solari_test.exs
@@ -1,0 +1,16 @@
+defmodule Screens.V2.CandidateGenerator.SolariTest do
+  use ExUnit.Case, async: true
+
+  alias Screens.V2.CandidateGenerator.Solari
+
+  describe "screen_template/0" do
+    test "returns correct template" do
+      assert {:screen,
+              %{
+                normal: [:header_normal, :main_content_normal],
+                overhead: [:header_overhead, :main_content_overhead],
+                takeover: [:full_screen]
+              }} == Solari.screen_template()
+    end
+  end
+end


### PR DESCRIPTION
**Asana task**: [Backend templates](https://app.asana.com/0/1185117109217413/1200050362904587)

Notes:
- For double-stack e-ink, I only included one medium flex zone (i.e. there's no option for two small ones).
- For the GL single-stack, I considered the "flex zone" which takes over one of the two departures to be part of main content. That is, it doesn't appear in the template. (The same is true for the small inline alert at the bottom of that screen.) That's because these overlap with the footprint of the main content slot, so we wouldn't be able to choose their contents independently.