### PR TITLE
feat: automatically handle multiple westbound shuttles at Kenmore

### DIFF
--- a/lib/screens/dup_screen_data.ex
+++ b/lib/screens/dup_screen_data.ex
@@ -4,14 +4,12 @@ defmodule Screens.DupScreenData do
   alias Screens.Config.{Dup, State}
 
   alias Screens.Config.Dup.Override.{
-    FreeTextLine,
     FullscreenAlert,
     FullscreenImage,
-    PartialAlert,
     PartialAlertList
   }
 
-  alias Screens.DupScreenData.{Data, Request, Response}
+  alias Screens.DupScreenData.{Data, Request, Response, SpecialCases}
 
   def by_screen_id(screen_id, rotation_index)
 
@@ -59,7 +57,7 @@ defmodule Screens.DupScreenData do
   end
 
   defp primary_screen_response(primary_departures, rotation_index) do
-    case handle_special_cases(primary_departures, rotation_index) do
+    case SpecialCases.handle_special_cases(primary_departures, rotation_index) do
       {:ok, response} ->
         response
 
@@ -87,240 +85,6 @@ defmodule Screens.DupScreenData do
         fetch_fullscreen_alert_response(primary_departures, alerts, line_count)
     end
   end
-
-  defp handle_special_cases(
-         %Dup.Departures{
-           sections: [
-             %Dup.Section{
-               stop_ids: ["place-kencl"] = stop_ids,
-               route_ids: ["Green-B", "Green-C", "Green-D"] = route_ids,
-               pill: pill
-             }
-           ]
-         } = primary_departures,
-         rotation_index
-       ) do
-    alerts = Request.fetch_alerts(stop_ids, route_ids)
-
-    interpreted_alerts =
-      alerts
-      |> Enum.map(fn alert ->
-        Map.put(
-          Data.interpret_alert(alert, stop_ids, pill),
-          :routes,
-          Data.alert_routes_at_station(alert, stop_ids)
-        )
-      end)
-      |> Enum.sort_by(& &1.routes)
-
-    render_kenmore_alerts(interpreted_alerts, primary_departures, rotation_index)
-  end
-
-  defp handle_special_cases(_, _), do: nil
-
-  defp render_kenmore_alerts(interpreted_alerts, primary_departures, "0") do
-    current_time = DateTime.utc_now()
-
-    case kenmore_partial_alert_text(interpreted_alerts) do
-      {:ok, text} ->
-        line = %FreeTextLine{icon: :warning, text: text}
-        override = %PartialAlertList{alerts: [%PartialAlert{color: :green, content: line}]}
-
-        {:ok,
-         fetch_partial_alert_response(primary_departures, override, current_time, override: true)}
-
-      {:ok, text, headway_message} ->
-        render_kenmore_headway_alert(text, headway_message)
-
-      _ ->
-        nil
-    end
-  end
-
-  defp render_kenmore_headway_alert(text, headway_message) do
-    current_time = DateTime.utc_now()
-    line = %FreeTextLine{icon: :warning, text: text}
-    override = %PartialAlertList{alerts: [%PartialAlert{color: :green, content: line}]}
-
-    response = %{
-      force_reload: false,
-      success: true,
-      header: "Kenmore",
-      sections: [%{headway: headway_message}],
-      alerts: PartialAlertList.to_json(override).alerts,
-      current_time: Screens.Util.format_time(current_time),
-      type: :departures
-    }
-
-    {:ok, response}
-  end
-
-  defp render_kenmore_alerts(interpreted_alerts, _primary_departures, "1") do
-    case kenmore_fullscreen_alert_text(interpreted_alerts) do
-      nil ->
-        nil
-
-      issue_text ->
-        issue = %{
-          icon: :warning,
-          text: issue_text
-        }
-
-        remedy = %{
-          icon: :shuttle,
-          text: [%{format: :bold, text: "Use shuttle bus"}]
-        }
-
-        response = %{
-          type: :full_screen_alert,
-          force_reload: false,
-          success: true,
-          header: "Kenmore",
-          pattern: :x,
-          color: :green,
-          issue: issue,
-          remedy: remedy
-        }
-
-        {:ok, response}
-    end
-  end
-
-  defp kenmore_partial_alert_text([
-         %{effect: :shuttle, region: :boundary, routes: ["Green-B"], headsign: "Boston College"},
-         %{effect: :shuttle, region: :boundary, routes: ["Green-C"], headsign: "Cleveland Circle"}
-       ]) do
-    {:ok, ["No", %{format: :bold, text: "Bost Coll/Clvlnd Cir"}]}
-  end
-
-  defp kenmore_partial_alert_text([
-         %{effect: :shuttle, region: :boundary, routes: ["Green-B"], headsign: "Boston College"},
-         %{effect: :shuttle, region: :boundary, routes: ["Green-D"], headsign: "Riverside"}
-       ]) do
-    {:ok, ["No", %{format: :bold, text: "Bost Coll / Riverside"}]}
-  end
-
-  defp kenmore_partial_alert_text([
-         %{
-           effect: :shuttle,
-           region: :boundary,
-           routes: ["Green-C"],
-           headsign: "Cleveland Circle"
-         },
-         %{effect: :shuttle, region: :boundary, routes: ["Green-D"], headsign: "Riverside"}
-       ]) do
-    {:ok, ["No", %{format: :bold, text: "Clvlnd Cir/Riverside"}]}
-  end
-
-  defp kenmore_partial_alert_text([
-         %{effect: :shuttle, region: :boundary, routes: ["Green-B"], headsign: "Boston College"},
-         %{
-           effect: :shuttle,
-           region: :boundary,
-           routes: ["Green-C"],
-           headsign: "Cleveland Circle"
-         },
-         %{effect: :shuttle, region: :boundary, routes: ["Green-D"], headsign: "Riverside"}
-       ]) do
-    partial_alert_text = ["No", %{format: :bold, text: "Westbound"}, "trains"]
-
-    kenmore_headway_id = "green_trunk"
-    time_ranges = Screens.SignsUiConfig.State.time_ranges(kenmore_headway_id)
-    current_time_period = DateTime.utc_now() |> Screens.Util.time_period()
-
-    case time_ranges do
-      %{^current_time_period => {lo, hi}} ->
-        headway_message = %{
-          icon: "subway-negative-black",
-          text: [
-            %{color: :green, text: "GREEN LINE"},
-            %{special: :break},
-            "every",
-            %{format: :bold, text: "#{lo}-#{hi}"},
-            "minutes"
-          ]
-        }
-
-        {:ok, partial_alert_text, headway_message}
-
-      _ ->
-        {:ok, partial_alert_text}
-    end
-  end
-
-  defp kenmore_partial_alert_text(_), do: nil
-
-  defp kenmore_fullscreen_alert_text([
-         %{effect: :shuttle, region: :boundary, routes: ["Green-B"], headsign: "Boston College"},
-         %{effect: :shuttle, region: :boundary, routes: ["Green-C"], headsign: "Cleveland Circle"}
-       ]) do
-    [
-      "No",
-      %{icon: :green_b},
-      %{format: :bold, text: "Boston Coll"},
-      "or",
-      %{icon: :green_c},
-      %{format: :bold, text: "Cleveland Cir"},
-      "trains"
-    ]
-  end
-
-  defp kenmore_fullscreen_alert_text([
-         %{effect: :shuttle, region: :boundary, routes: ["Green-B"], headsign: "Boston College"},
-         %{effect: :shuttle, region: :boundary, routes: ["Green-D"], headsign: "Riverside"}
-       ]) do
-    [
-      "No",
-      %{icon: :green_b},
-      %{format: :bold, text: "Boston College"},
-      "or",
-      %{icon: :green_d},
-      %{format: :bold, text: "Riverside"},
-      "trains"
-    ]
-  end
-
-  defp kenmore_fullscreen_alert_text([
-         %{
-           effect: :shuttle,
-           region: :boundary,
-           routes: ["Green-C"],
-           headsign: "Cleveland Circle"
-         },
-         %{effect: :shuttle, region: :boundary, routes: ["Green-D"], headsign: "Riverside"}
-       ]) do
-    [
-      "No",
-      %{icon: :green_c},
-      %{format: :bold, text: "Cleveland Cir"},
-      "or",
-      %{icon: :green_d},
-      %{format: :bold, text: "Riverside"},
-      "trains"
-    ]
-  end
-
-  defp kenmore_fullscreen_alert_text([
-         %{effect: :shuttle, region: :boundary, routes: ["Green-B"], headsign: "Boston College"},
-         %{
-           effect: :shuttle,
-           region: :boundary,
-           routes: ["Green-C"],
-           headsign: "Cleveland Circle"
-         },
-         %{effect: :shuttle, region: :boundary, routes: ["Green-D"], headsign: "Riverside"}
-       ]) do
-    [
-      "No",
-      %{icon: :green_b},
-      %{icon: :green_c},
-      %{icon: :green_d},
-      %{format: :bold, text: "Westbound"},
-      "trains"
-    ]
-  end
-
-  defp kenmore_fullscreen_alert_text(_), do: nil
 
   defp primary_screen_response_with_override(
          primary_departures,
@@ -433,12 +197,12 @@ defmodule Screens.DupScreenData do
     end
   end
 
-  defp fetch_partial_alert_response(
-         primary_departures,
-         alerts_or_override,
-         current_time,
-         opts \\ []
-       ) do
+  def fetch_partial_alert_response(
+        primary_departures,
+        alerts_or_override,
+        current_time,
+        opts \\ []
+      ) do
     override? = Keyword.get(opts, :override, false)
     alerts_by_section = if(override?, do: %{}, else: alerts_or_override)
     alerts = if(override?, do: alerts_or_override, else: flatten_alerts(alerts_by_section))

--- a/lib/screens/dup_screen_data/data.ex
+++ b/lib/screens/dup_screen_data/data.ex
@@ -32,6 +32,22 @@ defmodule Screens.DupScreenData.Data do
     }
   end
 
