### PR TITLE
fix: Fix now value used by evergreen_content

### DIFF
--- a/lib/screens/v2/candidate_generator/widgets/evergreen.ex
+++ b/lib/screens/v2/candidate_generator/widgets/evergreen.ex
@@ -28,7 +28,8 @@ defmodule Screens.V2.CandidateGenerator.Widgets.Evergreen do
       slot_names: slot_names,
       asset_url: Assets.s3_asset_url(asset_path),
       priority: priority,
-      schedule: schedule
+      schedule: schedule,
+      now: DateTime.utc_now()
     }
   end
 end

--- a/lib/screens/v2/widget_instance/evergreen_content.ex
+++ b/lib/screens/v2/widget_instance/evergreen_content.ex
@@ -5,13 +5,13 @@ defmodule Screens.V2.WidgetInstance.EvergreenContent do
   alias Screens.Config.V2.Schedule
   alias Screens.V2.WidgetInstance
 
-  @enforce_keys ~w[screen slot_names asset_url priority]a
+  @enforce_keys ~w[screen slot_names asset_url priority now]a
   defstruct screen: nil,
             slot_names: nil,
             asset_url: nil,
             priority: nil,
             schedule: [%Schedule{}],
-            now: DateTime.utc_now()
+            now: nil
 
   @type t :: %__MODULE__{
           screen: Screen.t(),


### PR DESCRIPTION
**Asana task**: [Add ability to schedule evergreen content](https://app.asana.com/0/1185117109217413/1200928169910248/f)

Original code used a default value for now, so DateTime comparisons were not working as expected. Changed from using a default value to a value passed in by the evergreen candidate generator.

- [ ] Needs version bump?
