### PR TITLE
fix: Visual tweaks for bus shelter screen

### DIFF
--- a/assets/css/bus_shelter_v2.scss
+++ b/assets/css/bus_shelter_v2.scss
@@ -2,6 +2,8 @@
 
 @import "colors";
 
+@import "v2/bus_shelter/screen_container";
+
 @import "v2/bus_shelter/screen/normal";
 @import "v2/bus_shelter/screen/takeover";
 

--- a/assets/css/v2/bus_eink/departures/time.scss
+++ b/assets/css/v2/bus_eink/departures/time.scss
@@ -8,6 +8,10 @@
   &:not(:first-child) {
     margin-top: 32px;
   }
+
+  .departure-time {
+    width: 264px;
+  }
 }
 
 .departure-time {
@@ -28,7 +32,7 @@
   display: inline-block;
   margin-left: 3px;
 
-  font-size: 120px;
+  font-size: 96px;
   line-height: 120px;
   font-weight: 800;
 }

--- a/assets/css/v2/bus_shelter/alert.scss
+++ b/assets/css/v2/bus_shelter/alert.scss
@@ -103,11 +103,11 @@
 
 .alert-widget--full-body {
   width: 1080px;
-  height: 1640px;
+  height: 1648px;
   background: #ffdd00;
 
   .alert-widget__card {
-    transform: translateY(8px);
+    transform: translateY(10px);
   }
 
   .alert-widget__content {

--- a/assets/css/v2/bus_shelter/body/normal.scss
+++ b/assets/css/v2/bus_shelter/body/normal.scss
@@ -1,24 +1,30 @@
+// body total height: 1648px
+
 .body-normal__main-content {
   position: absolute;
   top: 0px;
   left: 0px;
   width: 1080px;
-  height: 824px;
+  height: 832px;
+  box-shadow: 0px 10px 20px 0px rgba(23, 31, 38, 0.25);
+  z-index: 1;
 }
 
 .body-normal__flex-zone {
   position: absolute;
-  top: 824px;
+  top: 832px;
   left: 0px;
   width: 1080px;
   height: 660px;
-  background-color: #d9d6d0;
+  background-color: rgb(179, 177, 175);
 }
 
 .body-normal__footer {
   position: absolute;
-  top: 1468px;
+  top: 1492px;
   left: 0px;
   width: 1080px;
-  height: 172px;
+  height: 156px;
+  box-shadow: 0px 0px 20px 0px rgba(23, 31, 38, 0.25);
+  z-index: 1;
 }

--- a/assets/css/v2/bus_shelter/body/takeover.scss
+++ b/assets/css/v2/bus_shelter/body/takeover.scss
@@ -10,5 +10,5 @@
   top: 0px;
   left: 0px;
   width: 1080px;
-  height: 1640px;
+  height: 1648px;
 }

--- a/assets/css/v2/bus_shelter/departures.scss
+++ b/assets/css/v2/bus_shelter/departures.scss
@@ -3,5 +3,4 @@
   height: 832px;
   background-color: #e6e4e1;
   padding-top: 8px;
-  // border-bottom: 4px solid #cccbc8;
 }

--- a/assets/css/v2/bus_shelter/departures.scss
+++ b/assets/css/v2/bus_shelter/departures.scss
@@ -1,5 +1,7 @@
 .departures-container {
-  height: 820px;
+  box-sizing: border-box;
+  height: 832px;
   background-color: #e6e4e1;
-  border-bottom: 4px solid #cccbc8;
+  padding-top: 8px;
+  // border-bottom: 4px solid #cccbc8;
 }

--- a/assets/css/v2/bus_shelter/departures/time.scss
+++ b/assets/css/v2/bus_shelter/departures/time.scss
@@ -8,6 +8,10 @@
   &:not(:first-child) {
     margin-top: 16px;
   }
+
+  .departure-time {
+    width: 151px;
+  }
 }
 
 .departure-time {

--- a/assets/css/v2/bus_shelter/departures/time.scss
+++ b/assets/css/v2/bus_shelter/departures/time.scss
@@ -9,7 +9,7 @@
     margin-top: 16px;
   }
 
-  .departure-time {
+  .departure-time:not(.departure-time--timestamp) {
     width: 151px;
   }
 }