+  def alert_routes_at_station(alert, [parent_stop_id]) do
+    filter_fn = fn
+      %{stop: stop_id} -> stop_id == parent_stop_id
+      _ -> false
+    end
+
+    route_fn = fn
+      %{route: route_id} -> [route_id]
+      _ -> []
+    end
+
+    alert.informed_entities
+    |> Enum.filter(filter_fn)
+    |> Enum.flat_map(route_fn)
+  end
+
   def station_line_count(%Dup.Departures{sections: [section | _]}) do
     stop_id = hd(section.stop_ids)
     if stop_id in Application.get_env(:screens, :two_line_stops), do: 2, else: 1

--- a/lib/screens/dup_screen_data/special_cases.ex
+++ b/lib/screens/dup_screen_data/special_cases.ex
@@ -118,38 +118,85 @@ defmodule Screens.DupScreenData.SpecialCases do
          %{effect: :shuttle, region: :boundary, routes: ["Green-B"], headsign: "Boston College"},
          %{effect: :shuttle, region: :boundary, routes: ["Green-C"], headsign: "Cleveland Circle"}
        ]) do
+    kenmore_bc_partial_alert_text()
+  end
+
+  defp kenmore_partial_alert_text([
+         %{effect: :shuttle, region: :boundary, headsign: "BC/Clev. Circ."}
+       ]) do
+    kenmore_bc_partial_alert_text()
+  end
+
+  defp kenmore_partial_alert_text([
+         %{effect: :shuttle, region: :boundary, routes: ["Green-B"], headsign: "Boston College"},
+         %{effect: :shuttle, region: :boundary, routes: ["Green-D"], headsign: "Riverside"}
+       ]) do
+    kenmore_bd_partial_alert_text()
+  end
+
+  defp kenmore_partial_alert_text([
+         %{effect: :shuttle, region: :boundary, headsign: "BC/Riverside"}
+       ]) do
+    kenmore_bd_partial_alert_text()
+  end
+
+  defp kenmore_partial_alert_text([
+         %{
+           effect: :shuttle,
+           region: :boundary,
+           routes: ["Green-C"],
+           headsign: "Cleveland Circle"
+         },
+         %{
+           effect: :shuttle,
+           region: :boundary,
+           routes: ["Green-D"],
+           headsign: "Riverside"
+         }
+       ]) do
+    kenmore_cd_partial_alert_text()
+  end
+
+  defp kenmore_partial_alert_text([
+         %{effect: :shuttle, region: :boundary, headsign: "Clev. Circ./Riverside"}
+       ]) do
+    kenmore_cd_partial_alert_text()
+  end
+
+  defp kenmore_partial_alert_text([
+         %{effect: :shuttle, region: :boundary, routes: ["Green-B"], headsign: "Boston College"},
+         %{
+           effect: :shuttle,
+           region: :boundary,
+           routes: ["Green-C"],
+           headsign: "Cleveland Circle"
+         },
+         %{effect: :shuttle, region: :boundary, routes: ["Green-D"], headsign: "Riverside"}
+       ]) do
+    kenmore_bcd_partial_alert_text()
+  end
+
+  defp kenmore_partial_alert_text([
+         %{effect: :shuttle, region: :boundary, headsign: {:adj, "westbound"}}
+       ]) do
+    kenmore_bcd_partial_alert_text()
+  end
+
+  defp kenmore_partial_alert_text(_), do: nil
+
+  defp kenmore_bc_partial_alert_text do
     {:ok, ["No", %{format: :bold, text: "Bost Coll/Clvlnd Cir"}]}
   end
 
