### PR TITLE
fix: Use display: block for DUP stacked route pill parts

### DIFF
--- a/assets/css/dup/departure_route.scss
+++ b/assets/css/dup/departure_route.scss
@@ -15,14 +15,14 @@
   }
 
   .base-route-pill__route-text--with-slash__part1 {
-    display: flow;
+    display: block;
     line-height: 84px;
     text-align: start;
     margin-left: 42px;
   }
 
   .base-route-pill__route-text--with-slash__part2 {
-    display: flow;
+    display: block;
     line-height: 64px;
     text-align: start;
     margin-left: 42px;


### PR DESCRIPTION
**Asana task**: ad hoc

`display: flow` is not a valid property on Chrome. This fix makes the stacked slashed bus route pills display correctly on both Chrome and Firefox. (And hopefully on the DUP screens)

We'll need to make a new zip to get this change in.

- [ ] Needs version bump?
