### PR TITLE
feat: Fetch departures and create departures widgets in all candidate generators

### DIFF
--- a/lib/screens/v2/candidate_generator/bus_eink.ex
+++ b/lib/screens/v2/candidate_generator/bus_eink.ex
@@ -5,6 +5,7 @@ defmodule Screens.V2.CandidateGenerator.BusEink do
   alias Screens.Config.V2.{BusEink, Footer}
   alias Screens.Config.V2.Header.CurrentStopId
   alias Screens.V2.CandidateGenerator
+  alias Screens.V2.CandidateGenerator.Helpers
   alias Screens.V2.Template.Builder
   alias Screens.V2.WidgetInstance.{FareInfoFooter, NormalHeader, Placeholder}
 
@@ -34,14 +35,16 @@ defmodule Screens.V2.CandidateGenerator.BusEink do
   def candidate_instances(
         config,
         now \\ DateTime.utc_now(),
-        fetch_stop_name_fn \\ &fetch_stop_name/1
+        fetch_stop_name_fn \\ &fetch_stop_name/1,
+        departures_instances_fn \\ &Helpers.Departures.departures_instances/1
       ) do
-    header_instances(config, now, fetch_stop_name_fn) ++
-      footer_instances(config) ++
-      [
-        %Placeholder{color: :green, slot_names: [:main_content]},
-        %Placeholder{color: :red, slot_names: [:medium_flex]}
-      ]
+    [
+      header_instances(config, now, fetch_stop_name_fn),
+      departures_instances_fn.(config),
+      footer_instances(config),
+      placeholder_instances()
+    ]
+    |> List.flatten()
   end
 
   defp header_instances(config, now, fetch_stop_name_fn) do
@@ -75,5 +78,12 @@ defmodule Screens.V2.CandidateGenerator.BusEink do
       _ ->
         nil
     end
+  end
+
+  defp placeholder_instances do
+    [
+      %Placeholder{color: :green, slot_names: [:main_content]},
+      %Placeholder{color: :red, slot_names: [:medium_flex]}
+    ]
   end
 end

--- a/lib/screens/v2/candidate_generator/bus_shelter.ex
+++ b/lib/screens/v2/candidate_generator/bus_shelter.ex
@@ -5,6 +5,7 @@ defmodule Screens.V2.CandidateGenerator.BusShelter do
   alias Screens.Config.V2.{BusShelter, Footer}
   alias Screens.Config.V2.Header.CurrentStopId
   alias Screens.V2.CandidateGenerator
+  alias Screens.V2.CandidateGenerator.Helpers
   alias Screens.V2.Template.Builder
   alias Screens.V2.WidgetInstance.{LinkFooter, NormalHeader, Placeholder}
 
@@ -37,18 +38,16 @@ defmodule Screens.V2.CandidateGenerator.BusShelter do
   def candidate_instances(
         config,
         now \\ DateTime.utc_now(),
-        fetch_stop_name_fn \\ &fetch_stop_name/1
+        fetch_stop_name_fn \\ &fetch_stop_name/1,
+        departures_instances_fn \\ &Helpers.Departures.departures_instances/1
       ) do
-    header_instances(config, now, fetch_stop_name_fn) ++
-      footer_instances(config) ++
-      [
-        %Placeholder{color: :red, slot_names: [:main_content]},
-        %Placeholder{color: :green, slot_names: [:medium_left]},
-        %Placeholder{color: :blue, slot_names: [:small_upper_right]},
-        %Placeholder{color: :grey, slot_names: [:small_lower_right]},
-        %Placeholder{color: :green, slot_names: [:large]},
-        %Placeholder{color: :red, slot_names: [:large]}
-      ]
+    [
+      header_instances(config, now, fetch_stop_name_fn),
+      departures_instances_fn.(config),
+      footer_instances(config),
+      placeholder_instances()
+    ]
+    |> List.flatten()
   end
 
   defp header_instances(config, now, fetch_stop_name_fn) do
@@ -74,5 +73,16 @@ defmodule Screens.V2.CandidateGenerator.BusShelter do
       _ ->
         nil
     end
+  end
+
+  defp placeholder_instances do
+    [
+      %Placeholder{color: :red, slot_names: [:main_content]},
+      %Placeholder{color: :green, slot_names: [:medium_left]},
+      %Placeholder{color: :blue, slot_names: [:small_upper_right]},
+      %Placeholder{color: :grey, slot_names: [:small_lower_right]},
+      %Placeholder{color: :green, slot_names: [:large]},
+      %Placeholder{color: :red, slot_names: [:large]}
+    ]
   end
 end