-  defp kenmore_partial_alert_text([
-         %{effect: :shuttle, region: :boundary, routes: ["Green-B"], headsign: "Boston College"},
-         %{effect: :shuttle, region: :boundary, routes: ["Green-D"], headsign: "Riverside"}
-       ]) do
+  defp kenmore_bd_partial_alert_text do
     {:ok, ["No", %{format: :bold, text: "Bost Coll / Riverside"}]}
   end
 
-  defp kenmore_partial_alert_text([
-         %{
-           effect: :shuttle,
-           region: :boundary,
-           routes: ["Green-C"],
-           headsign: "Cleveland Circle"
-         },
-         %{effect: :shuttle, region: :boundary, routes: ["Green-D"], headsign: "Riverside"}
-       ]) do
+  defp kenmore_cd_partial_alert_text do
     {:ok, ["No", %{format: :bold, text: "Clvlnd Cir/Riverside"}]}
   end
 
-  defp kenmore_partial_alert_text([
-         %{effect: :shuttle, region: :boundary, routes: ["Green-B"], headsign: "Boston College"},
-         %{
-           effect: :shuttle,
-           region: :boundary,
-           routes: ["Green-C"],
-           headsign: "Cleveland Circle"
-         },
-         %{effect: :shuttle, region: :boundary, routes: ["Green-D"], headsign: "Riverside"}
-       ]) do
+  defp kenmore_bcd_partial_alert_text do
     partial_alert_text = ["No", %{format: :bold, text: "Westbound"}, "trains"]
 
     kenmore_headway_id = "green_trunk"
