### PR TITLE
feat: Add backend-defined data refresh to V2 apps

### DIFF
--- a/assets/css/v2/bus_shelter/subway_status.scss
+++ b/assets/css/v2/bus_shelter/subway_status.scss
@@ -39,12 +39,6 @@
   display: inline-block;
 }
 
-.subway-status-row__route-icon {
-  margin-top: 22px;
-  margin-right: 16px;
-  height: 74px;
-}
-
 .subway-status-row__status {
   display: inline-block;
   vertical-align: top;

--- a/assets/src/components/v2/subway_status.tsx
+++ b/assets/src/components/v2/subway_status.tsx
@@ -1,11 +1,11 @@
 import React, { useState, useLayoutEffect, useRef } from "react";
 
 import RoutePill from "Components/v2/departures/route_pill";
-import { classWithModifier, imagePath } from "Util/util";
+import { classWithModifier } from "Util/util";
 
-const GreenLineBIcon = (
+const GreenLineBIcon = () => (
   <svg
-    className="subway-status-row__route-icon"
+    className="subway-status-branch-row__route-icon"
     viewBox="0 0 140 139"
     version="1.1"
     xmlns="http://www.w3.org/2000/svg"
@@ -18,9 +18,9 @@ const GreenLineBIcon = (
   </svg>
 );
 
-const GreenLineCIcon = (
+const GreenLineCIcon = () => (
   <svg
-    className="subway-status-row__route-icon"
+    className="subway-status-branch-row__route-icon"
     viewBox="0 0 140 140"
     version="1.1"
     xmlns="http://www.w3.org/2000/svg"
@@ -40,9 +40,9 @@ const GreenLineCIcon = (
   </svg>
 );
 
-const GreenLineDIcon = (
+const GreenLineDIcon = () => (
   <svg
-    className="subway-status-row__route-icon"
+    className="subway-status-branch-row__route-icon"
     viewBox="0 0 139 139"
     version="1.1"
     xmlns="http://www.w3.org/2000/svg"
@@ -55,9 +55,9 @@ const GreenLineDIcon = (
   </svg>
 );
 
-const GreenLineEIcon = (
+const GreenLineEIcon = () => (
   <svg
-    className="subway-status-row__route-icon"
+    className="subway-status-branch-row__route-icon"
     viewBox="0 0 140 140"
     version="1.1"
     xmlns="http://www.w3.org/2000/svg"
@@ -144,13 +144,10 @@ const SubwayStatusGreenLineMultipleAlertsRow = ({ statuses }) => {
         {statuses.map(([routes, status]) => (
           <div className="subway-status-branch-row__group" key={status}>
             <div className="subway-status-branch-row__group-routes">
-              {routes.map((route) => (
-                <img
-                  className="subway-status-branch-row__route-icon"
-                  src={iconForRoute(route)}
-                  key={route}
-                />
-              ))}
+              {routes.map((route) => {
+                const IconComponent = iconForRoute(route);
+                return <IconComponent key={route} />;
+              })}
             </div>
             <div
               className={classWithModifier(

--- a/assets/src/hooks/v2/use_api_response.tsx
+++ b/assets/src/hooks/v2/use_api_response.tsx
@@ -5,18 +5,17 @@ const MINUTE_IN_MS = 60_000;
 
 interface UseApiResponseArgs {
   id: string;
-  refreshMs?: number;
   failureModeElapsedMs?: number;
 }
 
 const useApiResponse = ({
   id,
-  refreshMs,
   failureModeElapsedMs = MINUTE_IN_MS,
-}) => {
+}: UseApiResponseArgs) => {
   const [apiResponse, setApiResponse] = useState<object | null>(null);
   const [lastSuccess, setLastSuccess] = useState<number>(Date.now());
-  const lastRefresh = document.getElementById("app").dataset.lastRefresh;
+  const { lastRefresh, refreshRate } = document.getElementById("app").dataset;
+  const refreshMs = parseInt(refreshRate, 10) * 1000;
   const apiPath = `/v2/api/screen/${id}?last_refresh=${lastRefresh}`;
 
   const fetchData = async () => {

--- a/lib/screens/v2/screen_data.ex
+++ b/lib/screens/v2/screen_data.ex
@@ -4,9 +4,9 @@ defmodule Screens.V2.ScreenData do
   require Logger
 
   alias Screens.Util
+  alias Screens.V2.ScreenData.Parameters
   alias Screens.V2.Template
   alias Screens.V2.WidgetInstance
-  alias Screens.V2.ScreenData.Parameters
 
   import Screens.V2.Template.Guards
 

--- a/lib/screens/v2/screen_data.ex
+++ b/lib/screens/v2/screen_data.ex
@@ -4,15 +4,14 @@ defmodule Screens.V2.ScreenData do
   require Logger
 
   alias Screens.Util
-  alias Screens.V2.CandidateGenerator
   alias Screens.V2.Template
   alias Screens.V2.WidgetInstance
+  alias Screens.V2.ScreenData.Parameters
 
   import Screens.V2.Template.Guards
 
   @type screen_id :: String.t()
   @type config :: Screens.Config.Screen.t()
-  @type candidate_generator :: module()
   @type candidate_instances :: list(WidgetInstance.t())
   @type selected_instances_map :: %{Template.slot_id() => WidgetInstance.t()}
   @type non_paged_selected_instances_map :: %{Template.non_paged_slot_id() => WidgetInstance.t()}
@@ -22,27 +21,11 @@ defmodule Screens.V2.ScreenData do
             {page_index :: non_neg_integer(), num_pages :: pos_integer()}
         }
 
-  @app_id_to_candidate_generator %{
-    bus_eink_v2: CandidateGenerator.BusEink,
-    bus_shelter_v2: CandidateGenerator.BusShelter,
-    gl_eink_v2: CandidateGenerator.GlEink,
-    solari_v2: CandidateGenerator.Solari,
-    solari_large_v2: CandidateGenerator.SolariLarge
-  }
-
-  @app_id_to_refresh_rate %{
-    bus_eink_v2: 30,
-    bus_shelter_v2: 15,
-    gl_eink_v2: 30,
-    solari_v2: 15,
-    solari_large_v2: 15
-  }
-
   @spec by_screen_id(screen_id()) :: serializable_map()
   def by_screen_id(screen_id) do
     config = get_config(screen_id)
-    candidate_generator = get_candidate_generator(config)
-    refresh_rate = get_refresh_rate(config)
+    candidate_generator = Parameters.get_candidate_generator(config)
+    refresh_rate = Parameters.get_refresh_rate(config)
     screen_template = candidate_generator.screen_template()
 
     candidate_instances =
@@ -59,16 +42,6 @@ defmodule Screens.V2.ScreenData do
   @spec get_config(screen_id()) :: config()
   def get_config(screen_id) do
     Screens.Config.State.screen(screen_id)
-  end
-
-  @spec get_candidate_generator(config()) :: candidate_generator()
-  def get_candidate_generator(%Screens.Config.Screen{app_id: app_id}) do
-    Map.get(@app_id_to_candidate_generator, app_id)
-  end
-
-  @spec get_refresh_rate(config()) :: pos_integer() | nil
-  def get_refresh_rate(%Screens.Config.Screen{app_id: app_id}) do
-    Map.get(@app_id_to_refresh_rate, app_id)
   end
 
   @spec pick_instances(Template.template(), candidate_instances()) ::

--- a/lib/screens/v2/screen_data/parameters.ex
+++ b/lib/screens/v2/screen_data/parameters.ex
@@ -1,0 +1,41 @@
+defmodule Screens.V2.ScreenData.Parameters do
+  @moduledoc false
+
+  alias Screens.V2.CandidateGenerator
+
+  @type candidate_generator :: module()
+
+  @app_id_to_candidate_generator %{
+    bus_eink_v2: CandidateGenerator.BusEink,
+    bus_shelter_v2: CandidateGenerator.BusShelter,
+    gl_eink_v2: CandidateGenerator.GlEink,
+    solari_v2: CandidateGenerator.Solari,
+    solari_large_v2: CandidateGenerator.SolariLarge
+  }
+
+  @app_id_to_refresh_rate %{
+    bus_eink_v2: 30,
+    bus_shelter_v2: 20,
+    gl_eink_v2: 30,
+    solari_v2: 15,
+    solari_large_v2: 15
+  }
+
+  @spec get_candidate_generator(Screens.Config.Screen.t() | atom()) :: candidate_generator()
+  def get_candidate_generator(%Screens.Config.Screen{app_id: app_id}) do
+    get_candidate_generator(app_id)
+  end
+
+  def get_candidate_generator(app_id) do
+    Map.get(@app_id_to_candidate_generator, app_id)
+  end
+
+  @spec get_refresh_rate(Screens.Config.Screen.t() | atom()) :: pos_integer() | nil
+  def get_refresh_rate(%Screens.Config.Screen{app_id: app_id}) do
+    get_refresh_rate(app_id)
+  end
+
+  def get_refresh_rate(app_id) do
+    Map.get(@app_id_to_refresh_rate, app_id)
+  end
+end

--- a/lib/screens_web/controllers/v2/screen_controller.ex
+++ b/lib/screens_web/controllers/v2/screen_controller.ex
@@ -2,6 +2,7 @@ defmodule ScreensWeb.V2.ScreenController do
   use ScreensWeb, :controller
 
   alias Screens.Config.{Screen, State}
+  alias Screens.V2.ScreenData.Parameters
 
   @default_app_id :bus_eink
 
@@ -38,6 +39,7 @@ defmodule ScreensWeb.V2.ScreenController do
       %Screen{app_id: app_id} ->
         conn
         |> assign(:app_id, app_id)
+        |> assign(:refresh_rate, Parameters.get_refresh_rate(app_id))
         |> put_view(ScreensWeb.V2.ScreenView)
         |> put_layout({ScreensWeb.V2.LayoutView, "app.html"})
         |> render("index.html")

--- a/lib/screens_web/templates/v2/screen/index.html.eex
+++ b/lib/screens_web/templates/v2/screen/index.html.eex
@@ -1,1 +1,6 @@
-<div id="app" data-last-refresh="<%= @last_refresh %>" data-environment-name="<%= @environment_name %>"></div>
+<div
+  id="app"
+  data-last-refresh="<%= @last_refresh %>"
+  data-environment-name="<%= @environment_name %>"
+  data-refresh-rate="<%= @refresh_rate %>"
+></div>


### PR DESCRIPTION
**Asana task**: [Update bus shelter data refresh rate to every 20 seconds](https://app.asana.com/0/1185117109217413/1200812598281098/f)

(And change the bus shelter app's refresh rate to 20s, as requested)

V2 app refresh rates are defined in a module on the backend and the appropriate one is passed to the client app via a data attribute, similar to the `lastRefresh` value.

- [ ] Needs version bump?
