### PR TITLE
feat: move DUP long headsign mapping to backend, add 214/216

### DIFF
--- a/assets/src/components/dup/destination.tsx
+++ b/assets/src/components/dup/destination.tsx
@@ -16,22 +16,6 @@ const ABBREVIATIONS = {
   Washington: "Wash",
 };
 
-// Adjustments to specific problematic headsigns
-const REPLACEMENTS = {
-  "Holbrook/Randolph": "Holbrook / Randolph",
-  "Charlestown Navy Yard": "Charlestown",
-  "Saugus Center via Kennedy Dr & Square One Mall":
-    "Saugus Center via Kndy Dr & Square One",
-  "Malden via Square One Mall & Kennedy Dr":
-    "Malden via Square One Mall & Kndy Dr",
-  "Washington St & Pleasant St Weymouth": "Washington St & Plsnt St Weymouth",
-  "Woodland Rd via Gateway Center": "Woodland Rd via Gatew'y Center",
-  "Sullivan (Limited Stops)": "Sullivan",
-  "Ruggles (Limited Stops)": "Ruggles",
-  "Wickford Junction": "Wickford Jct",
-  "Needham Heights": "Needham Hts",
-};
-
 enum PHASES {
   ONE_LINE_FULL,
   ONE_LINE_ABBREV,
@@ -63,8 +47,7 @@ const Destination = ({ destination, currentPage }) => {
   const firstLineRef = useRef(null);
   const secondLineRef = useRef(null);
 
-  const correctedDestination = REPLACEMENTS[destination] || destination;
-  let parts = correctedDestination.split(" ");
+  let parts = destination.split(" ");
 
   const [index1, setIndex1] = useState(parts.length);
   const [index2, setIndex2] = useState(parts.length);

--- a/lib/screens/dup_screen_data/request.ex
+++ b/lib/screens/dup_screen_data/request.ex
@@ -24,6 +24,21 @@ defmodule Screens.DupScreenData.Request do
     "Braintree"
   ]
 
+  @headsign_replacements %{
+    "Holbrook/Randolph" => "Holbrook / Randolph",
+    "Charlestown Navy Yard" => "Charlestown",
+    "Saugus Center via Kennedy Dr & Square One Mall" => "Saugus Center via Kndy Dr & Square One",
+    "Malden via Square One Mall & Kennedy Dr" => "Malden via Square One Mall & Kndy Dr",
+    "Washington St & Pleasant St Weymouth" => "Washington St & Plsnt St Weymouth",
+    "Woodland Rd via Gateway Center" => "Woodland Rd via Gatew'y Center",
+    "Sullivan (Limited Stops)" => "Sullivan",
+    "Ruggles (Limited Stops)" => "Ruggles",
+    "Wickford Junction" => "Wickford Jct",
+    "Needham Heights" => "Needham Hts",
+    "Houghs Neck Via McGrath & Germantown" => "Houghs Neck Via McGth & Gtwn",
+    "Houghs Neck Via Germantown" => "Houghs Neck Via Germntwn"
+  }
+
   def fetch_alerts(stop_ids, route_ids) do
     opts = [
       stop_ids: stop_ids,
@@ -161,6 +176,7 @@ defmodule Screens.DupScreenData.Request do
           |> Enum.map(&Map.from_struct/1)
           |> Enum.sort_by(& &1.time)
           |> Enum.take(num_rows)
+          |> Enum.map(&replace_long_headsigns/1)
 
         _ =
           case section_departures do
@@ -173,6 +189,11 @@ defmodule Screens.DupScreenData.Request do
       :error ->
         :error
     end
+  end
+
+  defp replace_long_headsigns(%{destination: destination} = departure_map) do
+    replaced_destination = Map.get(@headsign_replacements, destination, destination)
+    %{departure_map | destination: replaced_destination}
   end
 
   defp relevant?(alert) do


### PR DESCRIPTION
**Asana tasks**:
- [Add 214/216 to list of custom abbreviations for long headsigns](https://app.asana.com/0/1185117109217413/1200064893145449)
- [Move custom headsign abbreviation mapping to the backend](https://app.asana.com/0/1199892628355780/1200064461121641)

Note: It should be OK to deploy the server-side changes while the current DUP client is still on the screens; once we make the changes on the back-end, none of the front-end replacements will match.