### PR TITLE
feat: Add Screens.Config.Struct and use it throughout config modules

### DIFF
--- a/lib/screens/config.ex
+++ b/lib/screens/config.ex
@@ -2,7 +2,6 @@ defmodule Screens.Config do
   @moduledoc false
 
   alias Screens.Config.{Devops, Screen}
-  alias Screens.Util
 
   @type t :: %__MODULE__{
           screens: %{
@@ -17,22 +16,7 @@ defmodule Screens.Config do
   defstruct screens: nil,
             devops: Devops.from_json(:default)
 
-  @spec from_json(map()) :: t()
-  def from_json(%{} = json) do
-    struct_map =
-      json
-      |> Map.take(Util.struct_keys(__MODULE__))
-      |> Enum.into(%{}, fn {k, v} -> {String.to_existing_atom(k), value_from_json(k, v)} end)
-
-    struct!(__MODULE__, struct_map)
-  end
-
-  @spec to_json(t()) :: map()
-  def to_json(%__MODULE__{} = t) do
-    t
-    |> Map.from_struct()
-    |> Enum.into(%{}, fn {k, v} -> {k, value_to_json(k, v)} end)
-  end
+  use Screens.Config.Struct, children: [screens: {:map, Screen}, devops: Devops]
 
   @spec schedule_refresh_for_screen_ids(t(), list(String.t())) :: t()
   def schedule_refresh_for_screen_ids(config, screen_ids) do
@@ -57,27 +41,7 @@ defmodule Screens.Config do
     %__MODULE__{screens: new_screens, devops: devops}
   end
 
-  defp value_from_json("screens", screens) do
-    Enum.into(screens, %{}, fn {screen_id, screen_config} ->
-      {screen_id, Screen.from_json(screen_config)}
-    end)
-  end
-
-  defp value_from_json("devops", devops) do
-    Devops.from_json(devops)
-  end
-
   defp value_from_json(_, value), do: value
-
-  defp value_to_json(:screens, screens) do
-    Enum.into(screens, %{}, fn {screen_id, screen_config} ->
-      {screen_id, Screen.to_json(screen_config)}
-    end)
-  end
-
-  defp value_to_json(:devops, devops) do
-    Devops.to_json(devops)
-  end
 
   defp value_to_json(_, value), do: value
 end

--- a/lib/screens/config/audio_psa.ex
+++ b/lib/screens/config/audio_psa.ex
@@ -1,6 +1,8 @@
 defmodule Screens.Config.AudioPsa do
   @moduledoc false
 
+  @behaviour Screens.Config.Behaviour
+
   @type t :: {format, String.t(), type} | nil
 
   @typep format :: :plaintext | :ssml
@@ -9,6 +11,7 @@ defmodule Screens.Config.AudioPsa do
   @default_psa_format :plaintext
   @default_psa_type :end
 
+  @impl true
   @spec from_json(map() | :default) :: t()
   def from_json(%{"format" => format, "name" => name, "type" => type}) when is_binary(name) do
     {format_from_json(format), name, type_from_json(type)}
@@ -18,6 +21,7 @@ defmodule Screens.Config.AudioPsa do
     nil
   end
 
+  @impl true
   @spec to_json(t()) :: map()
   def to_json({format, name, type}) do
     %{

--- a/lib/screens/config/behaviour.ex
+++ b/lib/screens/config/behaviour.ex
@@ -1,0 +1,16 @@
+defmodule Screens.Config.Behaviour do
+  @moduledoc false
+
+  @typedoc """
+  Usually a struct or a list, but could conceivably be any other Elixir term.
+  """
+  @type config :: term()
+
+  @typedoc """
+  Usually a map or a list, but could conceivably be another JSON-originated value.
+  """
+  @type json_config :: term()
+
+  @callback from_json(json_config()) :: config()
+  @callback to_json(config()) :: json_config()
+end

--- a/lib/screens/config/behaviour.ex
+++ b/lib/screens/config/behaviour.ex
@@ -2,12 +2,12 @@ defmodule Screens.Config.Behaviour do
   @moduledoc false
 
   @typedoc """
-  Usually a struct or a list, but could conceivably be any other Elixir term.
+  Usually a struct or a tuple, but could conceivably be any other Elixir term.
   """
   @type config :: term()
 
   @typedoc """
-  Usually a map or a list, but could conceivably be another JSON-originated value.
+  Usually a map or a list, but could conceivably be any other JSON-originated value.
   """
   @type json_config :: term()
 

--- a/lib/screens/config/bus.ex
+++ b/lib/screens/config/bus.ex
@@ -3,7 +3,6 @@ defmodule Screens.Config.Bus do
 
   alias Screens.Config.NearbyConnections
   alias Screens.Config.PsaConfig
-  alias Screens.Util
 
   @type t :: %__MODULE__{
           stop_id: String.t(),
@@ -18,40 +17,10 @@ defmodule Screens.Config.Bus do
             psa_config: PsaConfig.from_json(:default),
             nearby_connections: NearbyConnections.from_json(:default)
 
-  @spec from_json(map()) :: t()
-  def from_json(%{} = json) do
-    struct_map =
-      json
-      |> Map.take(Util.struct_keys(__MODULE__))
-      |> Enum.into(%{}, fn {k, v} -> {String.to_existing_atom(k), value_from_json(k, v)} end)
-
-    struct!(__MODULE__, struct_map)
-  end
-
-  @spec to_json(t()) :: map()
-  def to_json(%__MODULE__{} = t) do
-    t
-    |> Map.from_struct()
-    |> Enum.into(%{}, fn {k, v} -> {k, value_to_json(k, v)} end)
-  end
-
-  defp value_from_json("psa_config", psa_config) do
-    PsaConfig.from_json(psa_config)
-  end
-
-  defp value_from_json("nearby_connections", nearby_connections) do
-    NearbyConnections.from_json(nearby_connections)
-  end
+  use Screens.Config.Struct,
+    children: [psa_config: PsaConfig, nearby_connections: NearbyConnections]
 
   defp value_from_json(_, value), do: value
-
-  defp value_to_json(:psa_config, psa_config) do
-    PsaConfig.to_json(psa_config)
-  end
-
-  defp value_to_json(:nearby_connections, nearby_connections) do
-    NearbyConnections.to_json(nearby_connections)
-  end
 
   defp value_to_json(_, value), do: value
 end

--- a/lib/screens/config/devops.ex
+++ b/lib/screens/config/devops.ex
@@ -11,18 +11,13 @@ defmodule Screens.Config.Devops do
 
   defstruct disabled_modes: []
 
-  @spec from_json(map() | :default) :: t()
-  def from_json(%{"disabled_modes" => mode_string_list}) do
-    mode_atom_list = Enum.map(mode_string_list, &mode_string_to_atom/1)
-    %__MODULE__{disabled_modes: mode_atom_list}
+  use Screens.Config.Struct, with_default: true
+
+  defp value_from_json("disabled_modes", modes) do
+    Enum.map(modes, &mode_string_to_atom/1)
   end
 
-  def from_json(:default), do: %__MODULE__{}
-
-  @spec to_json(t()) :: map()
-  def to_json(%__MODULE__{} = t) do
-    Map.from_struct(t)
-  end
+  defp value_to_json(_, value), do: value
 
   for mode <- @modes do
     mode_string = Atom.to_string(mode)

--- a/lib/screens/config/dup.ex
+++ b/lib/screens/config/dup.ex
@@ -2,7 +2,6 @@ defmodule Screens.Config.Dup do
   @moduledoc false
 
   alias Screens.Config.Dup.{Departures, Override}
-  alias Screens.Util
 
   @type t :: %__MODULE__{
           primary: Departures.t(),
@@ -14,46 +13,13 @@ defmodule Screens.Config.Dup do
             secondary: Departures.from_json(:default),
             override: nil
 
-  @spec from_json(map()) :: t()
-  def from_json(%{} = json) do
-    struct_map =
-      json
-      |> Map.take(Util.struct_keys(__MODULE__))
-      |> Enum.into(%{}, fn {k, v} -> {String.to_existing_atom(k), value_from_json(k, v)} end)
-
-    struct!(__MODULE__, struct_map)
-  end
-
-  @spec to_json(t()) :: map()
-  def to_json(%__MODULE__{} = t) do
-    t
-    |> Map.from_struct()
-    |> Enum.into(%{}, fn {k, v} -> {k, value_to_json(k, v)} end)
-  end
-
-  defp value_from_json("primary", primary) do
-    Departures.from_json(primary)
-  end
-
-  defp value_from_json("secondary", secondary) do
-    Departures.from_json(secondary)
-  end
+  use Screens.Config.Struct, children: [primary: Departures, secondary: Departures]
 
   defp value_from_json("override", [screen0, screen1]) do
     {Override.screen0_from_json(screen0), Override.screen1_from_json(screen1)}
   end
 
   defp value_from_json(_, value), do: value
-
-  defp value_to_json(:primary, primary) do
-    Departures.to_json(primary)
-  end
-
-  defp value_to_json(:secondary, secondary) do
-    Departures.to_json(secondary)
-  end
-
-  defp value_to_json(:override, nil), do: nil
 
   defp value_to_json(:override, {screen0, screen1}) do
     [Override.screen0_to_json(screen0), Override.screen1_to_json(screen1)]

--- a/lib/screens/config/dup/departures.ex
+++ b/lib/screens/config/dup/departures.ex
@@ -2,7 +2,6 @@ defmodule Screens.Config.Dup.Departures do
   @moduledoc false
 
   alias Screens.Config.Dup.Section
-  alias Screens.Util
 
   @type t :: %__MODULE__{
           header: String.t(),
@@ -12,36 +11,9 @@ defmodule Screens.Config.Dup.Departures do
   defstruct header: "",
             sections: []
 
-  @spec from_json(map() | :default) :: t()
-  def from_json(%{} = json) do
-    struct_map =
-      json
-      |> Map.take(Util.struct_keys(__MODULE__))
-      |> Enum.into(%{}, fn {k, v} -> {String.to_existing_atom(k), value_from_json(k, v)} end)
-
-    struct!(__MODULE__, struct_map)
-  end
-
-  def from_json(:default) do
-    %__MODULE__{}
-  end
-
-  @spec to_json(t()) :: map()
-  def to_json(%__MODULE__{} = t) do
-    t
-    |> Map.from_struct()
-    |> Enum.into(%{}, fn {k, v} -> {k, value_to_json(k, v)} end)
-  end
-
-  defp value_from_json("sections", sections) when is_list(sections) do
-    Enum.map(sections, &Section.from_json/1)
-  end
+  use Screens.Config.Struct, with_default: true, children: [sections: {:list, Section}]
 
   defp value_from_json(_, value), do: value
-
-  defp value_to_json(:sections, sections) do
-    Enum.map(sections, &Section.to_json/1)
-  end
 
   defp value_to_json(_, value), do: value
 end

--- a/lib/screens/config/dup/override/free_text.ex
+++ b/lib/screens/config/dup/override/free_text.ex
@@ -1,6 +1,8 @@
 defmodule Screens.Config.Dup.Override.FreeText do
   @moduledoc false
 
+  @behaviour Screens.Config.Behaviour
+
   @type t ::
           String.t()
           | %{format: format, text: String.t()}
@@ -24,6 +26,7 @@ defmodule Screens.Config.Dup.Override.FreeText do
   @type color :: :red | :blue | :orange | :green | :silver | :purple
   @type special :: :break
 
+  @impl true
   def from_json(text) when is_binary(text) do
     text
   end
@@ -69,5 +72,6 @@ defmodule Screens.Config.Dup.Override.FreeText do
     end
   end
 
+  @impl true
   def to_json(value), do: value
 end

--- a/lib/screens/config/dup/override/free_text_line.ex
+++ b/lib/screens/config/dup/override/free_text_line.ex
@@ -29,29 +29,18 @@ defmodule Screens.Config.Dup.Override.FreeTextLine do
   @enforce_keys ~w[icon text]a
   defstruct @enforce_keys
 
+  use Screens.Config.Struct, children: [text: {:list, FreeText}]
+
   for icon <-
         ~w[warning x shuttle subway cr walk red blue orange green silver green_b green_c green_d green_e]a do
     icon_string = Atom.to_string(icon)
 
-    def from_json(%{"icon" => unquote(icon_string), "text" => free_text_elements}) do
-      %__MODULE__{
-        icon: unquote(icon),
-        text: Enum.map(free_text_elements, &FreeText.from_json/1)
-      }
+    defp value_from_json(unquote(icon_string)) do
+      unquote(icon)
     end
   end
 
-  def from_json(%{"icon" => nil, "text" => free_text_elements}) do
-    %__MODULE__{
-      icon: nil,
-      text: Enum.map(free_text_elements, &FreeText.from_json/1)
-    }
-  end
+  defp value_from_json(_, value), do: value
 
-  def to_json(%__MODULE__{icon: icon, text: free_text_elements}) do
-    %{
-      icon: icon,
-      text: Enum.map(free_text_elements, &FreeText.to_json/1)
-    }
-  end
+  defp value_to_json(_, value), do: value
 end

--- a/lib/screens/config/dup/override/free_text_line.ex
+++ b/lib/screens/config/dup/override/free_text_line.ex
@@ -35,7 +35,7 @@ defmodule Screens.Config.Dup.Override.FreeTextLine do
         ~w[warning x shuttle subway cr walk red blue orange green silver green_b green_c green_d green_e]a do
     icon_string = Atom.to_string(icon)
 
-    defp value_from_json(unquote(icon_string)) do
+    defp value_from_json("icon", unquote(icon_string)) do
       unquote(icon)
     end
   end

--- a/lib/screens/config/dup/override/fullscreen_alert.ex
+++ b/lib/screens/config/dup/override/fullscreen_alert.ex
@@ -2,7 +2,6 @@ defmodule Screens.Config.Dup.Override.FullscreenAlert do
   @moduledoc false
 
   alias Screens.Config.Dup.Override.FreeTextLine
-  alias Screens.Util
 
   @type t :: %__MODULE__{
           header: String.t() | nil,
@@ -18,30 +17,12 @@ defmodule Screens.Config.Dup.Override.FullscreenAlert do
   @enforce_keys ~w[pattern color issue remedy]a
   defstruct [header: nil] ++ @enforce_keys
 
-  @spec from_json(map()) :: t()
-  def from_json(%{} = json) do
-    struct_map =
-      json
-      |> Map.take(Util.struct_keys(__MODULE__))
-      |> Enum.into(%{}, fn {k, v} -> {String.to_existing_atom(k), value_from_json(k, v)} end)
+  use Screens.Config.Struct, children: [issue: FreeTextLine, remedy: FreeTextLine]
 
-    struct!(__MODULE__, struct_map)
-  end
-
-  @spec to_json(t()) :: map()
   def to_json(%__MODULE__{} = t) do
     t
-    |> Map.from_struct()
-    |> Enum.into(%{}, fn {k, v} -> {k, value_to_json(k, v)} end)
+    |> super()
     |> Map.put(:type, :fullscreen)
-  end
-
-  defp value_from_json("issue", issue) do
-    FreeTextLine.from_json(issue)
-  end
-
-  defp value_from_json("remedy", remedy) do
-    FreeTextLine.from_json(remedy)
   end
 
   for pattern <- ~w[hatched chevron x]a do
@@ -61,14 +42,6 @@ defmodule Screens.Config.Dup.Override.FullscreenAlert do
   end
 
   defp value_from_json(_, value), do: value
-
-  defp value_to_json(:issue, issue) do
-    FreeTextLine.to_json(issue)
-  end
-
-  defp value_to_json(:remedy, remedy) do
-    FreeTextLine.to_json(remedy)
-  end
 
   defp value_to_json(_, value), do: value
 end

--- a/lib/screens/config/dup/override/fullscreen_image.ex
+++ b/lib/screens/config/dup/override/fullscreen_image.ex
@@ -14,4 +14,8 @@ defmodule Screens.Config.Dup.Override.FullscreenImage do
     |> super()
     |> Map.put(:type, :image)
   end
+
+  defp value_from_json(_, value), do: value
+
+  defp value_to_json(_, value), do: value
 end

--- a/lib/screens/config/dup/override/fullscreen_image.ex
+++ b/lib/screens/config/dup/override/fullscreen_image.ex
@@ -7,15 +7,11 @@ defmodule Screens.Config.Dup.Override.FullscreenImage do
 
   defstruct image_url: nil
 
-  @spec from_json(map()) :: t()
-  def from_json(%{"image_url" => image_url}) do
-    %__MODULE__{image_url: image_url}
-  end
+  use Screens.Config.Struct
 
-  @spec to_json(t()) :: map()
   def to_json(%__MODULE__{} = t) do
     t
-    |> Map.from_struct()
+    |> super()
     |> Map.put(:type, :image)
   end
 end

--- a/lib/screens/config/dup/override/partial_alert.ex
+++ b/lib/screens/config/dup/override/partial_alert.ex
@@ -13,21 +13,15 @@ defmodule Screens.Config.Dup.Override.PartialAlert do
   @enforce_keys ~w[color content]a
   defstruct @enforce_keys
 
+  use Screens.Config.Struct, children: [content: FreeTextLine]
+
   for color <- ~w[red orange green blue silver purple yellow]a do
     color_string = Atom.to_string(color)
 
-    def from_json(%{"color" => unquote(color_string), "content" => content}) do
-      %__MODULE__{
-        color: unquote(color),
-        content: FreeTextLine.from_json(content)
-      }
+    defp value_from_json("color", unquote(color_string)) do
+      unquote(color)
     end
   end
 
-  def to_json(%__MODULE__{color: color, content: content}) do
-    %{
-      color: color,
-      content: FreeTextLine.to_json(content)
-    }
-  end
+  defp value_to_json(_, value), do: value
 end

--- a/lib/screens/config/dup/override/partial_alert_list.ex
+++ b/lib/screens/config/dup/override/partial_alert_list.ex
@@ -8,14 +8,11 @@ defmodule Screens.Config.Dup.Override.PartialAlertList do
   @enforce_keys [:alerts]
   defstruct @enforce_keys
 
-  def from_json(%{"alerts" => alerts}) do
-    %__MODULE__{alerts: Enum.map(alerts, &PartialAlert.from_json/1)}
-  end
+  use Screens.Config.Struct, children: [alerts: {:list, PartialAlert}]
 
-  def to_json(%__MODULE__{alerts: alerts}) do
-    %{
-      type: :partial,
-      alerts: Enum.map(alerts, &PartialAlert.to_json/1)
-    }
+  def to_json(%__MODULE__{} = t) do
+    t
+    |> super()
+    |> Map.put(:type, :partial)
   end
 end

--- a/lib/screens/config/dup/section.ex
+++ b/lib/screens/config/dup/section.ex
@@ -3,7 +3,6 @@ defmodule Screens.Config.Dup.Section do
 
   alias Screens.Config.Dup.Section.Headway
   alias Screens.RouteType
-  alias Screens.Util
 
   @type t :: %__MODULE__{
           stop_ids: list(stop_id()),
@@ -23,22 +22,7 @@ defmodule Screens.Config.Dup.Section do
             pill: nil,
             headway: Headway.from_json(:default)
 
-  @spec from_json(map()) :: t()
-  def from_json(%{} = json) do
-    struct_map =
-      json
-      |> Map.take(Util.struct_keys(__MODULE__))
-      |> Enum.into(%{}, fn {k, v} -> {String.to_existing_atom(k), value_from_json(k, v)} end)
-
-    struct!(__MODULE__, struct_map)
-  end
-
-  @spec to_json(t()) :: map()
-  def to_json(%__MODULE__{} = t) do
-    t
-    |> Map.from_struct()
-    |> Enum.into(%{}, fn {k, v} -> {k, value_to_json(k, v)} end)
-  end
+  use Screens.Config.Struct, children: [headway: Headway]
 
   for pill <- ~w[bus red orange green blue cr mattapan silver ferry]a do
     pill_string = Atom.to_string(pill)
@@ -48,19 +32,11 @@ defmodule Screens.Config.Dup.Section do
     end
   end
 
-  defp value_from_json("headway", headway) do
-    Headway.from_json(headway)
-  end
-
   defp value_from_json("route_type", route_type) when is_binary(route_type) do
     RouteType.from_string(route_type)
   end
 
   defp value_from_json(_, value), do: value
-
-  defp value_to_json(:headway, headway) do
-    Headway.to_json(headway)
-  end
 
   defp value_to_json(_, value), do: value
 end

--- a/lib/screens/config/dup/section/headway.ex
+++ b/lib/screens/config/dup/section/headway.ex
@@ -2,8 +2,6 @@ defmodule Screens.Config.Dup.Section.Headway do
   @moduledoc false
   # credo:disable-for-this-file Credo.Check.Design.DuplicatedCode
 
-  alias Screens.Util
-
   @typep sign_id :: String.t()
   @typep headway_id :: String.t() | nil
   @typep override :: {pos_integer, pos_integer} | nil
@@ -18,26 +16,7 @@ defmodule Screens.Config.Dup.Section.Headway do
             headway_id: nil,
             override: nil
 
-  @spec from_json(map() | :default) :: t()
-  def from_json(%{} = json) do
-    struct_map =
-      json
-      |> Map.take(Util.struct_keys(__MODULE__))
-      |> Enum.into(%{}, fn {k, v} -> {String.to_existing_atom(k), value_from_json(k, v)} end)
-
-    struct!(__MODULE__, struct_map)
-  end
-
-  def from_json(:default) do
-    %__MODULE__{}
-  end
-
-  @spec to_json(t()) :: map()
-  def to_json(t) do
-    t
-    |> Map.from_struct()
-    |> Enum.into(%{}, fn {k, v} -> {k, value_to_json(k, v)} end)
-  end
+  use Screens.Config.Struct, with_default: true
 
   defp value_from_json("override", [lo, hi]), do: {lo, hi}
   defp value_from_json(_, value), do: value

--- a/lib/screens/config/gl.ex
+++ b/lib/screens/config/gl.ex
@@ -2,7 +2,6 @@ defmodule Screens.Config.Gl do
   @moduledoc false
 
   alias Screens.Config.PsaConfig
-  alias Screens.Util
 
   @type t :: %__MODULE__{
           stop_id: String.t(),
@@ -25,32 +24,9 @@ defmodule Screens.Config.Gl do
             psa_config: PsaConfig.from_json(:default),
             nearby_departures: []
 
-  @spec from_json(map()) :: t()
-  def from_json(%{} = json) do
-    struct_map =
-      json
-      |> Map.take(Util.struct_keys(__MODULE__))
-      |> Enum.into(%{}, fn {k, v} -> {String.to_existing_atom(k), value_from_json(k, v)} end)
-
-    struct!(__MODULE__, struct_map)
-  end
-
-  @spec to_json(t()) :: map()
-  def to_json(%__MODULE__{} = t) do
-    t
-    |> Map.from_struct()
-    |> Enum.into(%{}, fn {k, v} -> {k, value_to_json(k, v)} end)
-  end
-
-  defp value_from_json("psa_config", psa_config) do
-    PsaConfig.from_json(psa_config)
-  end
+  use Screens.Config.Struct, children: [psa_config: PsaConfig]
 
   defp value_from_json(_, value), do: value
-
-  defp value_to_json(:psa_config, psa_config) do
-    PsaConfig.to_json(psa_config)
-  end
 
   defp value_to_json(_, value), do: value
 end

--- a/lib/screens/config/nearby_connection.ex
+++ b/lib/screens/config/nearby_connection.ex
@@ -7,12 +7,14 @@ defmodule Screens.Config.NearbyConnection do
   @typep stop_id :: String.t()
   @typep route_id :: String.t()
 
+  @impl true
   @spec from_json(map()) :: t()
   def from_json(%{"stop" => stop, "routes_at_stop" => routes_at_stop})
       when is_list(routes_at_stop) do
     {stop, routes_at_stop}
   end
 
+  @impl true
   @spec to_json(t()) :: map()
   def to_json({stop, routes_at_stop}) do
     %{"stop" => stop, "routes_at_stop" => routes_at_stop}

--- a/lib/screens/config/nearby_connection.ex
+++ b/lib/screens/config/nearby_connection.ex
@@ -1,6 +1,8 @@
 defmodule Screens.Config.NearbyConnection do
   @moduledoc false
 
+  @behaviour Screens.Config.Behaviour
+
   @type t :: {stop_id, list(route_id)}
   @typep stop_id :: String.t()
   @typep route_id :: String.t()

--- a/lib/screens/config/nearby_connections.ex
+++ b/lib/screens/config/nearby_connections.ex
@@ -1,10 +1,13 @@
 defmodule Screens.Config.NearbyConnections do
   @moduledoc false
 
+  @behaviour Screens.Config.Behaviour
+
   alias Screens.Config.NearbyConnection
 
   @type t :: list(NearbyConnection.t())
 
+  @impl true
   @spec from_json(list() | :default) :: t()
   def from_json(json) when is_list(json) do
     Enum.map(json, &NearbyConnection.from_json/1)
@@ -12,6 +15,7 @@ defmodule Screens.Config.NearbyConnections do
 
   def from_json(:default), do: []
 
+  @impl true
   @spec to_json(t()) :: list()
   def to_json(nearby_connections) do
     Enum.map(nearby_connections, &NearbyConnection.to_json/1)

--- a/lib/screens/config/psa_config.ex
+++ b/lib/screens/config/psa_config.ex
@@ -2,7 +2,6 @@ defmodule Screens.Config.PsaConfig do
   @moduledoc false
 
   alias Screens.Config.PsaConfig.{OverrideList, PsaList}
-  alias Screens.Util
 
   @type t :: %__MODULE__{
           default_list: PsaList.t(),
@@ -12,44 +11,11 @@ defmodule Screens.Config.PsaConfig do
   defstruct default_list: PsaList.from_json(:default),
             scheduled_overrides: []
 
-  @spec from_json(map() | :default) :: t()
-  def from_json(%{} = json) do
-    struct_map =
-      json
-      |> Map.take(Util.struct_keys(__MODULE__))
-      |> Enum.into(%{}, fn {k, v} -> {String.to_existing_atom(k), value_from_json(k, v)} end)
-
-    struct!(__MODULE__, struct_map)
-  end
-
-  def from_json(:default) do
-    %__MODULE__{}
-  end
-
-  @spec to_json(t()) :: map()
-  def to_json(%__MODULE__{} = t) do
-    t
-    |> Map.from_struct()
-    |> Enum.into(%{}, fn {k, v} -> {k, value_to_json(k, v)} end)
-  end
-
-  defp value_from_json("default_list", default_list) do
-    PsaList.from_json(default_list)
-  end
-
-  defp value_from_json("scheduled_overrides", scheduled_overrides) do
-    Enum.map(scheduled_overrides, &OverrideList.from_json/1)
-  end
+  use Screens.Config.Struct,
+    with_default: true,
+    children: [default_list: PsaList, scheduled_overrides: {:list, OverrideList}]
 
   defp value_from_json(_, value), do: value
-
-  defp value_to_json(:default_list, default_list) do
-    PsaList.to_json(default_list)
-  end
-
-  defp value_to_json(:scheduled_overrides, scheduled_overrides) do
-    Enum.map(scheduled_overrides, &OverrideList.to_json/1)
-  end
 
   defp value_to_json(_, value), do: value
 end

--- a/lib/screens/config/psa_config/override_list.ex
+++ b/lib/screens/config/psa_config/override_list.ex
@@ -2,7 +2,6 @@ defmodule Screens.Config.PsaConfig.OverrideList do
   @moduledoc false
 
   alias Screens.Config.PsaConfig.PsaList
-  alias Screens.Util
 
   @type t :: %__MODULE__{
           psa_list: PsaList.t(),
@@ -15,22 +14,7 @@ defmodule Screens.Config.PsaConfig.OverrideList do
   @enforce_keys ~w[psa_list start_time end_time]a
   defstruct @enforce_keys
 
-  @spec from_json(map()) :: t()
-  def from_json(%{} = json) do
-    struct_map =
-      json
-      |> Map.take(Util.struct_keys(__MODULE__))
-      |> Enum.into(%{}, fn {k, v} -> {String.to_existing_atom(k), value_from_json(k, v)} end)
-
-    struct!(__MODULE__, struct_map)
-  end
-
-  @spec to_json(t()) :: map()
-  def to_json(%__MODULE__{} = t) do
-    t
-    |> Map.from_struct()
-    |> Enum.into(%{}, fn {k, v} -> {k, value_to_json(k, v)} end)
-  end
+  use Screens.Config.Struct, children: [psa_list: PsaList]
 
   for datetime_key <- ~w[start_time end_time]a do
     datetime_key_string = Atom.to_string(datetime_key)
@@ -49,15 +33,7 @@ defmodule Screens.Config.PsaConfig.OverrideList do
     end
   end
 
-  defp value_from_json("psa_list", psa_list) do
-    PsaList.from_json(psa_list)
-  end
-
   defp value_from_json(_, value), do: value
-
-  defp value_to_json(:psa_list, psa_list) do
-    PsaList.to_json(psa_list)
-  end
 
   defp value_to_json(_, value), do: value
 end

--- a/lib/screens/config/psa_config/psa_list.ex
+++ b/lib/screens/config/psa_config/psa_list.ex
@@ -1,6 +1,8 @@
 defmodule Screens.Config.PsaConfig.PsaList do
   @moduledoc false
 
+  @behaviour Screens.Config.Behaviour
+
   @type t :: {
           psa_type,
           list(String.t())
@@ -14,6 +16,7 @@ defmodule Screens.Config.PsaConfig.PsaList do
   @type gl_psa_type :: :double | :takeover | :departure
   @type solari_psa_type :: :slide_in | :takeover
 
+  @impl true
   @spec from_json(map() | :default) :: t()
   def from_json(%{} = json) do
     type = Map.get(json, "type", :default)
@@ -27,6 +30,7 @@ defmodule Screens.Config.PsaConfig.PsaList do
     {@default_psa_type, []}
   end
 
+  @impl true
   @spec to_json(t()) :: map()
   def to_json({type, paths}) do
     %{

--- a/lib/screens/config/psa_config/psa_list.ex
+++ b/lib/screens/config/psa_config/psa_list.ex
@@ -27,7 +27,7 @@ defmodule Screens.Config.PsaConfig.PsaList do
     {@default_psa_type, []}
   end
 
-  @spec to_json(t) :: map()
+  @spec to_json(t()) :: map()
   def to_json({type, paths}) do
     %{
       type: type,

--- a/lib/screens/config/query.ex
+++ b/lib/screens/config/query.ex
@@ -2,7 +2,6 @@ defmodule Screens.Config.Query do
   @moduledoc false
 
   alias Screens.Config.Query.{Opts, Params}
-  alias Screens.Util
 
   @type t :: %__MODULE__{
           params: Params.t(),
@@ -12,40 +11,5 @@ defmodule Screens.Config.Query do
   defstruct params: Params.from_json(:default),
             opts: Opts.from_json(:default)
 
-  @spec from_json(map() | :default) :: t()
-  def from_json(%{} = json) do
-    struct_map =
-      json
-      |> Map.take(Util.struct_keys(__MODULE__))
-      |> Enum.into(%{}, fn {k, v} -> {String.to_existing_atom(k), value_from_json(k, v)} end)
-
-    struct!(__MODULE__, struct_map)
-  end
-
-  def from_json(:default) do
-    %__MODULE__{}
-  end
-
-  @spec to_json(t()) :: map()
-  def to_json(%__MODULE__{} = t) do
-    t
-    |> Map.from_struct()
-    |> Enum.into(%{}, fn {k, v} -> {k, value_to_json(k, v)} end)
-  end
-
-  defp value_from_json("params", params) do
-    Params.from_json(params)
-  end
-
-  defp value_from_json("opts", opts) do
-    Opts.from_json(opts)
-  end
-
-  defp value_to_json(:params, params) do
-    Params.to_json(params)
-  end
-
-  defp value_to_json(:opts, opts) do
-    Opts.to_json(opts)
-  end
+  use Screens.Config.Struct, with_default: true, children: [params: Params, opts: Opts]
 end

--- a/lib/screens/config/query/opts.ex
+++ b/lib/screens/config/query/opts.ex
@@ -2,34 +2,13 @@ defmodule Screens.Config.Query.Opts do
   @moduledoc false
   # credo:disable-for-this-file Credo.Check.Design.DuplicatedCode
 
-  alias Screens.Util
-
   @type t :: %__MODULE__{
           include_schedules: boolean()
         }
 
   defstruct include_schedules: false
 
-  @spec from_json(map() | :default) :: t()
-  def from_json(%{} = json) do
-    struct_map =
-      json
-      |> Map.take(Util.struct_keys(__MODULE__))
-      |> Enum.into(%{}, fn {k, v} -> {String.to_existing_atom(k), value_from_json(k, v)} end)
-
-    struct!(__MODULE__, struct_map)
-  end
-
-  def from_json(:default) do
-    %__MODULE__{}
-  end
-
-  @spec to_json(t()) :: map()
-  def to_json(%__MODULE__{} = t) do
-    t
-    |> Map.from_struct()
-    |> Enum.into(%{}, fn {k, v} -> {k, value_to_json(k, v)} end)
-  end
+  use Screens.Config.Struct, with_default: true
 
   defp value_from_json(_, value), do: value
 

--- a/lib/screens/config/query/params.ex
+++ b/lib/screens/config/query/params.ex
@@ -3,7 +3,6 @@ defmodule Screens.Config.Query.Params do
   # credo:disable-for-this-file Credo.Check.Design.DuplicatedCode
 
   alias Screens.RouteType
-  alias Screens.Util
 
   @type t :: %__MODULE__{
           stop_ids: list(String.t()),
@@ -17,26 +16,7 @@ defmodule Screens.Config.Query.Params do
             direction_id: :both,
             route_type: nil
 
-  @spec from_json(map() | :default) :: t()
-  def from_json(%{} = json) do
-    struct_map =
-      json
-      |> Map.take(Util.struct_keys(__MODULE__))
-      |> Enum.into(%{}, fn {k, v} -> {String.to_existing_atom(k), value_from_json(k, v)} end)
-
-    struct!(__MODULE__, struct_map)
-  end
-
-  def from_json(:default) do
-    %__MODULE__{}
-  end
-
-  @spec to_json(t()) :: map()
-  def to_json(%__MODULE__{} = t) do
-    t
-    |> Map.from_struct()
-    |> Enum.into(%{}, fn {k, v} -> {k, value_to_json(k, v)} end)
-  end
+  use Screens.Config.Struct, with_default: true
 
   defp value_from_json("direction_id", "both"), do: :both
 

--- a/lib/screens/config/screen.ex
+++ b/lib/screens/config/screen.ex
@@ -1,6 +1,8 @@
 defmodule Screens.Config.Screen do
   @moduledoc false
 
+  @behaviour Screens.Config.Behaviour
+
   alias Screens.Config.{Bus, Dup, Gl, Solari, V2}
   alias Screens.Util
 
@@ -68,6 +70,7 @@ defmodule Screens.Config.Screen do
             app_params: nil,
             tags: []
 
+  @impl true
   @spec from_json(map()) :: t() | nil
   def from_json(%{"app_id" => app_id} = json) when app_id in @recognized_app_id_strings do
     app_id = String.to_existing_atom(app_id)
@@ -85,6 +88,7 @@ defmodule Screens.Config.Screen do
   # Prevents the application from breaking if we introduce a new app_id
   def from_json(_), do: nil
 
+  @impl true
   @spec to_json(t()) :: map()
   def to_json(%__MODULE__{app_id: app_id} = t) do
     t

--- a/lib/screens/config/solari.ex
+++ b/lib/screens/config/solari.ex
@@ -2,7 +2,6 @@ defmodule Screens.Config.Solari do
   @moduledoc false
 
   alias Screens.Config.{AudioPsa, PsaConfig, Solari.Section}
-  alias Screens.Util
 
   @type t :: %__MODULE__{
           station_name: String.t(),
@@ -21,22 +20,8 @@ defmodule Screens.Config.Solari do
             psa_config: PsaConfig.from_json(:default),
             audio_psa: AudioPsa.from_json(:default)
 
-  @spec from_json(map()) :: t()
-  def from_json(%{} = json) do
-    struct_map =
-      json
-      |> Map.take(Util.struct_keys(__MODULE__))
-      |> Enum.into(%{}, fn {k, v} -> {String.to_existing_atom(k), value_from_json(k, v)} end)
-
-    struct!(__MODULE__, struct_map)
-  end
-
-  @spec to_json(t()) :: map()
-  def to_json(%__MODULE__{} = t) do
-    t
-    |> Map.from_struct()
-    |> Enum.into(%{}, fn {k, v} -> {k, value_to_json(k, v)} end)
-  end
+  use Screens.Config.Struct,
+    children: [sections: {:list, Section}, psa_config: PsaConfig, audio_psa: AudioPsa]
 
   for headers <- ~w[normal vertical none]a do
     headers_string = Atom.to_string(headers)
@@ -46,31 +31,7 @@ defmodule Screens.Config.Solari do
     end
   end
 
-  defp value_from_json("sections", sections) when is_list(sections) do
-    Enum.map(sections, &Section.from_json/1)
-  end
-
-  defp value_from_json("psa_config", psa_config) do
-    PsaConfig.from_json(psa_config)
-  end
-
-  defp value_from_json("audio_psa", audio_psa) do
-    AudioPsa.from_json(audio_psa)
-  end
-
   defp value_from_json(_, value), do: value
-
-  defp value_to_json(:sections, sections) do
-    Enum.map(sections, &Section.to_json/1)
-  end
-
-  defp value_to_json(:psa_config, psa_config) do
-    PsaConfig.to_json(psa_config)
-  end
-
-  defp value_to_json(:audio_psa, audio_psa) do
-    AudioPsa.to_json(audio_psa)
-  end
 
   defp value_to_json(_, value), do: value
 end

--- a/lib/screens/config/solari/section.ex
+++ b/lib/screens/config/solari/section.ex
@@ -3,7 +3,6 @@ defmodule Screens.Config.Solari.Section do
 
   alias Screens.Config.Query
   alias Screens.Config.Solari.Section.{Audio, Headway, Layout}
-  alias Screens.Util
 
   @type t :: %__MODULE__{
           name: String.t(),
@@ -24,22 +23,8 @@ defmodule Screens.Config.Solari.Section do
             pill: nil,
             headway: Headway.from_json(:default)
 
-  @spec from_json(map()) :: t()
-  def from_json(%{} = json) do
-    struct_map =
-      json
-      |> Map.take(Util.struct_keys(__MODULE__))
-      |> Enum.into(%{}, fn {k, v} -> {String.to_existing_atom(k), value_from_json(k, v)} end)
-
-    struct!(__MODULE__, struct_map)
-  end
-
-  @spec to_json(t()) :: map()
-  def to_json(%__MODULE__{} = t) do
-    t
-    |> Map.from_struct()
-    |> Enum.into(%{}, fn {k, v} -> {k, value_to_json(k, v)} end)
-  end
+  use Screens.Config.Struct,
+    children: [query: Query, layout: Layout, audio: Audio, headway: Headway]
 
   for arrow <- ~w[n e s w ne se sw nw]a do
     arrow_string = Atom.to_string(arrow)
@@ -47,18 +32,6 @@ defmodule Screens.Config.Solari.Section do
     defp value_from_json("arrow", unquote(arrow_string)) do
       unquote(arrow)
     end
-  end
-
-  defp value_from_json("query", query) do
-    Query.from_json(query)
-  end
-
-  defp value_from_json("layout", layout) do
-    Layout.from_json(layout)
-  end
-
-  defp value_from_json("audio", audio) do
-    Audio.from_json(audio)
   end
 
   for pill <- ~w[bus red orange green blue cr mattapan silver]a do
@@ -69,27 +42,7 @@ defmodule Screens.Config.Solari.Section do
     end
   end
 
-  defp value_from_json("headway", headway) do
-    Headway.from_json(headway)
-  end
-
   defp value_from_json(_, value), do: value
-
-  defp value_to_json(:query, query) do
-    Query.to_json(query)
-  end
-
-  defp value_to_json(:layout, layout) do
-    Layout.to_json(layout)
-  end
-
-  defp value_to_json(:audio, audio) do
-    Audio.to_json(audio)
-  end
-
-  defp value_to_json(:headway, headway) do
-    Headway.to_json(headway)
-  end
 
   defp value_to_json(_, value), do: value
 end

--- a/lib/screens/config/solari/section/audio.ex
+++ b/lib/screens/config/solari/section/audio.ex
@@ -1,34 +1,13 @@
 defmodule Screens.Config.Solari.Section.Audio do
   @moduledoc false
 
-  alias Screens.Util
-
   @type t :: %__MODULE__{
           wayfinding: String.t() | nil
         }
 
   defstruct wayfinding: nil
 
-  @spec from_json(map() | :default) :: t()
-  def from_json(%{} = json) do
-    struct_map =
-      json
-      |> Map.take(Util.struct_keys(__MODULE__))
-      |> Enum.into(%{}, fn {k, v} -> {String.to_existing_atom(k), value_from_json(k, v)} end)
-
-    struct!(__MODULE__, struct_map)
-  end
-
-  def from_json(:default) do
-    %__MODULE__{}
-  end
-
-  @spec to_json(t()) :: map()
-  def to_json(%__MODULE__{} = t) do
-    t
-    |> Map.from_struct()
-    |> Enum.into(%{}, fn {k, v} -> {k, value_to_json(k, v)} end)
-  end
+  use Screens.Config.Struct, with_default: true
 
   defp value_from_json(_, value), do: value
 

--- a/lib/screens/config/solari/section/headway.ex
+++ b/lib/screens/config/solari/section/headway.ex
@@ -1,8 +1,6 @@
 defmodule Screens.Config.Solari.Section.Headway do
   @moduledoc false
 
-  alias Screens.Util
-
   @typep sign_id :: String.t()
   @typep headway_id :: String.t()
   @typep headsign :: String.t()
@@ -17,22 +15,9 @@ defmodule Screens.Config.Solari.Section.Headway do
             headway_id: nil,
             headsigns: []
 
-  @spec from_json(map() | :default) :: t()
-  def from_json(%{} = json) do
-    struct_map =
-      json
-      |> Map.take(Util.struct_keys(__MODULE__))
-      |> Enum.into(%{}, fn {k, v} -> {String.to_existing_atom(k), v} end)
+  use Screens.Config.Struct, with_default: true
 
-    struct!(__MODULE__, struct_map)
-  end
+  defp value_from_json(_, value), do: value
 
-  def from_json(:default) do
-    %__MODULE__{}
-  end
-
-  @spec to_json(t()) :: map()
-  def to_json(t) do
-    Map.from_struct(t)
-  end
+  defp value_to_json(_, value), do: value
 end

--- a/lib/screens/config/solari/section/layout.ex
+++ b/lib/screens/config/solari/section/layout.ex
@@ -3,6 +3,8 @@ defmodule Screens.Config.Solari.Section.Layout do
 
   alias Screens.Config.Solari.Section.Layout.{Bidirectional, Upcoming}
 
+  @behaviour Screens.Config.Behaviour
+
   @type t ::
           Bidirectional.t()
           | Upcoming.t()
@@ -14,6 +16,7 @@ defmodule Screens.Config.Solari.Section.Layout do
     upcoming: Upcoming
   }
 
+  @impl true
   @spec from_json(map() | :default) :: t()
   def from_json(%{} = json) do
     type = Map.get(json, "type", :default)
@@ -26,6 +29,7 @@ defmodule Screens.Config.Solari.Section.Layout do
     @opts_modules[@default_type].from_json(:default)
   end
 
+  @impl true
   @spec to_json(t()) :: map()
   def to_json(%Bidirectional{} = layout) do
     %{

--- a/lib/screens/config/solari/section/layout/bidirectional.ex
+++ b/lib/screens/config/solari/section/layout/bidirectional.ex
@@ -9,36 +9,9 @@ defmodule Screens.Config.Solari.Section.Layout.Bidirectional do
 
   defstruct routes: RouteConfig.from_json(:default)
 
-  @spec from_json(map() | :default) :: t()
-  def from_json(%{} = json) do
-    struct_map =
-      json
-      |> Map.take(~w[routes])
-      |> Enum.into(%{}, fn {k, v} -> {String.to_existing_atom(k), value_from_json(k, v)} end)
-
-    struct!(__MODULE__, struct_map)
-  end
-
-  def from_json(:default) do
-    %__MODULE__{}
-  end
-
-  @spec to_json(t()) :: map()
-  def to_json(%__MODULE__{} = t) do
-    t
-    |> Map.from_struct()
-    |> Enum.into(%{}, fn {k, v} -> {k, value_to_json(k, v)} end)
-  end
-
-  defp value_from_json("routes", routes) do
-    RouteConfig.from_json(routes)
-  end
+  use Screens.Config.Struct, with_default: true, children: [routes: RouteConfig]
 
   defp value_from_json(_, value), do: value
-
-  defp value_to_json(:routes, routes) do
-    RouteConfig.to_json(routes)
-  end
 
   defp value_to_json(_, value), do: value
 end

--- a/lib/screens/config/solari/section/layout/route_config.ex
+++ b/lib/screens/config/solari/section/layout/route_config.ex
@@ -3,10 +3,13 @@ defmodule Screens.Config.Solari.Section.Layout.RouteConfig do
 
   alias Screens.Config.Solari.Section.Layout.RouteConfig.RouteDescriptor
 
+  @behaviour Screens.Config.Behaviour
+
   @type t :: {:exclude | :include, list(RouteDescriptor.t())}
 
   @default_action :exclude
 
+  @impl true
   @spec from_json(map() | :default) :: t()
   def from_json(%{} = json) do
     action = Map.get(json, "action", :default)
@@ -23,6 +26,7 @@ defmodule Screens.Config.Solari.Section.Layout.RouteConfig do
     {@default_action, []}
   end
 
+  @impl true
   @spec to_json(t()) :: map()
   def to_json({action, route_list}) do
     %{

--- a/lib/screens/config/solari/section/layout/route_config/route_descriptor.ex
+++ b/lib/screens/config/solari/section/layout/route_config/route_descriptor.ex
@@ -1,15 +1,19 @@
 defmodule Screens.Config.Solari.Section.Layout.RouteConfig.RouteDescriptor do
   @moduledoc false
 
+  @behaviour Screens.Config.Behaviour
+
   @type t :: {String.t(), direction_id}
 
   @type direction_id :: 0 | 1
 
+  @impl true
   @spec from_json(map()) :: t()
   def from_json(%{"route" => route, "direction_id" => direction_id}) do
     {route, direction_id}
   end
 
+  @impl true
   @spec to_json(t()) :: map()
   def to_json({route, direction_id}) do
     %{"route" => route, "direction_id" => direction_id}

--- a/lib/screens/config/solari/section/layout/upcoming.ex
+++ b/lib/screens/config/solari/section/layout/upcoming.ex
@@ -2,7 +2,6 @@ defmodule Screens.Config.Solari.Section.Layout.Upcoming do
   @moduledoc false
 
   alias Screens.Config.Solari.Section.Layout.RouteConfig
-  alias Screens.Util
 
   @type t :: %__MODULE__{
           num_rows: pos_integer() | :infinity,
@@ -18,26 +17,7 @@ defmodule Screens.Config.Solari.Section.Layout.Upcoming do
             routes: RouteConfig.from_json(:default),
             max_minutes: :infinity
 
-  @spec from_json(map() | :default) :: t()
-  def from_json(%{} = json) do
-    struct_map =
-      json
-      |> Map.take(Util.struct_keys(__MODULE__))
-      |> Enum.into(%{}, fn {k, v} -> {String.to_existing_atom(k), value_from_json(k, v)} end)
-
-    struct!(__MODULE__, struct_map)
-  end
-
-  def from_json(:default) do
-    %__MODULE__{}
-  end
-
-  @spec to_json(t()) :: map()
-  def to_json(%__MODULE__{} = t) do
-    t
-    |> Map.from_struct()
-    |> Enum.into(%{}, fn {k, v} -> {k, value_to_json(k, v)} end)
-  end
+  use Screens.Config.Struct, with_default: true, children: [routes: RouteConfig]
 
   for key <- ~w[num_rows visible_rows max_minutes]a do
     key_string = Atom.to_string(key)
@@ -47,15 +27,7 @@ defmodule Screens.Config.Solari.Section.Layout.Upcoming do
     defp value_to_json(unquote(key), :infinity), do: "infinity"
   end
 
-  defp value_from_json("routes", routes) do
-    RouteConfig.from_json(routes)
-  end
-
   defp value_from_json(_, value), do: value
-
-  defp value_to_json(:routes, routes) do
-    RouteConfig.to_json(routes)
-  end
 
   defp value_to_json(_, value), do: value
 end

--- a/lib/screens/config/struct.ex
+++ b/lib/screens/config/struct.ex
@@ -21,7 +21,8 @@ defmodule Screens.Config.Struct do
 
     * A `t()` type definition for the struct
 
-    * Clauses of `value_from_json/2` and `value_to_json/2` for struct fields not described in the `:children` opt
+    * Clauses of `value_from_json/2` and `value_to_json/2` for struct fields not described in the `:children` opt,
+      as well as any `:children` fields that are nullable.
 
     * Any other fallback clauses of `value_from_json/2` and `value_to_json/2`
   """

--- a/lib/screens/config/struct.ex
+++ b/lib/screens/config/struct.ex
@@ -107,11 +107,15 @@ defmodule Screens.Config.Struct do
 
       defp _value_to_json(key, value), do: value_to_json(key, value)
 
-      defp value_from_json("__never_matches__", _value), do: nil
+      defp value_from_json(_key, _value) do
+        raise "value_from_json/2 not implemented"
+      end
 
-      defp value_to_json(:__never_matches__, _value), do: nil
+      defp value_to_json(_key, _value) do
+        raise "value_to_json/2 not implemented"
+      end
 
-      defoverridable from_json: 1, to_json: 1
+      defoverridable from_json: 1, to_json: 1, value_from_json: 2, value_to_json: 2
     end
   end
 end

--- a/lib/screens/config/struct.ex
+++ b/lib/screens/config/struct.ex
@@ -1,0 +1,106 @@
+defmodule Screens.Config.Struct do
+  @moduledoc """
+  A `use`-able convenience macro that generates boilerplate code for
+  a JSON-serializable config struct. Modules that use this will automatically
+  adopt `Screens.Config.Behaviour`.
+
+  This shouldn't be used in all cases--it's just for the more straightforward
+  pieces of config.
+
+  In the using module, you MUST define the following:
+
+    * A struct
+
+    * A `t()` type definition for the struct
+
+    * `value_from_json/2` and `value_to_json/2`, if you do not pass a `children` list in the `use` call
+
+  You MAY also define the following:
+
+    * Additional clauses of `value_from_json/2` and `value_to_json/2`
+
+  ## Options
+
+    * `:with_default` - set true to have the generated `from_json/1` accept `:default` as its argument.
+      Default false.
+
+    * `:children` - pass a keyword list of {struct_key, child_config_module | {:list, child_config_module}},
+      where child_config_module is a module that adopts `Screens.Config.Behaviour`.
+  """
+
+  @type opt ::
+          {:with_default, boolean()}
+          | {:children, keyword(module() | {:list, module()})}
+
+  @type opts :: list(opt())
+
+  @spec __using__(opts()) :: term()
+  defmacro __using__(opts \\ []) do
+    with_default = opts[:with_default] || false
+    children = opts[:children] || []
+
+    quote location: :keep, bind_quoted: [with_default: with_default, children: children] do
+      alias Screens.Util
+
+      @behaviour Screens.Config.Behaviour
+
+      @impl true
+      if with_default do
+        @spec from_json(map() | :default) :: t()
+      else
+        @spec from_json(map()) :: t()
+      end
+
+      def from_json(%{} = json) do
+        struct_map =
+          json
+          |> Map.take(Util.struct_keys(__MODULE__))
+          |> Enum.into(%{}, fn {k, v} -> {String.to_existing_atom(k), value_from_json(k, v)} end)
+
+        struct!(__MODULE__, struct_map)
+      end
+
+      if with_default do
+        def from_json(:default), do: %__MODULE__{}
+      end
+
+      @impl true
+      @spec to_json(t()) :: map()
+      def to_json(%__MODULE__{} = t) do
+        t
+        |> Map.from_struct()
+        |> Enum.into(%{}, fn {k, v} -> {k, value_to_json(k, v)} end)
+      end
+
+      defp value_from_json(string_key, value)
+
+      defp value_to_json(key, value)
+
+      for {key, child_module} <- children do
+        string_key = Atom.to_string(key)
+
+        case child_module do
+          {:list, module} ->
+            defp value_from_json(unquote(string_key), values) do
+              Enum.map(values, &unquote(module).from_json/1)
+            end
+
+            defp value_to_json(unquote(key), values) do
+              Enum.map(values, &unquote(module).to_json/1)
+            end
+
+          module ->
+            defp value_from_json(unquote(string_key), value) do
+              unquote(module).from_json(value)
+            end
+
+            defp value_to_json(unquote(key), value) do
+              unquote(module).to_json(value)
+            end
+        end
+      end
+
+      defoverridable value_from_json: 2, value_to_json: 2
+    end
+  end
+end

--- a/lib/screens/config/struct.ex
+++ b/lib/screens/config/struct.ex
@@ -108,11 +108,11 @@ defmodule Screens.Config.Struct do
       defp _value_to_json(key, value), do: value_to_json(key, value)
 
       defp value_from_json(_key, _value) do
-        raise "value_from_json/2 not implemented"
+        raise "#{__MODULE__}.value_from_json/2 not implemented"
       end
 
       defp value_to_json(_key, _value) do
-        raise "value_to_json/2 not implemented"
+        raise "#{__MODULE__}.value_to_json/2 not implemented"
       end
 
       defoverridable from_json: 1, to_json: 1, value_from_json: 2, value_to_json: 2

--- a/lib/screens/config/struct.ex
+++ b/lib/screens/config/struct.ex
@@ -108,12 +108,12 @@ defmodule Screens.Config.Struct do
 
       defp _value_to_json(key, value), do: value_to_json(key, value)
 
-      defp value_from_json(_key, _value) do
-        raise "#{__MODULE__}.value_from_json/2 not implemented"
+      defp value_from_json(key, _value) do
+        raise "#{__MODULE__}.value_from_json/2 not implemented (key: `#{key}`)"
       end
 
-      defp value_to_json(_key, _value) do
-        raise "#{__MODULE__}.value_to_json/2 not implemented"
+      defp value_to_json(key, _value) do
+        raise "#{__MODULE__}.value_to_json/2 not implemented (key: `#{key}`)"
       end
 
       defoverridable from_json: 1, to_json: 1, value_from_json: 2, value_to_json: 2

--- a/lib/screens/config/v2/bus_eink.ex
+++ b/lib/screens/config/v2/bus_eink.ex
@@ -4,7 +4,6 @@ defmodule Screens.Config.V2.BusEink do
 
   alias Screens.Config.V2.{Departures, Footer}
   alias Screens.Config.V2.Header.CurrentStopId
-  alias Screens.Util
 
   @type t :: %__MODULE__{
           departures: Departures.t(),
@@ -17,44 +16,6 @@ defmodule Screens.Config.V2.BusEink do
             footer: nil,
             header: nil
 
-  @spec from_json(map()) :: t()
-  def from_json(%{} = json) do
-    struct_map =
-      json
-      |> Map.take(Util.struct_keys(__MODULE__))
-      |> Enum.into(%{}, fn {k, v} -> {String.to_existing_atom(k), value_from_json(k, v)} end)
-
-    struct!(__MODULE__, struct_map)
-  end
-
-  @spec to_json(t()) :: map()
-  def to_json(%__MODULE__{} = t) do
-    t
-    |> Map.from_struct()
-    |> Enum.into(%{}, fn {k, v} -> {k, value_to_json(k, v)} end)
-  end
-
-  defp value_from_json("departures", departures) do
-    Departures.from_json(departures)
-  end
-
-  defp value_from_json("footer", footer) do
-    Footer.from_json(footer)
-  end
-
-  defp value_from_json("header", header) do
-    CurrentStopId.from_json(header)
-  end
-
-  defp value_to_json(:departures, departures) do
-    Departures.to_json(departures)
-  end
-
-  defp value_to_json(:footer, footer) do
-    Footer.to_json(footer)
-  end
-
-  defp value_to_json(:header, header) do
-    CurrentStopId.to_json(header)
-  end
+  use Screens.Config.Struct,
+    children: [departures: Departures, footer: Footer, header: CurrentStopId]
 end

--- a/lib/screens/config/v2/bus_shelter.ex
+++ b/lib/screens/config/v2/bus_shelter.ex
@@ -4,7 +4,6 @@ defmodule Screens.Config.V2.BusShelter do
 
   alias Screens.Config.V2.{Departures, Footer}
   alias Screens.Config.V2.Header.CurrentStopId
-  alias Screens.Util
 
   @type t :: %__MODULE__{
           departures: Departures.t(),
@@ -17,44 +16,6 @@ defmodule Screens.Config.V2.BusShelter do
             footer: nil,
             header: nil
 
-  @spec from_json(map()) :: t()
-  def from_json(%{} = json) do
-    struct_map =
-      json
-      |> Map.take(Util.struct_keys(__MODULE__))
-      |> Enum.into(%{}, fn {k, v} -> {String.to_existing_atom(k), value_from_json(k, v)} end)
-
-    struct!(__MODULE__, struct_map)
-  end
-
-  @spec to_json(t()) :: map()
-  def to_json(%__MODULE__{} = t) do
-    t
-    |> Map.from_struct()
-    |> Enum.into(%{}, fn {k, v} -> {k, value_to_json(k, v)} end)
-  end
-
-  defp value_from_json("departures", departures) do
-    Departures.from_json(departures)
-  end
-
-  defp value_from_json("footer", footer) do
-    Footer.from_json(footer)
-  end
-
-  defp value_from_json("header", header) do
-    CurrentStopId.from_json(header)
-  end
-
-  defp value_to_json(:departures, departures) do
-    Departures.to_json(departures)
-  end
-
-  defp value_to_json(:footer, footer) do
-    Footer.to_json(footer)
-  end
-
-  defp value_to_json(:header, header) do
-    CurrentStopId.to_json(header)
-  end
+  use Screens.Config.Struct,
+    children: [departures: Departures, footer: Footer, header: CurrentStopId]
 end

--- a/lib/screens/config/v2/departures.ex
+++ b/lib/screens/config/v2/departures.ex
@@ -2,35 +2,11 @@ defmodule Screens.Config.V2.Departures do
   @moduledoc false
 
   alias Screens.Config.V2.Departures.Section
-  alias Screens.Util
 
   @type t :: %__MODULE__{sections: list(Section.t())}
 
   @enforce_keys [:sections]
   defstruct sections: []
 
-  @spec from_json(map()) :: t()
-  def from_json(%{} = json) do
-    struct_map =
-      json
-      |> Map.take(Util.struct_keys(__MODULE__))
-      |> Enum.into(%{}, fn {k, v} -> {String.to_existing_atom(k), value_from_json(k, v)} end)
-
-    struct!(__MODULE__, struct_map)
-  end
-
-  defp value_from_json("sections", sections) when is_list(sections) do
-    Enum.map(sections, &Section.from_json/1)
-  end
-
-  @spec to_json(t()) :: map()
-  def to_json(%__MODULE__{} = t) do
-    t
-    |> Map.from_struct()
-    |> Enum.into(%{}, fn {k, v} -> {k, value_to_json(k, v)} end)
-  end
-
-  defp value_to_json(:sections, sections) do
-    Enum.map(sections, &Section.to_json/1)
-  end
+  use Screens.Config.Struct, children: [sections: {:list, Section}]
 end

--- a/lib/screens/config/v2/departures/filter.ex
+++ b/lib/screens/config/v2/departures/filter.ex
@@ -2,7 +2,6 @@ defmodule Screens.Config.V2.Departures.Filter do
   @moduledoc false
 
   alias Screens.Config.V2.Departures.Filter.RouteDirection
-  alias Screens.Util
 
   @type t :: %__MODULE__{
           action: :include | :exclude,
@@ -13,33 +12,10 @@ defmodule Screens.Config.V2.Departures.Filter do
   defstruct action: nil,
             route_directions: []
 
-  @spec from_json(map()) :: t()
-  def from_json(%{} = json) do
-    struct_map =
-      json
-      |> Map.take(Util.struct_keys(__MODULE__))
-      |> Enum.into(%{}, fn {k, v} -> {String.to_existing_atom(k), value_from_json(k, v)} end)
-
-    struct!(__MODULE__, struct_map)
-  end
+  use Screens.Config.Struct, children: [route_directions: {:list, RouteDirection}]
 
   defp value_from_json("action", "include"), do: :include
   defp value_from_json("action", "exclude"), do: :exclude
-
-  defp value_from_json("route_directions", route_directions) do
-    Enum.map(route_directions, &RouteDirection.to_json/1)
-  end
-
-  @spec to_json(t()) :: map()
-  def to_json(%__MODULE__{} = t) do
-    t
-    |> Map.from_struct()
-    |> Enum.into(%{}, fn {k, v} -> {k, value_to_json(k, v)} end)
-  end
-
-  defp value_to_json(:route_directions, route_directions) do
-    Enum.map(route_directions, &RouteDirection.from_json/1)
-  end
 
   defp value_to_json(_, value), do: value
 end

--- a/lib/screens/config/v2/departures/filter/route_direction.ex
+++ b/lib/screens/config/v2/departures/filter/route_direction.ex
@@ -10,14 +10,9 @@ defmodule Screens.Config.V2.Departures.Filter.RouteDirection do
   defstruct route_id: nil,
             direction_id: nil
 
-  @spec from_json(map()) :: t()
-  def from_json(%{"route_id" => route_id} = json) do
-    direction_id = Map.get(json, "direction_id")
-    %__MODULE__{route_id: route_id, direction_id: direction_id}
-  end
+  use Screens.Config.Struct
 
-  @spec to_json(t()) :: map()
-  def to_json(%__MODULE__{route_id: route_id, direction_id: direction_id}) do
-    %{route_id: route_id, direction_id: direction_id}
-  end
+  defp value_from_json(_, value), do: value
+
+  defp value_to_json(_, value), do: value
 end

--- a/lib/screens/config/v2/departures/headway.ex
+++ b/lib/screens/config/v2/departures/headway.ex
@@ -2,8 +2,6 @@ defmodule Screens.Config.V2.Departures.Headway do
   @moduledoc false
   # credo:disable-for-this-file Credo.Check.Design.DuplicatedCode
 
-  alias Screens.Util
-
   @typep sign_id :: String.t()
   @typep headway_id :: String.t() | nil
   @typep override :: {pos_integer, pos_integer} | nil
@@ -18,26 +16,7 @@ defmodule Screens.Config.V2.Departures.Headway do
             headway_id: nil,
             override: nil
 
-  @spec from_json(map() | :default) :: t()
-  def from_json(%{} = json) do
-    struct_map =
-      json
-      |> Map.take(Util.struct_keys(__MODULE__))
-      |> Enum.into(%{}, fn {k, v} -> {String.to_existing_atom(k), value_from_json(k, v)} end)
-
-    struct!(__MODULE__, struct_map)
-  end
-
-  def from_json(:default) do
-    %__MODULE__{}
-  end
-
-  @spec to_json(t()) :: map()
-  def to_json(t) do
-    t
-    |> Map.from_struct()
-    |> Enum.into(%{}, fn {k, v} -> {k, value_to_json(k, v)} end)
-  end
+  use Screens.Config.Struct, with_default: true
 
   defp value_from_json("override", [lo, hi]), do: {lo, hi}
   defp value_from_json(_, value), do: value

--- a/lib/screens/config/v2/departures/query.ex
+++ b/lib/screens/config/v2/departures/query.ex
@@ -2,7 +2,6 @@ defmodule Screens.Config.V2.Departures.Query do
   @moduledoc false
 
   alias Screens.Config.V2.Departures.Query.{Opts, Params}
-  alias Screens.Util
 
   @type t :: %__MODULE__{
           params: Params.t(),
@@ -12,40 +11,5 @@ defmodule Screens.Config.V2.Departures.Query do
   defstruct params: Params.from_json(:default),
             opts: Opts.from_json(:default)
 
-  @spec from_json(map() | :default) :: t()
-  def from_json(%{} = json) do
-    struct_map =
-      json
-      |> Map.take(Util.struct_keys(__MODULE__))
-      |> Enum.into(%{}, fn {k, v} -> {String.to_existing_atom(k), value_from_json(k, v)} end)
-
-    struct!(__MODULE__, struct_map)
-  end
-
-  def from_json(:default) do
-    %__MODULE__{}
-  end
-
-  @spec to_json(t()) :: map()
-  def to_json(%__MODULE__{} = t) do
-    t
-    |> Map.from_struct()
-    |> Enum.into(%{}, fn {k, v} -> {k, value_to_json(k, v)} end)
-  end
-
-  defp value_from_json("params", params) do
-    Params.from_json(params)
-  end
-
-  defp value_from_json("opts", opts) do
-    Opts.from_json(opts)
-  end
-
-  defp value_to_json(:params, params) do
-    Params.to_json(params)
-  end
-
-  defp value_to_json(:opts, opts) do
-    Opts.to_json(opts)
-  end
+  use Screens.Config.Struct, with_default: true, children: [params: Params, opts: Opts]
 end

--- a/lib/screens/config/v2/departures/query/opts.ex
+++ b/lib/screens/config/v2/departures/query/opts.ex
@@ -2,34 +2,13 @@ defmodule Screens.Config.V2.Departures.Query.Opts do
   @moduledoc false
   # credo:disable-for-this-file Credo.Check.Design.DuplicatedCode
 
-  alias Screens.Util
-
   @type t :: %__MODULE__{
           include_schedules: boolean()
         }
 
   defstruct include_schedules: false
 
-  @spec from_json(map() | :default) :: t()
-  def from_json(%{} = json) do
-    struct_map =
-      json
-      |> Map.take(Util.struct_keys(__MODULE__))
-      |> Enum.into(%{}, fn {k, v} -> {String.to_existing_atom(k), value_from_json(k, v)} end)
-
-    struct!(__MODULE__, struct_map)
-  end
-
-  def from_json(:default) do
-    %__MODULE__{}
-  end
-
-  @spec to_json(t()) :: map()
-  def to_json(%__MODULE__{} = t) do
-    t
-    |> Map.from_struct()
-    |> Enum.into(%{}, fn {k, v} -> {k, value_to_json(k, v)} end)
-  end
+  use Screens.Config.Struct, with_default: true
 
   defp value_from_json(_, value), do: value
 

--- a/lib/screens/config/v2/departures/query/params.ex
+++ b/lib/screens/config/v2/departures/query/params.ex
@@ -3,7 +3,6 @@ defmodule Screens.Config.V2.Departures.Query.Params do
   # credo:disable-for-this-file Credo.Check.Design.DuplicatedCode
 
   alias Screens.RouteType
-  alias Screens.Util
 
   @type t :: %__MODULE__{
           stop_ids: list(String.t()),
@@ -17,26 +16,7 @@ defmodule Screens.Config.V2.Departures.Query.Params do
             direction_id: :both,
             route_type: nil
 
-  @spec from_json(map() | :default) :: t()
-  def from_json(%{} = json) do
-    struct_map =
-      json
-      |> Map.take(Util.struct_keys(__MODULE__))
-      |> Enum.into(%{}, fn {k, v} -> {String.to_existing_atom(k), value_from_json(k, v)} end)
-
-    struct!(__MODULE__, struct_map)
-  end
-
-  def from_json(:default) do
-    %__MODULE__{}
-  end
-
-  @spec to_json(t()) :: map()
-  def to_json(%__MODULE__{} = t) do
-    t
-    |> Map.from_struct()
-    |> Enum.into(%{}, fn {k, v} -> {k, value_to_json(k, v)} end)
-  end
+  use Screens.Config.Struct, with_default: true
 
   defp value_from_json("direction_id", "both"), do: :both
 

--- a/lib/screens/config/v2/departures/section.ex
+++ b/lib/screens/config/v2/departures/section.ex
@@ -2,7 +2,6 @@ defmodule Screens.Config.V2.Departures.Section do
   @moduledoc false
 
   alias Screens.Config.V2.Departures.{Filter, Headway, Query}
-  alias Screens.Util
 
   @type t :: %__MODULE__{
           query: Query.t(),
@@ -15,48 +14,9 @@ defmodule Screens.Config.V2.Departures.Section do
             filter: nil,
             headway: Headway.from_json(:default)
 
-  @spec from_json(map()) :: t()
-  def from_json(%{} = json) do
-    struct_map =
-      json
-      |> Map.take(Util.struct_keys(__MODULE__))
-      |> Enum.into(%{}, fn {k, v} -> {String.to_existing_atom(k), value_from_json(k, v)} end)
+  use Screens.Config.Struct, children: [query: Query, filter: Filter, headway: Headway]
 
-    struct!(__MODULE__, struct_map)
-  end
+  defp value_from_json(_, value), do: value
 
-  defp value_from_json("query", query) do
-    Query.from_json(query)
-  end
-
-  defp value_from_json("filter", nil), do: nil
-
-  defp value_from_json("filter", filter) do
-    Filter.from_json(filter)
-  end
-
-  defp value_from_json("headway", headway) do
-    Headway.from_json(headway)
-  end
-
-  @spec to_json(t()) :: map()
-  def to_json(%__MODULE__{} = t) do
-    t
-    |> Map.from_struct()
-    |> Enum.into(%{}, fn {k, v} -> {k, value_to_json(k, v)} end)
-  end
-
-  defp value_to_json(:query, query) do
-    Query.to_json(query)
-  end
-
-  defp value_to_json(:filter, nil), do: nil
-
-  defp value_to_json(:filter, filter) do
-    Filter.to_json(filter)
-  end
-
-  defp value_to_json(:headway, headway) do
-    Headway.to_json(headway)
-  end
+  defp value_to_json(_, value), do: value
 end

--- a/lib/screens/config/v2/footer.ex
+++ b/lib/screens/config/v2/footer.ex
@@ -5,13 +5,9 @@ defmodule Screens.Config.V2.Footer do
 
   defstruct stop_id: nil
 
-  @spec from_json(map()) :: t()
-  def from_json(%{"stop_id" => stop_id}) do
-    %__MODULE__{stop_id: stop_id}
-  end
+  use Screens.Config.Struct
 
-  @spec to_json(t()) :: map()
-  def to_json(%__MODULE__{stop_id: stop_id}) do
-    %{stop_id: stop_id}
-  end
+  defp value_from_json(_, value), do: value
+
+  defp value_to_json(_, value), do: value
 end

--- a/lib/screens/config/v2/gl_eink.ex
+++ b/lib/screens/config/v2/gl_eink.ex
@@ -4,7 +4,6 @@ defmodule Screens.Config.V2.GlEink do
 
   alias Screens.Config.V2.{Departures, Footer}
   alias Screens.Config.V2.Header.Destination
-  alias Screens.Util
 
   @type t :: %__MODULE__{
           departures: Departures.t(),
@@ -17,44 +16,6 @@ defmodule Screens.Config.V2.GlEink do
             footer: nil,
             header: nil
 
-  @spec from_json(map()) :: t()
-  def from_json(%{} = json) do
-    struct_map =
-      json
-      |> Map.take(Util.struct_keys(__MODULE__))
-      |> Enum.into(%{}, fn {k, v} -> {String.to_existing_atom(k), value_from_json(k, v)} end)
-
-    struct!(__MODULE__, struct_map)
-  end
-
-  @spec to_json(t()) :: map()
-  def to_json(%__MODULE__{} = t) do
-    t
-    |> Map.from_struct()
-    |> Enum.into(%{}, fn {k, v} -> {k, value_to_json(k, v)} end)
-  end
-
-  defp value_from_json("departures", departures) do
-    Departures.from_json(departures)
-  end
-
-  defp value_from_json("footer", footer) do
-    Footer.from_json(footer)
-  end
-
-  defp value_from_json("header", header) do
-    Destination.from_json(header)
-  end
-
-  defp value_to_json(:departures, departures) do
-    Departures.to_json(departures)
-  end
-
-  defp value_to_json(:footer, footer) do
-    Footer.to_json(footer)
-  end
-
-  defp value_to_json(:header, header) do
-    Destination.to_json(header)
-  end
+  use Screens.Config.Struct,
+    children: [departures: Departures, footer: Footer, header: Destination]
 end

--- a/lib/screens/config/v2/header/current_stop_id.ex
+++ b/lib/screens/config/v2/header/current_stop_id.ex
@@ -6,13 +6,9 @@ defmodule Screens.Config.V2.Header.CurrentStopId do
   @enforce_keys [:stop_id]
   defstruct stop_id: nil
 
-  @spec from_json(map()) :: t()
-  def from_json(%{"stop_id" => stop_id}) do
-    %__MODULE__{stop_id: stop_id}
-  end
+  use Screens.Config.Struct
 
-  @spec to_json(t()) :: map()
-  def to_json(%__MODULE__{stop_id: stop_id}) do
-    %{stop_id: stop_id}
-  end
+  defp value_from_json(_, value), do: value
+
+  defp value_to_json(_, value), do: value
 end

--- a/lib/screens/config/v2/header/current_stop_name.ex
+++ b/lib/screens/config/v2/header/current_stop_name.ex
@@ -6,13 +6,9 @@ defmodule Screens.Config.V2.Header.CurrentStopName do
   @enforce_keys [:stop_name]
   defstruct stop_name: nil
 
-  @spec from_json(map()) :: t()
-  def from_json(%{"stop_name" => stop_name}) do
-    %__MODULE__{stop_name: stop_name}
-  end
+  use Screens.Config.Struct
 
-  @spec to_json(t()) :: map()
-  def to_json(%__MODULE__{stop_name: stop_name}) do
-    %{stop_name: stop_name}
-  end
+  defp value_from_json(_, value), do: value
+
+  defp value_to_json(_, value), do: value
 end

--- a/lib/screens/config/v2/header/destination.ex
+++ b/lib/screens/config/v2/header/destination.ex
@@ -7,13 +7,9 @@ defmodule Screens.Config.V2.Header.Destination do
   defstruct route_id: nil,
             direction_id: nil
 
-  @spec from_json(map()) :: t()
-  def from_json(%{"route_id" => route_id, "direction_id" => direction_id}) do
-    %__MODULE__{route_id: route_id, direction_id: direction_id}
-  end
+  use Screens.Config.Struct
 
-  @spec to_json(t()) :: map()
-  def to_json(%__MODULE__{route_id: route_id, direction_id: direction_id}) do
-    %{route_id: route_id, direction_id: direction_id}
-  end
+  defp value_from_json(_, value), do: value
+
+  defp value_to_json(_, value), do: value
 end

--- a/lib/screens/config/v2/solari.ex
+++ b/lib/screens/config/v2/solari.ex
@@ -1,10 +1,8 @@
 defmodule Screens.Config.V2.Solari do
   @moduledoc false
-  # credo:disable-for-this-file Credo.Check.Design.DuplicatedCode
 
   alias Screens.Config.V2.Departures
   alias Screens.Config.V2.Header.CurrentStopName
-  alias Screens.Util
 
   @type t :: %__MODULE__{
           departures: Departures.t(),
@@ -15,36 +13,5 @@ defmodule Screens.Config.V2.Solari do
   defstruct departures: nil,
             header: nil
 
-  @spec from_json(map()) :: t()
-  def from_json(%{} = json) do
-    struct_map =
-      json
-      |> Map.take(Util.struct_keys(__MODULE__))
-      |> Enum.into(%{}, fn {k, v} -> {String.to_existing_atom(k), value_from_json(k, v)} end)
-
-    struct!(__MODULE__, struct_map)
-  end
-
-  @spec to_json(t()) :: map()
-  def to_json(%__MODULE__{} = t) do
-    t
-    |> Map.from_struct()
-    |> Enum.into(%{}, fn {k, v} -> {k, value_to_json(k, v)} end)
-  end
-
-  defp value_from_json("departures", departures) do
-    Departures.from_json(departures)
-  end
-
-  defp value_from_json("header", header) do
-    CurrentStopName.from_json(header)
-  end
-
-  defp value_to_json(:departures, departures) do
-    Departures.to_json(departures)
-  end
-
-  defp value_to_json(:header, header) do
-    CurrentStopName.to_json(header)
-  end
+  use Screens.Config.Struct, children: [departures: Departures, header: CurrentStopName]
 end

--- a/lib/screens/config/v2/solari_large.ex
+++ b/lib/screens/config/v2/solari_large.ex
@@ -4,7 +4,6 @@ defmodule Screens.Config.V2.SolariLarge do
 
   alias Screens.Config.V2.Departures
   alias Screens.Config.V2.Header.CurrentStopName
-  alias Screens.Util
 
   @type t :: %__MODULE__{
           departures: Departures.t(),
@@ -15,36 +14,5 @@ defmodule Screens.Config.V2.SolariLarge do
   defstruct departures: nil,
             header: nil
 
-  @spec from_json(map()) :: t()
-  def from_json(%{} = json) do
-    struct_map =
-      json
-      |> Map.take(Util.struct_keys(__MODULE__))
-      |> Enum.into(%{}, fn {k, v} -> {String.to_existing_atom(k), value_from_json(k, v)} end)
-
-    struct!(__MODULE__, struct_map)
-  end
-
-  @spec to_json(t()) :: map()
-  def to_json(%__MODULE__{} = t) do
-    t
-    |> Map.from_struct()
-    |> Enum.into(%{}, fn {k, v} -> {k, value_to_json(k, v)} end)
-  end
-
-  defp value_from_json("departures", departures) do
-    Departures.from_json(departures)
-  end
-
-  defp value_from_json("header", header) do
-    CurrentStopName.from_json(header)
-  end
-
-  defp value_to_json(:departures, departures) do
-    Departures.to_json(departures)
-  end
-
-  defp value_to_json(:header, header) do
-    CurrentStopName.to_json(header)
-  end
+  use Screens.Config.Struct, children: [departures: Departures, header: CurrentStopName]
 end

--- a/test/screens/config/struct_test.exs
+++ b/test/screens/config/struct_test.exs
@@ -188,7 +188,7 @@ defmodule Screens.Config.StructTest do
       assert %Config6{child: nil} == Config6.from_json(%{"child" => nil})
 
       assert_raise RuntimeError,
-                   "Elixir.TEST.Config7.value_from_json/2 not implemented",
+                   "Elixir.TEST.Config7.value_from_json/2 not implemented (key: `child`)",
                    fn -> Config7.from_json(%{"child" => nil}) end
     end
 
@@ -196,7 +196,7 @@ defmodule Screens.Config.StructTest do
       original_json1 = %{"a" => "foo"}
 
       assert_raise RuntimeError,
-                   "Elixir.TEST.Config8.value_from_json/2 not implemented",
+                   "Elixir.TEST.Config8.value_from_json/2 not implemented (key: `a`)",
                    fn -> Config8.from_json(original_json1) end
 
       config = %Config9{a: "foo", b: false}

--- a/test/screens/config/struct_test.exs
+++ b/test/screens/config/struct_test.exs
@@ -92,14 +92,34 @@ defmodule TEST.Config7 do
   use Screens.Config.Struct, children: [child: TEST.Config2]
 end
 
+defmodule TEST.Config8 do
+  @type t :: %__MODULE__{a: String.t() | nil}
+
+  defstruct a: nil
+
+  use Screens.Config.Struct
+end
+
+defmodule TEST.Config9 do
+  @type t :: %__MODULE__{a: String.t() | nil, b: boolean()}
+
+  defstruct a: nil,
+            b: false
+
+  use Screens.Config.Struct
+
+  defp value_from_json("a", value), do: value
+  defp value_to_json(:a, value), do: value
+end
+
 defmodule Screens.Config.StructTest do
   use ExUnit.Case, async: true
 
-  alias TEST.{Config1, Config2, Config3, Config4, Config5, Config6, Config7}
+  alias TEST.{Config1, Config2, Config3, Config4, Config5, Config6, Config7, Config8, Config9}
 
   describe "__using__/1" do
     test "generates a functioning config module when passed default options" do
-      original_json = %{"action" => "exclude", "values" => ["a", "b"]}
+      original_json = %{"action" => "exclude", "values" => ["a", "b"], "unsupported_key" => "foo"}
       config = %Config1{action: :exclude, values: ["a", "b"]}
       serialized_config = %{action: :exclude, values: ["a", "b"]}
 
@@ -167,7 +187,25 @@ defmodule Screens.Config.StructTest do
     test "defers to the using module for handling (or not handling) nil-valued children" do
       assert %Config6{child: nil} == Config6.from_json(%{"child" => nil})
 
-      assert_raise FunctionClauseError, fn -> Config7.from_json(%{"child" => nil}) end
+      assert_raise RuntimeError,
+                   "Elixir.TEST.Config7.value_from_json/2 not implemented",
+                   fn -> Config7.from_json(%{"child" => nil}) end
+    end
+
+    test "defers to the using module for handling (or not handling) fields not defined in `children` list" do
+      original_json1 = %{"a" => "foo"}
+
+      assert_raise RuntimeError,
+                   "Elixir.TEST.Config8.value_from_json/2 not implemented",
+                   fn -> Config8.from_json(original_json1) end
+
+      config = %Config9{a: "foo", b: false}
+
+      assert config == Config9.from_json(original_json1)
+
+      original_json2 = %{"a" => "foo", "b" => true}
+
+      assert_raise FunctionClauseError, fn -> Config9.from_json(original_json2) end
     end
   end
 end

--- a/test/screens/config/struct_test.exs
+++ b/test/screens/config/struct_test.exs
@@ -1,0 +1,134 @@
+defmodule TEST.Config1 do
+  @type t :: %__MODULE__{
+          action: :include | :exclude,
+          values: list(String.t())
+        }
+
+  @enforce_keys [:action, :values]
+  defstruct @enforce_keys
+
+  use Screens.Config.Struct
+
+  defp value_from_json("action", "include"), do: :include
+  defp value_from_json("action", "exclude"), do: :exclude
+
+  defp value_from_json(_, value), do: value
+
+  defp value_to_json(_, value), do: value
+end
+
+defmodule TEST.Config2 do
+  @type t :: %__MODULE__{
+          action: :include | :exclude,
+          values: list(String.t())
+        }
+
+  defstruct action: :include,
+            values: []
+
+  use Screens.Config.Struct, with_default: true
+
+  defp value_from_json("action", "include"), do: :include
+  defp value_from_json("action", "exclude"), do: :exclude
+
+  defp value_from_json(_, value), do: value
+
+  defp value_to_json(_, value), do: value
+end
+
+defmodule TEST.Config3 do
+  @type t :: %__MODULE__{
+          daughter: TEST.Config1.t(),
+          son: TEST.Config2.t()
+        }
+
+  @enforce_keys [:daughter]
+  defstruct daughter: nil,
+            son: TEST.Config2.from_json(:default)
+
+  use Screens.Config.Struct, children: [daughter: TEST.Config1, son: TEST.Config2]
+end
+
+defmodule TEST.Config4 do
+  @type t :: %__MODULE__{
+          daughter: TEST.Config1.t(),
+          sons: list(TEST.Config2.t())
+        }
+
+  @enforce_keys [:daughter]
+  defstruct daughter: nil,
+            sons: []
+
+  use Screens.Config.Struct, children: [daughter: TEST.Config1, sons: {:list, TEST.Config2}]
+end
+
+defmodule Screens.Config.StructTest do
+  use ExUnit.Case, async: true
+
+  alias TEST.{Config1, Config2, Config3, Config4}
+
+  describe "__using__/1" do
+    test "generates a functioning config module when passed default options" do
+      original_json = %{"action" => "exclude", "values" => ["a", "b"]}
+      config = %Config1{action: :exclude, values: ["a", "b"]}
+      serialized_config = %{action: :exclude, values: ["a", "b"]}
+
+      assert config == Config1.from_json(original_json)
+      assert serialized_config == Config1.to_json(config)
+    end
+
+    test "includes handling of :default when directed to do so" do
+      expected_config = %Config2{action: :include, values: []}
+
+      assert expected_config == Config2.from_json(:default)
+    end
+
+    test "does not include handling of :default when not directed to do so" do
+      assert_raise FunctionClauseError, fn -> Config1.from_json(:default) end
+    end
+
+    test "generates value_from_json/2, value_to_json/2 for child config fields" do
+      original_json = %{"daughter" => %{"action" => "include", "values" => ["c"]}}
+
+      config = %Config3{
+        daughter: %Config1{action: :include, values: ["c"]},
+        son: %Config2{action: :include, values: []}
+      }
+
+      assert config == Config3.from_json(original_json)
+    end
+
+    test "supports generating functions for list-valued child config fields" do
+      original_json = %{
+        "daughter" => %{"action" => "include", "values" => ["d"]},
+        "sons" => [%{"values" => ["e", "f"]}, %{"action" => "exclude", "values" => ["g"]}]
+      }
+
+      config = %Config4{
+        daughter: %Config1{action: :include, values: ["d"]},
+        sons: [
+          %Config2{action: :include, values: ["e", "f"]},
+          %Config2{action: :exclude, values: ["g"]}
+        ]
+      }
+
+      assert config == Config4.from_json(original_json)
+    end
+
+    test "fails if the using module doesn't provide `children` and doesn't define value_from_json/2, value_to_json/2" do
+      assert_raise ArgumentError, fn ->
+        defmodule TEST.InvalidConfig do
+          @type t :: %__MODULE__{
+                  action: :include | :exclude,
+                  values: list(String.t())
+                }
+
+          @enforce_keys [:action, :values]
+          defstruct @enforce_keys
+
+          use Screens.Config.Struct
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Asana task**: [Reduce code duplication in backend config modules](https://app.asana.com/0/1185117109217413/1200260123173553/f)

A PR with more code deleted than added 😌

This adds the `Screens.Config.Behaviour` behaviour to informally define config modules as having `from_json/1` and `to_json/1` definitions.

It also defines a `use`-able `Screens.Config.Struct` module that takes most of the work out of defining struct-based parts of the config. I attempted to [document](https://github.com/mbta/screens/pull/851/files#diff-e2c917994e0191f0d115dd625745214f0771ff8a05b4e22aa1c407ba78c44fb5) it for ease of use.

This change is purely a refactor. No config shapes have changed (hopefully).

- [ ] Needs version bump?
