### PR TITLE
fix: Subway status branch icons for both single & multiple GL alert row types

### DIFF
--- a/assets/css/v2/bus_shelter/subway_status.scss
+++ b/assets/css/v2/bus_shelter/subway_status.scss
@@ -39,6 +39,12 @@
   display: inline-block;
 }
 
+.subway-status-row__route-icon {
+  margin-top: 22px;
+  margin-right: 16px;
+  height: 74px;
+}
+
 .subway-status-row__status {
   display: inline-block;
   vertical-align: top;


### PR DESCRIPTION
**Asana task**: ad hoc

My previous fix used the wrong styles for the branch icon in a single-alert GL status row, and also passed a react component as a child of a div rather than actually rendering that component (`{Component}` vs `<Component />`).
This fixes that (and adds type declarations for everything, because I wanted to make sure nothing else was broken).

- [ ] Needs version bump?
