### PR TITLE
feat: normal header backend

### DIFF
--- a/assets/src/components/v2/widget.tsx
+++ b/assets/src/components/v2/widget.tsx
@@ -9,6 +9,10 @@ interface Props {
 const MappingContext = React.createContext({});
 
 const Widget: React.ComponentType<Props> = ({ data }) => {
+  if (data === null) {
+    return null;
+  }
+
   const { type, ...props } = data;
   const typeToComponent = useContext(MappingContext);
   const Component = typeToComponent[type];

--- a/lib/screens/config/screen.ex
+++ b/lib/screens/config/screen.ex
@@ -5,13 +5,13 @@ defmodule Screens.Config.Screen do
   alias Screens.Util
 
   @type t :: %__MODULE__{
-          vendor: :gds | :mercury | :solari | :c3ms | :outfront,
+          vendor: :gds | :mercury | :solari | :c3ms | :outfront | :lg_mri,
           device_id: String.t(),
           name: String.t(),
-          app_id: :bus_eink | :gl_eink_single | :gl_eink_double | :solari | :dup,
+          app_id: :bus_eink | :bus_shelter | :gl_eink_single | :gl_eink_double | :solari | :dup,
           refresh_if_loaded_before: DateTime.t() | nil,
           disabled: boolean(),
-          app_params: Bus.t() | Dup.t() | Gl.t() | Solari.t(),
+          app_params: Bus.t() | BusShelter.t() | Dup.t() | Gl.t() | Solari.t(),
           tags: list(String.t())
         }
 

--- a/lib/screens/v2/candidate_generator/bus_eink.ex
+++ b/lib/screens/v2/candidate_generator/bus_eink.ex
@@ -27,8 +27,12 @@ defmodule Screens.V2.CandidateGenerator.BusEink do
   end
 
   @impl CandidateGenerator
-  def candidate_instances(config) do
-    header_instances(config) ++
+  def candidate_instances(
+        config,
+        now \\ DateTime.utc_now(),
+        fetch_stop_name_fn \\ &fetch_stop_name/1
+      ) do
+    header_instances(config, now, fetch_stop_name_fn) ++
       [
         %Placeholder{color: :blue, slot_names: [:footer]},
         %Placeholder{color: :green, slot_names: [:main_content]},
@@ -36,16 +40,23 @@ defmodule Screens.V2.CandidateGenerator.BusEink do
       ]
   end
 
-  defp header_instances(config) do
+  defp header_instances(config, now, fetch_stop_name_fn) do
     %Screen{app_params: %Bus{stop_id: stop_id}} = config
 
+    case fetch_stop_name_fn.(stop_id) do
+      nil -> []
+      stop_name -> [%NormalHeader{screen: config, text: stop_name, time: now}]
+    end
+  end
+
+  defp fetch_stop_name(stop_id) do
     case Screens.V3Api.get_json("stops", %{"filter[id]" => stop_id}) do
       {:ok, %{"data" => [stop_data]}} ->
         %{"attributes" => %{"name" => stop_name}} = stop_data
-        [%NormalHeader{screen: config, text: stop_name, time: DateTime.utc_now()}]
+        stop_name
 
       _ ->
-        []
+        nil
     end
   end
 end

--- a/lib/screens/v2/candidate_generator/bus_eink.ex
+++ b/lib/screens/v2/candidate_generator/bus_eink.ex
@@ -1,8 +1,9 @@
 defmodule Screens.V2.CandidateGenerator.BusEink do
   @moduledoc false
 
+  alias Screens.Config.{Bus, Screen}
   alias Screens.V2.CandidateGenerator
-  alias Screens.V2.WidgetInstance.Placeholder
+  alias Screens.V2.WidgetInstance.{NormalHeader, Placeholder}
 
   @behaviour CandidateGenerator
 
@@ -26,12 +27,25 @@ defmodule Screens.V2.CandidateGenerator.BusEink do
   end
 
   @impl CandidateGenerator
-  def candidate_instances(_config) do
-    [
-      %Placeholder{color: :blue, slot_names: [:header]},
-      %Placeholder{color: :blue, slot_names: [:footer]},
-      %Placeholder{color: :green, slot_names: [:main_content]},
-      %Placeholder{color: :red, slot_names: [:medium_flex]}
-    ]
+  def candidate_instances(config) do
+    header_instances(config) ++
+      [
+        %Placeholder{color: :blue, slot_names: [:footer]},
+        %Placeholder{color: :green, slot_names: [:main_content]},
+        %Placeholder{color: :red, slot_names: [:medium_flex]}
+      ]
+  end
+
+  defp header_instances(config) do
+    %Screen{app_params: %Bus{stop_id: stop_id}} = config
+
+    case Screens.V3Api.get_json("stops", %{"filter[id]" => stop_id}) do
+      {:ok, %{"data" => [stop_data]}} ->
+        %{"attributes" => %{"name" => stop_name}} = stop_data
+        [%NormalHeader{screen: config, text: stop_name, time: DateTime.utc_now()}]
+
+      _ ->
+        []
+    end
   end
 end

--- a/lib/screens/v2/candidate_generator/bus_shelter.ex
+++ b/lib/screens/v2/candidate_generator/bus_shelter.ex
@@ -27,8 +27,12 @@ defmodule Screens.V2.CandidateGenerator.BusShelter do
   end
 
   @impl CandidateGenerator
-  def candidate_instances(config) do
-    header_instances(config) ++
+  def candidate_instances(
+        config,
+        now \\ DateTime.utc_now(),
+        fetch_stop_name_fn \\ &fetch_stop_name/1
+      ) do
+    header_instances(config, now, fetch_stop_name_fn) ++
       [
         %Placeholder{color: :blue, slot_names: [:footer]},
         %Placeholder{color: :red, slot_names: [:main_content]},
@@ -38,16 +42,23 @@ defmodule Screens.V2.CandidateGenerator.BusShelter do
       ]
   end
 
-  defp header_instances(config) do
+  defp header_instances(config, now, fetch_stop_name_fn) do
     %Screen{app_params: %BusShelter{stop_id: stop_id}} = config
 
+    case fetch_stop_name_fn.(stop_id) do
+      nil -> []
+      stop_name -> [%NormalHeader{screen: config, text: stop_name, time: now}]
+    end
+  end
+
+  defp fetch_stop_name(stop_id) do
     case Screens.V3Api.get_json("stops", %{"filter[id]" => stop_id}) do
       {:ok, %{"data" => [stop_data]}} ->
         %{"attributes" => %{"name" => stop_name}} = stop_data
-        [%NormalHeader{screen: config, text: stop_name, time: DateTime.utc_now()}]
+        stop_name
 
       _ ->
-        []
+        nil
     end
   end
 end

--- a/lib/screens/v2/candidate_generator/bus_shelter.ex
+++ b/lib/screens/v2/candidate_generator/bus_shelter.ex
@@ -1,8 +1,9 @@
 defmodule Screens.V2.CandidateGenerator.BusShelter do
   @moduledoc false
 
+  alias Screens.Config.{BusShelter, Screen}
   alias Screens.V2.CandidateGenerator
-  alias Screens.V2.WidgetInstance.Placeholder
+  alias Screens.V2.WidgetInstance.{NormalHeader, Placeholder}
 
   @behaviour CandidateGenerator
 
@@ -26,14 +27,27 @@ defmodule Screens.V2.CandidateGenerator.BusShelter do
   end
 
   @impl CandidateGenerator
-  def candidate_instances(_) do
-    [
-      %Placeholder{color: :blue, slot_names: [:header]},
-      %Placeholder{color: :blue, slot_names: [:footer]},
-      %Placeholder{color: :red, slot_names: [:main_content]},
-      %Placeholder{color: :green, slot_names: [:medium_left]},
-      %Placeholder{color: :blue, slot_names: [:small_upper_right]},
-      %Placeholder{color: :grey, slot_names: [:small_lower_right]}
-    ]
+  def candidate_instances(config) do
+    header_instances(config) ++
+      [
+        %Placeholder{color: :blue, slot_names: [:footer]},
+        %Placeholder{color: :red, slot_names: [:main_content]},
+        %Placeholder{color: :green, slot_names: [:medium_left]},
+        %Placeholder{color: :blue, slot_names: [:small_upper_right]},
+        %Placeholder{color: :grey, slot_names: [:small_lower_right]}
+      ]
+  end
+
+  defp header_instances(config) do
+    %Screen{app_params: %BusShelter{stop_id: stop_id}} = config
+
+    case Screens.V3Api.get_json("stops", %{"filter[id]" => stop_id}) do
+      {:ok, %{"data" => [stop_data]}} ->
+        %{"attributes" => %{"name" => stop_name}} = stop_data
+        [%NormalHeader{screen: config, text: stop_name, time: DateTime.utc_now()}]
+
+      _ ->
+        []
+    end
   end
 end

--- a/lib/screens/v2/candidate_generator/dup.ex
+++ b/lib/screens/v2/candidate_generator/dup.ex
@@ -1,8 +1,9 @@
 defmodule Screens.V2.CandidateGenerator.Dup do
   @moduledoc false
 
+  alias Screens.Config.{Dup, Screen}
   alias Screens.V2.CandidateGenerator
-  alias Screens.V2.WidgetInstance.Placeholder
+  alias Screens.V2.WidgetInstance.{NormalHeader, Placeholder}
 
   @behaviour CandidateGenerator
 
@@ -16,10 +17,15 @@ defmodule Screens.V2.CandidateGenerator.Dup do
   end
 
   @impl CandidateGenerator
-  def candidate_instances(_config) do
-    [
-      %Placeholder{color: :grey, slot_names: [:header]},
-      %Placeholder{color: :red, slot_names: [:main_content]}
-    ]
+  def candidate_instances(config) do
+    header_instances(config) ++
+      [
+        %Placeholder{color: :red, slot_names: [:main_content]}
+      ]
+  end
+
+  defp header_instances(config) do
+    %Screen{app_params: %Dup{primary: %Dup.Departures{header: header_text}}} = config
+    [%NormalHeader{screen: config, icon: :logo, text: header_text, time: DateTime.utc_now()}]
   end
 end

--- a/lib/screens/v2/candidate_generator/dup.ex
+++ b/lib/screens/v2/candidate_generator/dup.ex
@@ -17,15 +17,15 @@ defmodule Screens.V2.CandidateGenerator.Dup do
   end
 
   @impl CandidateGenerator
-  def candidate_instances(config) do
-    header_instances(config) ++
+  def candidate_instances(config, now \\ DateTime.utc_now()) do
+    header_instances(config, now) ++
       [
         %Placeholder{color: :red, slot_names: [:main_content]}
       ]
   end
 
-  defp header_instances(config) do
+  defp header_instances(config, now) do
     %Screen{app_params: %Dup{primary: %Dup.Departures{header: header_text}}} = config
-    [%NormalHeader{screen: config, icon: :logo, text: header_text, time: DateTime.utc_now()}]
+    [%NormalHeader{screen: config, icon: :logo, text: header_text, time: now}]
   end
 end

--- a/lib/screens/v2/candidate_generator/gl_eink_double.ex
+++ b/lib/screens/v2/candidate_generator/gl_eink_double.ex
@@ -26,8 +26,12 @@ defmodule Screens.V2.CandidateGenerator.GlEinkDouble do
   end
 
   @impl CandidateGenerator
-  def candidate_instances(config) do
-    CandidateGenerator.Helpers.gl_header_instances(config) ++
+  def candidate_instances(
+        config,
+        now \\ DateTime.utc_now(),
+        fetch_destination_fn \\ &CandidateGenerator.Helpers.fetch_destination/2
+      ) do
+    CandidateGenerator.Helpers.gl_header_instances(config, now, fetch_destination_fn) ++
       [
         %Placeholder{color: :red, slot_names: [:footer]},
         %Placeholder{color: :blue, slot_names: [:main_content]},

--- a/lib/screens/v2/candidate_generator/gl_eink_double.ex
+++ b/lib/screens/v2/candidate_generator/gl_eink_double.ex
@@ -26,12 +26,12 @@ defmodule Screens.V2.CandidateGenerator.GlEinkDouble do
   end
 
   @impl CandidateGenerator
-  def candidate_instances(_config) do
-    [
-      %Placeholder{color: :red, slot_names: [:header]},
-      %Placeholder{color: :red, slot_names: [:footer]},
-      %Placeholder{color: :blue, slot_names: [:main_content]},
-      %Placeholder{color: :green, slot_names: [:medium_flex]}
-    ]
+  def candidate_instances(config) do
+    CandidateGenerator.Helpers.gl_header_instances(config) ++
+      [
+        %Placeholder{color: :red, slot_names: [:footer]},
+        %Placeholder{color: :blue, slot_names: [:main_content]},
+        %Placeholder{color: :green, slot_names: [:medium_flex]}
+      ]
   end
 end

--- a/lib/screens/v2/candidate_generator/gl_eink_single.ex
+++ b/lib/screens/v2/candidate_generator/gl_eink_single.ex
@@ -20,11 +20,11 @@ defmodule Screens.V2.CandidateGenerator.GlEinkSingle do
   end
 
   @impl CandidateGenerator
-  def candidate_instances(_config) do
-    [
-      %Placeholder{color: :blue, slot_names: [:header]},
-      %Placeholder{color: :blue, slot_names: [:footer]},
-      %Placeholder{color: :green, slot_names: [:main_content]}
-    ]
+  def candidate_instances(config) do
+    CandidateGenerator.Helpers.gl_header_instances(config) ++
+      [
+        %Placeholder{color: :blue, slot_names: [:footer]},
+        %Placeholder{color: :green, slot_names: [:main_content]}
+      ]
   end
 end

--- a/lib/screens/v2/candidate_generator/gl_eink_single.ex
+++ b/lib/screens/v2/candidate_generator/gl_eink_single.ex
@@ -20,8 +20,12 @@ defmodule Screens.V2.CandidateGenerator.GlEinkSingle do
   end
 
   @impl CandidateGenerator
-  def candidate_instances(config) do
-    CandidateGenerator.Helpers.gl_header_instances(config) ++
+  def candidate_instances(
+        config,
+        now \\ DateTime.utc_now(),
+        fetch_destination_fn \\ &CandidateGenerator.Helpers.fetch_destination/2
+      ) do
+    CandidateGenerator.Helpers.gl_header_instances(config, now, fetch_destination_fn) ++
       [
         %Placeholder{color: :blue, slot_names: [:footer]},
         %Placeholder{color: :green, slot_names: [:main_content]}

--- a/lib/screens/v2/candidate_generator/helpers.ex
+++ b/lib/screens/v2/candidate_generator/helpers.ex
@@ -4,7 +4,7 @@ defmodule Screens.V2.CandidateGenerator.Helpers do
   alias Screens.Config.{Gl, Screen}
   alias Screens.V2.WidgetInstance.NormalHeader
 
-  def gl_header_instances(config) do
+  def gl_header_instances(config, now, fetch_destination_fn) do
     %Screen{app_params: %Gl{route_id: route_id, direction_id: direction_id}} = config
 
     icons_by_route_id = %{
@@ -14,14 +14,21 @@ defmodule Screens.V2.CandidateGenerator.Helpers do
       "Green-E" => :green_e
     }
 
+    icon = Map.get(icons_by_route_id, route_id)
+
+    case fetch_destination_fn.(route_id, direction_id) do
+      nil -> []
+      destination -> [%NormalHeader{screen: config, text: destination, icon: icon, time: now}]
+    end
+  end
+
+  def fetch_destination(route_id, direction_id) do
     case Screens.Routes.Route.by_id(route_id) do
       {:ok, %{direction_destinations: destinations}} ->
-        destination = Enum.at(destinations, direction_id)
-        icon = Map.get(icons_by_route_id, route_id)
-        [%NormalHeader{screen: config, text: destination, icon: icon, time: DateTime.utc_now()}]
+        Enum.at(destinations, direction_id)
 
       _ ->
-        []
+        nil
     end
   end
 end

--- a/lib/screens/v2/candidate_generator/helpers.ex
+++ b/lib/screens/v2/candidate_generator/helpers.ex
@@ -1,0 +1,27 @@
+defmodule Screens.V2.CandidateGenerator.Helpers do
+  @moduledoc false
+
+  alias Screens.Config.{Gl, Screen}
+  alias Screens.V2.WidgetInstance.NormalHeader
+
+  def gl_header_instances(config) do
+    %Screen{app_params: %Gl{route_id: route_id, direction_id: direction_id}} = config
+
+    icons_by_route_id = %{
+      "Green-B" => :green_b,
+      "Green-C" => :green_c,
+      "Green-D" => :green_d,
+      "Green-E" => :green_e
+    }
+
+    case Screens.Routes.Route.by_id(route_id) do
+      {:ok, %{direction_destinations: destinations}} ->
+        destination = Enum.at(destinations, direction_id)
+        icon = Map.get(icons_by_route_id, route_id)
+        [%NormalHeader{screen: config, text: destination, icon: icon, time: DateTime.utc_now()}]
+
+      _ ->
+        []
+    end
+  end
+end

--- a/lib/screens/v2/candidate_generator/solari.ex
+++ b/lib/screens/v2/candidate_generator/solari.ex
@@ -19,15 +19,15 @@ defmodule Screens.V2.CandidateGenerator.Solari do
   end
 
   @impl CandidateGenerator
-  def candidate_instances(config) do
-    header_instances(config) ++
+  def candidate_instances(config, now \\ DateTime.utc_now()) do
+    header_instances(config, now) ++
       [
         %Placeholder{color: :blue, slot_names: [:main_content_normal]}
       ]
   end
 
-  defp header_instances(config) do
+  defp header_instances(config, now) do
     %Screen{app_params: %Solari{station_name: header_text}} = config
-    [%NormalHeader{screen: config, text: header_text, time: DateTime.utc_now()}]
+    [%NormalHeader{screen: config, text: header_text, time: now}]
   end
 end

--- a/lib/screens/v2/candidate_generator/solari.ex
+++ b/lib/screens/v2/candidate_generator/solari.ex
@@ -2,7 +2,9 @@ defmodule Screens.V2.CandidateGenerator.Solari do
   @moduledoc false
 
   alias Screens.V2.CandidateGenerator
-  alias Screens.V2.WidgetInstance.Placeholder
+  alias Screens.V2.WidgetInstance.{NormalHeader, Placeholder}
+
+  alias Screens.Config.{Screen, Solari}
 
   @behaviour CandidateGenerator
 
@@ -17,10 +19,15 @@ defmodule Screens.V2.CandidateGenerator.Solari do
   end
 
   @impl CandidateGenerator
-  def candidate_instances(_config) do
-    [
-      %Placeholder{color: :green, slot_names: [:header_normal]},
-      %Placeholder{color: :blue, slot_names: [:main_content_normal]}
-    ]
+  def candidate_instances(config) do
+    header_instances(config) ++
+      [
+        %Placeholder{color: :blue, slot_names: [:main_content_normal]}
+      ]
+  end
+
+  defp header_instances(config) do
+    %Screen{app_params: %Solari{station_name: header_text}} = config
+    [%NormalHeader{screen: config, text: header_text, time: DateTime.utc_now()}]
   end
 end

--- a/lib/screens/v2/widget_instance/alert_header.ex
+++ b/lib/screens/v2/widget_instance/alert_header.ex
@@ -11,7 +11,7 @@ defmodule Screens.V2.WidgetInstance.AlertHeader do
             time: nil
 
   @type icon :: :logo | :green_b | :green_c | :green_d | :green_e
-  @type color :: :blue | :green | :orange | :purple | :red | :yellow
+  @type color :: :blue | :green | :orange | :purple | :red | :yellow | :silver
   @type accent :: :x | :hatched | :chevron
 
   @type t :: %__MODULE__{

--- a/lib/screens/v2/widget_instance/alert_header.ex
+++ b/lib/screens/v2/widget_instance/alert_header.ex
@@ -1,0 +1,43 @@
+defmodule Screens.V2.WidgetInstance.AlertHeader do
+  @moduledoc false
+
+  alias Screens.V2.WidgetInstance.AlertHeader
+
+  defstruct screen: nil,
+            text: nil,
+            icon: nil,
+            color: nil,
+            accent: nil,
+            time: nil
+
+  @type icon :: :logo | :green_b | :green_c | :green_d | :green_e
+  @type color :: :blue | :green | :orange | :purple | :red | :yellow
+  @type accent :: :x | :hatched | :chevron
+
+  @type t :: %__MODULE__{
+          screen: Screens.Config.Screen.t(),
+          text: String.t(),
+          icon: icon,
+          color: color,
+          accent: accent,
+          time: DateTime.t() | nil
+        }
+
+  defimpl Screens.V2.WidgetInstance do
+    def priority(_instance), do: [2]
+
+    def serialize(%AlertHeader{text: text, icon: icon, color: color, accent: accent, time: time}) do
+      %{text: text, icon: icon, color: color, accent: accent, time: serialize_time(time)}
+    end
+
+    defp serialize_time(%DateTime{} = time) do
+      DateTime.to_iso8601(time)
+    end
+
+    defp serialize_time(nil), do: nil
+
+    def slot_names(_instance), do: [:header]
+
+    def widget_type(_instance), do: :alert_header
+  end
+end

--- a/lib/screens/v2/widget_instance/normal_header.ex
+++ b/lib/screens/v2/widget_instance/normal_header.ex
@@ -2,6 +2,7 @@ defmodule Screens.V2.WidgetInstance.NormalHeader do
   @moduledoc false
 
   alias Screens.V2.WidgetInstance.NormalHeader
+  alias Screens.Config.{Screen, Solari}
 
   defstruct screen: nil,
             icon: nil,
@@ -21,6 +22,13 @@ defmodule Screens.V2.WidgetInstance.NormalHeader do
 
     def serialize(%NormalHeader{icon: icon, text: text, time: time}) do
       %{icon: icon, text: text, time: DateTime.to_iso8601(time)}
+    end
+
+    def slot_names(%NormalHeader{screen: %Screen{app_params: %Solari{overhead: overhead}}}) do
+      case overhead do
+        true -> [:header_overhead]
+        false -> [:header_normal]
+      end
     end
 
     def slot_names(_instance), do: [:header]

--- a/lib/screens/v2/widget_instance/normal_header.ex
+++ b/lib/screens/v2/widget_instance/normal_header.ex
@@ -4,21 +4,23 @@ defmodule Screens.V2.WidgetInstance.NormalHeader do
   alias Screens.V2.WidgetInstance.NormalHeader
 
   defstruct screen: nil,
-            station_name: nil,
+            icon: nil,
+            text: nil,
             time: nil
 
-  @type config :: :ok
+  @type icon :: :logo | :x | :green_b | :green_c | :green_d | :green_e
   @type t :: %__MODULE__{
-          screen: config(),
-          station_name: String.t(),
+          screen: Screens.Config.Screen.t(),
+          icon: icon | nil,
+          text: String.t(),
           time: DateTime.t()
         }
 
   defimpl Screens.V2.WidgetInstance do
     def priority(_instance), do: [2]
 
-    def serialize(%NormalHeader{station_name: station_name, time: time}) do
-      %{station_name: station_name, time: DateTime.to_iso8601(time)}
+    def serialize(%NormalHeader{icon: icon, text: text, time: time}) do
+      %{icon: icon, text: text, time: DateTime.to_iso8601(time)}
     end
 
     def slot_names(_instance), do: [:header]

--- a/test/screens/v2/candidate_generator/bus_eink_test.exs
+++ b/test/screens/v2/candidate_generator/bus_eink_test.exs
@@ -42,15 +42,14 @@ defmodule Screens.V2.CandidateGenerator.BusEinkTest do
       fetch_stop_fn = fn "1722" -> "1624 Blue Hill Ave @ Mattapan Sq" end
       now = ~U[2020-04-06T10:00:00Z]
 
-      assert [%NormalHeader{} = header_widget | _] =
-               BusEink.candidate_instances(config, now, fetch_stop_fn)
+      expected_header = %NormalHeader{
+        screen: config,
+        icon: nil,
+        text: "1624 Blue Hill Ave @ Mattapan Sq",
+        time: ~U[2020-04-06T10:00:00Z]
+      }
 
-      assert %NormalHeader{
-               screen: config,
-               icon: nil,
-               text: "1624 Blue Hill Ave @ Mattapan Sq",
-               time: ~U[2020-04-06T10:00:00Z]
-             } == header_widget
+      assert expected_header in BusEink.candidate_instances(config, now, fetch_stop_fn)
     end
   end
 end

--- a/test/screens/v2/candidate_generator/bus_eink_test.exs
+++ b/test/screens/v2/candidate_generator/bus_eink_test.exs
@@ -1,7 +1,21 @@
 defmodule Screens.V2.CandidateGenerator.BusEinkTest do
   use ExUnit.Case, async: true
 
+  alias Screens.Config
   alias Screens.V2.CandidateGenerator.BusEink
+  alias Screens.V2.WidgetInstance.NormalHeader
+
+  setup do
+    config = %Config.Screen{
+      app_params: %Config.Bus{stop_id: "1722"},
+      vendor: :gds,
+      device_id: "TEST",
+      name: "TEST",
+      app_id: :bus_eink
+    }
+
+    %{config: config}
+  end
 
   describe "screen_template/0" do
     test "returns correct template" do
@@ -20,6 +34,23 @@ defmodule Screens.V2.CandidateGenerator.BusEinkTest do
                 ],
                 full_takeover: [:full_screen]
               }} == BusEink.screen_template()
+    end
+  end
+
+  describe "candidate_instances/3" do
+    test "returns expected header", %{config: config} do
+      fetch_stop_fn = fn "1722" -> "1624 Blue Hill Ave @ Mattapan Sq" end
+      now = ~U[2020-04-06T10:00:00Z]
+
+      assert [%NormalHeader{} = header_widget | _] =
+               BusEink.candidate_instances(config, now, fetch_stop_fn)
+
+      assert %NormalHeader{
+               screen: config,
+               icon: nil,
+               text: "1624 Blue Hill Ave @ Mattapan Sq",
+               time: ~U[2020-04-06T10:00:00Z]
+             } == header_widget
     end
   end
 end

--- a/test/screens/v2/candidate_generator/bus_shelter_test.exs
+++ b/test/screens/v2/candidate_generator/bus_shelter_test.exs
@@ -42,15 +42,14 @@ defmodule Screens.V2.CandidateGenerator.BusShelterTest do
       fetch_stop_fn = fn "1216" -> "Columbus Ave @ Dimock St" end
       now = ~U[2020-04-06T10:00:00Z]
 
-      assert [%NormalHeader{} = header_widget | _] =
-               BusShelter.candidate_instances(config, now, fetch_stop_fn)
+      expected_header = %NormalHeader{
+        screen: config,
+        icon: nil,
+        text: "Columbus Ave @ Dimock St",
+        time: ~U[2020-04-06T10:00:00Z]
+      }
 
-      assert %NormalHeader{
-               screen: config,
-               icon: nil,
-               text: "Columbus Ave @ Dimock St",
-               time: ~U[2020-04-06T10:00:00Z]
-             } == header_widget
+      assert expected_header in BusShelter.candidate_instances(config, now, fetch_stop_fn)
     end
   end
 end

--- a/test/screens/v2/candidate_generator/bus_shelter_test.exs
+++ b/test/screens/v2/candidate_generator/bus_shelter_test.exs
@@ -1,7 +1,21 @@
 defmodule Screens.V2.CandidateGenerator.BusShelterTest do
   use ExUnit.Case, async: true
 
+  alias Screens.Config
   alias Screens.V2.CandidateGenerator.BusShelter
+  alias Screens.V2.WidgetInstance.NormalHeader
+
+  setup do
+    config = %Config.Screen{
+      app_params: %Config.BusShelter{stop_id: "1216"},
+      vendor: :lg_mri,
+      device_id: "TEST",
+      name: "TEST",
+      app_id: :bus_shelter
+    }
+
+    %{config: config}
+  end
 
   describe "screen_template/0" do
     test "returns template" do
@@ -20,6 +34,23 @@ defmodule Screens.V2.CandidateGenerator.BusShelterTest do
                 ],
                 takeover: [:full_screen]
               }} == BusShelter.screen_template()
