### PR TITLE
feat: Implement WidgetInstance.slot_names/1 for Alert widget

### DIFF
--- a/lib/screens/v2/widget_instance/alert.ex
+++ b/lib/screens/v2/widget_instance/alert.ex
@@ -48,23 +48,26 @@ defmodule Screens.V2.WidgetInstance.Alert do
     %{}
   end
 
-  def slot_names(%__MODULE__{screen: %Screen{app_id: app_id}} = t)
-      when app_id in [:bus_shelter_v2, :bus_eink_v2] do
-    if active?(t) and effect(t) in [:stop_closure, :stop_move, :suspension, :detour] and
-         informs_all_active_routes_at_home_stop?(t) do
-      [:full_screen]
-    else
-      [:medium_left, :medium_right]
-    end
+  def slot_names(%__MODULE__{screen: %Screen{app_id: :bus_shelter_v2}} = t) do
+    if bus_app_full_screen_alert?(t), do: [:full_screen], else: [:medium_left, :medium_right]
+  end
+
+  def slot_names(%__MODULE__{screen: %Screen{app_id: :bus_eink_v2}} = t) do
+    if bus_app_full_screen_alert?(t), do: [:full_screen], else: [:medium_flex]
   end
 
   def slot_names(%__MODULE__{screen: %Screen{app_id: :gl_eink_v2}} = t) do
-    if active?(t) and effect(t) in [:station_closure, :suspension, :shuttle] and
-         location(t) == :inside do
-      [:full_screen]
-    else
-      [:medium_flex]
-    end
+    if gl_app_full_screen_alert?(t), do: [:full_screen], else: [:medium_flex]
+  end
+
+  defp bus_app_full_screen_alert?(t) do
+    active?(t) and effect(t) in [:stop_closure, :stop_move, :suspension, :detour] and
+      informs_all_active_routes_at_home_stop?(t)
+  end
+
+  defp gl_app_full_screen_alert?(t) do
+    active?(t) and effect(t) in [:station_closure, :suspension, :shuttle] and
+      location(t) == :inside
   end
 
   def widget_type(_t) do

--- a/test/screens/v2/widget_instance/alert_test.exs
+++ b/test/screens/v2/widget_instance/alert_test.exs
@@ -3,7 +3,7 @@ defmodule Screens.V2.WidgetInstance.AlertTest do
 
   alias Screens.Alerts.Alert
   alias Screens.Config.Screen
-  alias Screens.Config.V2.{BusShelter, Solari}
+  alias Screens.Config.V2.{BusShelter, GlEink, Solari}
   alias Screens.RouteType
   alias Screens.V2.WidgetInstance.Alert, as: AlertWidget
 
@@ -59,11 +59,7 @@ defmodule Screens.V2.WidgetInstance.AlertTest do
   end
 
   defp ie(opts \\ []) do
-    %{
-      stop: opts[:stop] || nil,
-      route: opts[:route] || nil,
-      route_type: opts[:route_type] || nil
-    }
+    %{stop: opts[:stop], route: opts[:route], route_type: opts[:route_type]}
   end
 
   defp setup_home_stop(%{widget: widget}) do
@@ -119,25 +115,36 @@ defmodule Screens.V2.WidgetInstance.AlertTest do
     %{widget: put_effect(widget, :stop_closure)}
   end
 