@@ -176,12 +223,72 @@ defmodule Screens.DupScreenData.SpecialCases do
     end
   end
 
-  defp kenmore_partial_alert_text(_), do: nil
-
   defp kenmore_fullscreen_alert_text([
          %{effect: :shuttle, region: :boundary, routes: ["Green-B"], headsign: "Boston College"},
          %{effect: :shuttle, region: :boundary, routes: ["Green-C"], headsign: "Cleveland Circle"}
        ]) do
+    kenmore_bc_fullscreen_alert_text()
+  end
+
+  defp kenmore_fullscreen_alert_text([
+         %{effect: :shuttle, region: :boundary, headsign: "BC/Clev. Circ."}
+       ]) do
+    kenmore_bc_fullscreen_alert_text()
+  end
+
+  defp kenmore_fullscreen_alert_text([
+         %{effect: :shuttle, region: :boundary, routes: ["Green-B"], headsign: "Boston College"},
+         %{effect: :shuttle, region: :boundary, routes: ["Green-D"], headsign: "Riverside"}
+       ]) do
+    kenmore_bd_fullscreen_alert_text()
+  end
+
+  defp kenmore_fullscreen_alert_text([
+         %{effect: :shuttle, region: :boundary, headsign: "BC/Riverside"}
+       ]) do
+    kenmore_bd_fullscreen_alert_text()
+  end
+
+  defp kenmore_fullscreen_alert_text([
+         %{
+           effect: :shuttle,
+           region: :boundary,
+           routes: ["Green-C"],
+           headsign: "Cleveland Circle"
+         },
+         %{effect: :shuttle, region: :boundary, routes: ["Green-D"], headsign: "Riverside"}
+       ]) do
+    kenmore_cd_fullscreen_alert_text()
+  end
+
+  defp kenmore_fullscreen_alert_text([
+         %{effect: :shuttle, region: :boundary, headsign: "Clev. Circ./Riverside"}
+       ]) do
+    kenmore_cd_fullscreen_alert_text()
+  end
+
+  defp kenmore_fullscreen_alert_text([
+         %{effect: :shuttle, region: :boundary, routes: ["Green-B"], headsign: "Boston College"},
+         %{
+           effect: :shuttle,
+           region: :boundary,
+           routes: ["Green-C"],
+           headsign: "Cleveland Circle"
+         },
+         %{effect: :shuttle, region: :boundary, routes: ["Green-D"], headsign: "Riverside"}
+       ]) do
+    kenmore_bcd_fullscreen_alert_text()
+  end
+
+  defp kenmore_fullscreen_alert_text([
+         %{effect: :shuttle, region: :boundary, headsign: {:adj, "westbound"}}
+       ]) do
+    kenmore_bcd_fullscreen_alert_text()
+  end
+
+  defp kenmore_fullscreen_alert_text(_), do: nil
+
+  defp kenmore_bc_fullscreen_alert_text do
     [
       "No",
       %{icon: :green_b},
@@ -193,10 +300,7 @@ defmodule Screens.DupScreenData.SpecialCases do
     ]
   end
 
