### PR TITLE
feat: Alert widget serialize function; factored-out route pill logic

### DIFF
--- a/lib/screens/alerts/alert.ex
+++ b/lib/screens/alerts/alert.ex
@@ -15,7 +15,8 @@ defmodule Screens.Alerts.Alert do
             lifecycle: nil,
             timeframe: nil,
             created_at: nil,
-            updated_at: nil
+            updated_at: nil,
+            url: nil
 
   @type cause ::
           :accident

--- a/lib/screens/alerts/parser.ex
+++ b/lib/screens/alerts/parser.ex
@@ -19,7 +19,8 @@ defmodule Screens.Alerts.Parser do
         "informed_entity" => informed_entities,
         "lifecycle" => lifecycle,
         "severity" => severity,
-        "timeframe" => timeframe
+        "timeframe" => timeframe,
+        "url" => url
       } ->
         %Screens.Alerts.Alert{
           id: id,
@@ -32,7 +33,8 @@ defmodule Screens.Alerts.Parser do
           lifecycle: lifecycle,
           timeframe: timeframe,
           created_at: parse_time(created_at),
-          updated_at: parse_time(updated_at)
+          updated_at: parse_time(updated_at),
+          url: url
         }
 
       _ ->

--- a/lib/screens/v2/widget_instance/alert.ex
+++ b/lib/screens/v2/widget_instance/alert.ex
@@ -247,12 +247,7 @@ defmodule Screens.V2.WidgetInstance.Alert do
 
   @spec tiebreaker_effect(t()) :: pos_integer() | WidgetInstance.no_render()
   def tiebreaker_effect(%__MODULE__{} = t) do
-    e = effect(t)
-
-    Enum.find_value(@effect_priorities, :no_render, fn
-      {^e, priority} -> priority
-      _ -> false
-    end)
+    Keyword.get(@effect_priorities, effect(t), :no_render)
   end
 
   defp informs_all_active_routes_at_home_stop?(t) do

--- a/lib/screens/v2/widget_instance/departures.ex
+++ b/lib/screens/v2/widget_instance/departures.ex
@@ -5,6 +5,7 @@ defmodule Screens.V2.WidgetInstance.Departures do
   alias Screens.Config.Screen
   alias Screens.V2.Departure
   alias Screens.V2.WidgetInstance.Departures
+  alias Screens.V2.WidgetInstance.Serializer.RoutePill
 
   defstruct screen: nil,
             section_data: []
@@ -77,54 +78,8 @@ defmodule Screens.V2.WidgetInstance.Departures do
     route_type = Departure.route_type(first_departure)
     track_number = Departure.track_number(first_departure)
 
-    route =
-      cond do
-        not is_nil(track_number) ->
-          %{type: :text, text: "TR#{track_number}"}
-
-        route_type == :rail ->
-          %{type: :icon, icon: :rail}
-
-        route_type == :ferry ->
-          %{type: :icon, icon: :boat}
-
-        String.contains?(route_name, "/") ->
-          [part1, part2] = String.split(route_name, "/")
-          %{type: :slashed, part1: part1, part2: part2}
-
-        true ->
-          %{type: :text, text: get_text_for_route(route_id, route_name)}
-      end
-
-    Map.merge(route, %{color: get_color_for_route(route_id, route_type)})
+    RoutePill.serialize_for_departure(route_id, route_name, route_type, track_number)
   end
-
-  defp get_text_for_route("Red", _), do: "RL"
-  defp get_text_for_route("Mattapan", _), do: "M"
-  defp get_text_for_route("Orange", _), do: "OL"
-  defp get_text_for_route("Blue", _), do: "BL"
-  defp get_text_for_route("Green-B", _), do: "GL"
-  defp get_text_for_route("Green-C", _), do: "GL"
-  defp get_text_for_route("Green-D", _), do: "GL"
-  defp get_text_for_route("Green-E", _), do: "GL"
-  defp get_text_for_route(_, route_name), do: route_name
-
-  defp get_color_for_route("Red", _), do: :red
-  defp get_color_for_route("Mattapan", _), do: :red
-  defp get_color_for_route("Orange", _), do: :orange
-  defp get_color_for_route("Blue", _), do: :blue
-
-  defp get_color_for_route(route_id, _)
-       when route_id in ["Green-B", "Green-C", "Green-D", "Green-E"],
-       do: :green
-
-  defp get_color_for_route(route_id, _)
-       when route_id in ["741", "742", "743", "746", "749", "751"],
-       do: :silver
-
-  defp get_color_for_route(_, :rail), do: :purple
-  defp get_color_for_route(_, :ferry), do: :teal
-  defp get_color_for_route(_, _), do: :yellow
 
   def serialize_headsign([first_departure | _]) do
     headsign = Departure.headsign(first_departure)