+    end
+  end
+
+  describe "candidate_instances/3" do
+    test "returns expected header", %{config: config} do
+      fetch_stop_fn = fn "1216" -> "Columbus Ave @ Dimock St" end
+      now = ~U[2020-04-06T10:00:00Z]
+
+      assert [%NormalHeader{} = header_widget | _] =
+               BusShelter.candidate_instances(config, now, fetch_stop_fn)
+
+      assert %NormalHeader{
+               screen: config,
+               icon: nil,
+               text: "Columbus Ave @ Dimock St",
+               time: ~U[2020-04-06T10:00:00Z]
+             } == header_widget
     end
   end
 end

--- a/test/screens/v2/candidate_generator/dup_test.exs
+++ b/test/screens/v2/candidate_generator/dup_test.exs
@@ -30,14 +30,15 @@ defmodule Screens.V2.CandidateGenerator.DupTest do
   describe "candidate_instances/2" do
     test "returns expected header", %{config: config} do
       now = ~U[2020-04-06T10:00:00Z]
-      assert [%NormalHeader{} = header_widget | _] = Dup.candidate_instances(config, now)
 
-      assert %NormalHeader{
-               screen: config,
-               icon: :logo,
-               text: "Tufts Medical Ctr",
-               time: ~U[2020-04-06T10:00:00Z]
-             } == header_widget
+      expected_header = %NormalHeader{
+        screen: config,
+        icon: :logo,
+        text: "Tufts Medical Ctr",
+        time: ~U[2020-04-06T10:00:00Z]
+      }
+
+      assert expected_header in Dup.candidate_instances(config, now)
     end
   end
 end

