### PR TITLE
test: try disabling vendor logging to see if it fixes timeouts

### DIFF
--- a/lib/screens/application.ex
+++ b/lib/screens/application.ex
@@ -16,12 +16,8 @@ defmodule Screens.Application do
       # {Screens.Worker, arg},
       Screens.Config.State.Supervisor,
       Screens.SignsUiConfig.State.Supervisor,
-      Screens.GdsData.Supervisor,
-      Screens.MercuryData.Supervisor,
       :hackney_pool.child_spec(:ex_aws_pool, []),
-      :hackney_pool.child_spec(:api_v3_pool, []),
-      :hackney_pool.child_spec(:gds_api_pool, []),
-      :hackney_pool.child_spec(:mercury_api_pool, [])
+      :hackney_pool.child_spec(:api_v3_pool, [])
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html


### PR DESCRIPTION
**Asana task**: ad hoc

Testing out whether GDS logging is somehow causing problems for all HTTP requests. (e.g. maybe there are too many GDS screens now such that it takes more than a minute to do all of the logging we do every minute and it gets backed up? We use a separate Hackney pool for GDS and the APIv3 for that reason, but it's not inconceivable that some other resource is getting exhausted...)