### PR TITLE
Pass all screen templates through Builder.build_template/1

### DIFF
--- a/lib/screens/v2/candidate_generator/bus_eink.ex
+++ b/lib/screens/v2/candidate_generator/bus_eink.ex
@@ -3,6 +3,7 @@ defmodule Screens.V2.CandidateGenerator.BusEink do
 
   alias Screens.Config.{Bus, Screen}
   alias Screens.V2.CandidateGenerator
+  alias Screens.V2.Template.Builder
   alias Screens.V2.WidgetInstance.{FareInfoFooter, NormalHeader, Placeholder}
 
   @behaviour CandidateGenerator
@@ -24,6 +25,7 @@ defmodule Screens.V2.CandidateGenerator.BusEink do
        ],
        full_takeover: [:full_screen]
      }}
+    |> Builder.build_template()
   end
 
   @impl CandidateGenerator

--- a/lib/screens/v2/candidate_generator/dup.ex
+++ b/lib/screens/v2/candidate_generator/dup.ex
@@ -3,6 +3,7 @@ defmodule Screens.V2.CandidateGenerator.Dup do
 
   alias Screens.Config.{Dup, Screen}
   alias Screens.V2.CandidateGenerator
+  alias Screens.V2.Template.Builder
   alias Screens.V2.WidgetInstance.{NormalHeader, Placeholder}
 
   @behaviour CandidateGenerator
@@ -14,6 +15,7 @@ defmodule Screens.V2.CandidateGenerator.Dup do
        normal: [:header, :main_content],
        full_takeover: [:full_screen]
      }}
+    |> Builder.build_template()
   end
 
   @impl CandidateGenerator

--- a/lib/screens/v2/candidate_generator/gl_eink_double.ex
+++ b/lib/screens/v2/candidate_generator/gl_eink_double.ex
@@ -3,6 +3,7 @@ defmodule Screens.V2.CandidateGenerator.GlEinkDouble do
 
   alias Screens.Config.{Gl, Screen}
   alias Screens.V2.CandidateGenerator
+  alias Screens.V2.Template.Builder
   alias Screens.V2.WidgetInstance.{FareInfoFooter, Placeholder}
 
   @behaviour CandidateGenerator
@@ -24,6 +25,7 @@ defmodule Screens.V2.CandidateGenerator.GlEinkDouble do
        ],
        full_takeover: [:full_screen]
      }}
+    |> Builder.build_template()
   end
 
   @impl CandidateGenerator

--- a/lib/screens/v2/candidate_generator/gl_eink_single.ex
+++ b/lib/screens/v2/candidate_generator/gl_eink_single.ex
@@ -3,6 +3,7 @@ defmodule Screens.V2.CandidateGenerator.GlEinkSingle do
 
   alias Screens.Config.{Gl, Screen}
   alias Screens.V2.CandidateGenerator
+  alias Screens.V2.Template.Builder
   alias Screens.V2.WidgetInstance.{LinkFooter, Placeholder}
 
   @behaviour CandidateGenerator
@@ -18,6 +19,7 @@ defmodule Screens.V2.CandidateGenerator.GlEinkSingle do
        ],
        full_takeover: [:full_screen]
      }}
+    |> Builder.build_template()
   end
 
   @impl CandidateGenerator

--- a/lib/screens/v2/candidate_generator/solari.ex
+++ b/lib/screens/v2/candidate_generator/solari.ex
@@ -2,6 +2,7 @@ defmodule Screens.V2.CandidateGenerator.Solari do
   @moduledoc false
 
   alias Screens.V2.CandidateGenerator
+  alias Screens.V2.Template.Builder
   alias Screens.V2.WidgetInstance.{NormalHeader, Placeholder}
 
   alias Screens.Config.{Screen, Solari}
@@ -15,6 +16,7 @@ defmodule Screens.V2.CandidateGenerator.Solari do
        normal: [:header, :main_content],
        takeover: [:full_screen]
      }}
+    |> Builder.build_template()
   end
 
   @impl CandidateGenerator

--- a/lib/screens/v2/candidate_generator/solari_large.ex
+++ b/lib/screens/v2/candidate_generator/solari_large.ex
@@ -2,6 +2,7 @@ defmodule Screens.V2.CandidateGenerator.SolariLarge do
   @moduledoc false
 
   alias Screens.V2.CandidateGenerator
+  alias Screens.V2.Template.Builder
   alias Screens.V2.WidgetInstance.{NormalHeader, Placeholder}
 
   alias Screens.Config.{Screen, Solari}
@@ -15,6 +16,7 @@ defmodule Screens.V2.CandidateGenerator.SolariLarge do
        normal: [:header, :main_content],
        takeover: [:full_screen]
      }}
+    |> Builder.build_template()
   end
 
   @impl CandidateGenerator


### PR DESCRIPTION
**Asana task**: ad hoc

This updates all screens to pass their "draft" templates through `build_template/1` before returning from `screen_template/0`. This has no effect on any template besides the bus shelter one for now, but if/when we add backend paging to more screen types, it will be necessary.