-  defp kenmore_fullscreen_alert_text([
-         %{effect: :shuttle, region: :boundary, routes: ["Green-B"], headsign: "Boston College"},
-         %{effect: :shuttle, region: :boundary, routes: ["Green-D"], headsign: "Riverside"}
-       ]) do
+  defp kenmore_bd_fullscreen_alert_text do
     [
       "No",
       %{icon: :green_b},
@@ -208,15 +312,7 @@ defmodule Screens.DupScreenData.SpecialCases do
     ]
   end
 
-  defp kenmore_fullscreen_alert_text([
-         %{
-           effect: :shuttle,
-           region: :boundary,
-           routes: ["Green-C"],
-           headsign: "Cleveland Circle"
-         },
-         %{effect: :shuttle, region: :boundary, routes: ["Green-D"], headsign: "Riverside"}
-       ]) do
+  defp kenmore_cd_fullscreen_alert_text do
     [
       "No",
       %{icon: :green_c},
@@ -228,16 +324,7 @@ defmodule Screens.DupScreenData.SpecialCases do
     ]
   end
 
-  defp kenmore_fullscreen_alert_text([
-         %{effect: :shuttle, region: :boundary, routes: ["Green-B"], headsign: "Boston College"},
-         %{
-           effect: :shuttle,
-           region: :boundary,
-           routes: ["Green-C"],
-           headsign: "Cleveland Circle"
-         },
-         %{effect: :shuttle, region: :boundary, routes: ["Green-D"], headsign: "Riverside"}
-       ]) do
+  defp kenmore_bcd_fullscreen_alert_text do
     [
       "No",
       %{icon: :green_b},
@@ -247,6 +334,4 @@ defmodule Screens.DupScreenData.SpecialCases do
       "trains"
     ]
   end
