### PR TITLE
feat: Evergreen content for EInk screens

### DIFF
--- a/assets/css/bus_eink_v2.scss
+++ b/assets/css/bus_eink_v2.scss
@@ -17,6 +17,8 @@
 @import "v2/bus_eink/departures/crowding";
 @import "v2/bus_eink/departures/alerts";
 
+@import "v2/bus_eink/evergreen/image";
+
 body {
   margin: 0px;
 }

--- a/assets/css/gl_eink_v2.scss
+++ b/assets/css/gl_eink_v2.scss
@@ -15,6 +15,8 @@
 @import "v2/gl_eink/departures/alerts";
 @import "v2/gl_eink/line_map";
 
+@import "v2/gl_eink/evergreen/image";
+
 body {
   margin: 0px;
 }

--- a/assets/css/v2/bus_eink/evergreen/image.scss
+++ b/assets/css/v2/bus_eink/evergreen/image.scss
@@ -1,0 +1,95 @@
+.evergreen-content-image__container {
+    background-color: #e4e6e1;
+    overflow: hidden;
+  }
+  
+  .flex-one-medium-two-small__left,
+  .flex-two-medium__left,
+  .flex-two-medium__right {
+    .evergreen-content-image__container {
+      border-radius: 16px;
+      box-shadow: 0px 12px 24px 0px rgba(23, 31, 38, 0.25);
+      width: 480px;
+      height: 580px;
+    }
+  
+    .evergreen-content-image__image {
+      width: 480px;
+      height: 580px;
+    }
+  }
+  
+  .flex-one-large__large {
+    .evergreen-content-image__container {
+      border-radius: 16px;
+      box-shadow: 0px 12px 24px 0px rgba(23, 31, 38, 0.25);
+      width: 1024px;
+      height: 576px;
+    }
+  
+    .evergreen-content-image__image {
+      width: 1024px;
+      height: 576px;
+    }
+  }
+  
+  .body-normal__main-content {
+    .evergreen-content-image__container {
+      width: 1080px;
+      height: 832px;
+    }
+  
+    .evergreen-content-image__image {
+      width: 1080px;
+      height: 832px;
+    }
+  }
+  
+  .body-normal__footer {
+    .evergreen-content-image__container {
+      width: 1080px;
+      height: 156px;
+    }
+  
+    .evergreen-content-image__image {
+      width: 1080px;
+      height: 156px;
+    }
+  }
+  
+  .body-takeover__full-body {
+    .evergreen-content-image__container {
+      width: 1080px;
+      height: 1648px;
+    }
+  
+    .evergreen-content-image__image {
+      width: 1080px;
+      height: 1648px;
+    }
+  }
+  
+  .screen-normal__header {
+    .evergreen-content-image__container {
+      width: 1080px;
+      height: 272px;
+    }
+  
+    .evergreen-content-image__image {
+      width: 1080px;
+      height: 272px;
+    }
+  }
+  
+  .screen-takeover__full-screen {
+    .evergreen-content-image__container {
+      width: 1080px;
+      height: 1920px;
+    }
+  
+    .evergreen-content-image__image {
+      width: 1080px;
+      height: 1920px;
+    }
+  }
+  

--- a/assets/css/v2/bus_eink/evergreen/image.scss
+++ b/assets/css/v2/bus_eink/evergreen/image.scss
@@ -1,11 +1,8 @@
 .evergreen-content-image__container {
-  background-color: #e4e6e1;
   overflow: hidden;
 }
 
