### PR TITLE
fix: Subway status visual fixes

### DIFF
--- a/assets/css/v2/bus_shelter/subway_status.scss
+++ b/assets/css/v2/bus_shelter/subway_status.scss
@@ -58,19 +58,26 @@
   font-weight: 600;
   font-size: 48px;
   line-height: 74px;
+
+  overflow: hidden;
+  text-overflow: clip;
+  width: 808px;
+
+  .subway-status-row--done & {
+    white-space: nowrap;
+  }
 }
 
 .subway-status-row__location {
   display: inline-block;
-  vertical-align: top;
-  margin-top: 39px;
+  vertical-align: middle;
   margin-left: 12px;
 
   color: #171f26;
   font-family: Inter;
   font-weight: 500;
   font-size: 32px;
-  line-height: 48px;
+  line-height: 32px;
 }
 
 .subway-status-branch-row__route {
@@ -94,6 +101,14 @@
 
   margin-top: 22px;
   margin-bottom: 22px;
+
+  overflow: hidden;
+  text-overflow: clip;
+  width: 808px;
+
+  .subway-status-row--done & {
+    white-space: nowrap;
+  }
 }
 
 .subway-status-branch-row__group {
@@ -105,6 +120,7 @@
   display: inline-block;
   vertical-align: top;
   margin-right: 16px;
+  height: 74px;
 }
 
 .subway-status-branch-row__group-status {

--- a/assets/css/v2/bus_shelter/subway_status.scss
+++ b/assets/css/v2/bus_shelter/subway_status.scss
@@ -1,9 +1,11 @@
 .subway-status {
+  position: relative;
   background-color: #e4e6e1;
   border-radius: 16px;
   box-shadow: 0px 12px 24px 0px rgba(23, 31, 38, 0.25);
   height: 576px;
   width: 1024px;
+  overflow: hidden;
 }
 
 .subway-status-body {
@@ -124,12 +126,11 @@
 }
 
 .subway-status-footer {
-  position: relative;
+  position: absolute;
+  bottom: 0;
   background-color: #737373;
-  width: 1024px;
+  width: 100%;
   height: 80px;
-
-  border-radius: 0 0 16px 16px;
 }
 
 .subway-status-footer__link {

--- a/assets/src/components/v2/subway_status.tsx
+++ b/assets/src/components/v2/subway_status.tsx
@@ -119,6 +119,7 @@ const SubwayStatusNormalRow: ComponentType<SubwayStatusNormalRowProps> = ({
 }) => {
   const [abbreviate, setAbbreviate] = useState(false);
   const [dropTimes, setDropTimes] = useState(false);
+  const [doneSizing, setDoneSizing] = useState(false);
   const ref = useRef<HTMLElement>(null);
 
   useLayoutEffect(() => {
@@ -126,9 +127,12 @@ const SubwayStatusNormalRow: ComponentType<SubwayStatusNormalRowProps> = ({
       if (ref.current.clientHeight > 122) {
         if (abbreviate && !dropTimes) {
           setDropTimes(true);
+          setDoneSizing(true);
         } else {
           setAbbreviate(true);
         }
+      } else {
+        setDoneSizing(true);
       }
     }
   });
@@ -141,8 +145,12 @@ const SubwayStatusNormalRow: ComponentType<SubwayStatusNormalRowProps> = ({
     status = "Delays";
   }
 
+  const rowClassName = doneSizing
+    ? classWithModifier("subway-status-row", "done")
+    : "subway-status-row";
+
   return (
-    <div className="subway-status-row" ref={ref}>
+    <div className={rowClassName} ref={ref}>
       <div className="subway-status-row__route">
         <RoutePill {...route} />
       </div>
@@ -154,44 +162,76 @@ const SubwayStatusNormalRow: ComponentType<SubwayStatusNormalRowProps> = ({
           />
         </div>
       )}
-      <div className="subway-status-row__status">{status}</div>
-      {location && (
-        <div className="subway-status-row__location">
-          {abbreviate ? location.abbrev : location.full}
-        </div>
-      )}
+      <div className="subway-status-row__status">
+        {status}
+        {location && (
+          <div className="subway-status-row__location">
+            {abbreviate ? location.abbrev : location.full}
+          </div>
+        )}
+      </div>
     </div>
   );
 };
 
 interface GlMultipleProps {
-  statuses: [IconRouteId[], string][];
+  statuses: [IconRouteId[] | null, string][];
 }
 
 const SubwayStatusGreenLineMultipleAlertsRow: ComponentType<GlMultipleProps> =
   ({ statuses }) => {
+    const [dropTimes, setDropTimes] = useState(false);
+    const [doneSizing, setDoneSizing] = useState(false);
+    const ref = useRef<HTMLElement>(null);
+
     const includesStopClosure = statuses.some(([_, status]) =>
       status.toLowerCase().startsWith("bypassing")
     );
     const modifier = includesStopClosure ? "small" : "normal";
 
+    useLayoutEffect(() => {
+      if (ref.current) {
+        if (ref.current.clientHeight > 122) {
+          if (!dropTimes) {
+            setDropTimes(true);
+            setDoneSizing(true);
+          }
+        } else {
+          setDoneSizing(true);
+        }
+      }
+    });
+
+    if (dropTimes) {
+      statuses = statuses.map(([routes, status]) => [
+        routes,
+        status.startsWith("Delays") ? "Delays" : status,
+      ]);
+    }
+
+    const rowClassName = doneSizing
+      ? classWithModifier("subway-status-row", "done")
+      : "subway-status-row";
+
     return (
-      <div className="subway-status-row">
+      <div className={rowClassName} ref={ref}>
         <div className="subway-status-branch-row__route">
           <RoutePill type="text" color="green" text="GL" />
         </div>
         <div className="subway-status-branch-row__groups">
           {statuses.map(([routes, status]) => (
             <div className="subway-status-branch-row__group" key={status}>
-              <div className="subway-status-branch-row__group-routes">
-                {routes.map((route) => (
-                  <IconForRoute
-                    className="subway-status-branch-row__route-icon"
-                    routeId={route}
-                    key={route}
-                  />
-                ))}
-              </div>
+              {routes && (
+                <div className="subway-status-branch-row__group-routes">
+                  {routes.map((route) => (
+                    <IconForRoute
+                      className="subway-status-branch-row__route-icon"
+                      routeId={route}
+                      key={route}
+                    />
+                  ))}
+                </div>
+              )}
               <div
                 className={classWithModifier(
                   "subway-status-branch-row__group-status",

--- a/lib/screens/v2/widget_instance/subway_status.ex
+++ b/lib/screens/v2/widget_instance/subway_status.ex
@@ -507,7 +507,7 @@ defmodule Screens.V2.WidgetInstance.SubwayStatus do
     statuses_by_route
     |> Enum.flat_map(fn {route, statuses} -> Enum.map(statuses, fn s -> {route, s} end) end)
     |> Enum.group_by(fn {_route, status} -> status end, fn {route, _status} -> route end)
-    |> Enum.map(fn {status, routes} -> [routes, status] end)
+    |> Enum.map(fn {status, routes} -> [Enum.uniq(routes), status] end)
     |> Enum.sort_by(fn [[first_route | _other_routes], _status] -> first_route end)
   end
 
@@ -558,10 +558,7 @@ defmodule Screens.V2.WidgetInstance.SubwayStatus do
 
       _ ->
         # If there are multiple alerts on the GL trunk, log it and serialize the count
-        _ =
-          Logger.info(
-            "[subway_status_multiple_alerts] route=#{"Green-Trunk"} count=#{alert_count}"
-          )
+        _ = Logger.info("[subway_status_multiple_alerts] route=Green-Trunk count=#{alert_count}")
 
         %{
           type: :single,
@@ -588,10 +585,7 @@ defmodule Screens.V2.WidgetInstance.SubwayStatus do
 
       _ ->
         # One GL trunk alert and 2+ GL branch alerts
-        _ =
-          Logger.info(
-            "[subway_status_multiple_alerts] route=#{"Green-Trunk"} count=#{alert_count}"
-          )
+        _ = Logger.info("[subway_status_multiple_alerts] route=Green-Trunk count=#{alert_count}")
 
         %{
           type: :single,


### PR DESCRIPTION
**Asana task**: [Subway status: prevent text overflows from affecting other rows](https://app.asana.com/0/1185117109217413/1200831960721500/f) | [Subway status: drop delay times in GL row](https://app.asana.com/0/1185117109217413/1200663189183711/f) | [Subway status: multiple GL branch disruptions overflow row, even with all shortening measures](https://app.asana.com/0/1185117109217413/1200831960721494/f)

Overall this PR makes some changes to prevent rows from wrapping, in favor of getting clipped at the end of the line.

I also fixed the client to handle non-branch GL statuses, where the list of branches is `null`, and made sure the list of branches for each status doesn't contain duplicates.

Commit messages describe the changes in detail.

- [ ] Needs version bump?
