### PR TITLE
feat: Log new Solari screen data requests

### DIFF
--- a/lib/screens_web/controllers/audio_controller.ex
+++ b/lib/screens_web/controllers/audio_controller.ex
@@ -28,7 +28,7 @@ defmodule ScreensWeb.AudioController do
       |> Map.get("disposition")
       |> disposition_atom()
 
-    is_screen = ScreensWeb.UserAgent.is_screen_conn?(conn)
+    is_screen = ScreensWeb.UserAgent.is_screen_conn?(conn, screen_id)
 
     _ = Screens.LogScreenData.log_audio_request(screen_id, is_screen)
 

--- a/lib/screens_web/controllers/screen_api_controller.ex
+++ b/lib/screens_web/controllers/screen_api_controller.ex
@@ -26,7 +26,6 @@ defmodule ScreensWeb.ScreenApiController do
     is_screen = ScreensWeb.UserAgent.is_screen_conn?(conn)
 
     _ = Screens.LogScreenData.log_data_request(screen_id, last_refresh, is_screen)
-    _ = log_solari_user_agent(screen_id, conn)
 
     data =
       Screens.ScreenData.by_screen_id(screen_id, is_screen,
@@ -46,17 +45,4 @@ defmodule ScreensWeb.ScreenApiController do
 
     json(conn, data)
   end
-
-  defp log_solari_user_agent(screen_id, conn) when "300" < screen_id and screen_id < "320" do
-    user_agent =
-      conn.req_headers
-      |> Enum.into(%{})
-      |> Map.get("user-agent")
-
-    if !is_nil(user_agent) do
-      Logger.info("[user agent] #{user_agent}")
-    end
-  end
-
-  defp log_solari_user_agent(_screen_id, _conn), do: nil
 end

--- a/lib/screens_web/controllers/screen_api_controller.ex
+++ b/lib/screens_web/controllers/screen_api_controller.ex
@@ -23,7 +23,7 @@ defmodule ScreensWeb.ScreenApiController do
   end
 
   def show(conn, %{"id" => screen_id, "last_refresh" => last_refresh}) do
-    is_screen = ScreensWeb.UserAgent.is_screen_conn?(conn)
+    is_screen = ScreensWeb.UserAgent.is_screen_conn?(conn, screen_id)
 
     _ = Screens.LogScreenData.log_data_request(screen_id, last_refresh, is_screen)
 
@@ -37,7 +37,7 @@ defmodule ScreensWeb.ScreenApiController do
   end
 
   def show_dup(conn, %{"id" => screen_id, "rotation_index" => rotation_index}) do
-    is_screen = ScreensWeb.UserAgent.is_screen_conn?(conn)
+    is_screen = ScreensWeb.UserAgent.is_screen_conn?(conn, screen_id)
 
     _ = Screens.LogScreenData.log_data_request(screen_id, nil, is_screen)
 

--- a/lib/screens_web/controllers/screen_controller.ex
+++ b/lib/screens_web/controllers/screen_controller.ex
@@ -73,7 +73,7 @@ defmodule ScreensWeb.ScreenController do
   end
 
   def index(conn, %{"id" => screen_id}) do
-    is_screen = ScreensWeb.UserAgent.is_screen_conn?(conn)
+    is_screen = ScreensWeb.UserAgent.is_screen_conn?(conn, screen_id)
 
     _ = Screens.LogScreenData.log_page_load(screen_id, is_screen)
 

--- a/lib/screens_web/controllers/v2/screen_api_controller.ex
+++ b/lib/screens_web/controllers/v2/screen_api_controller.ex
@@ -16,7 +16,7 @@ defmodule ScreensWeb.V2.ScreenApiController do
   end
 
   def show(conn, %{"id" => screen_id, "last_refresh" => last_refresh}) do
-    is_screen = ScreensWeb.UserAgent.is_screen_conn?(conn)
+    is_screen = ScreensWeb.UserAgent.is_screen_conn?(conn, screen_id)
 
     _ = Screens.LogScreenData.log_data_request(screen_id, last_refresh, is_screen)
 

--- a/lib/screens_web/controllers/v2/screen_controller.ex
+++ b/lib/screens_web/controllers/v2/screen_controller.ex
@@ -30,7 +30,7 @@ defmodule ScreensWeb.V2.ScreenController do
   end
 
   def index(conn, %{"id" => screen_id}) do
-    is_screen = ScreensWeb.UserAgent.is_screen_conn?(conn)
+    is_screen = ScreensWeb.UserAgent.is_screen_conn?(conn, screen_id)
 
     _ = Screens.LogScreenData.log_page_load(screen_id, is_screen)
 


### PR DESCRIPTION
**Asana task**: [Log data requests from new Solari screens](https://app.asana.com/0/1185117109217413/1200074998406104/f)

`is_screen_conn?` now takes the screen ID as well. Solari user agents are just standard Ubuntu + latest/recent Firefox now, so I added a check on the requested screen ID to try and filter out as many non-screen requests as possible.

We still will probably get a few false-positive logs (e.g. if Ryan looks at the Solari app on his Ubuntu machine) but there isn't much we can do about that.

- [ ] Needs version bump?
