### PR TITLE
feat: detect new solari screen user agent

### DIFF
--- a/lib/screens_web/controllers/screen_api_controller.ex
+++ b/lib/screens_web/controllers/screen_api_controller.ex
@@ -26,7 +26,6 @@ defmodule ScreensWeb.ScreenApiController do
     is_screen = ScreensWeb.UserAgent.is_screen_conn?(conn)
 
     _ = Screens.LogScreenData.log_data_request(screen_id, last_refresh, is_screen)
-    _ = log_solari_user_agent(screen_id, conn)
 
     data =
       Screens.ScreenData.by_screen_id(screen_id, is_screen,
@@ -46,17 +45,4 @@ defmodule ScreensWeb.ScreenApiController do
 
     json(conn, data)
   end
-
-  defp log_solari_user_agent(screen_id, conn) when "300" < screen_id and screen_id < "320" do
-    user_agent =
-      conn.req_headers
-      |> Enum.into(%{})
-      |> Map.get("user-agent")
-
-    if !is_nil(user_agent) do
-      Logger.info("[user agent] #{user_agent}")
-    end
-  end
-
-  defp log_solari_user_agent(_screen_id, _conn), do: nil
 end

--- a/lib/screens_web/user_agent.ex
+++ b/lib/screens_web/user_agent.ex
@@ -25,14 +25,22 @@ defmodule ScreensWeb.UserAgent do
   end
 
   defp is_solari?(user_agent) do
-    is_solari_audio?(user_agent) or is_solari_browser?(user_agent)
+    is_solari_old?(user_agent) or is_solari_new?(user_agent)
   end
 
-  defp is_solari_audio?(user_agent) do
+  defp is_solari_new?(user_agent) do
+    String.contains?(user_agent, "BrightSign/L2D674000659/6.2.94")
+  end
+
+  defp is_solari_old?(user_agent) do
+    is_solari_audio_old?(user_agent) or is_solari_browser_old?(user_agent)
+  end
+
+  defp is_solari_audio_old?(user_agent) do
     String.contains?(user_agent, "MPlayer")
   end
 
-  defp is_solari_browser?(user_agent) do
+  defp is_solari_browser_old?(user_agent) do
     String.contains?(user_agent, "(X11; Ubuntu; Linux i686; rv:22.0)") and
       String.contains?(user_agent, "Firefox/22.0")
   end


### PR DESCRIPTION
**Asana task**: [Log data requests from new Solari screens](https://app.asana.com/0/1185117109217413/1200074998406104)

The new user agent appears to be:
`BrightSign/L2D676000639/6.2.94 (XD232) Mozilla/5.0 (Unknown; Linux mips) AppleWebKit/537.36 (KHTML, like Gecko) QtWebEngine/5.6.0 Chrome/45.0.2454.101 Safari/537.36`

This PR detects the new user agent and stops logging Solari screen user agents.