--- a/lib/screens/v2/widget_instance/serializer.ex
+++ b/lib/screens/v2/widget_instance/serializer.ex
@@ -1,0 +1,3 @@
+defmodule Screens.V2.WidgetInstance.Serializer do
+  @moduledoc false
+end

--- a/lib/screens/v2/widget_instance/serializer/route_pill.ex
+++ b/lib/screens/v2/widget_instance/serializer/route_pill.ex
@@ -81,7 +81,7 @@ defmodule Screens.V2.WidgetInstance.Serializer.RoutePill do
 
   @spec serialize_for_alert(Route.id()) :: t()
   def serialize_for_alert(route_id) do
-    route = do_serialize(route_id, %{gl_branch: true, cr_abbrev: true, ferry_abbrev: true})
+    route = do_serialize(route_id, %{gl_branch: true, cr_abbrev: true})
 
     Map.merge(route, %{color: get_color_for_route(route_id)})
   end
@@ -89,7 +89,6 @@ defmodule Screens.V2.WidgetInstance.Serializer.RoutePill do
   @typep serialize_opts :: %{
            optional(:gl_branch) => boolean(),
            optional(:cr_abbrev) => boolean(),
-           optional(:ferry_abbrev) => boolean(),
            optional(:route_name) => String.t()
          }
 
@@ -118,13 +117,6 @@ defmodule Screens.V2.WidgetInstance.Serializer.RoutePill do
 
   defp do_serialize("CR-" <> _line, _) do
     %{type: :icon, icon: :rail}
-  end
-
-  defp do_serialize("Boat-" <> line, %{ferry_abbrev: true}) do
-    case line do
-      "F1" -> %{type: :slashed, part1: "HNG", part2: "HUL"}
-      "F4" -> %{type: :text, text: "CTN"}
-    end
   end
 
   defp do_serialize("Boat-" <> _line, _) do

