### PR TITLE
feat: departure component autosizing and styles for bus shelter screens

### DIFF
--- a/assets/css/bus_shelter_v2.scss
+++ b/assets/css/bus_shelter_v2.scss
@@ -14,6 +14,7 @@
 @import "v2/bus_shelter/link_footer";
 
 @import "v2/bus_shelter/route_pill";
+@import "v2/bus_shelter/departures";
 @import "v2/bus_shelter/departures/row";
 @import "v2/bus_shelter/departures/destination";
 @import "v2/bus_shelter/departures/time";

--- a/assets/css/bus_shelter_v2.scss
+++ b/assets/css/bus_shelter_v2.scss
@@ -5,6 +5,7 @@
 @import "v2/bus_shelter/screen/normal";
 @import "v2/bus_shelter/screen/takeover";
 
+@import "v2/bus_shelter/flex/page_indicator";
 @import "v2/bus_shelter/flex/one_large";
 @import "v2/bus_shelter/flex/one_medium_two_small";
 @import "v2/bus_shelter/flex/two_medium";

--- a/assets/css/v2/bus_shelter/departures.scss
+++ b/assets/css/v2/bus_shelter/departures.scss
@@ -1,0 +1,7 @@
+.departures-container {
+  height: 100%;
+  background-color: #e6e4e1;
+}
+
+.departures {
+}

--- a/assets/css/v2/bus_shelter/departures.scss
+++ b/assets/css/v2/bus_shelter/departures.scss
@@ -1,7 +1,5 @@
 .departures-container {
-  height: 100%;
+  height: 820px;
   background-color: #e6e4e1;
-}
-
-.departures {
+  border-bottom: 4px solid #cccbc8;
 }

