### PR TITLE
feat: widgetized Green Line e-Ink line map

### DIFF
--- a/assets/css/bus_eink_v2.scss
+++ b/assets/css/bus_eink_v2.scss
@@ -23,6 +23,12 @@
 @import "v2/bus_eink/departures/time";
 @import "v2/bus_eink/departures/crowding";
 
+@import "v2/bus_eink/route_pill";
+@import "v2/bus_eink/departures/row";
+@import "v2/bus_eink/departures/destination";
+@import "v2/bus_eink/departures/time";
+@import "v2/bus_eink/departures/crowding";
+
 body {
   margin: 0px;
 }

--- a/assets/css/bus_eink_v2.scss
+++ b/assets/css/bus_eink_v2.scss
@@ -17,18 +17,6 @@
 @import "v2/bus_eink/departures/crowding";
 @import "v2/bus_eink/departures/alerts";
 
-@import "v2/bus_eink/route_pill";
-@import "v2/bus_eink/departures/row";
-@import "v2/bus_eink/departures/destination";
-@import "v2/bus_eink/departures/time";
-@import "v2/bus_eink/departures/crowding";
-
-@import "v2/bus_eink/route_pill";
-@import "v2/bus_eink/departures/row";
-@import "v2/bus_eink/departures/destination";
-@import "v2/bus_eink/departures/time";
-@import "v2/bus_eink/departures/crowding";
-
 body {
   margin: 0px;
 }

--- a/assets/css/bus_shelter_v2.scss
+++ b/assets/css/bus_shelter_v2.scss
@@ -13,7 +13,6 @@
 @import "v2/placeholder";
 @import "v2/bus_shelter/normal_header";
 @import "v2/bus_shelter/link_footer";
-
 @import "v2/bus_shelter/route_pill";
 @import "v2/bus_shelter/free_text";
 

--- a/assets/css/gl_eink_v2.scss
+++ b/assets/css/gl_eink_v2.scss
@@ -14,9 +14,6 @@
 @import "v2/gl_eink/departures/time";
 @import "v2/gl_eink/departures/alerts";
 
-@import "v2/gl_eink/departures/row";
-@import "v2/gl_eink/departures/time";
-
 body {
   margin: 0px;
 }

--- a/assets/css/gl_eink_v2.scss
+++ b/assets/css/gl_eink_v2.scss
@@ -13,6 +13,7 @@
 @import "v2/gl_eink/departures/row";
 @import "v2/gl_eink/departures/time";
 @import "v2/gl_eink/departures/alerts";
+@import "v2/gl_eink/line_map";
 
 body {
   margin: 0px;

--- a/assets/css/v2/bus_eink/departures/crowding.scss
+++ b/assets/css/v2/bus_eink/departures/crowding.scss
@@ -2,7 +2,7 @@
   display: inline-block;
   vertical-align: middle;
 
-  margin-right: 16px;
+  margin-right: 24px;
 }
 
 .departure-crowding__icon {

--- a/assets/css/v2/bus_eink/departures/crowding.scss
+++ b/assets/css/v2/bus_eink/departures/crowding.scss
@@ -2,7 +2,7 @@
   display: inline-block;
   vertical-align: middle;
 
-  margin-right: 24px;
+  margin-right: 16px;
 }
 
 .departure-crowding__icon {

--- a/assets/css/v2/gl_eink/departures/time.scss
+++ b/assets/css/v2/gl_eink/departures/time.scss
@@ -7,7 +7,7 @@
     content: "";
     position: absolute;
     bottom: 0px;
-    left: 374px;
+    left: 0px;
 
     width: 794px;
     height: 2px;

--- a/assets/css/v2/gl_eink/line_map.scss
+++ b/assets/css/v2/gl_eink/line_map.scss
@@ -1,0 +1,64 @@
+.line-map--future {
+  fill: #000000;
+}
+
+.line-map--past {
+  fill: #cccccc;
+}
+
+.line-map__stop {
+  fill: #ffffff;
+}
+
+.line-map__stop-label {
+  font-family: "neue-haas-grotesk-text";
+  font-size: 24px;
+  line-height: 32px;
+
+  &--current {
+    font-weight: 600;
+  }
+
+  &--past {
+    fill: #999999;
+  }
+}
+
+.line-map__vehicle-droplet {
+  stroke: white;
+  stroke-width: 8;
+  stroke-linejoin: round;
+}
+
+.line-map__vehicle-label {
+  font-family: "neue-haas-grotesk-text";
+}
+
+.line-map__vehicle-label--text {
+  font-size: 40px;
+  font-weight: 700;
+}
+
+.line-map__vehicle-label--minutes {
+  font-size: 40px;
+  font-weight: 700;
+}
+
+.line-map__vehicle-label--minutes-label {
+  font-size: 30px;
+  font-weight: 400;
+}
+
+.line-map__scheduled-departure {
+  font-family: "neue-haas-grotesk-text";
+  fill: #999999;
+
+  &--time {
+    font-size: 40px;
+    font-weight: 700;
+  }
+
+  &--message {
+    font-size: 24px;
+  }
+}

--- a/assets/css/v2/gl_eink/screen/normal.scss
+++ b/assets/css/v2/gl_eink/screen/normal.scss
@@ -13,11 +13,19 @@
   height: 288px;
 }
 