--- a/lib/screens/v2/widget_instance/serializer/route_pill.ex
+++ b/lib/screens/v2/widget_instance/serializer/route_pill.ex
@@ -1,0 +1,168 @@
+defmodule Screens.V2.WidgetInstance.Serializer.RoutePill do
+  @moduledoc false
+
+  alias Screens.Routes.Route
+  alias Screens.RouteType
+
+  @type t :: text_pill() | icon_pill() | slashed_route_pill()
+
+  @type text_pill :: %{
+          type: :text,
+          text: String.t(),
+          color: color()
+        }
+
+  @type icon_pill :: %{
+          type: :icon,
+          icon: :rail | :boat,
+          color: color()
+        }
+
+  @type slashed_route_pill :: %{
+          type: :slashed,
+          part1: String.t(),
+          part2: String.t(),
+          color: color()
+        }
+
+  @type color :: :red | :orange | :green | :blue | :purple | :yellow | :teal
+
+  @sl_route_ids ~w[741 742 743 746 749 751]
+
+  @ct_route_ids ~w[708 747]
+
+  @spec serialize_for_departure(Route.id(), String.t(), RouteType.t(), pos_integer() | nil) :: t()
+  def serialize_for_departure(route_id, route_name, route_type, track_number) do
+    route =
+      cond do
+        not is_nil(track_number) ->
+          %{type: :text, text: "TR#{track_number}"}
+
+        route_type == :rail ->
+          %{type: :icon, icon: :rail}
+
+        route_type == :ferry ->
+          %{type: :icon, icon: :boat}
+
+        String.contains?(route_name, "/") ->
+          [part1, part2] = String.split(route_name, "/")
+          %{type: :slashed, part1: part1, part2: part2}
+
+        true ->
+          do_serialize(route_id, route_name: route_name)
+      end
+
+    Map.merge(route, %{color: get_color_for_route(route_id, route_type)})
+  end
+
+  @spec serialize_for_alert(Route.id()) :: t()
+  def serialize_for_alert(route_id) do
+    route = do_serialize(route_id, gl_branch: true, cr_abbrev: true, ferry_abbrev: true)
+
+    Map.merge(route, %{color: get_color_for_route(route_id)})
+  end
+
+  @typep bool_opt :: :gl_branch | :cr_abbrev | :ferry_abbrev
+  @typep serialize_opt :: {bool_opt(), boolean()} | {:route_name, String.t()}
+  @typep serialize_opts :: list(serialize_opt())
+
+  @spec do_serialize(Route.id(), serialize_opts()) :: map()
+  # credo:disable-for-next-line Credo.Check.Refactor.CyclomaticComplexity
+  defp do_serialize(route_id, opts)
+
+  defp do_serialize("Red", _), do: %{type: :text, text: "RL"}
+  defp do_serialize("Mattapan", _), do: %{type: :text, text: "M"}
+  defp do_serialize("Orange", _), do: %{type: :text, text: "OL"}
+
+  defp do_serialize("Green-" <> branch, opts) do
+    %{type: :text, text: if(opts[:gl_branch], do: "GL·" <> branch, else: "GL")}
+  end
+
+  defp do_serialize("Blue", _), do: %{type: :text, text: "BL"}
+
+  defp do_serialize("CR-" <> line, opts) do
+    if opts[:cr_abbrev] do
+      line_abbrev =
+        case line do
+          "Haverhill" -> "HVL"
+          "Newburyport" -> "NBP"
+          "Lowell" -> "LWL"
+          "Fitchburg" -> "FBG"
+          "Worcester" -> "WOR"
+          "Needham" -> "NDM"
+          "Franklin" -> "FRK"
+          "Providence" -> "PVD"
+          "Fairmount" -> "FMT"
+          "Middleborough" -> "MID"
+          "Kingston" -> "KNG"
+          "Greenbush" -> "GRB"
+        end
+
+      %{type: :text, text: line_abbrev}
+    else
+      %{type: :icon, icon: :rail}
+    end
+  end
+
+  defp do_serialize("Boat-" <> line, opts) do
+    if opts[:ferry_abbrev] do
+      case line do
+        "F1" -> %{type: :slashed, part1: "HNG", part2: "HUL"}
+        "F4" -> %{type: :text, text: "CTN"}
+      end
+    else
+      %{type: :icon, icon: :boat}
+    end
+  end
+
+  defp do_serialize(route_id, _) when route_id in @sl_route_ids do
+    text =
+      case route_id do
+        "741" -> "SL1"
+        "742" -> "SL2"
+        "743" -> "SL3"
+        "751" -> "SL4"
+        "749" -> "SL5"
+        "746" -> "SLW"
+      end
+
+    %{type: :text, text: text}
+  end
+
+  defp do_serialize(route_id, _) when route_id in @ct_route_ids do
+    text =
+      case route_id do
+        "747" -> "CT2"
+        "708" -> "CT3"
+      end
+
+    %{type: :text, text: text}
+  end
+
+  defp do_serialize(route_id, opts) do
+    route_name = Keyword.get(opts, :route_name, "")
+
+    %{
+      type: :text,
+      text: if(not is_nil(route_name) and route_name != "", do: route_name, else: route_id)
+    }
+  end
+
+  defp get_color_for_route(route_id, route_type \\ nil)
+
+  defp get_color_for_route("Red", _), do: :red
+  defp get_color_for_route("Mattapan", _), do: :red
+  defp get_color_for_route("Orange", _), do: :orange
+  defp get_color_for_route("Green-" <> _, _), do: :green
+  defp get_color_for_route("Blue", _), do: :blue
+  defp get_color_for_route("CR-" <> _, _), do: :purple
+  defp get_color_for_route("Boat-" <> _, _), do: :teal
+
+  defp get_color_for_route(route_id, _)
+       when route_id in @sl_route_ids,
+       do: :silver
+
+  defp get_color_for_route(_, :rail), do: :purple
+  defp get_color_for_route(_, :ferry), do: :teal
+  defp get_color_for_route(_, _), do: :yellow
+end

--- a/test/screens/alerts/alert_test.exs
+++ b/test/screens/alerts/alert_test.exs
@@ -16,7 +16,8 @@ defmodule Screens.Alerts.AlertTest do
         "informed_entity" => [],
         "lifecycle" => nil,
         "severity" => nil,
-        "timeframe" => nil
+        "timeframe" => nil,
+        "url" => nil
       }
     }
   end

--- a/test/screens/v2/widget_instance/alert_test.exs
+++ b/test/screens/v2/widget_instance/alert_test.exs
@@ -162,6 +162,32 @@ defmodule Screens.V2.WidgetInstance.AlertTest do
     end
   end
 
+  describe "serialize/1" do
+    setup @valid_alert_setup_group ++ [:setup_display_values]
+
+    defp setup_display_values(%{widget: widget}) do
+      widget = %{widget | alert: %{widget.alert | header: "Stop is closed."}}
+
+      %{widget: widget}
+    end
+
+    test "serializes an alert widget", %{widget: widget} do
+      expected_json_map = %{
+        route_pills: [
+          %{type: :text, text: "a", color: :yellow},
+          %{type: :text, text: "b", color: :yellow},
+          %{type: :text, text: "c", color: :yellow}
+        ],
+        icon: :x,
+        header: "Stop Closed",
+        body: "Stop is closed.",
+        url: "mbta.com/alerts"
+      }
+
+      assert expected_json_map == AlertWidget.serialize(widget)
+    end
+  end
+
   describe "slot_names/1 for bus apps (Bus Shelter and Bus E-Ink)" do
     setup @alert_widget_context_setup_group
 