--- a/test/screens/v2/candidate_generator/dup_test.exs
+++ b/test/screens/v2/candidate_generator/dup_test.exs
@@ -1,7 +1,21 @@
 defmodule Screens.V2.CandidateGenerator.DupTest do
   use ExUnit.Case, async: true
 
+  alias Screens.Config
   alias Screens.V2.CandidateGenerator.Dup
+  alias Screens.V2.WidgetInstance.NormalHeader
+
+  setup do
+    config = %Config.Screen{
+      app_params: %Config.Dup{primary: %Config.Dup.Departures{header: "Tufts Medical Ctr"}},
+      vendor: :outfront,
+      device_id: "TEST",
+      name: "TEST",
+      app_id: :dup
+    }
+
+    %{config: config}
+  end
 
   describe "screen_template/0" do
     test "returns correct template" do
@@ -10,6 +24,20 @@ defmodule Screens.V2.CandidateGenerator.DupTest do
                 normal: [:header, :main_content],
                 full_takeover: [:full_screen]
               }} == Dup.screen_template()
+    end
+  end
+
+  describe "candidate_instances/2" do
+    test "returns expected header", %{config: config} do
+      now = ~U[2020-04-06T10:00:00Z]
+      assert [%NormalHeader{} = header_widget | _] = Dup.candidate_instances(config, now)
+
+      assert %NormalHeader{
+               screen: config,
+               icon: :logo,
+               text: "Tufts Medical Ctr",
+               time: ~U[2020-04-06T10:00:00Z]
+             } == header_widget
     end
   end
 end