-  # Pass this to `setup` to set up a stop_closure alert that is currently active (just started) and affects the home stop.
-  @valid_alert_setup_group [
+  # Pass this to `setup` to set up "context" data on the alert widget, without setting up the API alert itself.
+  @alert_widget_context_setup_group [
     :setup_home_stop,
     :setup_stop_sequences,
     :setup_routes,
     :setup_screen_config,
-    :setup_now,
-    :setup_informed_entities,
-    :setup_active_period,
-    :setup_effect
+    :setup_now
   ]
+
+  # Pass this to `setup` to set up a stop_closure alert that is currently active (just started) and affects the home stop.
+  @valid_alert_setup_group @alert_widget_context_setup_group ++
+                             [
+                               :setup_informed_entities,
+                               :setup_active_period,
+                               :setup_effect
+                             ]
 
   describe "priority/1" do
     setup @valid_alert_setup_group
 
+    test "returns [1] when slot_names(widget) == [:full_screen]", %{widget: widget} do
+      assert [1] == AlertWidget.priority(widget)
+    end
+
     test "returns a list of tiebreaker values when widget should be considered for placement", %{
       widget: widget
     } do
-      assert [_ | _] = AlertWidget.priority(widget)
+      widget = put_effect(widget, :snow_route)
+
+      assert [2 | _] = AlertWidget.priority(widget)
     end
 
     test "returns :no_render if any of the tiebreaker functions returns :no_render", %{
@@ -152,6 +159,148 @@ defmodule Screens.V2.WidgetInstance.AlertTest do
       widget = put_active_period(widget, active_period)
 
       assert :no_render == AlertWidget.priority(widget)
+    end
+  end
+
+  describe "slot_names/1 for bus apps (Bus Shelter and Bus E-Ink)" do
+    setup @alert_widget_context_setup_group
+
+    # active | high-impact | informs all routes || full-screen?
+    # n      | n           | n                  || n
+    # y      | n           | n                  || n
+    # n      | y           | n                  || n
+    # y      | y           | n                  || n
+    # n      | n           | y                  || n
+    # y      | n           | y                  || n
+    # n      | y           | y                  || n
+    # y      | y           | y                  || y
+
+    @bus_slot_names_cases %{
+      {false, false, false} => [:medium_left, :medium_right],
+      {true, false, false} => [:medium_left, :medium_right],
+      {false, true, false} => [:medium_left, :medium_right],
+      {true, true, false} => [:medium_left, :medium_right],
+      {false, false, true} => [:medium_left, :medium_right],
+      {true, false, true} => [:medium_left, :medium_right],
+      {false, true, true} => [:medium_left, :medium_right],
+      {true, true, true} => [:full_screen]
+    }
+
+    for {{set_active?, set_high_impact_effect?, set_informs_all_active_routes?},
+         expected_slot_names} <- @bus_slot_names_cases do
+      false_to_not = fn
+        true -> ""
+        false -> "not "
+      end
+
+      test_description =
+        "returns #{inspect(expected_slot_names)} if alert is " <>
+          false_to_not.(set_active?) <>
+          "active and does " <>
+          false_to_not.(set_high_impact_effect?) <>
+          "have a high-impact effect and does " <>
+          false_to_not.(set_informs_all_active_routes?) <>
+          "inform all active routes at home stop"
+
+      test test_description, %{widget: widget} do
+        active_period =
+          if(unquote(set_active?),
+            do: [{~U[2021-01-01T00:00:00Z], ~U[2021-01-01T22:00:00Z]}],
+            else: [{~U[2021-01-02T00:00:00Z], ~U[2021-01-02T22:00:00Z]}]
+          )
+
+        effect = if(unquote(set_high_impact_effect?), do: :stop_closure, else: :snow_route)
+
+        informed_entities =
+          if(unquote(set_informs_all_active_routes?),
+            do: [ie(route: "a"), ie(route: "c")],
+            else: [ie(route: "a"), ie(route: "b")]
+          )
+
+        widget =
+          widget
+          |> put_active_period(active_period)
+          |> put_effect(effect)
+          |> put_informed_entities(informed_entities)
+
+        assert unquote(expected_slot_names) == AlertWidget.slot_names(widget)
+      end
+    end
+  end
+
+  describe "slot_names/1 for Green Line E-Ink app" do
+    setup @alert_widget_context_setup_group ++ [:setup_gl_eink_config]
+
+    defp setup_gl_eink_config(%{widget: widget}) do
+      widget =
+        widget
+        |> put_app_id(:gl_eink_v2)
+        |> put_home_stop(GlEink, "5")
+
+      %{widget: widget}
+    end
+
+    # active | high-impact | location :inside || full-screen?
+    # n      | n           | n                || n
+    # y      | n           | n                || n
+    # n      | y           | n                || n
+    # y      | y           | n                || n
+    # n      | n           | y                || n
+    # y      | n           | y                || n
+    # n      | y           | y                || n
+    # y      | y           | y                || y
+
+    @gl_slot_names_cases %{
+      {false, false, false} => [:medium_flex],
+      {true, false, false} => [:medium_flex],
+      {false, true, false} => [:medium_flex],
+      {true, true, false} => [:medium_flex],
+      {false, false, true} => [:medium_flex],
+      {true, false, true} => [:medium_flex],
+      {false, true, true} => [:medium_flex],
+      {true, true, true} => [:full_screen]
+    }
+
+    for {{set_active?, set_high_impact_effect?, set_location_inside?}, expected_slot_names} <-
+          @gl_slot_names_cases do
+      false_to_not = fn
+        true -> ""
+        false -> "not "
+      end
+
+      test_description =
+        "returns #{inspect(expected_slot_names)} if alert is " <>
+          false_to_not.(set_active?) <>
+          "active and does " <>
+          false_to_not.(set_high_impact_effect?) <>
+          "have a high-impact effect and does " <>
+          false_to_not.(set_location_inside?) <>
+          "contain home stop in informed region"
+
+      test test_description, %{widget: widget} do
+        active_period =
+          if(unquote(set_active?),
+            do: [{~U[2021-01-01T00:00:00Z], ~U[2021-01-01T22:00:00Z]}],
+            else: [{~U[2021-01-02T00:00:00Z], ~U[2021-01-02T22:00:00Z]}]
+          )
+
+        effect =
+          if(unquote(set_high_impact_effect?), do: :station_closure, else: :elevator_closure)
+
+        informed_entities =
+          if(unquote(set_location_inside?),
+            do: [ie(stop: "4"), ie(stop: "5"), ie(stop: "6")],
+            else: [ie(stop: "5"), ie(stop: "6")]
+          )
+
+        widget =
+          widget
+          |> put_active_period(active_period)
+          |> put_effect(effect)
+          |> put_informed_entities(informed_entities)
+
+        assert unquote(expected_slot_names) == AlertWidget.slot_names(widget)
+      end
     end
   end
 
@@ -271,7 +420,7 @@ defmodule Screens.V2.WidgetInstance.AlertTest do
   end
 
   describe "upstream_stop_id_set/1" do
-    setup [:setup_home_stop, :setup_stop_sequences]
+    setup @alert_widget_context_setup_group
 
     test "collects all stops upstream of the home stop into a set", %{widget: widget} do
       expected_upstream_stops = MapSet.new(~w[0 1 2 3 4] ++ ~w[10 20 30 4] ++ ~w[200 40])
@@ -281,7 +430,7 @@ defmodule Screens.V2.WidgetInstance.AlertTest do
   end
 
   describe "downstream_stop_id_set/1" do
-    setup [:setup_home_stop, :setup_stop_sequences]
+    setup @alert_widget_context_setup_group
 
     test "collects all stops downstream of the home stop into a set", %{widget: widget} do
       expected_downstream_stops = MapSet.new(~w[6 7 8 9] ++ ~w[7] ++ ~w[6 90])
@@ -291,7 +440,7 @@ defmodule Screens.V2.WidgetInstance.AlertTest do
   end
 
   describe "location/1" do
-    setup [:setup_home_stop, :setup_stop_sequences, :setup_routes, :setup_screen_config]
+    setup @alert_widget_context_setup_group
 
     test "handles empty informed entities", %{widget: widget} do
       widget = put_informed_entities(widget, [])

--- a/test/screens/v2/widget_instance/alert_test.exs
+++ b/test/screens/v2/widget_instance/alert_test.exs
@@ -3,7 +3,7 @@ defmodule Screens.V2.WidgetInstance.AlertTest do
 
   alias Screens.Alerts.Alert
   alias Screens.Config.Screen
-  alias Screens.Config.V2.{BusShelter, GlEink, Solari}
+  alias Screens.Config.V2.{BusEink, BusShelter, GlEink, Solari}
   alias Screens.RouteType
   alias Screens.V2.WidgetInstance.Alert, as: AlertWidget
 
@@ -225,6 +225,18 @@ defmodule Screens.V2.WidgetInstance.AlertTest do
 
         assert unquote(expected_slot_names) == AlertWidget.slot_names(widget)
       end
+    end
+
+    test "returns [:medium_flex] for a non-full-screen alert on Bus E-Ink", %{widget: widget} do
+      widget =
+        widget
+        |> put_app_id(:bus_eink_v2)
+        |> put_home_stop(BusEink, "5")
+        |> put_active_period([{~U[2021-01-02T00:00:00Z], ~U[2021-01-02T22:00:00Z]}])
+        |> put_effect(:snow_route)
+        |> put_informed_entities([ie(route: "a"), ie(route: "b")])
+
+      assert [:medium_flex] == AlertWidget.slot_names(widget)
     end
   end
 


### PR DESCRIPTION
**Asana task**: [determine widget slot name](https://app.asana.com/0/1185117109217413/1200354915858977/f)

Possibly helpful explanation of the big `reduce_while` inside `informs_all_active_routes_at_home_stop/1`: It starts with the set of routes that are actively serving the home stop on the current day as the accumulator. It looks at each informed entity one at a time, and removes any route IDs from the set.

If the set is empty after checking through all the informed entities, then the alert informs all active routes serving the home stop. If not, it does not inform all of them.

Note: I also updated `priority/1` to depend on `slot_names/1`. If `slot_names/1` returns `[:full_screen]`, then `priority/1` returns `[1]` in order to have the alert be placed before other widgets that might preclude it from getting the full-screen slot.

- [ ] Needs version bump?