-
-  defp kenmore_fullscreen_alert_text(_), do: nil
 end

--- a/lib/screens/dup_screen_data/special_cases.ex
+++ b/lib/screens/dup_screen_data/special_cases.ex
@@ -28,11 +28,9 @@ defmodule Screens.DupScreenData.SpecialCases do
     interpreted_alerts =
       alerts
       |> Enum.map(fn alert ->
-        Map.put(
-          Data.interpret_alert(alert, stop_ids, pill),
-          :routes,
-          Data.alert_routes_at_station(alert, stop_ids)
-        )
+        alert
+        |> Data.interpret_alert(stop_ids, pill)
+        |> Map.put(:routes, Data.alert_routes_at_station(alert, stop_ids))
       end)
       |> Enum.sort_by(& &1.routes)
 
@@ -294,6 +292,7 @@ defmodule Screens.DupScreenData.SpecialCases do
       %{icon: :green_b},
       %{format: :bold, text: "Boston Coll"},
       "or",
+      %{special: :break},
       %{icon: :green_c},
       %{format: :bold, text: "Cleveland Cir"},
       "trains"
@@ -306,6 +305,7 @@ defmodule Screens.DupScreenData.SpecialCases do
       %{icon: :green_b},
       %{format: :bold, text: "Boston College"},
       "or",
+      %{special: :break},
       %{icon: :green_d},
       %{format: :bold, text: "Riverside"},
       "trains"
@@ -318,6 +318,7 @@ defmodule Screens.DupScreenData.SpecialCases do
       %{icon: :green_c},
       %{format: :bold, text: "Cleveland Cir"},
       "or",
+      %{special: :break},
       %{icon: :green_d},
       %{format: :bold, text: "Riverside"},
       "trains"