--- a/test/screens/v2/candidate_generator/gl_eink_double_test.exs
+++ b/test/screens/v2/candidate_generator/gl_eink_double_test.exs
@@ -1,7 +1,26 @@
 defmodule Screens.V2.CandidateGenerator.GlEinkDoubleTest do
   use ExUnit.Case, async: true
 
+  alias Screens.Config
   alias Screens.V2.CandidateGenerator.GlEinkDouble
+  alias Screens.V2.WidgetInstance.NormalHeader
+
+  setup do
+    config = %Config.Screen{
+      app_params: %Config.Gl{
+        stop_id: "place-bland",
+        platform_id: "70149",
+        route_id: "Green-B",
+        direction_id: 0
+      },
+      vendor: :gds,
+      device_id: "TEST",
+      name: "TEST",
+      app_id: :gl_eink_double
+    }
+
+    %{config: config}
+  end
 
   describe "screen_template/0" do
     test "returns correct template" do
@@ -20,6 +39,23 @@ defmodule Screens.V2.CandidateGenerator.GlEinkDoubleTest do
                 ],
                 full_takeover: [:full_screen]
               }} == GlEinkDouble.screen_template()
+    end
+  end
+
+  describe "candidate_instances/1" do
+    test "returns expected header", %{config: config} do
+      fetch_destination_fn = fn "Green-B", 0 -> "Boston College" end
+      now = ~U[2020-04-06T10:00:00Z]
+
+      assert [%NormalHeader{} = header_widget | _] =
+               GlEinkDouble.candidate_instances(config, now, fetch_destination_fn)
+
+      assert %NormalHeader{
+               screen: config,
+               icon: :green_b,
+               text: "Boston College",
+               time: ~U[2020-04-06T10:00:00Z]
+             } == header_widget
     end
   end
 end

