### PR TITLE
fix: remove extra linebreak for kenmore B and D shuttles

### DIFF
--- a/lib/screens/dup_screen_data/special_cases.ex
+++ b/lib/screens/dup_screen_data/special_cases.ex
@@ -305,7 +305,6 @@ defmodule Screens.DupScreenData.SpecialCases do
       %{icon: :green_b},
       %{format: :bold, text: "Boston College"},
       "or",
-      %{special: :break},
       %{icon: :green_d},
       %{format: :bold, text: "Riverside"},
       "trains"


### PR DESCRIPTION
**Asana task**: ad hoc

"No (B) Boston College or" already wraps on DUPs, so adding another linebreak after the or was causing issues.