### PR TITLE
fix: update dup shuttle alert text

### DIFF
--- a/assets/css/dup/free_text.scss
+++ b/assets/css/dup/free_text.scss
@@ -5,6 +5,10 @@
 .free-text__line {
   display: inline-block;
   vertical-align: middle;
+
+  .free-text__route-pill {
+    transform: translateY(-20px);
+  }
 }
 
 .free-text__icon-container {
@@ -39,7 +43,6 @@
   font-family: Helvetica, sans-serif;
   font-weight: 700;
   text-align: center;
-  transform: translateY(-20px);
 
   &--green,
   &--green_b,

--- a/lib/screens/dup_screen_data/response.ex
+++ b/lib/screens/dup_screen_data/response.ex
@@ -121,8 +121,15 @@ defmodule Screens.DupScreenData.Response do
     }
   end
 
-  def alert_issue(%{region: :inside, cause: cause}, 1) do
-    %{icon: :x, text: [%{format: :bold, text: "STATION CLOSED"}, render_alert_cause(cause)]}
+  def alert_issue(%{region: :inside, cause: cause, pill: pill}, 1) do
+    %{
+      icon: :warning,
+      text: [
+        %{format: :bold, text: "No #{@pill_to_specifier[pill]}"},
+        "trains",
+        render_alert_cause(cause)
+      ]
+    }
   end
 
   def alert_issue(%{region: :inside, pill: pill}, 2) do
@@ -175,8 +182,8 @@ defmodule Screens.DupScreenData.Response do
     end
   end
 
-  defp service_to_headsign({:adj, headsign}), do: "#{headsign} service"
-  defp service_to_headsign(headsign), do: "service to #{headsign}"
+  defp service_to_headsign({:adj, headsign}), do: "#{headsign} trains"
+  defp service_to_headsign(headsign), do: "trains to #{headsign}"
 
   defp line_color(:bus), do: :yellow
   defp line_color(:cr), do: :purple


### PR DESCRIPTION
**Asana tasks**:
* [Update text on alert screen for DUPs during shuttle](https://app.asana.com/0/1199892628355780/1200064893145453)
* [Update text on full screen alert for boundary of shuttle](https://app.asana.com/0/1199892628355780/1200132302343963)

This PR makes two changes to how DUPs describe shuttle (and suspension) alerts:
1. No <line> trains due to <cause> replaces Station Closed due to <cause>
2. No <line> trains to <headsign> replaces No <line> service to <headsign>

Separately, I noticed that the `translateY` transform shouldn't apply to route pills when they're being used as an icon. This is an issue (for example) when we're showing headways on a DUP which has two sections.