--- a/test/screens/v2/candidate_generator/gl_eink_double_test.exs
+++ b/test/screens/v2/candidate_generator/gl_eink_double_test.exs
@@ -47,15 +47,18 @@ defmodule Screens.V2.CandidateGenerator.GlEinkDoubleTest do
       fetch_destination_fn = fn "Green-B", 0 -> "Boston College" end
       now = ~U[2020-04-06T10:00:00Z]
 
-      assert [%NormalHeader{} = header_widget | _] =
-               GlEinkDouble.candidate_instances(config, now, fetch_destination_fn)
+      expected_header = %NormalHeader{
+        screen: config,
+        icon: :green_b,
+        text: "Boston College",
+        time: ~U[2020-04-06T10:00:00Z]
+      }
 
-      assert %NormalHeader{
-               screen: config,
-               icon: :green_b,
-               text: "Boston College",
-               time: ~U[2020-04-06T10:00:00Z]
-             } == header_widget
+      assert expected_header in GlEinkDouble.candidate_instances(
+               config,
+               now,
+               fetch_destination_fn
+             )
     end
   end
 end

--- a/test/screens/v2/candidate_generator/gl_eink_single_test.exs
+++ b/test/screens/v2/candidate_generator/gl_eink_single_test.exs
@@ -1,7 +1,26 @@
 defmodule Screens.V2.CandidateGenerator.GlEinkSingleTest do
   use ExUnit.Case, async: true
 
