### PR TITLE
feat: Define evergreen content config

### DIFF
--- a/lib/screens/config/v2/bus_shelter.ex
+++ b/lib/screens/config/v2/bus_shelter.ex
@@ -2,22 +2,30 @@ defmodule Screens.Config.V2.BusShelter do
   @moduledoc false
   # credo:disable-for-this-file Credo.Check.Design.DuplicatedCode
 
-  alias Screens.Config.V2.{Alerts, Departures, Footer}
+  alias Screens.Config.V2.{Alerts, Departures, EvergreenContentInstance, Footer}
   alias Screens.Config.V2.Header.CurrentStopId
 
   @type t :: %__MODULE__{
           departures: Departures.t(),
           footer: Footer.t(),
           header: CurrentStopId.t(),
-          alerts: Alerts.t()
+          alerts: Alerts.t(),
+          evergreen_content: list(EvergreenContentInstance.t())
         }
 
   @enforce_keys [:departures, :footer, :header, :alerts]
   defstruct departures: nil,
             footer: nil,
             header: nil,
-            alerts: nil
+            alerts: nil,
+            evergreen_content: []
 
   use Screens.Config.Struct,
-    children: [departures: Departures, footer: Footer, header: CurrentStopId, alerts: Alerts]
+    children: [
+      departures: Departures,
+      footer: Footer,
+      header: CurrentStopId,
+      alerts: Alerts,
+      evergreen_content: {:list, EvergreenContentInstance}
+    ]
 end

--- a/lib/screens/config/v2/evergreen_content_instance.ex
+++ b/lib/screens/config/v2/evergreen_content_instance.ex
@@ -4,18 +4,18 @@ defmodule Screens.Config.V2.EvergreenContentInstance do
   alias Screens.V2.WidgetInstance
 
   @type t :: %__MODULE__{
-          slot_name: WidgetInstance.slot_id(),
+          slot_names: list(WidgetInstance.slot_id()),
           asset_path: String.t(),
           priority: WidgetInstance.priority()
         }
 
-  @enforce_keys ~w[slot_name asset_path priority]a
+  @enforce_keys ~w[slot_names asset_path priority]a
   defstruct @enforce_keys
 
   use Screens.Config.Struct
 
-  defp value_from_json("slot_name", slot_name) do
-    String.to_existing_atom(slot_name)
+  defp value_from_json("slot_names", slot_names) do
+    Enum.map(slot_names, &String.to_existing_atom/1)
   end
 
   defp value_from_json(_, value), do: value

--- a/lib/screens/config/v2/evergreen_content_instance.ex
+++ b/lib/screens/config/v2/evergreen_content_instance.ex
@@ -1,0 +1,24 @@
+defmodule Screens.Config.V2.EvergreenContentInstance do
+  @moduledoc false
+
+  alias Screens.V2.WidgetInstance
+
+  @type t :: %__MODULE__{
+          slot_name: WidgetInstance.slot_id(),
+          asset_path: String.t(),
+          priority: WidgetInstance.priority()
+        }
+
+  @enforce_keys ~w[slot_name asset_path priority]a
+  defstruct @enforce_keys
+
+  use Screens.Config.Struct
+
+  defp value_from_json("slot_name", slot_name) do
+    String.to_existing_atom(slot_name)
+  end
+
+  defp value_from_json(_, value), do: value
+
+  defp value_to_json(_, value), do: value
+end


### PR DESCRIPTION
**Asana task**: [lib/screens/config/v2/evergreen_content_instance.ex](https://app.asana.com/0/1185117109217413/1200625003989515/f)

One common config shape is used for both images and videos. We'll differentiate images from videos further down the request data flow, wherever it makes sense—might be safe to leave that to the frontend since the behavior of the two media formats doesn't really differ as far as the backend is concerned.

No `schedule` field for now--that will be added soon.

- [ ] Needs version bump?