--- a/assets/css/v2/bus_shelter/departures/row.scss
+++ b/assets/css/v2/bus_shelter/departures/row.scss
@@ -1,4 +1,18 @@
 .departure-row {
+  padding-bottom: 30px;
+  position: relative;
+
+  &:not(:last-child)::after {
+    content: "";
+    position: absolute;
+    bottom: 0px;
+    left: 200px;
+
+    width: 848px;
+    height: 4px;
+    border-radius: 2px;
+    background-color: #cccbc8;
+  }
 }
 
 .departure-row__route {

--- a/assets/css/v2/bus_shelter/flex/page_indicator.scss
+++ b/assets/css/v2/bus_shelter/flex/page_indicator.scss
@@ -1,0 +1,25 @@
+.flex-zone-page-indicator {
+  position: absolute;
+  top: 624px;
+  left: 0px;
+  width: 1024px;
+  height: 20px;
+  text-align: center;
+}
+
+.flex-zone-page-indicator__page {
+  display: inline-block;
+  width: 144px;
+  height: 16px;
+  border-radius: 24px;
+  margin-left: 44px;
+
+  &--selected {
+    background: #171f26;
+  }
+
+  &--unselected {
+    background: #cccbc8;
+    box-shadow: inset 1px 2px 6px 0px #bfbebb;
+  }
+}

--- a/assets/css/v2/bus_shelter/link_footer.scss
+++ b/assets/css/v2/bus_shelter/link_footer.scss
@@ -1,9 +1,7 @@
 .link-footer {
   position: relative;
   height: 152px;
-  margin-top: 16px;
-  border-top: 4px solid #cccbc8;
-  background: #e6e4e1;
+  background: #d9d6d0;
 }
 
 .link-footer__contents {

--- a/assets/css/v2/bus_shelter/screen/normal.scss
+++ b/assets/css/v2/bus_shelter/screen/normal.scss
@@ -26,7 +26,8 @@
   top: 1104px;
   left: 0px;
   width: 1080px;
-  height: 644px;
+  height: 660px;
+  background-color: #d9d6d0;
 }
 
 .screen-normal__footer {

--- a/assets/src/components/v2/bus_shelter/flex/one_large.tsx
+++ b/assets/src/components/v2/bus_shelter/flex/one_large.tsx
@@ -1,17 +1,25 @@
 import React from "react";
 
 import Widget, { WidgetData } from "Components/v2/widget";
+import FlexZonePageIndicator from "Components/v2/bus_shelter/flex/page_indicator";
 
 interface Props {
   large: WidgetData;
+  page_index: number;
+  num_pages: number;
 }
 
-const OneLarge: React.ComponentType<Props> = ({ large }) => {
+const OneLarge: React.ComponentType<Props> = ({
+  large,
+  num_pages: numPages,
+  page_index: pageIndex,
+}) => {
   return (
     <div className="flex-one-large">
       <div className="flex-one-large__large">
         <Widget data={large} />
       </div>
+      <FlexZonePageIndicator pageIndex={pageIndex} numPages={numPages} />
     </div>
   );
 };

--- a/assets/src/components/v2/bus_shelter/flex/one_medium_two_small.tsx
+++ b/assets/src/components/v2/bus_shelter/flex/one_medium_two_small.tsx
@@ -1,17 +1,22 @@
 import React from "react";
 
 import Widget, { WidgetData } from "Components/v2/widget";
+import FlexZonePageIndicator from "Components/v2/bus_shelter/flex/page_indicator";
 
 interface Props {
   medium_left: WidgetData;
   small_upper_right: WidgetData;
   small_lower_right: WidgetData;
+  page_index: number;
+  num_pages: number;
 }
 
 const OneMediumTwoSmall: React.ComponentType<Props> = ({
   medium_left: mediumLeft,
   small_upper_right: smallUpperRight,
   small_lower_right: smallLowerRight,
+  num_pages: numPages,
+  page_index: pageIndex,
 }) => {
   return (
     <div className="flex-one-medium-two-small">
@@ -24,6 +29,7 @@ const OneMediumTwoSmall: React.ComponentType<Props> = ({
       <div className="flex-one-medium-two-small__lower-right">
         <Widget data={smallLowerRight} />
       </div>
+      <FlexZonePageIndicator pageIndex={pageIndex} numPages={numPages} />
     </div>
   );
 };

--- a/assets/src/components/v2/bus_shelter/flex/page_indicator.tsx
+++ b/assets/src/components/v2/bus_shelter/flex/page_indicator.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+
+import { classWithModifier } from "Util/util";
+
+const FlexZonePageIndicator = ({ pageIndex, numPages }) => {
+  return (
+    <div className="flex-zone-page-indicator">
+      {Array.from({ length: numPages }).map((_, i) => {
+        const modifier = i === pageIndex ? "selected" : "unselected";
+
+        return (
+          <div
+            className={classWithModifier(
+              "flex-zone-page-indicator__page",
+              modifier
+            )}
+            key={i}
+          ></div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default FlexZonePageIndicator;

--- a/assets/src/components/v2/bus_shelter/flex/two_medium.tsx
+++ b/assets/src/components/v2/bus_shelter/flex/two_medium.tsx
@@ -1,15 +1,20 @@
 import React from "react";
 
 import Widget, { WidgetData } from "Components/v2/widget";
+import FlexZonePageIndicator from "Components/v2/bus_shelter/flex/page_indicator";
 
 interface Props {
   medium_left: WidgetData;
   medium_right: WidgetData;
+  page_index: number;
+  num_pages: number;
 }
 
 const TwoMedium: React.ComponentType<Props> = ({
   medium_left: mediumLeft,
   medium_right: mediumRight,
+  page_index: pageIndex,
+  num_pages: numPages,
 }) => {
   return (
     <div className="flex-two-medium">
@@ -19,6 +24,7 @@ const TwoMedium: React.ComponentType<Props> = ({
       <div className="flex-two-medium__right">
         <Widget data={mediumRight} />
       </div>
+      <FlexZonePageIndicator pageIndex={pageIndex} numPages={numPages} />
     </div>
   );
 };

--- a/assets/src/components/v2/departures/normal_departures.tsx
+++ b/assets/src/components/v2/departures/normal_departures.tsx
@@ -6,17 +6,19 @@ import NoticeSection from "Components/v2/departures/notice_section";
 const NormalDeparturesRenderer = forwardRef(
   ({ sections, sectionSizes }, ref) => {
     return (
-      <div className="departures" ref={ref}>
-        {sections.map(({ type, ...data }, i) => {
-          if (type === "normal_section") {
-            const { rows } = data;
-            return (
-              <NormalSection rows={rows.slice(0, sectionSizes[i])} key={i} />
-            );
-          } else if (type === "notice_section") {
-            return <NoticeSection {...data} key={i} />;
-          }
-        })}
+      <div className="departures-container">
+        <div className="departures" ref={ref}>
+          {sections.map(({ type, ...data }, i) => {
+            if (type === "normal_section") {
+              const { rows } = data;
+              return (
+                <NormalSection rows={rows.slice(0, sectionSizes[i])} key={i} />
+              );
+            } else if (type === "notice_section") {
+              return <NoticeSection {...data} key={i} />;
+            }
+          })}
+        </div>
       </div>
     );
   }
@@ -43,7 +45,7 @@ const NormalDeparturesSizer = ({ sections, onDoneSizing }) => {
   useLayoutEffect(() => {
     if (
       ref.current &&
-      ref.current.clientHeight > ref.current.parentNode.clientHeight
+      ref.current.clientHeight > ref.current.parentNode.parentNode.clientHeight
     ) {
       setTempSectionSizes((sectionSizes) => {
         return [sectionSizes[0] - 1];

--- a/assets/src/components/v2/departures/normal_departures.tsx
+++ b/assets/src/components/v2/departures/normal_departures.tsx
@@ -50,6 +50,8 @@ const NormalDeparturesSizer = ({ sections, onDoneSizing }) => {
       setTempSectionSizes((sectionSizes) => {
         return [sectionSizes[0] - 1];
       });
+    } else {
+      onDoneSizing(tempSectionSizes);
     }
   }, [sections, tempSectionSizes]);
 

--- a/assets/src/components/v2/departures/normal_departures.tsx
+++ b/assets/src/components/v2/departures/normal_departures.tsx
@@ -1,20 +1,83 @@
-import React from "react";
+import React, { useState, forwardRef, useLayoutEffect, useRef } from "react";
 
 import NormalSection from "Components/v2/departures/normal_section";
 import NoticeSection from "Components/v2/departures/notice_section";
 
-const NormalDepartures = ({ sections }) => {
-  return (
-    <div className="departures">
-      {sections.map(({ type, ...data }, i) => {
-        if (type === "normal_section") {
-          return <NormalSection {...data} key={i} />;
-        } else if (type === "notice_section") {
-          return <NoticeSection {...data} key={i} />;
-        }
-      })}
-    </div>
+const NormalDeparturesRenderer = forwardRef(
+  ({ sections, sectionSizes }, ref) => {
+    return (
+      <div className="departures" ref={ref}>
+        {sections.map(({ type, ...data }, i) => {
+          if (type === "normal_section") {
+            const { rows } = data;
+            return (
+              <NormalSection rows={rows.slice(0, sectionSizes[i])} key={i} />
+            );
+          } else if (type === "notice_section") {
+            return <NoticeSection {...data} key={i} />;
+          }
+        })}
+      </div>
+    );
+  }
+);
+
+const getInitialSectionSize = ({ type, ...data }) => {
+  if (type === "normal_section") {
+    return data.rows.length;
+  } else {
+    return 0;
+  }
+};
+
+const getInitialSectionSizes = (sections) => {
+  return sections.map((section) => getInitialSectionSize(section));
+};
+
+const NormalDeparturesSizer = ({ sections, onDoneSizing }) => {
+  const [tempSectionSizes, setTempSectionSizes] = useState(
+    getInitialSectionSizes(sections)
   );
+  const ref = useRef();
+
+  useLayoutEffect(() => {
+    if (
+      ref.current &&
+      ref.current.clientHeight > ref.current.parentNode.clientHeight
+    ) {
+      setTempSectionSizes((sectionSizes) => {
+        return [sectionSizes[0] - 1];
+      });
+    }
+  }, [sections, tempSectionSizes]);
+
+  return (
+    <NormalDeparturesRenderer
+      sections={sections}
+      sectionSizes={tempSectionSizes}
+      ref={ref}
+    />
+  );
+};
+
+const NormalDepartures = ({ sections }) => {
+  const [sectionSizes, setSectionSizes] = useState([]);
+
+  if (sectionSizes.length > 0) {
+    return (
+      <NormalDeparturesRenderer
+        sections={sections}
+        sectionSizes={sectionSizes}
+      />
+    );
+  } else {
+    return (
+      <NormalDeparturesSizer
+        sections={sections}
+        onDoneSizing={setSectionSizes}
+      />
+    );
+  }
 };
 
 export default NormalDepartures;


### PR DESCRIPTION
**Asana task**: [NormalDepartures section auto-sizing + Complete Bus Shelter departures](https://app.asana.com/0/1185117109217413/1200292816120184)

This PR adds auto-sizing to to `NormalDepartures`, though for now it only supports departures widgets with a single section. It also adds missing styles for bus shelter screens, including displaying which page is currently visible.