-.screen-normal__main-content {
+.screen-normal__left-sidebar {
   position: absolute;
   top: 288px;
   left: 0px;
-  width: 1200px;
+  width: 376px;
+  height: 1312px;
+}
+
+.screen-normal__main-content {
+  position: absolute;
+  top: 288px;
+  left: 376px;
+  width: 824px;
   height: 1312px;
 }
 

--- a/assets/src/apps/v2/gl_eink.tsx
+++ b/assets/src/apps/v2/gl_eink.tsx
@@ -14,6 +14,7 @@ import Placeholder from "Components/v2/placeholder";
 import FareInfoFooter from "Components/v2/eink/fare_info_footer";
 import NormalHeader from "Components/v2/eink/normal_header";
 import NormalDepartures from "Components/v2/departures/normal_departures";
+import LineMap from "Components/v2/gl_eink_double/line_map";
 
 const TYPE_TO_COMPONENT = {
   normal: NormalScreen,
@@ -22,6 +23,7 @@ const TYPE_TO_COMPONENT = {
   fare_info_footer: FareInfoFooter,
   normal_header: NormalHeader,
   departures: NormalDepartures,
+  line_map: LineMap,
 };
 
 const App = (): JSX.Element => {

--- a/assets/src/components/admin/admin_tables.tsx
+++ b/assets/src/components/admin/admin_tables.tsx
@@ -492,11 +492,25 @@ const BusEinkV2ScreensTable = (): JSX.Element => {
 };
 
 const GLEinkV2ScreensTable = (): JSX.Element => {
+  const lineMapColumn = {
+    Header: "Line Map",
+    accessor: buildAppParamAccessor("line_map"),
+    mutator: buildAppParamMutator("line_map"),
+    Cell: EditableTextarea,
+    disableFilters: true,
+    FormCell: FormTextarea,
+  };
+
   const dataFilter = ({ app_id }) => {
     return app_id === "gl_eink_v2";
   };
 
-  return <AdminTable columns={v2Columns} dataFilter={dataFilter} />;
+  return (
+    <AdminTable
+      columns={[...v2Columns, lineMapColumn]}
+      dataFilter={dataFilter}
+    />
+  );
 };
 
 const BusShelterV2ScreensTable = (): JSX.Element => {

--- a/assets/src/components/v2/gl_eink_double/line_map.tsx
+++ b/assets/src/components/v2/gl_eink_double/line_map.tsx
@@ -1,0 +1,418 @@
+import React from "react";
+
+import { classWithModifier } from "Util/util";
+
+const WIDTH = 374;
+const HEIGHT = 1312;
+
+const STOP_SPACING = 112;
+const LEFT_MARGIN = 84;
+const LINE_WIDTH = 40;
+const STOP_RADIUS = 14;
+const BIG_STOP_RADIUS = 30;
+const TOP_MARGIN = 124;
+const TEXT_LEFT_MARGIN = 18;
+const TEXT_TOP_MARGIN = 10;
+const VEHICLE_ICON_SIZE = 44;
+const SCHEDULED_DEPARTURE_SIZE = 192;
+
+const BaseMapFutureTerminal = () => {
+  return (
+    <circle
+      cx={LEFT_MARGIN + LINE_WIDTH / 2}
+      cy={TOP_MARGIN}
+      r={BIG_STOP_RADIUS}
+      className="line-map--future"
+    />
+  );
+};
+
+const BaseMapFutureArrow = () => {
+  const arrowHeight = LINE_WIDTH / 2;
+  const lineHeight = 72;
+
+  const pathData = [
+    "M",
+    LEFT_MARGIN,
+    TOP_MARGIN,
+    "L",
+    LEFT_MARGIN,
+    TOP_MARGIN - lineHeight,
+    "L",
+    LEFT_MARGIN + LINE_WIDTH / 2,
+    TOP_MARGIN - (lineHeight + arrowHeight),
+    "L",
+    LEFT_MARGIN + LINE_WIDTH,
+    TOP_MARGIN - lineHeight,
+    "L",
+    LEFT_MARGIN + LINE_WIDTH,
+    TOP_MARGIN,
+    "Z",
+  ].join(" ");
+
+  return <path d={pathData} className="line-map--future" />;
+};
+
+const BaseMapFuture = ({ stops }) => {
+  const numFutureStops = stops.findIndex((stop) => stop.current);
+
+  return (
+    <>
+      <rect
+        x={LEFT_MARGIN}
+        y={TOP_MARGIN}
+        width={LINE_WIDTH}
+        height={STOP_SPACING * numFutureStops}
+        className="line-map--future"
+      />
+      {stops[0].terminal ? <BaseMapFutureTerminal /> : <BaseMapFutureArrow />}
+    </>
+  );
+};
+
+const BaseMapCurrent = ({ stops }) => {
+  const numFutureStops = stops.findIndex((stop) => stop.current);
+
+  return (
+    <circle
+      cx={LEFT_MARGIN + LINE_WIDTH / 2}
+      cy={TOP_MARGIN + STOP_SPACING * numFutureStops}
+      r={BIG_STOP_RADIUS}
+      className="line-map--future"
+    />
+  );
+};
+
+const BaseMapPast = ({ stops }) => {
+  const numStops = stops.length;
+  const numFutureStops = stops.findIndex((stop) => stop.current);
+  const numPastStops = numStops - (numFutureStops + 1);
+
+  let height;
+  if (stops[stops.length - 1].terminal) {
+    height = STOP_SPACING * numPastStops;
+  } else {
+    height = HEIGHT - (TOP_MARGIN + STOP_SPACING * numFutureStops);
+  }
+
+  return (
+    <>
+      <rect
+        x={LEFT_MARGIN}
+        y={TOP_MARGIN + STOP_SPACING * numFutureStops}
+        width={LINE_WIDTH}
+        height={height}
+        className="line-map--past"
+      />
+
+      {stops[stops.length - 1].terminal && (
+        <circle
+          cx={LEFT_MARGIN + LINE_WIDTH / 2}
+          cy={TOP_MARGIN + STOP_SPACING * (numStops - 1)}
+          r={BIG_STOP_RADIUS}
+          className="line-map--past"
+        />
+      )}
+    </>
+  );
+};
+
+const BaseMapStops = ({ stops }) => {
+  return (
+    <>
+      {stops.map(({ label, downstream, current, terminal }, i) => {
+        const stopIcon = (
+          <circle
+            cx={LEFT_MARGIN + LINE_WIDTH / 2}
+            cy={TOP_MARGIN + STOP_SPACING * i}
+            r={STOP_RADIUS}
+            className="line-map__stop"
+          />
+        );
+
+        let stopLabel = null;
+        if (downstream || current || terminal) {
+          let modifier;
+          if (current) {
+            modifier = "current";
+          } else if (!downstream && !current) {
+            modifier = "past";
+          }
+
+          stopLabel = (
+            <text
+              x={LEFT_MARGIN + LINE_WIDTH + TEXT_LEFT_MARGIN}
+              y={TEXT_TOP_MARGIN + TOP_MARGIN + STOP_SPACING * i}
+              className={classWithModifier("line-map__stop-label", modifier)}
+            >
+              {label}
+            </text>
+          );
+        }
+
+        return (
+          <React.Fragment key={i}>
+            {stopIcon}
+            {stopLabel}
+          </React.Fragment>
+        );
+      })}
+    </>
+  );
+};
+
+const BaseMap = ({ stops }) => {
+  return (
+    <>
+      <BaseMapFuture stops={stops} />
+      <BaseMapPast stops={stops} />
+      <BaseMapCurrent stops={stops} />
+      <BaseMapStops stops={stops} />
+    </>
+  );
+};
+
+const ScheduledDepartureIcon = ({ cx, cy }) => {
+  return (
+    <>
+      <circle
+        cx={cx}
+        cy={cy}
+        r={BIG_STOP_RADIUS}
+        className="line-map__scheduled-departure"
+      />
+      <VehicleIcon cx={cx} cy={cy} iconSize={VEHICLE_ICON_SIZE} />
+    </>
+  );
+};
+
+const ScheduledDepartureDescription = ({ cx, cy, timestamp, stationName }) => {
+  const x = cx + LINE_WIDTH / 2 + TEXT_LEFT_MARGIN;
+  const y = cy + BIG_STOP_RADIUS / 2;
+
+  return (
+    <text x={x} y={y}>
+      <tspan
+        className={classWithModifier("line-map__scheduled-departure", "time")}
+      >
+        {timestamp}
+      </tspan>
+      <tspan
+        x={x}
+        dy="36"
+        className={classWithModifier(
+          "line-map__scheduled-departure",
+          "message"
+        )}
+      >
+        Scheduled to depart
+      </tspan>
+      <tspan
+        x={x}
+        dy="32"
+        className={classWithModifier(
+          "line-map__scheduled-departure",
+          "message"
+        )}
+      >
+        {stationName}
+      </tspan>
+    </text>
+  );
+};
+
+const ScheduledDeparture = ({
+  numStops,
+  timestamp,
+  station_name: stationName,
+}) => {
+  const cx = LEFT_MARGIN + LINE_WIDTH / 2;
+  const cy = TOP_MARGIN + STOP_SPACING * numStops;
+
+  return (
+    <>
+      <ScheduledDepartureIcon cx={cx} cy={cy} />
+      <ScheduledDepartureDescription
+        cx={cx}
+        cy={cy}
+        timestamp={timestamp}
+        stationName={stationName}
+      />
+    </>
+  );
+};
+
+const degreesToRadians = (angleInDegrees) => {
+  return (angleInDegrees * Math.PI) / 180.0;
+};
+
+const VehicleDroplet = ({ cx, cy }) => {
+  // Parameters
+  const radius = BIG_STOP_RADIUS;
+  const directionAngle = 45;
+
+  // Compute points
+  const centerAngle = 270;
+  const startAngle = degreesToRadians(centerAngle - directionAngle);
+  const endAngle = degreesToRadians(centerAngle + directionAngle);
+  const startX = cx + radius * Math.cos(startAngle);
+  const startY = cy + radius * Math.sin(startAngle);
+  const endX = cx + radius * Math.cos(endAngle);
+  const endY = cy + radius * Math.sin(endAngle);
+  const pointX = cx;
+  const pointY = cy - radius / Math.cos((startAngle - endAngle) / 2);
+
+  // Path data
+  const d = [
+    "M",
+    startX,
+    startY,
+    "A",
+    radius,
+    radius,
+    0,
+    1,
+    0,
+    endX,
+    endY,
+    "L",
+    pointX,
+    pointY,
+    "Z",
+  ].join(" ");
+
+  return <path d={d} className="line-map__vehicle-droplet" />;
+};
+
+const VehicleIcon = ({ cx, cy, iconSize }) => {
+  const viewBoxSize = 128; // property of the path
+  const scale = iconSize / viewBoxSize;
+
+  return (
+    <g
+      transform={
+        "translate(" +
+        (cx - iconSize / 2) +
+        ", " +
+        (cy - iconSize / 2) +
+        ") scale(" +
+        scale +
+        ")"
+      }
+    >
+      <path
+        d="M44.8825019,13.9985834 L45.200153,14.0009999 L83.117284,14.0000017 C91.2380941,14.0585408 97.8713422,20.576518 98.0335851,28.7341526 L98.0335851,28.7341526 L98.0335851,83.1671083 C97.9844822,90.1165254 93.1479625,96.113536 86.3665559,97.6335637 L86.3665559,97.6335637 L104,124 L94.000075,124 L81.4333436,105.566684 L46.7667569,105.566684 L34.2000255,124 L24,124 L41.5668439,97.6335637 C34.7855565,96.1134158 29.9491856,90.1164357 29.9001148,83.1671083 L29.9001148,83.1671083 L29.9001148,28.700853 C30.082492,20.4239828 36.9225061,13.8522867 45.200153,14.0009999 Z M47.3176012,76.8409304 C44.8263083,75.8090489 41.9587251,76.3794898 40.0520239,78.286253 C38.1453227,80.1930162 37.5750036,83.0605893 38.6070102,85.5518045 C39.6390167,88.0430198 42.0701085,89.6671433 44.7666519,89.6671433 C48.4485712,89.6669776 51.4332686,86.6821832 51.4332686,83.00031 C51.4332686,80.3038003 49.808894,77.872812 47.3176012,76.8409304 Z M82.9667974,76.2669608 C79.2728998,76.2669608 76.2758223,79.2565289 76.2665802,82.9503689 C76.2573808,86.6442089 79.2394957,89.6487022 82.9333473,89.6671433 L82.9333473,89.6671433 L83.0002475,89.6671433 C86.6940991,89.6487022 89.676214,86.6442089 89.6670146,82.9503689 C89.6577726,79.2565289 86.6606951,76.2669608 82.9667974,76.2669608 Z M82.5928589,29.1915756 L82.3000458,29.200948 L45.6333541,29.200948 C43.580738,29.0932838 41.5792601,29.864029 40.1290268,31.3205986 C38.6787935,32.7771681 37.9167965,34.7819715 38.0334351,36.8340716 L38.0334351,36.8340716 L38.0334351,46.6340736 C37.9428296,48.5591437 38.6207068,50.4413552 39.9179302,51.8666122 C41.2151536,53.2918691 43.0254527,54.1434122 44.9505524,54.2338976 C45.1779529,54.2446975 45.4059535,54.2446975 45.6333541,54.2338976 L45.6333541,54.2338976 L82.3000458,54.2338976 C84.2251399,54.3245019 86.1073749,53.6466332 87.5326497,52.349426 C88.9579245,51.0522188 89.8094782,49.2419425 89.8999647,47.3168668 C89.9107648,47.0890691 89.9107648,46.8614714 89.8999647,46.6340736 L89.8999647,46.6340736 L89.8999647,36.8340716 C90.0162165,34.7820752 89.2540943,32.7775009 87.8039495,31.3210202 C86.3538047,29.8645396 84.3525564,29.0936702 82.3000458,29.200948 Z M71.5000188,17.2343668 L56.6334816,17.2343668 C55.2724793,17.2333028 54.1538025,18.3077224 54.0999752,19.6676433 L54.0999752,19.6676433 L54.0999752,24.0010999 C54.108748,24.6641795 54.3806231,25.2966045 54.8557695,25.7591984 C55.3309159,26.2217922 55.9703964,26.4766462 56.6334816,26.4676753 L56.6334816,26.4676753 L71.4001185,26.500975 C72.7797632,26.5560897 73.9428956,25.4824218 73.998125,24.1027989 L73.998125,24.1027989 L73.999925,24.0010999 L73.999925,19.6676433 C73.9468627,18.3205696 72.8480507,17.2510446 71.5000188,17.2343668 L71.5000188,17.2343668 Z M58.4339861,4 C60.7721541,4.00011046 62.6675862,5.89551885 62.6676966,8.23365765 C62.6678071,10.5717964 60.7725541,12.4673839 58.4343861,12.4677153 L58.4343861,12.4677153 L58.4334861,12.4677153 C57.3110185,12.4692339 56.2335871,12.0230424 55.4393587,11.2285989 C54.6451304,10.4341554 54.1992386,9.35661107 54.1998748,8.23325762 C54.2002069,5.89511884 56.095818,3.99988954 58.4339861,4 Z M69.6667142,4.00119994 C72.004707,4.00119994 73.9000248,5.89649396 73.9000248,8.23445761 C73.9000248,10.5724213 72.004707,12.4677153 69.6667142,12.4677153 C68.543946,12.4677153 67.4671407,12.0218178 66.6732237,11.2279107 C65.8793067,10.4340036 65.4334036,9.35721174 65.4334036,8.23445761 C65.4334036,5.89649396 67.3287213,4.00119994 69.6667142,4.00119994 Z"
+        fill="white"
+      />
+    </g>
+  );
+};
+
+const VehicleTextLabel = ({ cx, cy, text }) => {
+  return (
+    <text
+      x={cx + LINE_WIDTH / 2 + TEXT_LEFT_MARGIN}
+      y={cy + VEHICLE_ICON_SIZE}
+      className={classWithModifier("line-map__vehicle-label", "text")}
+    >
+      {text}
+    </text>
+  );
+};
+
+const VehicleMinutesLabel = ({ cx, cy, minutes }) => {
+  return (
+    <text x={cx + LINE_WIDTH / 2 + TEXT_LEFT_MARGIN} y={cy + VEHICLE_ICON_SIZE}>
+      <tspan
+        className={classWithModifier("line-map__vehicle-label", "minutes")}
+      >
+        {minutes}
+      </tspan>
+      <tspan
+        dx="3"
+        className={classWithModifier(
+          "line-map__vehicle-label",
+          "minutes-label"
+        )}
+      >
+        m
+      </tspan>
+    </text>
+  );
+};
+
+const VehicleLabel = ({ cx, cy, label }) => {
+  if (label.type === "text") {
+    return <VehicleTextLabel cx={cx} cy={cy} text={label.text} />;
+  } else if (label.type === "minutes") {
+    return <VehicleMinutesLabel cx={cx} cy={cy} minutes={label.minutes} />;
+  }
+
+  return null;
+};
+
+const Vehicle = ({ id, index, label }) => {
+  const cx = LEFT_MARGIN + LINE_WIDTH / 2;
+  const cy = TOP_MARGIN + index * STOP_SPACING;
+
+  return (
+    <>
+      <VehicleDroplet cx={cx} cy={cy} />
+      <VehicleIcon cx={cx} cy={cy} iconSize={VEHICLE_ICON_SIZE} />
+      <VehicleLabel cx={cx} cy={cy} label={label} />
+    </>
+  );
+};
+
+const Vehicles = ({ vehicles, stops }) => {
+  const maxIndex = stops.length;
+  vehicles = vehicles.filter(({ index }) => index <= maxIndex);
+
+  return (
+    <>
+      {vehicles.map(({ id, ...data }) => (
+        <Vehicle {...data} key={id} />
+      ))}
+    </>
+  );
+};
+
+const truncateStops = (stops) => {
+  const n = Math.floor(
+    (HEIGHT - (TOP_MARGIN + BIG_STOP_RADIUS)) / STOP_SPACING
+  );
+  return stops.slice(0, n + 1);
+};
+
+const showScheduledDeparture = (stops) => {
+  return (
+    STOP_SPACING * (stops.length - 1) + SCHEDULED_DEPARTURE_SIZE <=
+    HEIGHT - TOP_MARGIN
+  );
+};
+
+const LineMap = ({
+  stops,
+  vehicles,
+  scheduled_departure: scheduledDeparture,
+}) => {
+  stops = truncateStops(stops);
+
+  return (
+    <svg
+      width={WIDTH + "px"}
+      height={HEIGHT + "px"}
+      viewBox={[0, 0, WIDTH, HEIGHT].join(" ")}
+      version="1.1"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <BaseMap stops={stops} />
+      {showScheduledDeparture(stops) && scheduledDeparture && (
+        <ScheduledDeparture numStops={stops.length} {...scheduledDeparture} />
+      )}
+      <Vehicles vehicles={vehicles} stops={stops} />
+    </svg>
+  );
+};
+
+export default LineMap;

--- a/assets/src/components/v2/gl_eink_double/normal_screen.tsx
+++ b/assets/src/components/v2/gl_eink_double/normal_screen.tsx
@@ -4,6 +4,7 @@ import Widget, { WidgetData } from "Components/v2/widget";
 
 interface Props {
   header: WidgetData;
+  left_sidebar: WidgetData;
   main_content: WidgetData;
   medium_flex: WidgetData;
   footer: WidgetData;
@@ -12,6 +13,7 @@ interface Props {
 const NormalScreen: React.ComponentType<Props> = ({
   header,
   footer,
+  left_sidebar: leftSidebar,
   main_content: mainContent,
   medium_flex: mediumFlex,
 }) => {
@@ -19,6 +21,9 @@ const NormalScreen: React.ComponentType<Props> = ({
     <div className="screen-normal">
       <div className="screen-normal__header">
         <Widget data={header} />
+      </div>
+      <div className="screen-normal__left-sidebar">
+        <Widget data={leftSidebar} />
       </div>
       <div className="screen-normal__main-content">
         <Widget data={mainContent} />

--- a/lib/screens/config/v2/gl_eink.ex
+++ b/lib/screens/config/v2/gl_eink.ex
@@ -2,7 +2,7 @@ defmodule Screens.Config.V2.GlEink do
   @moduledoc false
   # credo:disable-for-this-file Credo.Check.Design.DuplicatedCode
 
-  alias Screens.Config.V2.{Departures, LineMap, Footer}
+  alias Screens.Config.V2.{Departures, Footer, LineMap}
   alias Screens.Config.V2.Header.Destination
   alias Screens.Util
 

--- a/lib/screens/config/v2/gl_eink.ex
+++ b/lib/screens/config/v2/gl_eink.ex
@@ -2,20 +2,23 @@ defmodule Screens.Config.V2.GlEink do
   @moduledoc false
   # credo:disable-for-this-file Credo.Check.Design.DuplicatedCode
 
-  alias Screens.Config.V2.{Departures, Footer}
+  alias Screens.Config.V2.{Departures, LineMap, Footer}
   alias Screens.Config.V2.Header.Destination
+  alias Screens.Util
 
   @type t :: %__MODULE__{
           departures: Departures.t(),
           footer: Footer.t(),
-          header: Destination.t()
+          header: Destination.t(),
+          line_map: LineMap.t()
         }
 
-  @enforce_keys [:departures, :footer, :header]
+  @enforce_keys [:departures, :footer, :header, :line_map]
   defstruct departures: nil,
             footer: nil,
-            header: nil
+            header: nil,
+            line_map: nil
 
   use Screens.Config.Struct,
-    children: [departures: Departures, footer: Footer, header: Destination]
+    children: [departures: Departures, footer: Footer, header: Destination, line_map: LineMap]
 end

--- a/lib/screens/config/v2/line_map.ex
+++ b/lib/screens/config/v2/line_map.ex
@@ -14,21 +14,9 @@ defmodule Screens.Config.V2.LineMap do
             direction_id: nil,
             route_id: nil
 
-  def from_json(%{
-        "stop_id" => stop_id,
-        "station_id" => station_id,
-        "direction_id" => direction_id,
-        "route_id" => route_id
-      }) do
-    %__MODULE__{
-      stop_id: stop_id,
-      station_id: station_id,
-      direction_id: direction_id,
-      route_id: route_id
-    }
-  end
+  use Screens.Config.Struct
 
-  def to_json(t) do
-    Map.from_struct(t)
-  end
+  defp value_from_json(_, value), do: value
+
+  defp value_to_json(_, value), do: value
 end

--- a/lib/screens/config/v2/line_map.ex
+++ b/lib/screens/config/v2/line_map.ex
@@ -1,0 +1,34 @@
+defmodule Screens.Config.V2.LineMap do
+  @moduledoc false
+
+  @type t :: %__MODULE__{
+          stop_id: Screens.Stops.Stop.id(),
+          station_id: Screens.Stops.Stop.id(),
+          direction_id: 0 | 1,
+          route_id: Screens.Routes.Route.id()
+        }
+
+  @enforce_keys [:stop_id, :station_id, :direction_id, :route_id]
+  defstruct stop_id: nil,
+            station_id: nil,
+            direction_id: nil,
+            route_id: nil
+
+  def from_json(%{
+        "stop_id" => stop_id,
+        "station_id" => station_id,
+        "direction_id" => direction_id,
+        "route_id" => route_id
+      }) do
+    %__MODULE__{
+      stop_id: stop_id,
+      station_id: station_id,
+      direction_id: direction_id,
+      route_id: route_id
+    }
+  end
+
+  def to_json(t) do
+    Map.from_struct(t)
+  end
+end

--- a/lib/screens/v2/candidate_generator/gl_eink.ex
+++ b/lib/screens/v2/candidate_generator/gl_eink.ex
@@ -1,14 +1,14 @@
 defmodule Screens.V2.CandidateGenerator.GlEink do
   @moduledoc false
 
-  alias Screens.Config.Screen
-  alias Screens.Config.V2
-  alias Screens.Config.V2.{Footer, GlEink}
-  alias Screens.Config.V2.Header.Destination
+  alias Screens.Config.{Screen, V2}
+  alias Screens.Config.V2.{Footer, GlEink, Header}
   alias Screens.RoutePatterns.RoutePattern
   alias Screens.V2.CandidateGenerator
   alias Screens.V2.CandidateGenerator.Helpers
   alias Screens.V2.WidgetInstance.{FareInfoFooter, LineMap, NormalHeader, Placeholder}
+
+  @scheduled_terminal_departure_lookback_seconds 180
 
   @behaviour CandidateGenerator
 
@@ -65,7 +65,7 @@ defmodule Screens.V2.CandidateGenerator.GlEink do
     {:ok, departures} =
       Screens.V2.Departure.fetch(%{stop_ids: [station_id], direction_id: direction_id},
         include_schedules: true,
-        now: DateTime.add(DateTime.utc_now(), -180)
+        now: DateTime.add(DateTime.utc_now(), -@scheduled_terminal_departure_lookback_seconds)
       )
 
     [%LineMap{screen: config, stops: stops, departures: departures}]
@@ -74,7 +74,7 @@ defmodule Screens.V2.CandidateGenerator.GlEink do
   def header_instances(config, now, fetch_destination_fn) do
     %Screen{
       app_params: %GlEink{
-        header: %Destination{route_id: route_id, direction_id: direction_id}
+        header: %Header.Destination{route_id: route_id, direction_id: direction_id}
       }
     } = config
 

--- a/lib/screens/v2/departure.ex
+++ b/lib/screens/v2/departure.ex
@@ -17,12 +17,7 @@ defmodule Screens.V2.Departure do
             schedule: nil
 
   def fetch(params, opts \\ []) do
-    now =
-      if is_nil(opts[:now]) do
-        DateTime.utc_now()
-      else
-        opts[:now]
-      end
+    now = Keyword.get(opts, :now, DateTime.utc_now())
 
     if opts[:include_schedules] do
       fetch_predictions_and_schedules(params, now)

--- a/lib/screens/v2/widget_instance/departures.ex
+++ b/lib/screens/v2/widget_instance/departures.ex
@@ -168,7 +168,7 @@ defmodule Screens.V2.WidgetInstance.Departures do
     departure_time = Departure.time(departure)
 
     second_diff = DateTime.diff(departure_time, now)
-    minute_diff = 1 + div(second_diff - 1, 60)
+    minute_diff = round(second_diff / 60)
 
     time =
       cond do
@@ -192,7 +192,7 @@ defmodule Screens.V2.WidgetInstance.Departures do
     route_type = Departure.route_type(departure)
 
     second_diff = DateTime.diff(departure_time, now)
-    minute_diff = div(second_diff, 60)
+    minute_diff = round(second_diff / 60)
 
     time =
       cond do

--- a/lib/screens/v2/widget_instance/line_map.ex
+++ b/lib/screens/v2/widget_instance/line_map.ex
@@ -1,0 +1,146 @@
+defmodule Screens.V2.WidgetInstance.LineMap do
+  @moduledoc false
+
+  alias Screens.Config.{Screen, V2}
+  alias Screens.Predictions.Prediction
+  alias Screens.V2.Departure
+  alias Screens.V2.WidgetInstance.LineMap
+  alias Screens.Vehicles.Vehicle
+
+  defstruct screen: nil,
+            stops: [],
+            departures: []
+
+  @type t :: %__MODULE__{
+          screen: Screen.t(),
+          stops: list(Screens.Stops.Stop.t()),
+          departures: list(Departure.t())
+        }
+
+  defimpl Screens.V2.WidgetInstance do
+    def priority(_instance), do: [2]
+
+    def serialize(
+          %LineMap{screen: config, stops: stops, departures: departures},
+          now \\ DateTime.utc_now()
+        ) do
+      %Screen{
+        app_params: %V2.GlEink{
+          line_map: %V2.LineMap{stop_id: current_stop, direction_id: direction_id}
+        }
+      } = config
+
+      %{
+        stops: LineMap.serialize_stops(current_stop, stops),
+        vehicles: LineMap.serialize_vehicles(departures, stops, direction_id, current_stop, now),
+        scheduled_departure: LineMap.serialize_scheduled_departure(departures, stops)
+      }
+    end
+
+    def slot_names(_instance), do: [:left_sidebar]
+
+    def widget_type(_instance), do: :line_map
+  end
+
+  def serialize_stops(current_stop, stops) do
+    current_stop_index = Enum.find_index(stops, fn %{id: stop} -> stop == current_stop end)
+
+    stops
+    |> Enum.slice(0, current_stop_index + 3)
+    |> Enum.with_index()
+    |> Enum.map(fn {%Screens.Stops.Stop{name: label}, i} ->
+      %{
+        label: label,
+        downstream: i > current_stop_index,
+        current: i == current_stop_index,
+        terminal: i == 0 or i == length(stops) - 1
+      }
+    end)
+    |> Enum.reverse()
+  end
+
+  def serialize_vehicles(departures, stops, direction_id, current_stop, now) do
+    departures
+    |> Enum.reject(fn d -> is_nil(d.prediction) end)
+    |> Enum.reject(fn %{prediction: %{vehicle: v}} -> is_nil(v) end)
+    |> Enum.filter(fn %{prediction: %{vehicle: %{direction_id: d}}} -> d == direction_id end)
+    |> Enum.flat_map(&serialize_vehicle_departure(&1, stops, current_stop, now))
+  end
+
+  defp serialize_vehicle_departure(
+         %Departure{
+           prediction: %Prediction{
+             vehicle: %Vehicle{
+               id: vehicle_id,
+               current_status: vehicle_status,
+               stop_id: vehicle_stop
+             }
+           }
+         } = d,
+         stops,
+         current_stop,
+         now
+       ) do
+    vehicle_stop_index = Enum.find_index(stops, fn %{id: stop} -> stop == vehicle_stop end)
+    current_stop_index = Enum.find_index(stops, fn %{id: stop} -> stop == current_stop end)
+    future_stops = min(length(stops) - current_stop_index - 1, 2)
+
+    index =
+      future_stops + current_stop_index - vehicle_stop_index +
+        status_adjustment(vehicle_stop_index, vehicle_status)
+
+    label =
+      if index < future_stops do
+        nil
+      else
+        serialize_vehicle_label(d, now)
+      end
+
+    if index < 0 do
+      []
+    else
+      [%{id: vehicle_id, index: index, label: label}]
+    end
+  end
+
+  defp status_adjustment(0, _), do: 0.0
+  defp status_adjustment(_, :stopped_at), do: 0.0
+  defp status_adjustment(_, :in_transit_to), do: 0.7
+  defp status_adjustment(_, :incoming_at), do: 0.3
+
+  defp serialize_vehicle_label(d, now) do
+    departure_time = Departure.time(d)
+    second_diff = DateTime.diff(departure_time, now)
+    minute_diff = round(second_diff / 60)
+
+    if second_diff < 60 do
+      %{type: :text, text: "Now"}
+    else
+      %{type: :minutes, minutes: minute_diff}
+    end
+  end
+
+  def serialize_scheduled_departure(departures, stops) do
+    prediction_count =
+      departures
+      |> Enum.reject(fn d -> is_nil(d.prediction) end)
+      |> length()
+
+    if prediction_count < 2 do
+      %{name: origin_stop_name} = Enum.at(stops, 0)
+
+      {:ok, local_time} =
+        departures
+        |> Enum.filter(fn d -> is_nil(d.prediction) end)
+        |> Enum.at(0)
+        |> Departure.time()
+        |> DateTime.shift_zone("America/New_York")
+
+      {:ok, timestamp} = Timex.format(local_time, "{h12}:{m}")
+
+      %{timestamp: timestamp, station_name: origin_stop_name}
+    else
+      nil
+    end
+  end
+end

--- a/test/screens/v2/widget_instance/line_map_test.exs
+++ b/test/screens/v2/widget_instance/line_map_test.exs
@@ -31,11 +31,6 @@ defmodule Screens.V2.WidgetInstance.LineMapTest do
     end
   end
 
-  describe "serialize/1" do
-    test "returns stops, vehicles and scheduled_departure" do
-    end
-  end
-
   describe "serialize_stops/2" do
     test "returns past stops and up two future stops in order", %{stops: stops} do
       assert [

--- a/test/screens/v2/widget_instance/line_map_test.exs
+++ b/test/screens/v2/widget_instance/line_map_test.exs
@@ -1,0 +1,221 @@
+defmodule Screens.V2.WidgetInstance.LineMapTest do
+  use ExUnit.Case, async: true
+
+  alias Screens.Predictions.Prediction
+  alias Screens.Schedules.Schedule
+  alias Screens.Stops.Stop
+  alias Screens.V2.{Departure, WidgetInstance}
+  alias Screens.V2.WidgetInstance.LineMap
+  alias Screens.Vehicles.Vehicle
+
+  setup do
+    stops = [
+      %Stop{id: "70238", name: "Cleveland Circle"},
+      %Stop{id: "70236", name: "Englewood Avenue"},
+      %Stop{id: "70234", name: "Dean Road"},
+      %Stop{id: "70232", name: "Tappan Street"},
+      %Stop{id: "70230", name: "Washington Square"},
+      %Stop{id: "70200", name: "Park Street"},
+      %Stop{id: "70201", name: "Government Center"},
+      %Stop{id: "70203", name: "Haymarket"},
+      %Stop{id: "70205", name: "North Station"}
+    ]
+
+    %{stops: stops}
+  end
+
+  describe "priority/1" do
+    test "returns 2" do
+      instance = %LineMap{}
+      assert [2] == WidgetInstance.priority(instance)
+    end
+  end
+
+  describe "serialize/1" do
+    test "returns stops, vehicles and scheduled_departure" do
+    end
+  end
+
+  describe "serialize_stops/2" do
+    test "returns past stops and up two future stops in order", %{stops: stops} do
+      assert [
+               %{current: false, downstream: true, label: "Government Center", terminal: false},
+               %{current: false, downstream: true, label: "Park Street", terminal: false},
+               %{current: true, downstream: false, label: "Washington Square", terminal: false},
+               %{current: false, downstream: false, label: "Tappan Street", terminal: false},
+               %{current: false, downstream: false, label: "Dean Road", terminal: false},
+               %{current: false, downstream: false, label: "Englewood Avenue", terminal: false},
+               %{current: false, downstream: false, label: "Cleveland Circle", terminal: true}
+             ] == LineMap.serialize_stops("70230", stops)
+    end
+
+    test "handles fewer than two future stops", %{stops: stops} do
+      assert [
+               %{current: false, downstream: true, label: "North Station", terminal: true},
+               %{current: true, downstream: false, label: "Haymarket", terminal: false},
+               %{current: false, downstream: false, label: "Government Center", terminal: false},
+               %{current: false, downstream: false, label: "Park Street", terminal: false},
+               %{current: false, downstream: false, label: "Washington Square", terminal: false},
+               %{current: false, downstream: false, label: "Tappan Street", terminal: false},
+               %{current: false, downstream: false, label: "Dean Road", terminal: false},
+               %{current: false, downstream: false, label: "Englewood Avenue", terminal: false},
+               %{current: false, downstream: false, label: "Cleveland Circle", terminal: true}
+             ] == LineMap.serialize_stops("70203", stops)
+    end
+  end
+
+  describe "serialize_vehicles/5" do
+    test "filters irrelevant departures", %{stops: stops} do
+      d1 = %Departure{prediction: nil}
+      d2 = %Departure{prediction: %Prediction{vehicle: nil}}
+      d3 = %Departure{prediction: %Prediction{vehicle: %Vehicle{direction_id: 1}}}
+      departures = [d1, d2, d3]
+
+      direction_id = 0
+      current_stop = "70230"
+      now = ~U[2020-01-01T02:00:00Z]
+
+      assert [] == LineMap.serialize_vehicles(departures, stops, direction_id, current_stop, now)
+    end
+
+    test "correctly computes indexes of relevant departures", %{stops: stops} do
+      direction_id = 0
+      current_stop = "70230"
+      now = ~U[2020-01-01T02:00:00Z]
+
+      v = %Vehicle{id: "1", current_status: :stopped_at, stop_id: "70236", direction_id: 0}
+
+      d = %Departure{
+        prediction: %Prediction{departure_time: ~U[2020-01-01T02:02:00Z], vehicle: v}
+      }
+
+      assert [%{index: 5.0}] =
+               LineMap.serialize_vehicles([d], stops, direction_id, current_stop, now)
+
+      v = %Vehicle{v | stop_id: "70203"}
+
+      d = %Departure{
+        prediction: %Prediction{departure_time: ~U[2020-01-01T02:02:00Z], vehicle: v}
+      }
+
+      assert [] == LineMap.serialize_vehicles([d], stops, direction_id, current_stop, now)
+
+      v = %Vehicle{v | stop_id: "70238"}
+
+      d = %Departure{
+        prediction: %Prediction{departure_time: ~U[2020-01-01T02:02:00Z], vehicle: v}
+      }
+
+      assert [%{index: 6.0}] =
+               LineMap.serialize_vehicles([d], stops, direction_id, current_stop, now)
+
+      v = %Vehicle{v | current_status: :in_transit_to}
+
+      d = %Departure{
+        prediction: %Prediction{departure_time: ~U[2020-01-01T02:02:00Z], vehicle: v}
+      }
+
+      assert [%{index: 6.0}] =
+               LineMap.serialize_vehicles([d], stops, direction_id, current_stop, now)
+
+      v = %Vehicle{v | stop_id: "70230"}
+
+      d = %Departure{
+        prediction: %Prediction{departure_time: ~U[2020-01-01T02:02:00Z], vehicle: v}
+      }
+
+      assert [%{index: 2.7}] =
+               LineMap.serialize_vehicles([d], stops, direction_id, current_stop, now)
+    end
+
+    test "correctly serializes labels", %{stops: stops} do
+      direction_id = 0
+      current_stop = "70230"
+      now = ~U[2020-01-01T02:00:00Z]
+
+      v = %Vehicle{id: "1", current_status: :stopped_at, stop_id: "70236", direction_id: 0}
+
+      d = %Departure{
+        prediction: %Prediction{departure_time: ~U[2020-01-01T02:02:00Z], vehicle: v}
+      }
+
+      assert [%{id: "1", label: %{type: :minutes, minutes: 2}}] =
+               LineMap.serialize_vehicles([d], stops, direction_id, current_stop, now)
+
+      d = %Departure{
+        prediction: %Prediction{departure_time: ~U[2020-01-01T02:00:30Z], vehicle: v}
+      }
+
+      assert [%{id: "1", label: %{type: :text, text: "Now"}}] =
+               LineMap.serialize_vehicles([d], stops, direction_id, current_stop, now)
+    end
+
+    test "doesn't label departed vehicles", %{stops: stops} do
+      direction_id = 0
+      current_stop = "70230"
+      now = ~U[2020-01-01T02:00:00Z]
+
+      v = %Vehicle{id: "1", current_status: :stopped_at, stop_id: "70200", direction_id: 0}
+
+      d = %Departure{
+        prediction: %Prediction{departure_time: ~U[2020-01-01T02:02:00Z], vehicle: v}
+      }
+
+      assert [%{id: "1", label: nil}] =
+               LineMap.serialize_vehicles([d], stops, direction_id, current_stop, now)
+    end
+  end
+
+  describe "serialize_scheduled_departure/2" do
+    test "returns nil when there are two or more predictions", %{stops: stops} do
+      d1 = %Departure{prediction: %Prediction{}}
+      d2 = %Departure{prediction: %Prediction{}}
+
+      d3 = %Departure{
+        prediction: nil,
+        schedule: %Schedule{departure_time: ~U[2020-01-01T02:20:00Z]}
+      }
+
+      assert nil == LineMap.serialize_scheduled_departure([d1, d2, d3], stops)
+      assert not is_nil(LineMap.serialize_scheduled_departure([d1, d3], stops))
+    end
+
+    test "returns the next unpredicted departure", %{stops: stops} do
+      d1 = %Departure{
+        prediction: %Prediction{},
+        schedule: %Schedule{departure_time: ~U[2020-01-01T00:00:00Z]}
+      }
+
+      d2 = %Departure{
+        prediction: nil,
+        schedule: %Schedule{departure_time: ~U[2020-01-01T00:10:00Z]}
+      }
+
+      assert %{timestamp: "7:10"} = LineMap.serialize_scheduled_departure([d1, d2], stops)
+    end
+
+    test "returns the correct origin", %{stops: stops} do
+      d = %Departure{
+        prediction: nil,
+        schedule: %Schedule{departure_time: ~U[2020-01-01T00:00:00Z]}
+      }
+
+      assert %{station_name: "Cleveland Circle"} =
+               LineMap.serialize_scheduled_departure([d], stops)
+    end
+  end
+
+  describe "slot_names/1" do
+    test "returns left_sidebar" do
+      instance = %LineMap{}
+      assert [:left_sidebar] == WidgetInstance.slot_names(instance)
+    end
+  end
+
+  describe "widget_type/1" do
+    test "returns line_map" do
+      instance = %LineMap{}
+      assert :line_map == WidgetInstance.widget_type(instance)
+    end
+  end
+end


### PR DESCRIPTION
**Asana task**: [GL eink map component](https://app.asana.com/0/1185117109217413/1200281105971705)

This line map should work for arbitrary stops (i.e. it's ok if there are fewer than two downstream stops).

It uses the most typical route pattern for the route and direction to determine the stop order, rather than hard-coding the stop sequence. This is what we're doing in the v1 app line map, and we can continue doing it until we revisit the question of how to get a canonical stop ordering.