+  alias Screens.Config
   alias Screens.V2.CandidateGenerator.GlEinkSingle
+  alias Screens.V2.WidgetInstance.NormalHeader
+
+  setup do
+    config = %Config.Screen{
+      app_params: %Config.Gl{
+        stop_id: "place-bland",
+        platform_id: "70149",
+        route_id: "Green-B",
+        direction_id: 0
+      },
+      vendor: :gds,
+      device_id: "TEST",
+      name: "TEST",
+      app_id: :gl_eink_double
+    }
+
+    %{config: config}
+  end
 
   describe "screen_template/0" do
     test "returns correct template" do
@@ -14,6 +33,23 @@ defmodule Screens.V2.CandidateGenerator.GlEinkSingleTest do
                 ],
                 full_takeover: [:full_screen]
               }} == GlEinkSingle.screen_template()
+    end
+  end
+
+  describe "candidate_instances/1" do
+    test "returns expected header", %{config: config} do
+      fetch_destination_fn = fn "Green-B", 0 -> "Boston College" end
+      now = ~U[2020-04-06T10:00:00Z]
+
+      assert [%NormalHeader{} = header_widget | _] =
+               GlEinkSingle.candidate_instances(config, now, fetch_destination_fn)
+
+      assert %NormalHeader{
+               screen: config,
+               icon: :green_b,
+               text: "Boston College",
+               time: ~U[2020-04-06T10:00:00Z]
+             } == header_widget
     end
   end
 end

