### PR TITLE
feat: Schedules for Evergreen content

### DIFF
--- a/lib/screens/config/v2/evergreen_content_item.ex
+++ b/lib/screens/config/v2/evergreen_content_item.ex
@@ -12,8 +12,8 @@ defmodule Screens.Config.V2.EvergreenContentItem do
         }
 
   @enforce_keys ~w[slot_names asset_path priority]a
-  defstruct slot_names: [],
-            asset_path: "",
+  defstruct slot_names: nil,
+            asset_path: nil,
             priority: nil,
             schedule: [%Schedule{}]
 

--- a/lib/screens/config/v2/evergreen_content_item.ex
+++ b/lib/screens/config/v2/evergreen_content_item.ex
@@ -1,18 +1,23 @@
 defmodule Screens.Config.V2.EvergreenContentItem do
   @moduledoc false
 
+  alias Screens.Config.V2.Schedule
   alias Screens.V2.WidgetInstance
 
   @type t :: %__MODULE__{
           slot_names: list(WidgetInstance.slot_id()),
           asset_path: String.t(),
-          priority: WidgetInstance.priority()
+          priority: WidgetInstance.priority(),
+          schedule: list(Schedule.t())
         }
 
   @enforce_keys ~w[slot_names asset_path priority]a
-  defstruct @enforce_keys
+  defstruct slot_names: [],
+            asset_path: "",
+            priority: nil,
+            schedule: [%Schedule{}]
 
-  use Screens.Config.Struct
+  use Screens.Config.Struct, children: [schedule: {:list, Schedule}]
 
   defp value_from_json("slot_names", slot_names) do
     Enum.map(slot_names, &String.to_existing_atom/1)

--- a/lib/screens/config/v2/schedule.ex
+++ b/lib/screens/config/v2/schedule.ex
@@ -1,0 +1,31 @@
+defmodule Screens.Config.V2.Schedule do
+  @moduledoc false
+
+  @type t :: %__MODULE__{
+          start_dt: DateTime.t(),
+          end_dt: DateTime.t()
+        }
+
+  defstruct start_dt: nil,
+            end_dt: nil
+
+  use Screens.Config.Struct
+
+  defp value_from_json(_, nil), do: nil
+
+  defp value_from_json("start_dt", iso_string) do
+    {:ok, dt, _offset} = DateTime.from_iso8601(iso_string)
+    dt
+  end
+
+  defp value_from_json("end_dt", iso_string) do
+    {:ok, dt, _offset} = DateTime.from_iso8601(iso_string)
+    dt
+  end
+
+  defp value_to_json(_, nil), do: nil
+
+  defp value_to_json(_, datetime) do
+    DateTime.to_iso8601(datetime)
+  end
+end

--- a/lib/screens/config/v2/schedule.ex
+++ b/lib/screens/config/v2/schedule.ex
@@ -2,8 +2,8 @@ defmodule Screens.Config.V2.Schedule do
   @moduledoc false
 
   @type t :: %__MODULE__{
-          start_dt: DateTime.t(),
-          end_dt: DateTime.t()
+          start_dt: DateTime.t() | nil,
+          end_dt: DateTime.t() | nil
         }
 
   defstruct start_dt: nil,

--- a/lib/screens/v2/candidate_generator/widgets/evergreen.ex
+++ b/lib/screens/v2/candidate_generator/widgets/evergreen.ex
@@ -18,7 +18,8 @@ defmodule Screens.V2.CandidateGenerator.Widgets.Evergreen do
          %EvergreenContentItem{
            slot_names: slot_names,
            asset_path: asset_path,
-           priority: priority
+           priority: priority,
+           schedule: schedule
          },
          config
        ) do
@@ -26,7 +27,8 @@ defmodule Screens.V2.CandidateGenerator.Widgets.Evergreen do
       screen: config,
       slot_names: slot_names,
       asset_url: Assets.s3_asset_url(asset_path),
-      priority: priority
+      priority: priority,
+      schedule: schedule
     }
   end
 end

--- a/lib/screens/v2/widget_instance/evergreen_content.ex
+++ b/lib/screens/v2/widget_instance/evergreen_content.ex
@@ -30,7 +30,28 @@ defmodule Screens.V2.WidgetInstance.EvergreenContent do
 
   def widget_type(_instance), do: :evergreen_content
 
-  def valid_candidate?(_instance), do: true
+  def valid_candidate?(%__MODULE__{schedule: schedule, now: now}) do
+    schedule
+    |> Enum.map(fn x ->
+      case x do
+        %Schedule{start_dt: nil, end_dt: nil} ->
+          true
+
+        %Schedule{start_dt: start_dt, end_dt: nil} ->
+          DateTime.compare(start_dt, now) in [:lt, :eq]
+
+        %Schedule{start_dt: nil, end_dt: end_dt} ->
+          DateTime.compare(end_dt, now) == :gt
+
+        %Schedule{start_dt: start_dt, end_dt: end_dt} ->
+          DateTime.compare(start_dt, now) in [:lt, :eq] and DateTime.compare(end_dt, now) == :gt
+
+        _ ->
+          false
+      end
+    end)
+    |> Enum.any?(fn x -> x end)
+  end
 
   defimpl Screens.V2.WidgetInstance do
     alias Screens.V2.WidgetInstance.EvergreenContent

