### PR TITLE
feat: widgetized normal departures component without autosizing

### DIFF
--- a/assets/css/bus_shelter_v2.scss
+++ b/assets/css/bus_shelter_v2.scss
@@ -1,5 +1,7 @@
 @import url("https://rsms.me/inter/inter.css");
 
+@import "colors";
+
 @import "v2/bus_shelter/screen/normal";
 @import "v2/bus_shelter/screen/takeover";
 
@@ -10,6 +12,8 @@
 @import "v2/placeholder";
 @import "v2/bus_shelter/normal_header";
 @import "v2/bus_shelter/link_footer";
+
+@import "v2/bus_shelter/route_pill";
 
 body {
   margin: 0px;

--- a/assets/css/bus_shelter_v2.scss
+++ b/assets/css/bus_shelter_v2.scss
@@ -14,6 +14,8 @@
 @import "v2/bus_shelter/link_footer";
 
 @import "v2/bus_shelter/route_pill";
+@import "v2/bus_shelter/departures/row";
+@import "v2/bus_shelter/departures/destination";
 
 body {
   margin: 0px;

--- a/assets/css/bus_shelter_v2.scss
+++ b/assets/css/bus_shelter_v2.scss
@@ -16,6 +16,7 @@
 @import "v2/bus_shelter/route_pill";
 @import "v2/bus_shelter/departures/row";
 @import "v2/bus_shelter/departures/destination";
+@import "v2/bus_shelter/departures/time";
 
 body {
   margin: 0px;

--- a/assets/css/bus_shelter_v2.scss
+++ b/assets/css/bus_shelter_v2.scss
@@ -17,6 +17,7 @@
 @import "v2/bus_shelter/departures/row";
 @import "v2/bus_shelter/departures/destination";
 @import "v2/bus_shelter/departures/time";
+@import "v2/bus_shelter/departures/crowding";
 
 body {
   margin: 0px;

--- a/assets/css/colors.scss
+++ b/assets/css/colors.scss
@@ -4,5 +4,7 @@ $line-color-red: #da291c;
 $line-color-orange: #ed8b00;
 $line-color-silver: #7c878e;
 $line-color-cr: #80276c;
+$line-color-bus: #ffc72c;
+$line-color-ferry: #008eaa;
 
 $alert-yellow: #ffdd00;

--- a/assets/css/v2/bus_shelter/departures/crowding.scss
+++ b/assets/css/v2/bus_shelter/departures/crowding.scss
@@ -1,0 +1,10 @@
+.departure-crowding {
+  display: inline-block;
+  vertical-align: middle;
+
+  margin-right: 16px;
+}
+
+.departure-crowding__icon {
+  height: 64px;
+}

--- a/assets/css/v2/bus_shelter/departures/destination.scss
+++ b/assets/css/v2/bus_shelter/departures/destination.scss
@@ -1,0 +1,22 @@
+.departure-destination {
+  font-family: Inter;
+}
+
+.departure-destination__headsign {
+  width: 592px;
+
+  font-size: 64px;
+  line-height: 64px;
+  font-weight: 600;
+  color: #171f26;
+}
+
+.departure-destination__variation {
+  width: 592px;
+  margin-top: 8px;
+
+  font-size: 48px;
+  line-height: 56px;
+  font-weight: 400;
+  color: #171f26;
+}

--- a/assets/css/v2/bus_shelter/departures/destination.scss
+++ b/assets/css/v2/bus_shelter/departures/destination.scss
@@ -1,10 +1,9 @@
 .departure-destination {
+  width: 592px;
   font-family: Inter;
 }
 
 .departure-destination__headsign {
-  width: 592px;
-
   font-size: 64px;
   line-height: 64px;
   font-weight: 600;
@@ -12,7 +11,6 @@
 }
 
 .departure-destination__variation {
-  width: 592px;
   margin-top: 8px;
 
   font-size: 48px;

--- a/assets/css/v2/bus_shelter/departures/row.scss
+++ b/assets/css/v2/bus_shelter/departures/row.scss
@@ -14,3 +14,10 @@
   margin-left: 24px;
   margin-top: 32px;
 }
+
+.departure-row__time {
+  display: inline-block;
+  vertical-align: top;
+  margin-top: 32px;
+  margin-right: 32px;
+}

--- a/assets/css/v2/bus_shelter/departures/row.scss
+++ b/assets/css/v2/bus_shelter/departures/row.scss
@@ -1,0 +1,16 @@
+.departure-row {
+}
+
+.departure-row__route {
+  display: inline-block;
+  vertical-align: top;
+  margin-left: 32px;
+  margin-top: 27px;
+}
+
+.departure-row__destination {
+  display: inline-block;
+  vertical-align: top;
+  margin-left: 24px;
+  margin-top: 32px;
+}

--- a/assets/css/v2/bus_shelter/departures/time.scss
+++ b/assets/css/v2/bus_shelter/departures/time.scss
@@ -1,0 +1,43 @@
+.departure-times-with-crowding {
+  width: 256px;
+}
+
+.departure-time-with-crowding {
+  &:not(:first-child) {
+    margin-top: 16px;
+  }
+}
+
+.departure-time {
+  font-family: Inter;
+  text-align: right;
+  color: #171f26;
+}
+
+.departure-time__text {
+  font-size: 72px;
+  line-height: 64px;
+  font-weight: 800;
+}
+
+.departure-time__minutes {
+  display: inline-block;
+  margin-left: 4px;
+
+  font-size: 72px;
+  line-height: 64px;
+  font-weight: 800;
+}
+
+.departure-time__minutes-label {
+  display: inline-block;
+
+  font-size: 56px;
+  line-height: 56px;
+}
+
+.departure-time__timestamp {
+  font-size: 72px;
+  line-height: 64px;
+  font-weight: 800;
+}

--- a/assets/css/v2/bus_shelter/departures/time.scss
+++ b/assets/css/v2/bus_shelter/departures/time.scss
@@ -3,14 +3,18 @@
 }
 
 .departure-time-with-crowding {
+  text-align: right;
+
   &:not(:first-child) {
     margin-top: 16px;
   }
 }
 
 .departure-time {
+  display: inline-block;
+  vertical-align: middle;
+
   font-family: Inter;
-  text-align: right;
   color: #171f26;
 }
 

--- a/assets/css/v2/bus_shelter/route_pill.scss
+++ b/assets/css/v2/bus_shelter/route_pill.scss
@@ -60,3 +60,30 @@
     color: white;
   }
 }
+
+.route-pill__icon {
+  width: 100%;
+  text-align: center;
+}
+
+.route-pill__icon-image {
+  height: 60px;
+  margin-top: 7px;
+}
+
+.route-pill__slashed-text {
+  width: 100%;
+  text-align: center;
+  font-family: "neue-haas-grotesk-text";
+  font-size: 32px;
+  line-height: 74px;
+  font-weight: 700;
+}
+
+.route-pill__slashed-part-1 {
+  display: inline-block;
+}
+
+.route-pill__slashed-part-2 {
+  display: inline-block;
+}

--- a/assets/css/v2/bus_shelter/route_pill.scss
+++ b/assets/css/v2/bus_shelter/route_pill.scss
@@ -3,7 +3,6 @@
   width: 144px;
   height: 74px;
   border-radius: 100px;
-  margin-left: 32px;
 
   &--blue {
     background-color: $line-color-blue;

--- a/assets/css/v2/bus_shelter/route_pill.scss
+++ b/assets/css/v2/bus_shelter/route_pill.scss
@@ -1,0 +1,63 @@
+.route-pill {
+  position: relative;
+  width: 144px;
+  height: 74px;
+  border-radius: 100px;
+  margin-left: 32px;
+
+  &--blue {
+    background-color: $line-color-blue;
+  }
+
+  &--green {
+    background-color: $line-color-green;
+  }
+
+  &--orange {
+    background-color: $line-color-orange;
+  }
+
+  &--purple {
+    background-color: $line-color-cr;
+  }
+
+  &--red {
+    background-color: $line-color-red;
+  }
+
+  &--silver {
+    background-color: $line-color-silver;
+  }
+
+  &--teal {
+    background-color: $line-color-ferry;
+  }
+
+  &--yellow {
+    background-color: $line-color-bus;
+    box-shadow: 2px 4px 2px 0px rgba(0, 0, 0, 0.25);
+  }
+}
+
+.route-pill__text {
+  width: 100%;
+  text-align: center;
+  font-family: "neue-haas-grotesk-text";
+  font-size: 48px;
+  line-height: 74px;
+  font-weight: 700;
+
+  &--yellow {
+    color: black;
+  }
+
+  &--blue,
+  &--green,
+  &--orange,
+  &--purple,
+  &--red,
+  &--silver,
+  &--teal {
+    color: white;
+  }
+}

--- a/assets/src/apps/v2/bus_eink.tsx
+++ b/assets/src/apps/v2/bus_eink.tsx
@@ -14,6 +14,7 @@ import TakeoverScreen from "Components/v2/takeover_screen";
 import Placeholder from "Components/v2/placeholder";
 import NormalHeader from "Components/v2/eink/normal_header";
 import FareInfoFooter from "Components/v2/eink/fare_info_footer";
+import NormalDepartures from "Components/v2/departures/normal_departures";
 
 const TYPE_TO_COMPONENT = {
   normal: NormalScreen,
@@ -21,6 +22,7 @@ const TYPE_TO_COMPONENT = {
   placeholder: Placeholder,
   fare_info_footer: FareInfoFooter,
   normal_header: NormalHeader,
+  departures: NormalDepartures,
 };
 
 const App = (): JSX.Element => {

--- a/assets/src/apps/v2/bus_shelter.tsx
+++ b/assets/src/apps/v2/bus_shelter.tsx
@@ -18,6 +18,7 @@ import TwoMedium from "Components/v2/bus_shelter/flex/two_medium";
 import Placeholder from "Components/v2/placeholder";
 import LinkFooter from "Components/v2/bus_shelter/link_footer";
 import NormalHeader from "Components/v2/lcd/normal_header";
+import NormalDepartures from "Components/v2/departures/normal_departures";
 
 const TYPE_TO_COMPONENT = {
   normal: NormalScreen,
@@ -28,6 +29,7 @@ const TYPE_TO_COMPONENT = {
   placeholder: Placeholder,
   link_footer: LinkFooter,
   normal_header: NormalHeader,
+  departures: NormalDepartures,
 };
 
 const App = (): JSX.Element => {

--- a/assets/src/apps/v2/dup.tsx
+++ b/assets/src/apps/v2/dup.tsx
@@ -12,12 +12,14 @@ import NormalScreen from "Components/v2/dup/normal_screen";
 import TakeoverScreen from "Components/v2/takeover_screen";
 import Placeholder from "Components/v2/placeholder";
 import NormalHeader from "Components/v2/dup/normal_header";
+import NormalDepartures from "Components/v2/departures/normal_departures";
 
 const TYPE_TO_COMPONENT = {
   normal: NormalScreen,
   full_takeover: TakeoverScreen,
   placeholder: Placeholder,
   normal_header: NormalHeader,
+  departures: NormalDepartures,
 };
 
 const App = (): JSX.Element => {

--- a/assets/src/apps/v2/gl_eink.tsx
+++ b/assets/src/apps/v2/gl_eink.tsx
@@ -13,6 +13,7 @@ import TakeoverScreen from "Components/v2/takeover_screen";
 import Placeholder from "Components/v2/placeholder";
 import FareInfoFooter from "Components/v2/eink/fare_info_footer";
 import NormalHeader from "Components/v2/eink/normal_header";
+import NormalDepartures from "Components/v2/departures/normal_departures";
 
 const TYPE_TO_COMPONENT = {
   normal: NormalScreen,
@@ -20,6 +21,7 @@ const TYPE_TO_COMPONENT = {
   placeholder: Placeholder,
   fare_info_footer: FareInfoFooter,
   normal_header: NormalHeader,
+  departures: NormalDepartures,
 };
 
 const App = (): JSX.Element => {

--- a/assets/src/apps/v2/solari.tsx
+++ b/assets/src/apps/v2/solari.tsx
@@ -12,12 +12,14 @@ import NormalScreen from "Components/v2/solari/normal_screen";
 import TakeoverScreen from "Components/v2/takeover_screen";
 import Placeholder from "Components/v2/placeholder";
 import NormalHeader from "Components/v2/lcd/normal_header";
+import NormalDepartures from "Components/v2/departures/normal_departures";
 
 const TYPE_TO_COMPONENT = {
   normal: NormalScreen,
   takeover: TakeoverScreen,
   placeholder: Placeholder,
   normal_header: NormalHeader,
+  departures: NormalDepartures,
 };
 
 const App = (): JSX.Element => {

--- a/assets/src/apps/v2/solari_large.tsx
+++ b/assets/src/apps/v2/solari_large.tsx
@@ -12,12 +12,14 @@ import NormalScreen from "Components/v2/solari_large/normal_screen";
 import TakeoverScreen from "Components/v2/takeover_screen";
 import Placeholder from "Components/v2/placeholder";
 import NormalHeader from "Components/v2/lcd/normal_header";
+import NormalDepartures from "Components/v2/departures/normal_departures";
 
 const TYPE_TO_COMPONENT = {
   normal: NormalScreen,
   takeover: TakeoverScreen,
   placeholder: Placeholder,
   normal_header: NormalHeader,
+  departures: NormalDepartures,
 };
 
 const App = (): JSX.Element => {

--- a/assets/src/components/v2/departures/departure_alerts.tsx
+++ b/assets/src/components/v2/departures/departure_alerts.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const DepartureAlerts = () => {
+  return null;
+};
+
+export default DepartureAlerts;

--- a/assets/src/components/v2/departures/departure_crowding.tsx
+++ b/assets/src/components/v2/departures/departure_crowding.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+
+import { imagePath } from "Util/util";
+
+const DepartureCrowding = ({ crowdingLevel }) => {
+  const imgSrc = imagePath(`crowding-color-level-${crowdingLevel}.svg`);
+
+  return (
+    <div className="departure-crowding">
+      <img className="departure-crowding__icon" src={imgSrc} />
+    </div>
+  );
+};
+
+export default DepartureCrowding;

--- a/assets/src/components/v2/departures/departure_row.tsx
+++ b/assets/src/components/v2/departures/departure_row.tsx
@@ -20,7 +20,7 @@ const DepartureRow = ({
         <Destination {...headsign} />
       </div>
       <div className="departure-row__time">
-        <DepartureTimes data={timesWithCrowding} />
+        <DepartureTimes timesWithCrowding={timesWithCrowding} />
       </div>
       <div className="departure-row__alerts">
         <DepartureAlerts data={inlineAlerts} />

--- a/assets/src/components/v2/departures/departure_row.tsx
+++ b/assets/src/components/v2/departures/departure_row.tsx
@@ -1,12 +1,32 @@
 import React from "react";
 
+import RoutePill from "Components/v2/departures/route_pill";
+import Destination from "Components/v2/departures/destination";
+import DepartureTimes from "Components/v2/departures/departure_times";
+import DepartureAlerts from "Components/v2/departures/departure_alerts";
+
 const DepartureRow = ({
   headsign,
   route,
   times_with_crowding: timesWithCrowding,
   inline_alerts: inlineAlerts,
 }) => {
-  return null;
+  return (
+    <div className="departure-row">
+      <div className="departure-row__route">
+        <RoutePill {...route} />
+      </div>
+      <div className="departure-row__destination">
+        <Destination {...headsign} />
+      </div>
+      <div className="departure-row__time">
+        <DepartureTimes data={timesWithCrowding} />
+      </div>
+      <div className="departure-row__alerts">
+        <DepartureAlerts data={inlineAlerts} />
+      </div>
+    </div>
+  );
 };
 
 export default DepartureRow;

--- a/assets/src/components/v2/departures/departure_row.tsx
+++ b/assets/src/components/v2/departures/departure_row.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+
+const DepartureRow = ({
+  headsign,
+  route,
+  times_with_crowding: timesWithCrowding,
+  inline_alerts: inlineAlerts,
+}) => {
+  return null;
+};
+
+export default DepartureRow;

--- a/assets/src/components/v2/departures/departure_time.tsx
+++ b/assets/src/components/v2/departures/departure_time.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+
+const TextDepartureTime = ({ text }) => {
+  return <div className="departure-time__text">{text}</div>;
+};
+
+const MinutesDepartureTime = ({ minutes }) => {
+  return (
+    <>
+      <div className="departure-time__minutes">{minutes}</div>
+      <div className="departure-time__minutes-label">m</div>
+    </>
+  );
+};
+
+const TimestampDepartureTime = ({ hour, minute }) => {
+  const zeroFilledMinute = minute < 10 ? "0" + minute : minute;
+  const timestamp = `${hour}:${zeroFilledMinute}`;
+
+  return <div className="departure-time__timestamp">{timestamp}</div>;
+};
+
+const DepartureTime = ({ type, ...data }) => {
+  let inner;
+  if (type === "text") {
+    inner = <TextDepartureTime {...data} />;
+  } else if (type === "minutes") {
+    inner = <MinutesDepartureTime {...data} />;
+  } else if (type === "timestamp") {
+    inner = <TimestampDepartureTime {...data} />;
+  }
+
+  return <div className="departure-time">{inner}</div>;
+};
+
+export default DepartureTime;

--- a/assets/src/components/v2/departures/departure_times.tsx
+++ b/assets/src/components/v2/departures/departure_times.tsx
@@ -1,17 +1,14 @@
 import React from "react";
 
 import DepartureTime from "Components/v2/departures/departure_time";
-
-const DepartureCrowding = (props) => {
-  return null;
-};
+import DepartureCrowding from "Components/v2/departures/departure_crowding";
 
 const DepartureTimes = ({ timesWithCrowding }) => {
   return (
     <div className="departure-times-with-crowding">
       {timesWithCrowding.map(({ time, crowding }, i) => (
         <div className="departure-time-with-crowding" key={i}>
-          <DepartureCrowding {...crowding} />
+          {crowding && <DepartureCrowding crowdingLevel={crowding} />}
           <DepartureTime {...time} />
         </div>
       ))}

--- a/assets/src/components/v2/departures/departure_times.tsx
+++ b/assets/src/components/v2/departures/departure_times.tsx
@@ -1,7 +1,22 @@
 import React from "react";
 
-const DepartureTimes = () => {
+import DepartureTime from "Components/v2/departures/departure_time";
+
+const DepartureCrowding = (props) => {
   return null;
+};
+
+const DepartureTimes = ({ timesWithCrowding }) => {
+  return (
+    <div className="departure-times-with-crowding">
+      {timesWithCrowding.map(({ time, crowding }, i) => (
+        <div className="departure-time-with-crowding" key={i}>
+          <DepartureCrowding {...crowding} />
+          <DepartureTime {...time} />
+        </div>
+      ))}
+    </div>
+  );
 };
 
 export default DepartureTimes;

--- a/assets/src/components/v2/departures/departure_times.tsx
+++ b/assets/src/components/v2/departures/departure_times.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const DepartureTimes = () => {
+  return null;
+};
+
+export default DepartureTimes;

--- a/assets/src/components/v2/departures/departure_times.tsx
+++ b/assets/src/components/v2/departures/departure_times.tsx
@@ -6,8 +6,8 @@ import DepartureCrowding from "Components/v2/departures/departure_crowding";
 const DepartureTimes = ({ timesWithCrowding }) => {
   return (
     <div className="departure-times-with-crowding">
-      {timesWithCrowding.map(({ time, crowding }, i) => (
-        <div className="departure-time-with-crowding" key={i}>
+      {timesWithCrowding.map(({ id, time, crowding }) => (
+        <div className="departure-time-with-crowding" key={id}>
           {crowding && <DepartureCrowding crowdingLevel={crowding} />}
           <DepartureTime {...time} />
         </div>

--- a/assets/src/components/v2/departures/destination.tsx
+++ b/assets/src/components/v2/departures/destination.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const Destination = () => {
+  return null;
+};
+
+export default Destination;

--- a/assets/src/components/v2/departures/destination.tsx
+++ b/assets/src/components/v2/departures/destination.tsx
@@ -1,7 +1,14 @@
 import React from "react";
 
-const Destination = () => {
-  return null;
+const Destination = ({ headsign, variation }) => {
+  return (
+    <div className="departure-destination">
+      <div className="departure-destination__headsign">{headsign}</div>
+      {variation && (
+        <div className="departure-destination__variation">{variation}</div>
+      )}
+    </div>
+  );
 };
 
 export default Destination;

--- a/assets/src/components/v2/departures/normal_departures.tsx
+++ b/assets/src/components/v2/departures/normal_departures.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+
+import NormalSection from "Components/v2/departures/normal_section";
+import NoticeSection from "Components/v2/departures/notice_section";
+
+const NormalDepartures = ({ sections }) => {
+  return (
+    <div className="departures">
+      {sections.map(({ type, ...data }, i) => {
+        if (type === "normal_section") {
+          return <NormalSection {...data} key={i} />;
+        } else if (type === "notice_section") {
+          return <NoticeSection {...data} key={i} />;
+        }
+      })}
+    </div>
+  );
+};
+
+export default NormalDepartures;

--- a/assets/src/components/v2/departures/normal_section.tsx
+++ b/assets/src/components/v2/departures/normal_section.tsx
@@ -5,9 +5,10 @@ import DepartureRow from "Components/v2/departures/departure_row";
 const NormalSection = ({ rows }) => {
   return (
     <div className="departures-section">
-      {rows.map((rowProps) => (
-        <DepartureRow {...rowProps} key={JSON.stringify(rowProps)} />
-      ))}
+      {rows.map((rowProps) => {
+        const { id, ...data } = rowProps;
+        return <DepartureRow {...data} key={id} />;
+      })}
     </div>
   );
 };

--- a/assets/src/components/v2/departures/normal_section.tsx
+++ b/assets/src/components/v2/departures/normal_section.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const NormalSection = ({ rows }) => {
+  return null;
+};
+
+export default NormalSection;

--- a/assets/src/components/v2/departures/normal_section.tsx
+++ b/assets/src/components/v2/departures/normal_section.tsx
@@ -1,7 +1,15 @@
 import React from "react";
 
+import DepartureRow from "Components/v2/departures/departure_row";
+
 const NormalSection = ({ rows }) => {
-  return null;
+  return (
+    <div className="departures-section">
+      {rows.map((rowProps) => (
+        <DepartureRow {...rowProps} key={JSON.stringify(rowProps)} />
+      ))}
+    </div>
+  );
 };
 
 export default NormalSection;

--- a/assets/src/components/v2/departures/notice_section.tsx
+++ b/assets/src/components/v2/departures/notice_section.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const NoticeSection = () => {
+  return null;
+};
+
+export default NoticeSection;

--- a/assets/src/components/v2/departures/route_pill.tsx
+++ b/assets/src/components/v2/departures/route_pill.tsx
@@ -1,6 +1,65 @@
 import React from "react";
 
-const RoutePill = () => {
+import { imagePath, classWithModifiers } from "Util/util";
+
+const TextRoutePill = ({ color, text, outline }) => {
+  let modifiers = [color];
+  if (outline) {
+    modifiers.push("outline");
+  }
+
+  return (
+    <div className={classWithModifiers("route-pill", modifiers)}>
+      <div className="route-pill__text">{text}</div>
+    </div>
+  );
+};
+
+const pathForIcon = {
+  rail: "/commuter-rail.svg",
+  boat: "/ferry.svg",
+};
+
+const IconRoutePill = ({ icon, color, outline }) => {
+  let modifiers = [color];
+  if (outline) {
+    modifiers.push("outline");
+  }
+
+  const imgSrc = imagePath(pathForIcon[icon]);
+
+  return (
+    <div className={classWithModifiers("route-pill", modifiers)}>
+      <div className="route-pill__icon">
+        <img src={imgSrc} />
+      </div>
+    </div>
+  );
+};
+
+const SlashedRoutePill = ({ part1, part2, color, outline }) => {
+  let modifiers = [color];
+  if (outline) {
+    modifiers.push("outline");
+  }
+
+  return (
+    <div className={classWithModifiers("route-pill", modifiers)}>
+      <div className="route-pill__slashed-part-1">{part1}</div>/
+      <div className="route-pill__slashed-part-2">{part2}</div>
+    </div>
+  );
+};
+
+const RoutePill = ({ type, ...data }) => {
+  if (type === "text") {
+    return <TextRoutePill {...data} />;
+  } else if (type === "icon") {
+    return <IconRoutePill {...data} />;
+  } else if (type === "slashed") {
+    return <SlashedRoutePill {...data} />;
+  }
+
   return null;
 };
 

--- a/assets/src/components/v2/departures/route_pill.tsx
+++ b/assets/src/components/v2/departures/route_pill.tsx
@@ -3,14 +3,16 @@ import React from "react";
 import { imagePath, classWithModifiers } from "Util/util";
 
 const TextRoutePill = ({ color, text, outline }) => {
-  let modifiers = [color];
+  const modifiers = [color];
   if (outline) {
     modifiers.push("outline");
   }
 
   return (
     <div className={classWithModifiers("route-pill", modifiers)}>
-      <div className="route-pill__text">{text}</div>
+      <div className={classWithModifiers("route-pill__text", modifiers)}>
+        {text}
+      </div>
     </div>
   );
 };
@@ -21,7 +23,7 @@ const pathForIcon = {
 };
 
 const IconRoutePill = ({ icon, color, outline }) => {
-  let modifiers = [color];
+  const modifiers = [color];
   if (outline) {
     modifiers.push("outline");
   }
@@ -31,14 +33,14 @@ const IconRoutePill = ({ icon, color, outline }) => {
   return (
     <div className={classWithModifiers("route-pill", modifiers)}>
       <div className="route-pill__icon">
-        <img src={imgSrc} />
+        <img className="route-pill__icon-image" src={imgSrc} />
       </div>
     </div>
   );
 };
 
 const SlashedRoutePill = ({ part1, part2, color, outline }) => {
-  let modifiers = [color];
+  const modifiers = [color];
   if (outline) {
     modifiers.push("outline");
   }

--- a/assets/src/components/v2/departures/route_pill.tsx
+++ b/assets/src/components/v2/departures/route_pill.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const RoutePill = () => {
+  return null;
+};
+
+export default RoutePill;

--- a/assets/src/components/v2/departures/route_pill.tsx
+++ b/assets/src/components/v2/departures/route_pill.tsx
@@ -47,8 +47,10 @@ const SlashedRoutePill = ({ part1, part2, color, outline }) => {
 
   return (
     <div className={classWithModifiers("route-pill", modifiers)}>
-      <div className="route-pill__slashed-part-1">{part1}</div>/
-      <div className="route-pill__slashed-part-2">{part2}</div>
+      <div className="route-pill__slashed-text">
+        <div className="route-pill__slashed-part-1">{part1}/</div>
+        <div className="route-pill__slashed-part-2">{part2}</div>
+      </div>
     </div>
   );
 };

--- a/lib/screens/v2/departure.ex
+++ b/lib/screens/v2/departure.ex
@@ -108,6 +108,9 @@ defmodule Screens.V2.Departure do
     end
   end
 
+  def id(%__MODULE__{prediction: %Prediction{id: prediction_id}}), do: prediction_id
+  def id(%__MODULE__{schedule: %Schedule{id: schedule_id}}), do: schedule_id
+
   def route_id(%__MODULE__{prediction: %Prediction{route: %Route{id: route_id}}}) do
     route_id
   end

--- a/lib/screens/v2/widget_instance/departures.ex
+++ b/lib/screens/v2/widget_instance/departures.ex
@@ -52,7 +52,16 @@ defmodule Screens.V2.WidgetInstance.Departures do
   end
 
   defp serialize_row(departures, screen) do
+    departure_id_string =
+      departures
+      |> Enum.map(&Departure.id/1)
+      |> Enum.sort()
+      |> Enum.join("")
+
+    row_id = :md5 |> :crypto.hash(departure_id_string) |> Base.encode64()
+
     %{
+      id: row_id,
       route: serialize_route(departures),
       headsign: serialize_headsign(departures),
       times_with_crowding: serialize_times_with_crowding(departures, screen),
@@ -147,7 +156,10 @@ defmodule Screens.V2.WidgetInstance.Departures do
         _ -> serialize_time(departure, screen, now)
       end
 
-    Map.merge(serialized_time, %{crowding: serialize_crowding(departure)})
+    Map.merge(serialized_time, %{
+      id: Departure.id(departure),
+      crowding: serialize_crowding(departure)
+    })
   end
 
   # credo:disable-for-next-line Credo.Check.Refactor.CyclomaticComplexity

--- a/test/screens/v2/departure_test.exs
+++ b/test/screens/v2/departure_test.exs
@@ -160,6 +160,23 @@ defmodule Screens.V2.DepartureTest do
     end
   end
 
+  describe "id/1" do
+    test "returns prediction id when present" do
+      prediction = %Prediction{id: "prediction-01"}
+      schedule = %Schedule{id: "schedule-01"}
+      departure = %Departure{prediction: prediction, schedule: schedule}
+
+      assert "prediction-01" == Departure.id(departure)
+    end
+
+    test "returns schedule id when no prediction is present" do
+      schedule = %Schedule{id: "schedule-01"}
+      departure = %Departure{prediction: nil, schedule: schedule}
+
+      assert "schedule-01" == Departure.id(departure)
+    end
+  end
+
   describe "route_id/1" do
     test "returns prediction route_id when present" do
       prediction = %Prediction{route: %Route{id: "28"}}

--- a/test/screens/v2/widget_instance/departures_test.exs
+++ b/test/screens/v2/widget_instance/departures_test.exs
@@ -183,7 +183,7 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
     end
 
     test "identifies BRD from vehicle status", %{bus_shelter_screen: screen} do
-      serialized_boarding = [%{crowding: nil, time: %{text: "BRD", type: :text}}]
+      serialized_boarding = [%{id: nil, crowding: nil, time: %{text: "BRD", type: :text}}]
       now = ~U[2020-01-01T00:00:00Z]
 
       departure = %Departure{
@@ -221,7 +221,7 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
     end
 
     test "identifies BRD from stop type", %{bus_shelter_screen: screen} do
-      serialized_boarding = [%{crowding: nil, time: %{text: "BRD", type: :text}}]
+      serialized_boarding = [%{id: nil, crowding: nil, time: %{text: "BRD", type: :text}}]
       now = ~U[2020-01-01T00:00:00Z]
 
       departure = %Departure{
@@ -259,7 +259,7 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
     end
 
     test "identifies ARR", %{bus_shelter_screen: screen} do
-      serialized_arriving = [%{crowding: nil, time: %{text: "ARR", type: :text}}]
+      serialized_arriving = [%{id: nil, crowding: nil, time: %{text: "ARR", type: :text}}]
       now = ~U[2020-01-01T00:00:00Z]
 
       departure = %Departure{
@@ -286,7 +286,7 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
     end
 
     test "returns Now on e-Ink screens", %{bus_eink_screen: screen} do
-      serialized_now = [%{crowding: nil, time: %{text: "Now", type: :text}}]
+      serialized_now = [%{id: nil, crowding: nil, time: %{text: "Now", type: :text}}]
       now = ~U[2020-01-01T00:00:00Z]
 
       departure = %Departure{
@@ -362,7 +362,7 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
 
     test "correctly serializes timestamps", %{bus_shelter_screen: screen} do
       serialized_timestamp = [
-        %{crowding: nil, time: %{type: :timestamp, am_pm: :am, hour: 12, minute: 20}}
+        %{id: nil, crowding: nil, time: %{type: :timestamp, am_pm: :am, hour: 12, minute: 20}}
       ]
 
       now = ~U[2020-01-01T00:00:00Z]
@@ -397,6 +397,7 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
 
       assert [
                %{
+                 id: nil,
                  crowding: nil,
                  time: %{am_pm: :pm, hour: 9, minute: 20, type: :timestamp},
                  scheduled_time: %{am_pm: :pm, hour: 9, minute: 15, type: :timestamp}


### PR DESCRIPTION
**Asana task**: [NormalDepartures component](https://app.asana.com/0/1185117109217413/1200233815812793)

We can't yet implement the logic to dynamically determine how many rows fit on the screen, since that relies on rows actually taking up vertical space. We'll add that in once we're done with the rest of the departures front-end.