--- a/test/screens/v2/candidate_generator/gl_eink_single_test.exs
+++ b/test/screens/v2/candidate_generator/gl_eink_single_test.exs
@@ -41,15 +41,18 @@ defmodule Screens.V2.CandidateGenerator.GlEinkSingleTest do
       fetch_destination_fn = fn "Green-B", 0 -> "Boston College" end
       now = ~U[2020-04-06T10:00:00Z]
 
-      assert [%NormalHeader{} = header_widget | _] =
-               GlEinkSingle.candidate_instances(config, now, fetch_destination_fn)
+      expected_header = %NormalHeader{
+        screen: config,
+        icon: :green_b,
+        text: "Boston College",
+        time: ~U[2020-04-06T10:00:00Z]
+      }
 
-      assert %NormalHeader{
-               screen: config,
-               icon: :green_b,
-               text: "Boston College",
-               time: ~U[2020-04-06T10:00:00Z]
-             } == header_widget
+      assert expected_header in GlEinkSingle.candidate_instances(
+               config,
+               now,
+               fetch_destination_fn
+             )
     end
   end
 end

--- a/test/screens/v2/candidate_generator/solari_test.exs
+++ b/test/screens/v2/candidate_generator/solari_test.exs
@@ -31,14 +31,15 @@ defmodule Screens.V2.CandidateGenerator.SolariTest do
   describe "candidate_instances/2" do
     test "returns expected header", %{config: config} do
       now = ~U[2020-04-06T10:00:00Z]
-      assert [%NormalHeader{} = header_widget | _] = Solari.candidate_instances(config, now)
 