-.flex-one-medium-two-small__left,
-.flex-two-medium__left,
-.flex-two-medium__right {
+.screen-normal__medium-flex {
   .evergreen-content-image__container {
     border-radius: 16px;
     box-shadow: 0px 12px 24px 0px rgba(23, 31, 38, 0.25);
@@ -19,21 +16,7 @@
   }
 }
 
-.flex-one-large__large {
-  .evergreen-content-image__container {
-    border-radius: 16px;
-    box-shadow: 0px 12px 24px 0px rgba(23, 31, 38, 0.25);
-    width: 1200px;
-    height: 1312px;
-  }
-
-  .evergreen-content-image__image {
-    width: 1200px;
-    height: 1312px;
-  }
-}
-
-.body-normal__main-content {
+.screen-normal__main-content {
   .evergreen-content-image__container {
     width: 1200px;
     height: 1312px;
@@ -45,7 +28,7 @@
   }
 }
 
-.body-normal__footer {
+.screen-normal__footer {
   .evergreen-content-image__container {
     width: 1200px;
     height: 436px;
@@ -54,18 +37,6 @@
   .evergreen-content-image__image {
     width: 1200px;
     height: 436px;
-  }
-}
-
-.body-takeover__full-body {
-  .evergreen-content-image__container {
-    width: 1200px;
-    height: 1600px;
-  }
-
-  .evergreen-content-image__image {
-    width: 1200px;
-    height: 1600px;
   }
 }
 

--- a/assets/css/v2/bus_eink/evergreen/image.scss
+++ b/assets/css/v2/bus_eink/evergreen/image.scss
@@ -4,8 +4,7 @@
 
 .screen-normal__medium-flex {
   .evergreen-content-image__container {
-    border-radius: 16px;
-    box-shadow: 0px 12px 24px 0px rgba(23, 31, 38, 0.25);
+    border-radius: 32px;
     width: 1200px;
     height: 1164px;
   }

--- a/assets/css/v2/bus_eink/evergreen/image.scss
+++ b/assets/css/v2/bus_eink/evergreen/image.scss
@@ -1,95 +1,94 @@
 .evergreen-content-image__container {
-    background-color: #e4e6e1;
-    overflow: hidden;
+  background-color: #e4e6e1;
+  overflow: hidden;
+}
+
+.flex-one-medium-two-small__left,
+.flex-two-medium__left,
+.flex-two-medium__right {
+  .evergreen-content-image__container {
+    border-radius: 16px;
+    box-shadow: 0px 12px 24px 0px rgba(23, 31, 38, 0.25);
+    width: 1200px;
+    height: 1164px;
   }
-  
-  .flex-one-medium-two-small__left,
-  .flex-two-medium__left,
-  .flex-two-medium__right {
-    .evergreen-content-image__container {
-      border-radius: 16px;
-      box-shadow: 0px 12px 24px 0px rgba(23, 31, 38, 0.25);
-      width: 480px;
-      height: 580px;
-    }
-  
-    .evergreen-content-image__image {
-      width: 480px;
-      height: 580px;
-    }
+
+  .evergreen-content-image__image {
+    width: 1200px;
+    height: 1164px;
   }
-  
-  .flex-one-large__large {
-    .evergreen-content-image__container {
-      border-radius: 16px;
-      box-shadow: 0px 12px 24px 0px rgba(23, 31, 38, 0.25);
-      width: 1024px;
-      height: 576px;
-    }
-  
-    .evergreen-content-image__image {
-      width: 1024px;
-      height: 576px;
-    }
+}
+
+.flex-one-large__large {
+  .evergreen-content-image__container {
+    border-radius: 16px;
+    box-shadow: 0px 12px 24px 0px rgba(23, 31, 38, 0.25);
+    width: 1200px;
+    height: 1312px;
   }
-  
-  .body-normal__main-content {
-    .evergreen-content-image__container {
-      width: 1080px;
-      height: 832px;
-    }
-  
-    .evergreen-content-image__image {
-      width: 1080px;
-      height: 832px;
-    }
+
+  .evergreen-content-image__image {
+    width: 1200px;
+    height: 1312px;
   }
-  
-  .body-normal__footer {
-    .evergreen-content-image__container {
-      width: 1080px;
-      height: 156px;
-    }
-  
-    .evergreen-content-image__image {
-      width: 1080px;
-      height: 156px;
-    }
+}
+
+.body-normal__main-content {
+  .evergreen-content-image__container {
+    width: 1200px;
+    height: 1312px;
   }
-  
-  .body-takeover__full-body {
-    .evergreen-content-image__container {
-      width: 1080px;
-      height: 1648px;
-    }
-  
-    .evergreen-content-image__image {
-      width: 1080px;
-      height: 1648px;
-    }
+
+  .evergreen-content-image__image {
+    width: 1200px;
+    height: 1312px;
   }
-  
-  .screen-normal__header {
-    .evergreen-content-image__container {
-      width: 1080px;
-      height: 272px;
-    }
-  
-    .evergreen-content-image__image {
-      width: 1080px;
-      height: 272px;
-    }
+}
+
+.body-normal__footer {
+  .evergreen-content-image__container {
+    width: 1200px;
+    height: 436px;
   }
-  
-  .screen-takeover__full-screen {
-    .evergreen-content-image__container {
-      width: 1080px;
-      height: 1920px;
-    }
-  
-    .evergreen-content-image__image {
-      width: 1080px;
-      height: 1920px;
-    }
+
+  .evergreen-content-image__image {
+    width: 1200px;
+    height: 436px;
   }
-  
+}
+
+.body-takeover__full-body {
+  .evergreen-content-image__container {
+    width: 1200px;
+    height: 1600px;
+  }
+
+  .evergreen-content-image__image {
+    width: 1200px;
+    height: 1600px;
+  }
+}
+
+.screen-normal__header {
+  .evergreen-content-image__container {
+    width: 1200px;
+    height: 288px;
+  }
+
+  .evergreen-content-image__image {
+    width: 1200px;
+    height: 288px;
+  }
+}
+
+.screen-takeover__full-screen {
+  .evergreen-content-image__container {
+    width: 1200px;
+    height: 3200px;
+  }
+
+  .evergreen-content-image__image {
+    width: 1200px;
+    height: 3200px;
+  }
+}

--- a/assets/css/v2/gl_eink/evergreen/image.scss
+++ b/assets/css/v2/gl_eink/evergreen/image.scss
@@ -9,13 +9,13 @@
     .evergreen-content-image__container {
       border-radius: 16px;
       box-shadow: 0px 12px 24px 0px rgba(23, 31, 38, 0.25);
-      width: 480px;
-      height: 580px;
+      width: 1200px;
+      height: 1164px;
     }
   
     .evergreen-content-image__image {
-      width: 480px;
-      height: 580px;
+      width: 1200px;
+      height: 1164px;
     }
   }
   
@@ -23,73 +23,73 @@
     .evergreen-content-image__container {
       border-radius: 16px;
       box-shadow: 0px 12px 24px 0px rgba(23, 31, 38, 0.25);
-      width: 1024px;
-      height: 576px;
+      width: 1200px;
+      height: 1312px;
     }
   
     .evergreen-content-image__image {
-      width: 1024px;
-      height: 576px;
+      width: 1200px;
+      height: 1312px;
     }
   }
   
   .body-normal__main-content {
     .evergreen-content-image__container {
-      width: 1080px;
-      height: 832px;
+      width: 1200px;
+      height: 1312px;
     }
   
     .evergreen-content-image__image {
-      width: 1080px;
-      height: 832px;
+      width: 1200px;
+      height: 1312px;
     }
   }
   
   .body-normal__footer {
     .evergreen-content-image__container {
-      width: 1080px;
-      height: 156px;
+      width: 1200px;
+      height: 436px;
     }
   
     .evergreen-content-image__image {
-      width: 1080px;
-      height: 156px;
+      width: 1200px;
+      height: 436px;
     }
   }
   
   .body-takeover__full-body {
     .evergreen-content-image__container {
-      width: 1080px;
-      height: 1648px;
+      width: 1200px;
+      height: 1600px;
     }
   
     .evergreen-content-image__image {
-      width: 1080px;
-      height: 1648px;
+      width: 1200px;
+      height: 1600px;
     }
   }
   
   .screen-normal__header {
     .evergreen-content-image__container {
-      width: 1080px;
-      height: 272px;
+      width: 1200px;
+      height: 288px;
     }
   
     .evergreen-content-image__image {
-      width: 1080px;
-      height: 272px;
+      width: 1200px;
+      height: 288px;
     }
   }
   
   .screen-takeover__full-screen {
     .evergreen-content-image__container {
-      width: 1080px;
-      height: 1920px;
+      width: 1200px;
+      height: 3200px;
     }
   
     .evergreen-content-image__image {
-      width: 1080px;
-      height: 1920px;
+      width: 1200px;
+      height: 3200px;
     }
   }
   

--- a/assets/css/v2/gl_eink/evergreen/image.scss
+++ b/assets/css/v2/gl_eink/evergreen/image.scss
@@ -1,0 +1,95 @@
+.evergreen-content-image__container {
+    background-color: #e4e6e1;
+    overflow: hidden;
+  }
+  
+  .flex-one-medium-two-small__left,
+  .flex-two-medium__left,
+  .flex-two-medium__right {
+    .evergreen-content-image__container {
+      border-radius: 16px;
+      box-shadow: 0px 12px 24px 0px rgba(23, 31, 38, 0.25);
+      width: 480px;
+      height: 580px;
+    }
+  
+    .evergreen-content-image__image {
+      width: 480px;
+      height: 580px;
+    }
+  }
+  
+  .flex-one-large__large {
+    .evergreen-content-image__container {
+      border-radius: 16px;
+      box-shadow: 0px 12px 24px 0px rgba(23, 31, 38, 0.25);
+      width: 1024px;
+      height: 576px;
+    }
+  
+    .evergreen-content-image__image {
+      width: 1024px;
+      height: 576px;
+    }
+  }
+  
+  .body-normal__main-content {
+    .evergreen-content-image__container {
+      width: 1080px;
+      height: 832px;
+    }
+  
+    .evergreen-content-image__image {
+      width: 1080px;
+      height: 832px;
+    }
+  }
+  
+  .body-normal__footer {
+    .evergreen-content-image__container {
+      width: 1080px;
+      height: 156px;
+    }
+  
+    .evergreen-content-image__image {
+      width: 1080px;
+      height: 156px;
+    }
+  }
+  
+  .body-takeover__full-body {
+    .evergreen-content-image__container {
+      width: 1080px;
+      height: 1648px;
+    }
+  
+    .evergreen-content-image__image {
+      width: 1080px;
+      height: 1648px;
+    }
+  }
+  
+  .screen-normal__header {
+    .evergreen-content-image__container {
+      width: 1080px;
+      height: 272px;
+    }
+  
+    .evergreen-content-image__image {
+      width: 1080px;
+      height: 272px;
+    }
+  }
+  
+  .screen-takeover__full-screen {
+    .evergreen-content-image__container {
+      width: 1080px;
+      height: 1920px;
+    }
+  
+    .evergreen-content-image__image {
+      width: 1080px;
+      height: 1920px;
+    }
+  }
+  

--- a/assets/css/v2/gl_eink/evergreen/image.scss
+++ b/assets/css/v2/gl_eink/evergreen/image.scss
@@ -1,95 +1,77 @@
 .evergreen-content-image__container {
-    background-color: #e4e6e1;
-    overflow: hidden;
+  overflow: hidden;
+}
+
+.screen-normal__medium-flex {
+  .evergreen-content-image__container {
+    border-radius: 16px;
+    box-shadow: 0px 12px 24px 0px rgba(23, 31, 38, 0.25);
+    width: 1200px;
+    height: 1164px;
   }
-  
-  .flex-one-medium-two-small__left,
-  .flex-two-medium__left,
-  .flex-two-medium__right {
-    .evergreen-content-image__container {
-      border-radius: 16px;
-      box-shadow: 0px 12px 24px 0px rgba(23, 31, 38, 0.25);
-      width: 1200px;
-      height: 1164px;
-    }
-  
-    .evergreen-content-image__image {
-      width: 1200px;
-      height: 1164px;
-    }
+
+  .evergreen-content-image__image {
+    width: 1200px;
+    height: 1164px;
   }
-  
-  .flex-one-large__large {
-    .evergreen-content-image__container {
-      border-radius: 16px;
-      box-shadow: 0px 12px 24px 0px rgba(23, 31, 38, 0.25);
-      width: 1200px;
-      height: 1312px;
-    }
-  
-    .evergreen-content-image__image {
-      width: 1200px;
-      height: 1312px;
-    }
+}
+
+.screen-normal__main-content {
+  .evergreen-content-image__container {
+    width: 824px;
+    height: 1312px;
   }
-  
-  .body-normal__main-content {
-    .evergreen-content-image__container {
-      width: 1200px;
-      height: 1312px;
-    }
-  
-    .evergreen-content-image__image {
-      width: 1200px;
-      height: 1312px;
-    }
+
+  .evergreen-content-image__image {
+    width: 824px;
+    height: 1312px;
   }
-  
-  .body-normal__footer {
-    .evergreen-content-image__container {
-      width: 1200px;
-      height: 436px;
-    }
-  
-    .evergreen-content-image__image {
-      width: 1200px;
-      height: 436px;
-    }
+}
+
+.screen-normal__footer {
+  .evergreen-content-image__container {
+    width: 1200px;
+    height: 436px;
   }
-  
-  .body-takeover__full-body {
-    .evergreen-content-image__container {
-      width: 1200px;
-      height: 1600px;
-    }
-  
-    .evergreen-content-image__image {
-      width: 1200px;
-      height: 1600px;
-    }
+
+  .evergreen-content-image__image {
+    width: 1200px;
+    height: 436px;
   }
-  
-  .screen-normal__header {
-    .evergreen-content-image__container {
-      width: 1200px;
-      height: 288px;
-    }
-  
-    .evergreen-content-image__image {
-      width: 1200px;
-      height: 288px;
-    }
+}
+
+.screen-normal__header {
+  .evergreen-content-image__container {
+    width: 1200px;
+    height: 288px;
   }
-  
-  .screen-takeover__full-screen {
-    .evergreen-content-image__container {
-      width: 1200px;
-      height: 3200px;
-    }
-  
-    .evergreen-content-image__image {
-      width: 1200px;
-      height: 3200px;
-    }
+
+  .evergreen-content-image__image {
+    width: 1200px;
+    height: 288px;
   }
-  
+}
+
+.screen-takeover__full-screen {
+  .evergreen-content-image__container {
+    width: 1200px;
+    height: 3200px;
+  }
+
+  .evergreen-content-image__image {
+    width: 1200px;
+    height: 3200px;
+  }
+}
+
+.screen-normal__left-sidebar {
+  .evergreen-content-image__container {
+    width: 376px;
+    height: 1312px;
+  }
+
+  .evergreen-content-image__image {
+    width: 376px;
+    height: 1312px;
+  }
+}

--- a/assets/css/v2/gl_eink/evergreen/image.scss
+++ b/assets/css/v2/gl_eink/evergreen/image.scss
@@ -4,8 +4,7 @@
 
 .screen-normal__medium-flex {
   .evergreen-content-image__container {
-    border-radius: 16px;
-    box-shadow: 0px 12px 24px 0px rgba(23, 31, 38, 0.25);
+    border-radius: 32px;
     width: 1200px;
     height: 1164px;
   }

--- a/assets/src/apps/v2/bus_eink.tsx
+++ b/assets/src/apps/v2/bus_eink.tsx
@@ -15,6 +15,7 @@ import Placeholder from "Components/v2/placeholder";
 import NormalHeader from "Components/v2/eink/normal_header";
 import FareInfoFooter from "Components/v2/eink/fare_info_footer";
 import NormalDepartures from "Components/v2/departures/normal_departures";
+import EvergreenContent from "Components/v2/evergreen_content";
 
 const TYPE_TO_COMPONENT = {
   normal: NormalScreen,
@@ -23,6 +24,7 @@ const TYPE_TO_COMPONENT = {
   fare_info_footer: FareInfoFooter,
   normal_header: NormalHeader,
   departures: NormalDepartures,
+  evergreen_content: EvergreenContent
 };
 
 const App = (): JSX.Element => {

--- a/assets/src/apps/v2/gl_eink.tsx
+++ b/assets/src/apps/v2/gl_eink.tsx
@@ -15,6 +15,7 @@ import FareInfoFooter from "Components/v2/eink/fare_info_footer";
 import NormalHeader from "Components/v2/eink/normal_header";
 import NormalDepartures from "Components/v2/departures/normal_departures";
 import LineMap from "Components/v2/gl_eink_double/line_map";
+import EvergreenContent from "Components/v2/evergreen_content";
 
 const TYPE_TO_COMPONENT = {
   normal: NormalScreen,
@@ -24,6 +25,7 @@ const TYPE_TO_COMPONENT = {
   normal_header: NormalHeader,
   departures: NormalDepartures,
   line_map: LineMap,
+  evergreen_content: EvergreenContent
 };
 
 const App = (): JSX.Element => {

--- a/lib/screens/config/v2/bus_eink.ex
+++ b/lib/screens/config/v2/bus_eink.ex
@@ -2,22 +2,30 @@ defmodule Screens.Config.V2.BusEink do
   @moduledoc false
   # credo:disable-for-this-file Credo.Check.Design.DuplicatedCode
 
-  alias Screens.Config.V2.{Alerts, Departures, Footer}
+  alias Screens.Config.V2.{Alerts, Departures, Footer, EvergreenContentItem}
   alias Screens.Config.V2.Header.CurrentStopId
 
   @type t :: %__MODULE__{
           departures: Departures.t(),
           footer: Footer.t(),
           header: CurrentStopId.t(),
-          alerts: Alerts.t()
+          alerts: Alerts.t(),
+          evergreen_content: list(EvergreenContentItem.t())
         }
 
   @enforce_keys [:departures, :footer, :header, :alerts]
   defstruct departures: nil,
             footer: nil,
             header: nil,
-            alerts: nil
+            alerts: nil,
+            evergreen_content: []
 
   use Screens.Config.Struct,
-    children: [departures: Departures, footer: Footer, header: CurrentStopId, alerts: Alerts]
+    children: [
+      departures: Departures,
+      footer: Footer,
+      header: CurrentStopId,
+      alerts: Alerts,
+      evergreen_content: {:list, EvergreenContentItem}
+    ]
 end

--- a/lib/screens/config/v2/bus_eink.ex
+++ b/lib/screens/config/v2/bus_eink.ex
@@ -2,7 +2,7 @@ defmodule Screens.Config.V2.BusEink do
   @moduledoc false
   # credo:disable-for-this-file Credo.Check.Design.DuplicatedCode
 
-  alias Screens.Config.V2.{Alerts, Departures, Footer, EvergreenContentItem}
+  alias Screens.Config.V2.{Alerts, Departures, EvergreenContentItem, Footer}
   alias Screens.Config.V2.Header.CurrentStopId
 
   @type t :: %__MODULE__{

--- a/lib/screens/config/v2/gl_eink.ex
+++ b/lib/screens/config/v2/gl_eink.ex
@@ -2,7 +2,7 @@ defmodule Screens.Config.V2.GlEink do
   @moduledoc false
   # credo:disable-for-this-file Credo.Check.Design.DuplicatedCode
 
-  alias Screens.Config.V2.{Alerts, Departures, Footer, LineMap}
+  alias Screens.Config.V2.{Alerts, Departures, Footer, LineMap, EvergreenContentItem}
   alias Screens.Config.V2.Header.Destination
   alias Screens.Util
 
@@ -11,7 +11,8 @@ defmodule Screens.Config.V2.GlEink do
           footer: Footer.t(),
           header: Destination.t(),
           alerts: Alerts.t(),
-          line_map: LineMap.t()
+          line_map: LineMap.t(),
+          evergreen_content: list(EvergreenContentItem.t())
         }
 
   @enforce_keys [:departures, :footer, :header, :alerts, :line_map]
@@ -19,7 +20,8 @@ defmodule Screens.Config.V2.GlEink do
             footer: nil,
             header: nil,
             alerts: nil,
-            line_map: nil
+            line_map: nil,
+            evergreen_content: []
 
   use Screens.Config.Struct,
     children: [
@@ -27,6 +29,7 @@ defmodule Screens.Config.V2.GlEink do
       footer: Footer,
       header: Destination,
       alerts: Alerts,
-      line_map: LineMap
+      line_map: LineMap,
+      evergreen_content: {:list, EvergreenContentItem}
     ]
 end

--- a/lib/screens/config/v2/gl_eink.ex
+++ b/lib/screens/config/v2/gl_eink.ex
@@ -2,7 +2,7 @@ defmodule Screens.Config.V2.GlEink do
   @moduledoc false
   # credo:disable-for-this-file Credo.Check.Design.DuplicatedCode
 
-  alias Screens.Config.V2.{Alerts, Departures, Footer, LineMap, EvergreenContentItem}
+  alias Screens.Config.V2.{Alerts, Departures, EvergreenContentItem, Footer, LineMap}
   alias Screens.Config.V2.Header.Destination
   alias Screens.Util
 

--- a/lib/screens/util/assets.ex
+++ b/lib/screens/util/assets.ex
@@ -1,0 +1,8 @@
+defmodule Screens.Util.Assets do
+  @moduledoc false
+
+  def s3_asset_url(asset_path) do
+    env = Application.get_env(:screens, :environment_name, "screens-prod")
+    "https://mbta-screens.s3.amazonaws.com/#{env}/#{asset_path}"
+  end
+end

--- a/lib/screens/v2/candidate_generator/bus_eink.ex
+++ b/lib/screens/v2/candidate_generator/bus_eink.ex
@@ -2,12 +2,12 @@ defmodule Screens.V2.CandidateGenerator.BusEink do
   @moduledoc false
 
   alias Screens.Config.Screen
-  alias Screens.Config.V2.{BusEink, Footer}
+  alias Screens.Config.V2.{BusEink, Footer, EvergreenContentItem}
   alias Screens.Config.V2.Header.CurrentStopId
   alias Screens.V2.CandidateGenerator
   alias Screens.V2.CandidateGenerator.Widgets
   alias Screens.V2.Template.Builder
-  alias Screens.V2.WidgetInstance.{FareInfoFooter, NormalHeader, Placeholder}
+  alias Screens.V2.WidgetInstance.{FareInfoFooter, NormalHeader, Placeholder, EvergreenContent}
 
   @behaviour CandidateGenerator
 
@@ -45,7 +45,8 @@ defmodule Screens.V2.CandidateGenerator.BusEink do
       fn -> departures_instances_fn.(config) end,
       fn -> alert_instances_fn.(config) end,
       fn -> footer_instances(config) end,
-      fn -> placeholder_instances() end
+      fn -> placeholder_instances() end,
+      fn -> evergreen_content_instances(config) end
     ]
     |> Task.async_stream(& &1.(), ordered: false, timeout: :infinity)
     |> Enum.flat_map(fn {:ok, instances} -> instances end)
@@ -89,5 +90,32 @@ defmodule Screens.V2.CandidateGenerator.BusEink do
       %Placeholder{color: :green, slot_names: [:main_content]},
       %Placeholder{color: :red, slot_names: [:medium_flex]}
     ]
+  end
+
+  defp evergreen_content_instances(config) do
+    %Screen{app_params: %BusEink{evergreen_content: evergreen_content}} = config
+
+    Enum.map(evergreen_content, &evergreen_content_instance(&1, config))
+  end
+
+  defp evergreen_content_instance(
+         %EvergreenContentItem{
+           slot_names: slot_names,
+           asset_path: asset_path,
+           priority: priority
+         },
+         config
+       ) do
+    %EvergreenContent{
+      screen: config,
+      slot_names: slot_names,
+      asset_url: s3_asset_url(asset_path),
+      priority: priority
+    }
+  end
+
+  defp s3_asset_url(asset_path) do
+    env = Application.get_env(:screens, :environment_name, "screens-prod")
+    "https://mbta-screens.s3.amazonaws.com/#{env}/#{asset_path}"
   end
 end

--- a/lib/screens/v2/candidate_generator/bus_shelter.ex
+++ b/lib/screens/v2/candidate_generator/bus_shelter.ex
@@ -2,13 +2,14 @@ defmodule Screens.V2.CandidateGenerator.BusShelter do
   @moduledoc false
 
   alias Screens.Config.Screen
-  alias Screens.Config.V2.{BusShelter, EvergreenContentItem, Footer, Survey}
+  alias Screens.Config.V2.{BusShelter, Footer, Survey}
   alias Screens.Config.V2.Header.CurrentStopId
   alias Screens.V2.CandidateGenerator
   alias Screens.V2.CandidateGenerator.Widgets
   alias Screens.V2.Template.Builder
+  alias Screens.Util.Assets
 
-  alias Screens.V2.WidgetInstance.{EvergreenContent, LinkFooter, NormalHeader, SubwayStatus}
+  alias Screens.V2.WidgetInstance.{LinkFooter, NormalHeader, SubwayStatus}
 
   alias Screens.V2.WidgetInstance.Survey, as: SurveyInstance
 
@@ -50,7 +51,8 @@ defmodule Screens.V2.CandidateGenerator.BusShelter do
         now \\ DateTime.utc_now(),
         fetch_stop_name_fn \\ &fetch_stop_name/1,
         departures_instances_fn \\ &Widgets.Departures.departures_instances/1,
-        alert_instances_fn \\ &Widgets.Alerts.alert_instances/1
+        alert_instances_fn \\ &Widgets.Alerts.alert_instances/1,
+        evergreen_content_instances_fn \\ &Widgets.Evergreen.evergreen_content_instances/1
       ) do
     [
       fn -> header_instances(config, now, fetch_stop_name_fn) end,
@@ -58,7 +60,7 @@ defmodule Screens.V2.CandidateGenerator.BusShelter do
       fn -> alert_instances_fn.(config) end,
       fn -> footer_instances(config) end,
       fn -> subway_status_instances(config) end,
-      fn -> evergreen_content_instances(config) end,
+      fn -> evergreen_content_instances_fn.(config) end,
       fn -> survey_instances(config) end
     ]
     |> Task.async_stream(& &1.(), ordered: false, timeout: :infinity)
@@ -88,12 +90,6 @@ defmodule Screens.V2.CandidateGenerator.BusShelter do
     [%LinkFooter{screen: config, text: "More at", url: "mbta.com/stops/#{stop_id}"}]
   end
 
-  defp evergreen_content_instances(config) do
-    %Screen{app_params: %BusShelter{evergreen_content: evergreen_content}} = config
-
-    Enum.map(evergreen_content, &evergreen_content_instance(&1, config))
-  end
-
   defp survey_instances(config) do
     %Screen{
       app_params: %BusShelter{
@@ -109,31 +105,10 @@ defmodule Screens.V2.CandidateGenerator.BusShelter do
       %SurveyInstance{
         screen: config,
         enabled?: enabled,
-        medium_asset_url: s3_asset_url(medium_asset_path),
-        large_asset_url: s3_asset_url(large_asset_path)
+        medium_asset_url: Assets.s3_asset_url(medium_asset_path),
+        large_asset_url: Assets.s3_asset_url(large_asset_path)
       }
     ]
-  end
-
-  defp evergreen_content_instance(
-         %EvergreenContentItem{
-           slot_names: slot_names,
-           asset_path: asset_path,
-           priority: priority
-         },
-         config
-       ) do
-    %EvergreenContent{
-      screen: config,
-      slot_names: slot_names,
-      asset_url: s3_asset_url(asset_path),
-      priority: priority
-    }
-  end
-
-  defp s3_asset_url(asset_path) do
-    env = Application.get_env(:screens, :environment_name, "screens-prod")
-    "https://mbta-screens.s3.amazonaws.com/#{env}/#{asset_path}"
   end
 
   defp fetch_stop_name(stop_id) do

--- a/lib/screens/v2/candidate_generator/bus_shelter.ex
+++ b/lib/screens/v2/candidate_generator/bus_shelter.ex
@@ -4,10 +4,10 @@ defmodule Screens.V2.CandidateGenerator.BusShelter do
   alias Screens.Config.Screen
   alias Screens.Config.V2.{BusShelter, Footer, Survey}
   alias Screens.Config.V2.Header.CurrentStopId
+  alias Screens.Util.Assets
   alias Screens.V2.CandidateGenerator
   alias Screens.V2.CandidateGenerator.Widgets
   alias Screens.V2.Template.Builder
-  alias Screens.Util.Assets
 
   alias Screens.V2.WidgetInstance.{LinkFooter, NormalHeader, SubwayStatus}
 

--- a/lib/screens/v2/candidate_generator/gl_eink.ex
+++ b/lib/screens/v2/candidate_generator/gl_eink.ex
@@ -2,7 +2,7 @@ defmodule Screens.V2.CandidateGenerator.GlEink do
   @moduledoc false
 
   alias Screens.Config.{Screen, V2}
-  alias Screens.Config.V2.{Footer, GlEink, Header, EvergreenContentItem}
+  alias Screens.Config.V2.{Footer, GlEink, Header}
   alias Screens.RoutePatterns.RoutePattern
   alias Screens.V2.CandidateGenerator
   alias Screens.V2.CandidateGenerator.Widgets
@@ -11,8 +11,7 @@ defmodule Screens.V2.CandidateGenerator.GlEink do
     FareInfoFooter,
     LineMap,
     NormalHeader,
-    Placeholder,
-    EvergreenContent
+    Placeholder
   }
 
   @scheduled_terminal_departure_lookback_seconds 180
@@ -46,7 +45,8 @@ defmodule Screens.V2.CandidateGenerator.GlEink do
         now \\ DateTime.utc_now(),
         fetch_destination_fn \\ &fetch_destination/2,
         departures_instances_fn \\ &Widgets.Departures.departures_instances/1,
-        alert_instances_fn \\ &Widgets.Alerts.alert_instances/1
+        alert_instances_fn \\ &Widgets.Alerts.alert_instances/1,
+        evergreen_content_instances_fn \\ &Widgets.Evergreen.evergreen_content_instances/1
       ) do
     [
       fn -> header_instances(config, now, fetch_destination_fn) end,
@@ -55,7 +55,7 @@ defmodule Screens.V2.CandidateGenerator.GlEink do
       fn -> footer_instances(config) end,
       fn -> placeholder_instances() end,
       fn -> line_map_instances(config) end,
-      fn -> evergreen_content_instances(config) end
+      fn -> evergreen_content_instances_fn.(config) end
     ]
     |> Task.async_stream(& &1.(), ordered: false, timeout: :infinity)
     |> Enum.flat_map(fn {:ok, instances} -> instances end)
@@ -135,32 +135,5 @@ defmodule Screens.V2.CandidateGenerator.GlEink do
       %Placeholder{color: :blue, slot_names: [:main_content]},
       %Placeholder{color: :green, slot_names: [:medium_flex]}
     ]
-  end
-
-  defp evergreen_content_instances(config) do
-    %Screen{app_params: %GlEink{evergreen_content: evergreen_content}} = config
-
-    Enum.map(evergreen_content, &evergreen_content_instance(&1, config))
-  end
-
-  defp evergreen_content_instance(
-         %EvergreenContentItem{
-           slot_names: slot_names,
-           asset_path: asset_path,
-           priority: priority
-         },
-         config
-       ) do
-    %EvergreenContent{
-      screen: config,
-      slot_names: slot_names,
-      asset_url: s3_asset_url(asset_path),
-      priority: priority
-    }
-  end
-
-  defp s3_asset_url(asset_path) do
-    env = Application.get_env(:screens, :environment_name, "screens-prod")
-    "https://mbta-screens.s3.amazonaws.com/#{env}/#{asset_path}"
   end
 end

--- a/lib/screens/v2/candidate_generator/widgets/evergreen.ex
+++ b/lib/screens/v2/candidate_generator/widgets/evergreen.ex
@@ -1,0 +1,32 @@
+defmodule Screens.V2.CandidateGenerator.Widgets.Evergreen do
+  @moduledoc false
+
+  alias Screens.Config.Screen
+  alias Screens.Config.V2.EvergreenContentItem
+  alias Screens.V2.WidgetInstance.EvergreenContent
+  alias Screens.Config.V2.{BusEink, BusShelter, GlEink}
+  alias Screens.Util.Assets
+
+  def evergreen_content_instances(
+        %Screen{app_params: %app{evergreen_content: evergreen_content}} = config
+      )
+      when app in [BusEink, BusShelter, GlEink] do
+    Enum.map(evergreen_content, &evergreen_content_instance(&1, config))
+  end
+
+  defp evergreen_content_instance(
+         %EvergreenContentItem{
+           slot_names: slot_names,
+           asset_path: asset_path,
+           priority: priority
+         },
+         config
+       ) do
+    %EvergreenContent{
+      screen: config,
+      slot_names: slot_names,
+      asset_url: Assets.s3_asset_url(asset_path),
+      priority: priority
+    }
+  end
+end

--- a/test/screens/v2/candidate_generator/bus_eink_test.exs
+++ b/test/screens/v2/candidate_generator/bus_eink_test.exs
@@ -48,6 +48,7 @@ defmodule Screens.V2.CandidateGenerator.BusEinkTest do
       alerts_instances_fn = fn _ -> [] end
       fetch_stop_fn = fn "1722" -> "1624 Blue Hill Ave @ Mattapan Sq" end
       now = ~U[2020-04-06T10:00:00Z]
+      evergreen_content_instances_fn = fn _ -> [] end
 
       actual_instances =
         BusEink.candidate_instances(
@@ -55,7 +56,8 @@ defmodule Screens.V2.CandidateGenerator.BusEinkTest do
           now,
           fetch_stop_fn,
           departures_instances_fn,
-          alerts_instances_fn
+          alerts_instances_fn,
+          evergreen_content_instances_fn
         )
 
       expected_header = %NormalHeader{

--- a/test/screens/v2/candidate_generator/bus_shelter_test.exs
+++ b/test/screens/v2/candidate_generator/bus_shelter_test.exs
@@ -78,6 +78,7 @@ defmodule Screens.V2.CandidateGenerator.BusShelterTest do
       alert_instances_fn = fn _ -> [] end
       fetch_stop_fn = fn "1216" -> "Columbus Ave @ Dimock St" end
       now = ~U[2020-04-06T10:00:00Z]
+      evergreen_content_instances_fn = fn _ -> [] end
 
       expected_header = %NormalHeader{
         screen: config,
@@ -94,7 +95,8 @@ defmodule Screens.V2.CandidateGenerator.BusShelterTest do
           now,
           fetch_stop_fn,
           departures_instances_fn,
-          alert_instances_fn
+          alert_instances_fn,
+          evergreen_content_instances_fn
         )
 
       assert expected_header in actual_instances

--- a/test/screens/v2/candidate_generator/gl_eink_test.exs
+++ b/test/screens/v2/candidate_generator/gl_eink_test.exs
@@ -1,0 +1,89 @@
+defmodule Screens.V2.CandidateGenerator.GlEinkTest do
+  use ExUnit.Case, async: true
+
+  alias Screens.Config.{Screen, V2}
+  alias Screens.V2.CandidateGenerator.GlEink
+  alias Screens.V2.WidgetInstance.{FareInfoFooter, NormalHeader}
+
+  setup do
+    config = %Screen{
+      app_params: %V2.GlEink{
+        departures: %V2.Departures{sections: []},
+        header: %V2.Header.Destination{route_id: "Green-C", direction_id: 0},
+        footer: %V2.Footer{stop_id: "1722"},
+        alerts: %V2.Alerts{stop_id: "1722"},
+        line_map: %V2.LineMap{
+          direction_id: 0,
+          route_id: "Green-C",
+          station_id: "place-bcnwa",
+          stop_id: "1722"
+        }
+      },
+      vendor: :gds,
+      device_id: "TEST",
+      name: "TEST",
+      app_id: :gl_eink_v2
+    }
+
+    %{config: config}
+  end
+
+  describe "screen_template/0" do
+    test "returns correct template" do
+      assert {:screen,
+              %{
+                normal: [
+                  :header,
+                  :left_sidebar,
+                  :main_content,
+                  :medium_flex,
+                  :footer
+                ],
+                bottom_takeover: [
+                  :header,
+                  :left_sidebar,
+                  :main_content,
+                  :bottom_screen
+                ],
+                full_takeover: [:full_screen]
+              }} == GlEink.screen_template()
+    end
+  end
+
+  describe "candidate_instances/3" do
+    test "returns expected header", %{config: config} do
+      departures_instances_fn = fn _ -> [] end
+      alerts_instances_fn = fn _ -> [] end
+      fetch_destination_fn = fn "Green-C", 0 -> "Cleveland Circle" end
+      now = ~U[2020-04-06T10:00:00Z]
+      evergreen_content_instances_fn = fn _ -> [] end
+
+      actual_instances =
+        GlEink.candidate_instances(
+          config,
+          now,
+          fetch_destination_fn,
+          departures_instances_fn,
+          alerts_instances_fn,
+          evergreen_content_instances_fn
+        )
+
+      expected_header = %NormalHeader{
+        screen: config,
+        icon: :green_c,
+        text: "Cleveland Circle",
+        time: ~U[2020-04-06T10:00:00Z]
+      }
+
+      expected_footer = %FareInfoFooter{
+        screen: config,
+        mode: :subway,
+        text: "For real-time predictions and fare purchase locations:",
+        url: "mbta.com/stops/1722"
+      }
+
+      assert expected_header in actual_instances
+      assert expected_footer in actual_instances
+    end
+  end
+end


### PR DESCRIPTION
**Asana task**: [Add evergreen content to bus and green line e-Ink screens](https://app.asana.com/0/1185117109217413/1200928169910241/f)

Evergreen content can now be added to Bus and GL EInk screens. Styles should match resolution requirements for these screens, but please check me on that. Also found that GL EInk did not have a corresponding test file. Went ahead and added that here.

Description

- [ ] Needs version bump?