--- a/lib/screens/v2/candidate_generator/gl_eink.ex
+++ b/lib/screens/v2/candidate_generator/gl_eink.ex
@@ -5,6 +5,7 @@ defmodule Screens.V2.CandidateGenerator.GlEink do
   alias Screens.Config.V2.{Footer, GlEink}
   alias Screens.Config.V2.Header.Destination
   alias Screens.V2.CandidateGenerator
+  alias Screens.V2.CandidateGenerator.Helpers
   alias Screens.V2.WidgetInstance.{FareInfoFooter, NormalHeader, Placeholder}
 
   @behaviour CandidateGenerator
@@ -34,12 +35,13 @@ defmodule Screens.V2.CandidateGenerator.GlEink do
         now \\ DateTime.utc_now(),
         fetch_destination_fn \\ &fetch_destination/2
       ) do
-    header_instances(config, now, fetch_destination_fn) ++
-      footer_instances(config) ++
-      [
-        %Placeholder{color: :blue, slot_names: [:main_content]},
-        %Placeholder{color: :green, slot_names: [:medium_flex]}
-      ]
+    [
+      header_instances(config, now, fetch_destination_fn),
+      Helpers.Departures.departures_instances(config),
+      footer_instances(config),
+      placeholder_instances()
+    ]
+    |> List.flatten()
   end
 
   def header_instances(config, now, fetch_destination_fn) do
@@ -86,6 +88,13 @@ defmodule Screens.V2.CandidateGenerator.GlEink do
         text: "For real-time predictions and fare purchase locations:",
         url: "mbta.com/stops/#{stop_id}"
       }
+    ]
+  end
+
+  defp placeholder_instances do
+    [
+      %Placeholder{color: :blue, slot_names: [:main_content]},
+      %Placeholder{color: :green, slot_names: [:medium_flex]}
     ]
   end
 end

--- a/lib/screens/v2/candidate_generator/helpers.ex
+++ b/lib/screens/v2/candidate_generator/helpers.ex
@@ -1,0 +1,3 @@
+defmodule Screens.V2.CandidateGenerator.Helpers do
+  @moduledoc false
+end

--- a/lib/screens/v2/candidate_generator/helpers/departures.ex
+++ b/lib/screens/v2/candidate_generator/helpers/departures.ex
@@ -1,0 +1,71 @@
+defmodule Screens.V2.CandidateGenerator.Helpers.Departures do
+  @moduledoc false
+
+  alias Screens.Config.Screen
+  alias Screens.Config.V2.Departures.Filter.RouteDirection
+  alias Screens.Config.V2.Departures.{Filter, Query, Section}
+  alias Screens.Config.V2.{BusEink, BusShelter, Departures, GlEink, Solari, SolariLarge}
+  alias Screens.V2.Departure
+  alias Screens.V2.WidgetInstance.Departures, as: DeparturesWidget
+  alias Screens.V2.WidgetInstance.DeparturesNoData
+
+  def departures_instances(
+        %Screen{app_params: %app{departures: %Departures{sections: sections}}} = config,
+        fetch_section_departures_fn \\ &fetch_section_departures/1
+      )
+      when app in [BusEink, BusShelter, GlEink, SolariLarge, Solari] do
+    sections_data =
+      sections
+      |> Task.async_stream(fetch_section_departures_fn)
+      |> Enum.map(fn {:ok, data} -> data end)
+
+    departures_instance =
+      if Enum.any?(sections_data, &(&1 == :error)) do
+        %DeparturesNoData{screen: config}
+      else
+        sections =
+          Enum.map(sections_data, fn {:ok, departures} ->
+            %{type: :normal_section, departures: departures}
+          end)
+
+        %DeparturesWidget{screen: config, section_data: sections}
+      end
+
+    [departures_instance]
+  end
+
+  defp fetch_section_departures(%Section{query: query, filter: filter}) do
+    query
+    |> fetch_departures()
+    |> filter_departures(filter)
+  end
+
+  defp fetch_departures(%Query{opts: opts, params: params}) do
+    fetch_opts =
+      opts
+      |> Map.from_struct()
+      |> Keyword.new()
+
+    Departure.fetch(params, fetch_opts)
+  end
+
+  defp filter_departures(:error, _), do: :error
+
+  defp filter_departures({:ok, departures}, %Filter{
+         action: :include,
+         route_directions: route_directions
+       }) do
+    {:ok, Enum.filter(departures, &departure_in_route_directions?(&1, route_directions))}
+  end
+
+  defp filter_departures({:ok, departures}, %Filter{
+         action: :exclude,
+         route_directions: route_directions
+       }) do
+    {:ok, Enum.reject(departures, &departure_in_route_directions?(&1, route_directions))}
+  end
+
+  defp departure_in_route_directions?(d, route_directions) do
+    %RouteDirection{route_id: Departure.route_id(d), direction_id: Departure.direction_id(d)} in route_directions
+  end
+end

