### PR TITLE
temp feat: Only show here and now alerts on bus v2 screens

### DIFF
--- a/lib/screens/v2/widget_instance/alert.ex
+++ b/lib/screens/v2/widget_instance/alert.ex
@@ -168,8 +168,16 @@ defmodule Screens.V2.WidgetInstance.Alert do
     end
   end
 
-  def valid_candidate?(t) do
-    priority(t) != :no_render
+  def valid_candidate?(%__MODULE__{screen: %Screen{app_id: screen_type}} = t) do
+    cond do
+      screen_type in [:bus_shelter_v2, :bus_eink_v2] ->
+        priority(t) != :no_render and
+          location(t) == :inside and
+          active?(t)
+
+      screen_type == :gl_eink_v2 ->
+        priority(t) != :no_render
+    end
   end
 
   def active?(%__MODULE__{alert: alert, now: now}, happening_now? \\ &Alert.happening_now?/2) do

--- a/lib/screens/v2/widget_instance/alert.ex
+++ b/lib/screens/v2/widget_instance/alert.ex
@@ -168,16 +168,15 @@ defmodule Screens.V2.WidgetInstance.Alert do
     end
   end
 
-  def valid_candidate?(%__MODULE__{screen: %Screen{app_id: screen_type}} = t) do
-    cond do
-      screen_type in [:bus_shelter_v2, :bus_eink_v2] ->
-        priority(t) != :no_render and
-          location(t) == :inside and
-          active?(t)
+  def valid_candidate?(%__MODULE__{screen: %Screen{app_id: screen_type}} = t)
+      when screen_type in [:bus_shelter_v2, :bus_eink_v2] do
+    priority(t) != :no_render and
+      location(t) == :inside and
+      active?(t)
+  end
 
-      screen_type == :gl_eink_v2 ->
-        priority(t) != :no_render
-    end
+  def valid_candidate?(t) do
+    priority(t) != :no_render
   end
 
   def active?(%__MODULE__{alert: alert, now: now}, happening_now? \\ &Alert.happening_now?/2) do


### PR DESCRIPTION
**Asana task**: [Only show alerts now/here on bus screens](https://app.asana.com/0/1185117109217413/1200992643788400/f)

For the time being, v2 bus alerts that do not actively apply to a screen's location will be excluded from candidacy. This is temporary until a better display strategy is decided on for other alerts.

- [ ] Needs version bump?