--- a/test/screens/v2/widget_instance/serializer/route_pill_test.exs
+++ b/test/screens/v2/widget_instance/serializer/route_pill_test.exs
@@ -68,8 +68,8 @@ defmodule Screens.V2.WidgetInstance.Serializer.RoutePillTest do
       assert %{type: :text, text: "LWL", color: :purple} == serialize_for_alert("CR-Lowell")
     end
 
-    test "Abbreviates ferry route names" do
-      assert %{type: :text, text: "CTN", color: :teal} == serialize_for_alert("Boat-F4")
+    test "Returns boat icon for ferry routes" do
+      assert %{type: :icon, icon: :boat, color: :teal} == serialize_for_alert("Boat-F4")
     end
 
     test "Handles Silver Line routes" do

--- a/test/screens/v2/widget_instance/serializer/route_pill_test.exs
+++ b/test/screens/v2/widget_instance/serializer/route_pill_test.exs
@@ -1,0 +1,87 @@
+defmodule Screens.V2.WidgetInstance.Serializer.RoutePillTest do
+  use ExUnit.Case, async: true
+
+  import Screens.V2.WidgetInstance.Serializer.RoutePill
+
+  describe "serialize_for_departure/4" do
+    test "Uses track number if not nil" do
+      assert %{type: :text, text: "TR3", color: :purple} ==
+               serialize_for_departure("CR-Fairmount", "", :rail, 3)
+    end
+
+    test "Returns rail icon if route type is :rail" do
+      assert %{type: :icon, icon: :rail, color: :purple} ==
+               serialize_for_departure("CR-Fairmount", "", :rail, nil)
+    end
+
+    test "Returns boat icon if route type is :ferry" do
+      assert %{type: :icon, icon: :boat, color: :teal} ==
+               serialize_for_departure("Boat-F1", "", :ferry, nil)
+    end
+
+    test "Returns slashed route pill if route name contains `/`" do
+      assert %{type: :slashed, part1: "34", part2: "35", color: :yellow} ==
+               serialize_for_departure("3435", "34/35", :bus, nil)
+    end
+
+    test "Returns RL for Red Line" do
+      assert %{type: :text, text: "RL", color: :red} ==
+               serialize_for_departure("Red", "", :subway, nil)
+    end
+
+    test "Does not include branch name for Green Line" do
+      assert %{type: :text, text: "GL", color: :green} ==
+               serialize_for_departure("Green-B", "", :light_rail, nil)
+    end
+
+    test "Handles Silver Line routes" do
+      assert %{type: :text, text: "SL1", color: :silver} ==
+               serialize_for_departure("741", "", :bus, nil)
+    end
+
+    test "Handles cross-town routes" do
+      assert %{type: :text, text: "CT2", color: :yellow} ==
+               serialize_for_departure("747", "", :bus, nil)
+    end
+
+    test "Uses route ID for normal bus routes" do
+      assert %{type: :text, text: "44", color: :yellow} ==
+               serialize_for_departure("44", "", :bus, nil)
+    end
+
+    test "Uses route name for non-special case routes if not empty" do
+      assert %{type: :text, text: "NewRoute999", color: :yellow} ==
+               serialize_for_departure("999", "NewRoute999", :bus, nil)
+    end
+  end
+
+  describe "serialize_for_alert/1" do
+    test "Returns RL for Red Line" do
+      assert %{type: :text, text: "RL", color: :red} == serialize_for_alert("Red")
+    end
+
+    test "Includes branch name for Green Line" do
+      assert %{type: :text, text: "GL·B", color: :green} == serialize_for_alert("Green-B")
+    end
+
+    test "Abbreviates Commuter Rail route names" do
+      assert %{type: :text, text: "LWL", color: :purple} == serialize_for_alert("CR-Lowell")
+    end
+
+    test "Abbreviates ferry route names" do
+      assert %{type: :text, text: "CTN", color: :teal} == serialize_for_alert("Boat-F4")
+    end
+
+    test "Handles Silver Line routes" do
+      assert %{type: :text, text: "SL1", color: :silver} == serialize_for_alert("741")
+    end
+
+    test "Handles cross-town routes" do
+      assert %{type: :text, text: "CT2", color: :yellow} == serialize_for_alert("747")
+    end
+
+    test "Uses route ID for normal bus routes" do
+      assert %{type: :text, text: "44", color: :yellow} == serialize_for_alert("44")
+    end
+  end
+end


### PR DESCRIPTION
**Asana task**: [serialize widget](https://app.asana.com/0/1185117109217413/1200354915858979/f)

I tried to factor out the logic for serializing route pills so that we don't have duplicated code for departures, alerts, and other places that use route pills.

There's also some questionably-readable module attributes at the top of the alert widget module now, where I tried to link all of the effect-related hardcoded values together. I'm totally open to making those less of an eyesore if the current approach seems bad.

- [ ] Needs version bump?