--- a/lib/screens/v2/widget_instance/evergreen_content.ex
+++ b/lib/screens/v2/widget_instance/evergreen_content.ex
@@ -2,16 +2,24 @@ defmodule Screens.V2.WidgetInstance.EvergreenContent do
   @moduledoc false
 
   alias Screens.Config.Screen
+  alias Screens.Config.V2.Schedule
   alias Screens.V2.WidgetInstance
 
   @enforce_keys ~w[screen slot_names asset_url priority]a
-  defstruct @enforce_keys
+  defstruct screen: nil,
+            slot_names: [],
+            asset_url: "",
+            priority: nil,
+            schedule: [%Schedule{}],
+            now: DateTime.utc_now()
 
   @type t :: %__MODULE__{
           screen: Screen.t(),
           slot_names: list(WidgetInstance.slot_id()),
           asset_url: String.t(),
-          priority: WidgetInstance.priority()
+          priority: WidgetInstance.priority(),
+          schedule: list(Schedule.t()),
+          now: DateTime.t()
         }
 
   def priority(%__MODULE__{} = instance), do: instance.priority

--- a/lib/screens/v2/widget_instance/evergreen_content.ex
+++ b/lib/screens/v2/widget_instance/evergreen_content.ex
@@ -7,8 +7,8 @@ defmodule Screens.V2.WidgetInstance.EvergreenContent do
 
   @enforce_keys ~w[screen slot_names asset_url priority]a
   defstruct screen: nil,
-            slot_names: [],
-            asset_url: "",
+            slot_names: nil,
+            asset_url: nil,
             priority: nil,
             schedule: [%Schedule{}],
             now: DateTime.utc_now()
@@ -32,25 +32,19 @@ defmodule Screens.V2.WidgetInstance.EvergreenContent do
 
   def valid_candidate?(%__MODULE__{schedule: schedule, now: now}) do
     schedule
-    |> Enum.map(fn x ->
-      case x do
-        %Schedule{start_dt: nil, end_dt: nil} ->
-          true
+    |> Enum.any?(fn
+      %Schedule{start_dt: nil, end_dt: nil} ->
+        true
 
-        %Schedule{start_dt: start_dt, end_dt: nil} ->
-          DateTime.compare(start_dt, now) in [:lt, :eq]
+      %Schedule{start_dt: start_dt, end_dt: nil} ->
+        DateTime.compare(start_dt, now) in [:lt, :eq]
 
-        %Schedule{start_dt: nil, end_dt: end_dt} ->
-          DateTime.compare(end_dt, now) == :gt
+      %Schedule{start_dt: nil, end_dt: end_dt} ->
+        DateTime.compare(end_dt, now) == :gt
 
-        %Schedule{start_dt: start_dt, end_dt: end_dt} ->
-          DateTime.compare(start_dt, now) in [:lt, :eq] and DateTime.compare(end_dt, now) == :gt
-
-        _ ->
-          false
-      end
+      %Schedule{start_dt: start_dt, end_dt: end_dt} ->
+        DateTime.compare(start_dt, now) in [:lt, :eq] and DateTime.compare(end_dt, now) == :gt
     end)
-    |> Enum.any?(fn x -> x end)
   end
 
   defimpl Screens.V2.WidgetInstance do

--- a/test/screens/v2/widget_instance/evergreen_content_test.exs
+++ b/test/screens/v2/widget_instance/evergreen_content_test.exs
@@ -22,7 +22,7 @@ defmodule Screens.V2.WidgetInstance.EvergreenContentTest do
         asset_url: "https://mbta-screens.s3.amazonaws.com/screens-dev/videos/some-video.mp4",
         priority: [2, 3, 1],
         schedule: [
-          %Schedule{start_dt: DateTime.add(DateTime.utc_now(), 30, :second), end_dt: nil}
+          %Schedule{start_dt: ~U[2021-01-01T00:00:00Z], end_dt: ~U[2021-01-02T00:00:00Z]}
         ],
         now: DateTime.utc_now()
       }
@@ -62,7 +62,7 @@ defmodule Screens.V2.WidgetInstance.EvergreenContentTest do
     end
 
     test "returns false with old schedule", %{widget_old_schedule: widget_old_schedule} do
-      assert !WidgetInstance.valid_candidate?(widget_old_schedule)
+      refute WidgetInstance.valid_candidate?(widget_old_schedule)
     end
   end
 end

