### PR TITLE
feat: temporarily log user agent on solari api requests

### DIFF
--- a/lib/screens_web/controllers/screen_api_controller.ex
+++ b/lib/screens_web/controllers/screen_api_controller.ex
@@ -26,6 +26,7 @@ defmodule ScreensWeb.ScreenApiController do
     is_screen = ScreensWeb.UserAgent.is_screen_conn?(conn)
 
     _ = Screens.LogScreenData.log_data_request(screen_id, last_refresh, is_screen)
+    _ = log_solari_user_agent(screen_id, conn)
 
     data =
       Screens.ScreenData.by_screen_id(screen_id, is_screen,
@@ -45,4 +46,17 @@ defmodule ScreensWeb.ScreenApiController do
 
     json(conn, data)
   end
+
+  defp log_solari_user_agent(screen_id, conn) when "300" < screen_id and screen_id < "320" do
+    user_agent =
+      conn.req_headers
+      |> Enum.into(%{})
+      |> Map.get("user-agent")
+
+    if !is_nil(user_agent) do
+      Logger.info("[user agent] #{user_agent}")
+    end
+  end
+
+  defp log_solari_user_agent(_screen_id, _conn), do: nil
 end


### PR DESCRIPTION
**Asana task**: [Log data requests from new Solari screens](https://app.asana.com/0/1185117109217413/1200074998406104)

Once we know what the new user agent is, we can revert this and add it to `ScreensWeb.UserAgent`.