### PR TITLE
fix: Remove timeouts from all async_stream calls

### DIFF
--- a/lib/screens/dup_screen_data.ex
+++ b/lib/screens/dup_screen_data.ex
@@ -143,7 +143,7 @@ defmodule Screens.DupScreenData do
 
   defp fetch_and_interpret_alerts(%Dup.Departures{sections: sections}) do
     sections
-    |> Task.async_stream(&fetch_and_interpret_alert/1)
+    |> Task.async_stream(&fetch_and_interpret_alert/1, timeout: :infinity)
     |> Enum.map(fn {:ok, data} -> data end)
     |> Enum.into(%{})
   end

--- a/lib/screens/dup_screen_data/request.ex
+++ b/lib/screens/dup_screen_data/request.ex
@@ -54,7 +54,7 @@ defmodule Screens.DupScreenData.Request do
   def fetch_sections_data([_, _] = sections_with_alerts, current_time) do
     sections_data =
       sections_with_alerts
-      |> Task.async_stream(&fetch_section_data(&1, 2, current_time))
+      |> Task.async_stream(&fetch_section_data(&1, 2, current_time), timeout: :infinity)
       |> Enum.map(fn {:ok, data} -> data end)
 
     if Enum.any?(sections_data, fn data -> data == :error end) do

--- a/lib/screens/v2/candidate_generator/bus_eink.ex
+++ b/lib/screens/v2/candidate_generator/bus_eink.ex
@@ -47,7 +47,7 @@ defmodule Screens.V2.CandidateGenerator.BusEink do
       fn -> footer_instances(config) end,
       fn -> placeholder_instances() end
     ]
-    |> Task.async_stream(& &1.(), ordered: false)
+    |> Task.async_stream(& &1.(), ordered: false, timeout: :infinity)
     |> Enum.flat_map(fn {:ok, instances} -> instances end)
   end
 

--- a/lib/screens/v2/candidate_generator/bus_shelter.ex
+++ b/lib/screens/v2/candidate_generator/bus_shelter.ex
@@ -61,7 +61,7 @@ defmodule Screens.V2.CandidateGenerator.BusShelter do
       fn -> evergreen_content_instances(config) end,
       fn -> survey_instances(config) end
     ]
-    |> Task.async_stream(& &1.(), ordered: false)
+    |> Task.async_stream(& &1.(), ordered: false, timeout: :infinity)
     |> Enum.flat_map(fn {:ok, instances} -> instances end)
   end
 

--- a/lib/screens/v2/candidate_generator/gl_eink.ex
+++ b/lib/screens/v2/candidate_generator/gl_eink.ex
@@ -49,7 +49,7 @@ defmodule Screens.V2.CandidateGenerator.GlEink do
       fn -> placeholder_instances() end,
       fn -> line_map_instances(config) end
     ]
-    |> Task.async_stream(& &1.(), ordered: false)
+    |> Task.async_stream(& &1.(), ordered: false, timeout: :infinity)
     |> Enum.flat_map(fn {:ok, instances} -> instances end)
   end
 

--- a/lib/screens/v2/candidate_generator/solari.ex
+++ b/lib/screens/v2/candidate_generator/solari.ex
@@ -33,7 +33,7 @@ defmodule Screens.V2.CandidateGenerator.Solari do
       fn -> departures_instances_fn.(config) end,
       fn -> placeholder_instances() end
     ]
-    |> Task.async_stream(& &1.(), ordered: false)
+    |> Task.async_stream(& &1.(), ordered: false, timeout: :infinity)
     |> Enum.flat_map(fn {:ok, instances} -> instances end)
   end
 

--- a/lib/screens/v2/candidate_generator/solari_large.ex
+++ b/lib/screens/v2/candidate_generator/solari_large.ex
@@ -33,7 +33,7 @@ defmodule Screens.V2.CandidateGenerator.SolariLarge do
       fn -> departures_instances_fn.(config) end,
       fn -> placeholder_instances() end
     ]
-    |> Task.async_stream(& &1.(), ordered: false)
+    |> Task.async_stream(& &1.(), ordered: false, timeout: :infinity)
     |> Enum.flat_map(fn {:ok, instances} -> instances end)
   end
 

--- a/lib/screens/v2/candidate_generator/widgets/departures.ex
+++ b/lib/screens/v2/candidate_generator/widgets/departures.ex
@@ -16,7 +16,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.Departures do
       when app in [BusEink, BusShelter, GlEink, SolariLarge, Solari] do
     sections_data =
       sections
-      |> Task.async_stream(fetch_section_departures_fn)
+      |> Task.async_stream(fetch_section_departures_fn, timeout: :infinity)
       |> Enum.map(fn {:ok, data} -> data end)
 
     departures_instance =


### PR DESCRIPTION
**Asana task**: ad hoc

The functions invoked in these tasks always return—no need to add an extra layer of timeouts to confuse things.

- [ ] Needs version bump?