--- a/test/screens/v2/widget_instance/evergreen_content_test.exs
+++ b/test/screens/v2/widget_instance/evergreen_content_test.exs
@@ -4,6 +4,7 @@ defmodule Screens.V2.WidgetInstance.EvergreenContentTest do
   alias Screens.V2.WidgetInstance
   alias Screens.Config.Screen
   alias Screens.V2.WidgetInstance.EvergreenContent
+  alias Screens.Config.V2.Schedule
 
   setup do
     %{
@@ -11,7 +12,17 @@ defmodule Screens.V2.WidgetInstance.EvergreenContentTest do
         screen: %Screen{app_params: nil, vendor: nil, device_id: nil, name: nil, app_id: nil},
         slot_names: [:medium_left, :medium_right],
         asset_url: "https://mbta-screens.s3.amazonaws.com/screens-dev/videos/some-video.mp4",
-        priority: [2, 3, 1]
+        priority: [2, 3, 1],
+        schedule: [%Schedule{}],
+        now: DateTime.utc_now()
+      },
+      widget_old_schedule: %EvergreenContent{
+        screen: %Screen{app_params: nil, vendor: nil, device_id: nil, name: nil, app_id: nil},
+        slot_names: [:medium_left, :medium_right],
+        asset_url: "https://mbta-screens.s3.amazonaws.com/screens-dev/videos/some-video.mp4",
+        priority: [2, 3, 1],
+        schedule: [%Schedule{start_dt: DateTime.add(DateTime.utc_now(), 30, :second), end_dt: nil}],
+        now: DateTime.utc_now()
       }
     }
   end
@@ -44,8 +55,11 @@ defmodule Screens.V2.WidgetInstance.EvergreenContentTest do
   end
 
   describe "valid_candidate?/1" do
-    test "returns true", %{widget: widget} do
+    test "returns true with blank schedule", %{widget: widget} do
       assert WidgetInstance.valid_candidate?(widget)
+    end
+    test "returns false with old schedule", %{widget_old_schedule: widget_old_schedule} do
+      assert !WidgetInstance.valid_candidate?(widget_old_schedule)
     end
   end
 end

--- a/test/screens/v2/widget_instance/evergreen_content_test.exs
+++ b/test/screens/v2/widget_instance/evergreen_content_test.exs
@@ -21,7 +21,9 @@ defmodule Screens.V2.WidgetInstance.EvergreenContentTest do
         slot_names: [:medium_left, :medium_right],
         asset_url: "https://mbta-screens.s3.amazonaws.com/screens-dev/videos/some-video.mp4",
         priority: [2, 3, 1],
-        schedule: [%Schedule{start_dt: DateTime.add(DateTime.utc_now(), 30, :second), end_dt: nil}],
+        schedule: [
+          %Schedule{start_dt: DateTime.add(DateTime.utc_now(), 30, :second), end_dt: nil}
+        ],
         now: DateTime.utc_now()
       }
     }
@@ -58,6 +60,7 @@ defmodule Screens.V2.WidgetInstance.EvergreenContentTest do
     test "returns true with blank schedule", %{widget: widget} do
       assert WidgetInstance.valid_candidate?(widget)
     end
+
     test "returns false with old schedule", %{widget_old_schedule: widget_old_schedule} do
       assert !WidgetInstance.valid_candidate?(widget_old_schedule)
     end

--- a/test/screens/v2/widget_instance/evergreen_content_test.exs
+++ b/test/screens/v2/widget_instance/evergreen_content_test.exs
@@ -14,7 +14,7 @@ defmodule Screens.V2.WidgetInstance.EvergreenContentTest do
         asset_url: "https://mbta-screens.s3.amazonaws.com/screens-dev/videos/some-video.mp4",
         priority: [2, 3, 1],
         schedule: [%Schedule{}],
-        now: DateTime.utc_now()
+        now: ~U[2021-02-01T00:00:00Z]
       },
       widget_old_schedule: %EvergreenContent{
         screen: %Screen{app_params: nil, vendor: nil, device_id: nil, name: nil, app_id: nil},
@@ -24,7 +24,7 @@ defmodule Screens.V2.WidgetInstance.EvergreenContentTest do
         schedule: [
           %Schedule{start_dt: ~U[2021-01-01T00:00:00Z], end_dt: ~U[2021-01-02T00:00:00Z]}
         ],
-        now: DateTime.utc_now()
+        now: ~U[2021-02-01T00:00:00Z]
       }
     }
   end


### PR DESCRIPTION
**Asana task**: [Add ability to schedule evergreen content](https://app.asana.com/0/1185117109217413/1200928169910248/f)

Evergreen content can now have a schedule. Schedule will be a list of objects with a start and end date. Existing Evergreen content will have a default schedule of always (nil for start and end).

- [ ] Needs version bump?
