### PR TITLE
feat: "blink" element to reduce pixel burn-in, synced to screen data refreshes

### DIFF
--- a/assets/css/v2/bus_shelter/screen_container.scss
+++ b/assets/css/v2/bus_shelter/screen_container.scss
@@ -1,6 +1,17 @@
 .screen-container {
+  position: relative;
   width: 1080px;
   height: 1920px;
   margin: 0px auto;
   overflow: hidden;
+}
+
+.screen-container-blink {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: black;
+  z-index: 999;
 }

--- a/assets/src/apps/v2/bus_eink.tsx
+++ b/assets/src/apps/v2/bus_eink.tsx
@@ -24,7 +24,7 @@ const TYPE_TO_COMPONENT = {
   fare_info_footer: FareInfoFooter,
   normal_header: NormalHeader,
   departures: NormalDepartures,
-  evergreen_content: EvergreenContent
+  evergreen_content: EvergreenContent,
 };
 
 const App = (): JSX.Element => {

--- a/assets/src/apps/v2/bus_shelter.tsx
+++ b/assets/src/apps/v2/bus_shelter.tsx
@@ -9,6 +9,8 @@ import ScreenPage from "Components/v2/screen_page";
 import {
   ResponseMapper,
   ResponseMapperContext,
+  BlinkConfig,
+  BlinkConfigContext,
 } from "Components/v2/screen_container";
 import { MappingContext } from "Components/v2/widget";
 
@@ -78,6 +80,11 @@ const responseMapper: ResponseMapper = (apiResponse) => {
   }
 };
 
+const blinkConfig: BlinkConfig = {
+  refreshesPerBlink: 15,
+  durationMs: 16,
+};
+
 const App = (): JSX.Element => {
   return (
     <Router>
@@ -85,7 +92,9 @@ const App = (): JSX.Element => {
         <Route path="/v2/screen/:id">
           <MappingContext.Provider value={TYPE_TO_COMPONENT}>
             <ResponseMapperContext.Provider value={responseMapper}>
-              <ScreenPage />
+              <BlinkConfigContext.Provider value={blinkConfig}>
+                <ScreenPage />
+              </BlinkConfigContext.Provider>
             </ResponseMapperContext.Provider>
           </MappingContext.Provider>
         </Route>

--- a/assets/src/apps/v2/gl_eink.tsx
+++ b/assets/src/apps/v2/gl_eink.tsx
@@ -25,7 +25,7 @@ const TYPE_TO_COMPONENT = {
   normal_header: NormalHeader,
   departures: NormalDepartures,
   line_map: LineMap,
-  evergreen_content: EvergreenContent
+  evergreen_content: EvergreenContent,
 };
 
 const App = (): JSX.Element => {

--- a/assets/src/components/v2/screen_container.tsx
+++ b/assets/src/components/v2/screen_container.tsx
@@ -3,6 +3,7 @@ import React, {
   useContext,
   ComponentType,
   useState,
+  useEffect,
 } from "react";
 import useApiResponse, { ApiResponse } from "Hooks/v2/use_api_response";
 import Widget, { WidgetData } from "Components/v2/widget";
@@ -68,11 +69,24 @@ const ScreenLayout: ComponentType<ScreenLayoutProps> = ({
   );
 };
 
-const ScreenContainer = ({ id }: { id: string }) => {
+const ScreenContainer = ({ id }) => {
   const blinkConfig = useContext(BlinkConfigContext);
   const [showBlink, setShowBlink] = useState(false);
 
-  const apiResponse = useApiResponse({ id, blinkConfig, setShowBlink });
+  const { apiResponse, requestCount } = useApiResponse({ id });
+
+  useEffect(() => {
+    if (
+      blinkConfig != null &&
+      requestCount % blinkConfig.refreshesPerBlink == 0
+    ) {
+      setShowBlink(true);
+
+      setTimeout(() => {
+        setShowBlink(false);
+      }, blinkConfig.durationMs);
+    }
+  }, [requestCount]);
 
   return <ScreenLayout apiResponse={apiResponse} showBlink={showBlink} />;
 };

--- a/assets/src/components/v2/screen_container.tsx
+++ b/assets/src/components/v2/screen_container.tsx
@@ -1,4 +1,9 @@
-import React, { createContext, useContext, ComponentType } from "react";
+import React, {
+  createContext,
+  useContext,
+  ComponentType,
+  useState,
+} from "react";
 import useApiResponse, { ApiResponse } from "Hooks/v2/use_api_response";
 import Widget, { WidgetData } from "Components/v2/widget";
 
@@ -18,24 +23,60 @@ const ResponseMapperContext = createContext<ResponseMapper>(
   defaultResponseMapper
 );
 
-interface ScreenLayoutProps {
-  apiResponse: ApiResponse;
+/* "Blink" info
+ *
+ * Some screens need to have their pixels "flipped" every so often in order to
+ * reduce burn-in. The "blink" context set on a per-screen-type basis
+ * dictates whether, how frequently, and for what duration this occurs.
+ *
+ * Blink frequency is defined relative to screen data refreshes by
+ * `refreshesPerBlink`, in order to have blinks sync up with data refreshes.
+ * E.g. if a given app's refresh rate is 20 sec and `refreshesPerBlink` is 15,
+ * a blink will occur every 20 sec * 15 = 300 sec = 5 min.
+ *
+ * What the "blink" element looks like is up to you--define styles as
+ * appropriate on the "screen-container-blink" class.
+ */
+
+interface BlinkConfig {
+  refreshesPerBlink: number;
+  durationMs: number;
 }
 
-const ScreenLayout: ComponentType<ScreenLayoutProps> = ({ apiResponse }) => {
+const defaultBlinkConfig = null;
+
+const BlinkConfigContext = createContext<BlinkConfig | null>(
+  defaultBlinkConfig
+);
+
+interface ScreenLayoutProps {
+  apiResponse: ApiResponse;
+  showBlink: boolean;
+}
+
+const ScreenLayout: ComponentType<ScreenLayoutProps> = ({
+  apiResponse,
+  showBlink,
+}) => {
   const responseMapper = useContext(ResponseMapperContext);
 
   return (
     <div className="screen-container">
       {apiResponse && <Widget data={responseMapper(apiResponse)} />}
+      {showBlink && <div className="screen-container-blink" />}
     </div>
   );
 };
 
-const ScreenContainer = ({ id }) => {
-  const apiResponse = useApiResponse({ id });
-  return <ScreenLayout apiResponse={apiResponse} />;
+const ScreenContainer = ({ id }: { id: string }) => {
+  const blinkConfig = useContext(BlinkConfigContext);
+  const [showBlink, setShowBlink] = useState(false);
+
+  const apiResponse = useApiResponse({ id, blinkConfig, setShowBlink });
+
+  return <ScreenLayout apiResponse={apiResponse} showBlink={showBlink} />;
 };
 
 export default ScreenContainer;
 export { ResponseMapper, ResponseMapperContext };
+export { BlinkConfig, BlinkConfigContext };


### PR DESCRIPTION
**Asana task**: [Investigate how to update pixels to prevent burn in on bus shelter screens](https://app.asana.com/0/1185117109217413/1201010702999846/f)

I found a way to do this without too much extra code complexity within `useApiResponse`. Probably the right way to go as long as the approach seems understandable to reviewer(s)!

- [ ] Needs version bump?
