### PR TITLE
fix: Check whether screen needs refresh before checking if disabled

### DIFF
--- a/lib/screens/screen_data.ex
+++ b/lib/screens/screen_data.ex
@@ -24,8 +24,8 @@ defmodule Screens.ScreenData do
 
     response =
       cond do
-        check_disabled and disabled?(screen_id) -> @disabled_response
         check_outdated and outdated?(screen_id, last_refresh) -> @outdated_response
+        check_disabled and disabled?(screen_id) -> @disabled_response
         true -> fetch_data(screen_id, is_screen)
       end
 


### PR DESCRIPTION
**Asana task**: ad hoc

This changes the order in which the backend checks for the various quick-turnaround states (disabled, needs refresh) before actually fetching data for a screens API request.

Purpose: I want to tell clients pointed at screen 306 to refresh, but with the current server code that's not possible as long as they are disabled.

- [ ] Needs version bump?