-      assert %NormalHeader{
-               screen: config,
-               icon: nil,
-               text: "Ruggles",
-               time: ~U[2020-04-06T10:00:00Z]
-             } == header_widget
+      expected_header = %NormalHeader{
+        screen: config,
+        icon: nil,
+        text: "Ruggles",
+        time: ~U[2020-04-06T10:00:00Z]
+      }
+
+      assert expected_header in Solari.candidate_instances(config, now)
     end
   end
 end

--- a/test/screens/v2/candidate_generator/solari_test.exs
+++ b/test/screens/v2/candidate_generator/solari_test.exs
@@ -1,7 +1,21 @@
 defmodule Screens.V2.CandidateGenerator.SolariTest do
   use ExUnit.Case, async: true
 
+  alias Screens.Config
   alias Screens.V2.CandidateGenerator.Solari
+  alias Screens.V2.WidgetInstance.NormalHeader
+
+  setup do
+    config = %Config.Screen{
+      app_params: %Config.Solari{station_name: "Ruggles"},
+      vendor: :solari,
+      device_id: "TEST",
+      name: "TEST",
+      app_id: :solari
+    }
+
+    %{config: config}
+  end
 
   describe "screen_template/0" do
     test "returns correct template" do
@@ -11,6 +25,20 @@ defmodule Screens.V2.CandidateGenerator.SolariTest do
                 overhead: [:header_overhead, :main_content_overhead],
                 takeover: [:full_screen]
               }} == Solari.screen_template()
+    end
+  end
+
+  describe "candidate_instances/2" do
+    test "returns expected header", %{config: config} do
+      now = ~U[2020-04-06T10:00:00Z]
+      assert [%NormalHeader{} = header_widget | _] = Solari.candidate_instances(config, now)
+
+      assert %NormalHeader{
+               screen: config,
+               icon: nil,
+               text: "Ruggles",
+               time: ~U[2020-04-06T10:00:00Z]
+             } == header_widget
     end
   end
 end

--- a/test/screens/v2/widget_instance/alert_header_test.exs
+++ b/test/screens/v2/widget_instance/alert_header_test.exs
@@ -1,0 +1,63 @@
+defmodule Screens.V2.WidgetInstance.AlertHeaderTest do
+  use ExUnit.Case, async: true
+
+  alias Screens.V2.WidgetInstance
+
+  setup do
+    %{
+      instance_no_time: %WidgetInstance.AlertHeader{
+        text: "Copley",
+        icon: :logo,
+        accent: :hatched,
+        color: :green
+      },
+      instance_with_time: %WidgetInstance.AlertHeader{
+        text: "Back Bay",
+        icon: :logo,
+        accent: :x,
+        color: :orange,
+        time: ~U[2021-03-04 11:00:00Z]
+      }
+    }
+  end
+
+  describe "priority/1" do
+    test "returns 2", %{instance_no_time: instance} do
+      assert [2] == WidgetInstance.priority(instance)
+    end
+  end
+
+  describe "serialize/1" do
+    test "handles header without time", %{instance_no_time: instance} do
+      assert %{
+               icon: :logo,
+               text: "Copley",
+               accent: :hatched,
+               color: :green,
+               time: nil
+             } == WidgetInstance.serialize(instance)
+    end
+
+    test "handles header with time", %{instance_with_time: instance} do
+      assert %{
+               icon: :logo,
+               text: "Back Bay",
+               accent: :x,
+               color: :orange,
+               time: "2021-03-04T11:00:00Z"
+             } == WidgetInstance.serialize(instance)
+    end
+  end
+
+  describe "slot_names/1" do
+    test "returns header", %{instance_no_time: instance} do
+      assert [:header] == WidgetInstance.slot_names(instance)
+    end
+  end
+
+  describe "widget_type/1" do
+    test "returns alert_header", %{instance_no_time: instance} do
+      assert :alert_header == WidgetInstance.widget_type(instance)
+    end
+  end
+end

--- a/test/screens/v2/widget_instance/normal_header_test.exs
+++ b/test/screens/v2/widget_instance/normal_header_test.exs
@@ -6,7 +6,8 @@ defmodule Screens.V2.WidgetInstance.NormalHeaderTest do
   setup do
     %{
       instance: %WidgetInstance.NormalHeader{
-        station_name: "Ruggles",
+        icon: :logo,
+        text: "Ruggles",
         time: ~U[2021-03-04 11:00:00Z]
       }
     }
@@ -19,9 +20,10 @@ defmodule Screens.V2.WidgetInstance.NormalHeaderTest do
   end
 
   describe "serialize/1" do
-    test "returns serialized name and time", %{instance: instance} do
+    test "returns serialized text, icon and time", %{instance: instance} do
       assert %{
-               station_name: "Ruggles",
+               icon: :logo,
+               text: "Ruggles",
                time: "2021-03-04T11:00:00Z"
              } == WidgetInstance.serialize(instance)
     end


### PR DESCRIPTION
**Asana task**: [Backend real headers](https://app.asana.com/0/1185117109217413/1200050362904581)

This PR defines two header widgets:
- `NormalHeader` which has text, an optional icon, and a current time.
- `AlertHeader` which has text and an optional color, accent pattern, icon and current time.

These widgets are split by purpose: Most of the time, we'll use `NormalHeader`. The DUP headers on full screen alerts would use `AlertHeader`. I imagine that the GL e-Ink "Green Line Shuttle" header with a hatched border could, as well (for example).

This PR also modifies all of the screen candidate generators to return `NormalHeader` widgets. We can update them to return `AlertHeader` widgets when appropriate as a part of the future alerts epic.