--- a/lib/screens/v2/candidate_generator/solari.ex
+++ b/lib/screens/v2/candidate_generator/solari.ex
@@ -5,6 +5,7 @@ defmodule Screens.V2.CandidateGenerator.Solari do
   alias Screens.Config.V2.Header.CurrentStopName
   alias Screens.Config.V2.Solari
   alias Screens.V2.CandidateGenerator
+  alias Screens.V2.CandidateGenerator.Helpers
   alias Screens.V2.Template.Builder
   alias Screens.V2.WidgetInstance.{NormalHeader, Placeholder}
 
@@ -21,16 +22,28 @@ defmodule Screens.V2.CandidateGenerator.Solari do
   end
 
   @impl CandidateGenerator
-  def candidate_instances(config, now \\ DateTime.utc_now()) do
-    header_instances(config, now) ++
-      [
-        %Placeholder{color: :blue, slot_names: [:main_content]}
-      ]
+  def candidate_instances(
+        config,
+        now \\ DateTime.utc_now(),
+        departures_instances_fn \\ &Helpers.Departures.departures_instances/1
+      ) do
+    [
+      header_instances(config, now),
+      departures_instances_fn.(config),
+      placeholder_instances()
+    ]
+    |> List.flatten()
   end
 
   defp header_instances(config, now) do
     %Screen{app_params: %Solari{header: %CurrentStopName{stop_name: stop_name}}} = config
 
     [%NormalHeader{screen: config, icon: :logo, text: stop_name, time: now}]
+  end
+
+  defp placeholder_instances do
+    [
+      %Placeholder{color: :blue, slot_names: [:main_content]}
+    ]
   end
 end

--- a/lib/screens/v2/candidate_generator/solari_large.ex
+++ b/lib/screens/v2/candidate_generator/solari_large.ex
@@ -5,6 +5,7 @@ defmodule Screens.V2.CandidateGenerator.SolariLarge do
   alias Screens.Config.V2.Header.CurrentStopName
   alias Screens.Config.V2.SolariLarge
   alias Screens.V2.CandidateGenerator
+  alias Screens.V2.CandidateGenerator.Helpers
   alias Screens.V2.Template.Builder
   alias Screens.V2.WidgetInstance.{NormalHeader, Placeholder}
 
@@ -21,11 +22,17 @@ defmodule Screens.V2.CandidateGenerator.SolariLarge do
   end
 
   @impl CandidateGenerator
-  def candidate_instances(config, now \\ DateTime.utc_now()) do
-    header_instances(config, now) ++
-      [
-        %Placeholder{color: :blue, slot_names: [:main_content]}
-      ]
+  def candidate_instances(
+        config,
+        now \\ DateTime.utc_now(),
+        departures_instances_fn \\ &Helpers.Departures.departures_instances/1
+      ) do
+    [
+      header_instances(config, now),
+      departures_instances_fn.(config),
+      placeholder_instances()
+    ]
+    |> List.flatten()
   end
 
   defp header_instances(config, now) do
@@ -34,5 +41,11 @@ defmodule Screens.V2.CandidateGenerator.SolariLarge do
     } = config
 
     [%NormalHeader{screen: config, text: stop_name, time: now}]
+  end
+
+  defp placeholder_instances do
+    [
+      %Placeholder{color: :blue, slot_names: [:main_content]}
+    ]
   end
 end

--- a/lib/screens/v2/departure.ex
+++ b/lib/screens/v2/departure.ex
@@ -75,6 +75,17 @@ defmodule Screens.V2.Departure do
 
   def crowding_level(%__MODULE__{prediction: nil, schedule: _}), do: nil
 