--- a/lib/screens/dup_screen_data/special_cases.ex
+++ b/lib/screens/dup_screen_data/special_cases.ex
@@ -1,0 +1,252 @@
+defmodule Screens.DupScreenData.SpecialCases do
+  @moduledoc false
+
+  alias Screens.Config.Dup
+
+  alias Screens.Config.Dup.Override.{
+    FreeTextLine,
+    PartialAlert,
+    PartialAlertList
+  }
+
+  alias Screens.DupScreenData.{Data, Request}
+
+  def handle_special_cases(
+        %Dup.Departures{
+          sections: [
+            %Dup.Section{
+              stop_ids: ["place-kencl"] = stop_ids,
+              route_ids: ["Green-B", "Green-C", "Green-D"] = route_ids,
+              pill: pill
+            }
+          ]
+        } = primary_departures,
+        rotation_index
+      ) do
+    alerts = Request.fetch_alerts(stop_ids, route_ids)
+
+    interpreted_alerts =
+      alerts
+      |> Enum.map(fn alert ->
+        Map.put(
+          Data.interpret_alert(alert, stop_ids, pill),
+          :routes,
+          Data.alert_routes_at_station(alert, stop_ids)
+        )
+      end)
+      |> Enum.sort_by(& &1.routes)
+
+    render_kenmore_alerts(interpreted_alerts, primary_departures, rotation_index)
+  end
+
+  def handle_special_cases(_, _), do: nil
+
+  defp render_kenmore_alerts(interpreted_alerts, primary_departures, "0") do
+    current_time = DateTime.utc_now()
+
+    case kenmore_partial_alert_text(interpreted_alerts) do
+      {:ok, text} ->
+        line = %FreeTextLine{icon: :warning, text: text}
+        override = %PartialAlertList{alerts: [%PartialAlert{color: :green, content: line}]}
+
+        {:ok,
+         Screens.DupScreenData.fetch_partial_alert_response(
+           primary_departures,
+           override,
+           current_time,
+           override: true
+         )}
+
+      {:ok, text, headway_message} ->
+        render_kenmore_headway_alert(text, headway_message)
+
+      _ ->
+        nil
+    end
+  end
+
+  defp render_kenmore_alerts(interpreted_alerts, _primary_departures, "1") do
+    case kenmore_fullscreen_alert_text(interpreted_alerts) do
+      nil ->
+        nil
+
+      issue_text ->
+        issue = %{
+          icon: :warning,
+          text: issue_text
+        }
+
+        remedy = %{
+          icon: :shuttle,
+          text: [%{format: :bold, text: "Use shuttle bus"}]
+        }
+
+        response = %{
+          type: :full_screen_alert,
+          force_reload: false,
+          success: true,
+          header: "Kenmore",
+          pattern: :x,
+          color: :green,
+          issue: issue,
+          remedy: remedy
+        }
+
+        {:ok, response}
+    end
+  end
+
+  defp render_kenmore_headway_alert(text, headway_message) do
+    current_time = DateTime.utc_now()
+    line = %FreeTextLine{icon: :warning, text: text}
+    override = %PartialAlertList{alerts: [%PartialAlert{color: :green, content: line}]}
+
+    response = %{
+      force_reload: false,
+      success: true,
+      header: "Kenmore",
+      sections: [%{headway: headway_message}],
+      alerts: PartialAlertList.to_json(override).alerts,
+      current_time: Screens.Util.format_time(current_time),
+      type: :departures
+    }
+
+    {:ok, response}
+  end
+
+  defp kenmore_partial_alert_text([
+         %{effect: :shuttle, region: :boundary, routes: ["Green-B"], headsign: "Boston College"},
+         %{effect: :shuttle, region: :boundary, routes: ["Green-C"], headsign: "Cleveland Circle"}
+       ]) do
+    {:ok, ["No", %{format: :bold, text: "Bost Coll/Clvlnd Cir"}]}
+  end
+
+  defp kenmore_partial_alert_text([
+         %{effect: :shuttle, region: :boundary, routes: ["Green-B"], headsign: "Boston College"},
+         %{effect: :shuttle, region: :boundary, routes: ["Green-D"], headsign: "Riverside"}
+       ]) do
+    {:ok, ["No", %{format: :bold, text: "Bost Coll / Riverside"}]}
+  end
+
+  defp kenmore_partial_alert_text([
+         %{
+           effect: :shuttle,
+           region: :boundary,
+           routes: ["Green-C"],
+           headsign: "Cleveland Circle"
+         },
+         %{effect: :shuttle, region: :boundary, routes: ["Green-D"], headsign: "Riverside"}
+       ]) do
+    {:ok, ["No", %{format: :bold, text: "Clvlnd Cir/Riverside"}]}
+  end
+
+  defp kenmore_partial_alert_text([
+         %{effect: :shuttle, region: :boundary, routes: ["Green-B"], headsign: "Boston College"},
+         %{
+           effect: :shuttle,
+           region: :boundary,
+           routes: ["Green-C"],
+           headsign: "Cleveland Circle"
+         },
+         %{effect: :shuttle, region: :boundary, routes: ["Green-D"], headsign: "Riverside"}
+       ]) do
+    partial_alert_text = ["No", %{format: :bold, text: "Westbound"}, "trains"]
+
+    kenmore_headway_id = "green_trunk"
+    time_ranges = Screens.SignsUiConfig.State.time_ranges(kenmore_headway_id)
+    current_time_period = DateTime.utc_now() |> Screens.Util.time_period()
+
+    case time_ranges do
+      %{^current_time_period => {lo, hi}} ->
+        headway_message = %{
+          icon: "subway-negative-black",
+          text: [
+            %{color: :green, text: "GREEN LINE"},
+            %{special: :break},
+            "every",
+            %{format: :bold, text: "#{lo}-#{hi}"},
+            "minutes"
+          ]
+        }
+
+        {:ok, partial_alert_text, headway_message}
+
+      _ ->
+        {:ok, partial_alert_text}
+    end
+  end
+
+  defp kenmore_partial_alert_text(_), do: nil
+
+  defp kenmore_fullscreen_alert_text([
+         %{effect: :shuttle, region: :boundary, routes: ["Green-B"], headsign: "Boston College"},
+         %{effect: :shuttle, region: :boundary, routes: ["Green-C"], headsign: "Cleveland Circle"}
+       ]) do
+    [
+      "No",
+      %{icon: :green_b},
+      %{format: :bold, text: "Boston Coll"},
+      "or",
+      %{icon: :green_c},
+      %{format: :bold, text: "Cleveland Cir"},
+      "trains"
+    ]
+  end
+
+  defp kenmore_fullscreen_alert_text([
+         %{effect: :shuttle, region: :boundary, routes: ["Green-B"], headsign: "Boston College"},
+         %{effect: :shuttle, region: :boundary, routes: ["Green-D"], headsign: "Riverside"}
+       ]) do
+    [
+      "No",
+      %{icon: :green_b},
+      %{format: :bold, text: "Boston College"},
+      "or",
+      %{icon: :green_d},
+      %{format: :bold, text: "Riverside"},
+      "trains"
+    ]
+  end
+
+  defp kenmore_fullscreen_alert_text([
+         %{
+           effect: :shuttle,
+           region: :boundary,
+           routes: ["Green-C"],
+           headsign: "Cleveland Circle"
+         },
+         %{effect: :shuttle, region: :boundary, routes: ["Green-D"], headsign: "Riverside"}
+       ]) do
+    [
+      "No",
+      %{icon: :green_c},
+      %{format: :bold, text: "Cleveland Cir"},
+      "or",
+      %{icon: :green_d},
+      %{format: :bold, text: "Riverside"},
+      "trains"
+    ]
+  end
+
+  defp kenmore_fullscreen_alert_text([
+         %{effect: :shuttle, region: :boundary, routes: ["Green-B"], headsign: "Boston College"},
+         %{
+           effect: :shuttle,
+           region: :boundary,
+           routes: ["Green-C"],
+           headsign: "Cleveland Circle"
+         },
+         %{effect: :shuttle, region: :boundary, routes: ["Green-D"], headsign: "Riverside"}
+       ]) do
+    [
+      "No",
+      %{icon: :green_b},
+      %{icon: :green_c},
+      %{icon: :green_d},
+      %{format: :bold, text: "Westbound"},
+      "trains"
+    ]
+  end
+
+  defp kenmore_fullscreen_alert_text(_), do: nil
+end


### PR DESCRIPTION
**Asana task**: [Support for multiple shuttles at Kenmore](https://app.asana.com/0/1185117109217413/1200132302343957)

In addition to the partial and full-screen alerts specified in the linked Asana task, this PR sets a headway message for the Green Line when all three branches have shuttling (since, in this case, Kenmore is a temporary mid-route terminal and won't have any predictions). This is consistent with other situations where we have DUPs at mid-route shuttle endpoints.

Note: This PR assumes that each line's shuttle has its own alert. I believe this has been true in the past (when working on Beacon Junction outside of Kenmore, the C and D had their own shuttles), and Alerts UI doesn't seem to provide a way to specify stops on multiple routes as a part of the same alert.