--- a/assets/css/v2/bus_shelter/flex/one_large.scss
+++ b/assets/css/v2/bus_shelter/flex/one_large.scss
@@ -1,5 +1,6 @@
 .flex-one-large {
   position: relative;
+  z-index: 2;
 }
 
 .flex-one-large__large {

--- a/assets/css/v2/bus_shelter/flex/one_medium_two_small.scss
+++ b/assets/css/v2/bus_shelter/flex/one_medium_two_small.scss
@@ -1,5 +1,6 @@
 .flex-one-medium-two-small {
   position: relative;
+  z-index: 2;
 }
 
 .flex-one-medium-two-small__left {

--- a/assets/css/v2/bus_shelter/flex/two_medium.scss
+++ b/assets/css/v2/bus_shelter/flex/two_medium.scss
@@ -1,5 +1,6 @@
 .flex-two-medium {
   position: relative;
+  z-index: 2;
 }
 
 .flex-two-medium__left {

--- a/assets/css/v2/bus_shelter/link_footer.scss
+++ b/assets/css/v2/bus_shelter/link_footer.scss
@@ -1,13 +1,13 @@
 .link-footer {
   position: relative;
-  height: 152px;
+  height: 156px;
   background: #d9d6d0;
 }
 
 .link-footer__contents {
   position: absolute;
   left: 48px;
-  top: 22px;
+  top: 24px;
 }
 
 .link-footer__logo {

--- a/assets/css/v2/bus_shelter/screen/normal.scss
+++ b/assets/css/v2/bus_shelter/screen/normal.scss
@@ -10,13 +10,13 @@
   top: 0px;
   left: 0px;
   width: 1080px;
-  height: 280px;
+  height: 272px;
 }
 
 .screen-normal__body {
   position: absolute;
-  top: 280px;
+  top: 272px;
   left: 0px;
   width: 1080px;
-  height: 1640px;
+  height: 1648px;
 }

--- a/assets/css/v2/bus_shelter/screen_container.scss
+++ b/assets/css/v2/bus_shelter/screen_container.scss
@@ -2,4 +2,5 @@
   width: 1080px;
   height: 1920px;
   margin: 0px auto;
+  overflow: hidden;
 }

--- a/assets/css/v2/bus_shelter/subway_status.scss
+++ b/assets/css/v2/bus_shelter/subway_status.scss
@@ -1,7 +1,7 @@
 .subway-status {
   background-color: #e4e6e1;
   border-radius: 16px;
-  box-shadow: 0px 12px 24px 0px #cccbc8;
+  box-shadow: 0px 12px 24px 0px rgba(23, 31, 38, 0.25);
   height: 576px;
   width: 1024px;
 }

--- a/assets/css/v2/gl_eink/departures/time.scss
+++ b/assets/css/v2/gl_eink/departures/time.scss
@@ -24,7 +24,7 @@
 }
 
 .departure-time__text {
-  font-size: 360px;
+  font-size: 272px;
   line-height: 360px;
   font-weight: 800;
 }

--- a/assets/src/components/v2/departures/departure_time.tsx
+++ b/assets/src/components/v2/departures/departure_time.tsx
@@ -31,7 +31,9 @@ const DepartureTime = ({ type, ...data }) => {
     inner = <TimestampDepartureTime {...data} />;
   }
 
-  return <div className={classWithModifier("departure-time", type)}>{inner}</div>;
+  return (
+    <div className={classWithModifier("departure-time", type)}>{inner}</div>
+  );
 };
 
 export default DepartureTime;

--- a/assets/src/components/v2/departures/departure_time.tsx
+++ b/assets/src/components/v2/departures/departure_time.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { classWithModifier } from "Util/util";
 
 const TextDepartureTime = ({ text }) => {
   return <div className="departure-time__text">{text}</div>;
@@ -30,7 +31,7 @@ const DepartureTime = ({ type, ...data }) => {
     inner = <TimestampDepartureTime {...data} />;
   }
 
-  return <div className="departure-time">{inner}</div>;
+  return <div className={classWithModifier("departure-time", type)}>{inner}</div>;
 };
 
 export default DepartureTime;

--- a/lib/screens/v2/widget_instance/departures.ex
+++ b/lib/screens/v2/widget_instance/departures.ex
@@ -114,11 +114,25 @@ defmodule Screens.V2.WidgetInstance.Departures do
         _ -> serialize_time(departure, screen, now)
       end
 
+    crowding =
+      if crowding_compatible?(serialized_time) do
+        serialize_crowding(departure)
+      else
+        nil
+      end
+
     Map.merge(serialized_time, %{
       id: Departure.id(departure),
-      crowding: serialize_crowding(departure)
+      crowding: crowding
     })
   end
+
+  # Timestamps represent a time further in the future (except for CR, which doesn't have crowding)
+  # and can't physically fit on the same row as crowding icons.
+  # All other time representations are compatible.
+  defp crowding_compatible?(serialized_time)
+  defp crowding_compatible?(%{time: %{type: :timestamp}}), do: false
+  defp crowding_compatible?(_), do: true
 
   # credo:disable-for-next-line Credo.Check.Refactor.CyclomaticComplexity
   defp serialize_time(departure, %Screen{app_id: app_id}, now)


### PR DESCRIPTION
**Asana task**: [Updates from departures implementation review](https://app.asana.com/0/1185117109217413/1200480000015510/f)

Changes:
- [x] **Put crowding icons into a consistent column offset from the right by the width of the "ARR/BRD/Now" time div.**
  - [x] **bus shelter**
  - [x] **bus e-ink**
  - [ ] **bus shelter XL (single route)**: I don't think this is a thing anymore?
- [x] **Smaller font size for timestamps on e-ink**
  - [x] **bus e-ink**
  - [x] **GL e-ink**
- [x] **Suppress crowding info on departure rows with a timestamp (HH:MM) time.**
- [x] **GL e-ink: Shorten line between departures to 794px**: :warning: Appears to already be 794px. See [this line](https://github.com/mbta/screens/blob/master/assets/css/v2/gl_eink/departures/time.scss#L12).
- [x] **Shrink bus shelter header by 8px**: This originally called for an 8px bottom padding to be added to the header with the departures list background color, but given that the content below the header isn't always a departures list (e.g. a takeover alert), I decreased the header slot size and increased the main content slot size instead, and added top padding to the departures widget.
  - I also fixed the footer, which had a height greater than its slot height.
- [x] **Update flex zone slot with darker background/"sunken" look.**
  - I also gave the bus shelter screen container element `overflow: hidden` to ensure that the screen is always 1080x1920, and to hide parts of the main content and footer box shadows that are cast on the flex zone.

- [ ] Needs version bump?
