### PR TITLE
feat: Per-screen-type configurable "blink" element to reduce pixel burn-in

### DIFF
--- a/assets/css/v2/bus_shelter/screen_container.scss
+++ b/assets/css/v2/bus_shelter/screen_container.scss
@@ -1,6 +1,17 @@
 .screen-container {
+  position: relative;
   width: 1080px;
   height: 1920px;
   margin: 0px auto;
   overflow: hidden;
+}
+
+.screen-container-blink {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: black;
+  z-index: 999;
 }

--- a/assets/src/apps/v2/bus_eink.tsx
+++ b/assets/src/apps/v2/bus_eink.tsx
@@ -24,7 +24,7 @@ const TYPE_TO_COMPONENT = {
   fare_info_footer: FareInfoFooter,
   normal_header: NormalHeader,
   departures: NormalDepartures,
-  evergreen_content: EvergreenContent
+  evergreen_content: EvergreenContent,
 };
 
 const App = (): JSX.Element => {

--- a/assets/src/apps/v2/bus_shelter.tsx
+++ b/assets/src/apps/v2/bus_shelter.tsx
@@ -9,6 +9,8 @@ import ScreenPage from "Components/v2/screen_page";
 import {
   ResponseMapper,
   ResponseMapperContext,
+  BlinkConfig,
+  BlinkConfigContext,
 } from "Components/v2/screen_container";
 import { MappingContext } from "Components/v2/widget";
 
@@ -78,6 +80,11 @@ const responseMapper: ResponseMapper = (apiResponse) => {
   }
 };
 
+const blinkConfig: BlinkConfig = {
+  intervalMs: 1000 * 60 * 5,
+  durationMs: 16,
+};
+
 const App = (): JSX.Element => {
   return (
     <Router>
@@ -85,7 +92,9 @@ const App = (): JSX.Element => {
         <Route path="/v2/screen/:id">
           <MappingContext.Provider value={TYPE_TO_COMPONENT}>
             <ResponseMapperContext.Provider value={responseMapper}>
-              <ScreenPage />
+              <BlinkConfigContext.Provider value={blinkConfig}>
+                <ScreenPage />
+              </BlinkConfigContext.Provider>
             </ResponseMapperContext.Provider>
           </MappingContext.Provider>
         </Route>

--- a/assets/src/apps/v2/gl_eink.tsx
+++ b/assets/src/apps/v2/gl_eink.tsx
@@ -25,7 +25,7 @@ const TYPE_TO_COMPONENT = {
   normal_header: NormalHeader,
   departures: NormalDepartures,
   line_map: LineMap,
-  evergreen_content: EvergreenContent
+  evergreen_content: EvergreenContent,
 };
 
 const App = (): JSX.Element => {

--- a/assets/src/components/v2/screen_container.tsx
+++ b/assets/src/components/v2/screen_container.tsx
@@ -1,4 +1,10 @@
-import React, { createContext, useContext, ComponentType } from "react";
+import React, {
+  createContext,
+  useContext,
+  ComponentType,
+  useState,
+  useEffect,
+} from "react";
 import useApiResponse, { ApiResponse } from "Hooks/v2/use_api_response";
 import Widget, { WidgetData } from "Components/v2/widget";
 
@@ -18,16 +24,57 @@ const ResponseMapperContext = createContext<ResponseMapper>(
   defaultResponseMapper
 );
 
+/* "Blink" info
+ *
+ * Some screens need to have their pixels "flipped" every so often in order to
+ * reduce burn-in. The "blink" context set on a per-screen-type basis
+ * dictates whether, how frequently, and for what duration this occurs.
+ *
+ * What the "blink" element looks like is up to you--define styles as
+ * appropriate on the "screen-container-blink" class.
+ */
+
+interface BlinkConfig {
+  intervalMs: number;
+  durationMs: number;
+}
+
+const defaultBlinkConfig = null;
+
+const BlinkConfigContext = createContext<BlinkConfig | null>(
+  defaultBlinkConfig
+);
+
 interface ScreenLayoutProps {
   apiResponse: ApiResponse;
 }
 
 const ScreenLayout: ComponentType<ScreenLayoutProps> = ({ apiResponse }) => {
   const responseMapper = useContext(ResponseMapperContext);
+  const blinkConfig = useContext(BlinkConfigContext);
+
+  const [showBlink, setShowBlink] = useState(false);
+
+  if (blinkConfig != null) {
+    useEffect(() => {
+      const interval = setInterval(() => {
+        setShowBlink(true);
+
+        setTimeout(() => {
+          setShowBlink(false);
+        }, blinkConfig.durationMs);
+      }, blinkConfig.intervalMs);
+
+      return () => {
+        clearInterval(interval);
+      };
+    }, []);
+  }
 
   return (
     <div className="screen-container">
       {apiResponse && <Widget data={responseMapper(apiResponse)} />}
+      {showBlink && <div className="screen-container-blink" />}
     </div>
   );
 };
@@ -39,3 +86,4 @@ const ScreenContainer = ({ id }) => {
 
 export default ScreenContainer;
 export { ResponseMapper, ResponseMapperContext };
+export { BlinkConfig, BlinkConfigContext };


### PR DESCRIPTION
**Asana task**: [Investigate how to update pixels to prevent burn in on bus shelter screens](https://app.asana.com/0/1185117109217413/1201010702999846/f) (not actually investigating, but it was quick to implement so I'm reusing that task)

This adds another piece of React context to the V2 app frontend that can be set on a per-screen-type basis to add a "blink" element that displays on a regular interval. By default, it does not display.

For bus shelters, it's configured to display for 16ms every 5 minutes. It appears as a black rectangle that covers the entire screen during the short period while it's shown.

- [ ] Needs version bump?