+  def direction_id(%__MODULE__{prediction: %Prediction{trip: %Trip{direction_id: direction_id}}}) do
+    direction_id
+  end
+
+  def direction_id(%__MODULE__{prediction: nil, schedule: s}) do
+    case s do
+      %Schedule{trip: %Trip{direction_id: direction_id}} -> direction_id
+      _ -> nil
+    end
+  end
+
   def headsign(%__MODULE__{prediction: p, schedule: s}) when not is_nil(p) do
     %Prediction{trip: %Trip{headsign: headsign}} = p
 

--- a/lib/screens/v2/widget_instance/alert.ex
+++ b/lib/screens/v2/widget_instance/alert.ex
@@ -5,10 +5,10 @@ defmodule Screens.V2.WidgetInstance.Alert do
 
   alias __MODULE__, as: T
 
-  defstruct screen: :ok,
+  defstruct screen: nil,
             alert: nil
 
-  @type config :: :ok
+  @type config :: Screens.V2.ScreenData.config()
 
   @type t :: %T{
           screen: config(),

--- a/lib/screens/v2/widget_instance/static_image.ex
+++ b/lib/screens/v2/widget_instance/static_image.ex
@@ -8,7 +8,7 @@ defmodule Screens.V2.WidgetInstance.StaticImage do
             priority: nil,
             size: nil
 
-  @type config :: :ok
+  @type config :: Screens.V2.ScreenData.config()
   @type size :: :small | :medium | :large | :fullscreen
 
   @type t :: %__MODULE__{

--- a/test/screens/v2/candidate_generator/bus_eink_test.exs
+++ b/test/screens/v2/candidate_generator/bus_eink_test.exs
@@ -43,10 +43,12 @@ defmodule Screens.V2.CandidateGenerator.BusEinkTest do
 
   describe "candidate_instances/3" do
     test "returns expected header", %{config: config} do
+      departures_instances_fn = fn _ -> [] end
       fetch_stop_fn = fn "1722" -> "1624 Blue Hill Ave @ Mattapan Sq" end
       now = ~U[2020-04-06T10:00:00Z]
 
-      actual_instances = BusEink.candidate_instances(config, now, fetch_stop_fn)
+      actual_instances =
+        BusEink.candidate_instances(config, now, fetch_stop_fn, departures_instances_fn)
 
       expected_header = %NormalHeader{
         screen: config,

--- a/test/screens/v2/candidate_generator/bus_shelter_test.exs
+++ b/test/screens/v2/candidate_generator/bus_shelter_test.exs
@@ -67,6 +67,7 @@ defmodule Screens.V2.CandidateGenerator.BusShelterTest do
 
   describe "candidate_instances/3" do
     test "returns expected header and footer", %{config: config} do
+      departures_instances_fn = fn _ -> [] end
       fetch_stop_fn = fn "1216" -> "Columbus Ave @ Dimock St" end
       now = ~U[2020-04-06T10:00:00Z]
 
@@ -79,7 +80,8 @@ defmodule Screens.V2.CandidateGenerator.BusShelterTest do
 
       expected_footer = %LinkFooter{screen: config, text: "More at", url: "mbta.com/stops/1216"}
 
-      actual_instances = BusShelter.candidate_instances(config, now, fetch_stop_fn)
+      actual_instances =
+        BusShelter.candidate_instances(config, now, fetch_stop_fn, departures_instances_fn)
 
       assert expected_header in actual_instances
       assert expected_footer in actual_instances

--- a/test/screens/v2/candidate_generator/helpers/departures_test.exs
+++ b/test/screens/v2/candidate_generator/helpers/departures_test.exs
@@ -1,0 +1,94 @@
+defmodule Screens.V2.CandidateGenerator.Helpers.DeparturesTest do
+  use ExUnit.Case, async: true
+
+  alias Screens.Config.Screen
+  alias Screens.Config.V2.Departures.Section
+  alias Screens.Config.V2.BusShelter
+  alias Screens.Config.V2.Departures, as: DeparturesConfig
+  alias Screens.V2.CandidateGenerator.Helpers.Departures
+  alias Screens.V2.WidgetInstance.Departures, as: DeparturesWidget
+  alias Screens.V2.WidgetInstance.DeparturesNoData
+
+  setup do
+    config = %Screen{
+      app_params: %BusShelter{
+        departures: %DeparturesConfig{
+          sections: [
+            %Section{query: "query A", filter: nil},
+            %Section{query: "query B", filter: nil}
+          ]
+        },
+        header: nil,
+        footer: nil
+      },
+      vendor: nil,
+      device_id: nil,
+      name: nil,
+      app_id: nil
+    }
+
+    %{config: config}
+  end
+
+  describe "departures_instances/1" do
+    test "returns DeparturesWidget when all section requests succeed and receive departure data",
+         %{config: config} do
+      fetch_section_departures_fn = fn
+        %Section{query: "query A"} -> {:ok, ["departure A1", "departure A2"]}
+        %Section{query: "query B"} -> {:ok, ["departure B1", "departure B2"]}
+      end
+
+      expected_departures_instances = [
+        %DeparturesWidget{
+          screen: config,
+          section_data: [
+            %{type: :normal_section, departures: ["departure A1", "departure A2"]},
+            %{type: :normal_section, departures: ["departure B1", "departure B2"]}
+          ]
+        }
+      ]
+
+      actual_departures_instances =
+        Departures.departures_instances(config, fetch_section_departures_fn)
+
+      assert expected_departures_instances == actual_departures_instances
+    end
+
+    test "returns DeparturesWidget when all sections requests succeed but receive no departure data",
+         %{config: config} do
+      fetch_section_departures_fn = fn
+        %Section{query: "query A"} -> {:ok, []}
+        %Section{query: "query B"} -> {:ok, []}
+      end
+
+      expected_departures_instances = [
+        %DeparturesWidget{
+          screen: config,
+          section_data: [
+            %{type: :normal_section, departures: []},
+            %{type: :normal_section, departures: []}
+          ]
+        }
+      ]
+
+      actual_departures_instances =
+        Departures.departures_instances(config, fetch_section_departures_fn)
+
+      assert expected_departures_instances == actual_departures_instances
+    end
+
+    test "returns DeparturesNoData if any section request fails", %{config: config} do
+      fetch_section_departures_fn = fn
+        %Section{query: "query A"} -> {:ok, []}
+        %Section{query: "query B"} -> :error
+      end
+
+      expected_departures_instances = [%DeparturesNoData{screen: config}]
+
+      actual_departures_instances =
+        Departures.departures_instances(config, fetch_section_departures_fn)
+
+      assert expected_departures_instances == actual_departures_instances
+    end
+  end
+end

--- a/test/screens/v2/candidate_generator/solari_large_test.exs
+++ b/test/screens/v2/candidate_generator/solari_large_test.exs
@@ -32,6 +32,7 @@ defmodule Screens.V2.CandidateGenerator.SolariLargeTest do
 
   describe "candidate_instances/2" do
     test "returns expected header", %{config: config} do
+      departures_instances_fn = fn _ -> [] end
       now = ~U[2020-04-06T10:00:00Z]
 
       expected_header = %NormalHeader{
@@ -41,7 +42,9 @@ defmodule Screens.V2.CandidateGenerator.SolariLargeTest do
         time: ~U[2020-04-06T10:00:00Z]
       }
 
-      assert expected_header in SolariLarge.candidate_instances(config, now)
+      actual_instances = SolariLarge.candidate_instances(config, now, departures_instances_fn)
+
+      assert expected_header in actual_instances
     end
   end
 end

--- a/test/screens/v2/candidate_generator/solari_test.exs
+++ b/test/screens/v2/candidate_generator/solari_test.exs
@@ -32,6 +32,7 @@ defmodule Screens.V2.CandidateGenerator.SolariTest do
 
   describe "candidate_instances/2" do
     test "returns expected header", %{config: config} do
+      departures_instances_fn = fn _ -> [] end
       now = ~U[2020-04-06T10:00:00Z]
 
       expected_header = %NormalHeader{
@@ -41,7 +42,9 @@ defmodule Screens.V2.CandidateGenerator.SolariTest do
         time: ~U[2020-04-06T10:00:00Z]
       }
 
-      assert expected_header in Solari.candidate_instances(config, now)
+      actual_instances = Solari.candidate_instances(config, now, departures_instances_fn)
+
+      assert expected_header in actual_instances
     end
   end
 end


### PR DESCRIPTION
**Asana task**: [Return departures widgets from candidate generators](https://app.asana.com/0/1185117109217413/1200233815812789/f)

Since departures are fetched the same way for all screens (for now), I created a `CandidateGenerator.Helpers.Departures` module that provides the common fetching and client-side filtering logic.

- [ ] Needs version bump?
