### PR TITLE
feat: Modify typedefs for departures

### DIFF
--- a/lib/screens/v2/candidate_generator/widgets/departures.ex
+++ b/lib/screens/v2/candidate_generator/widgets/departures.ex
@@ -36,7 +36,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.Departures do
       else
         sections =
           Enum.map(sections_data, fn {:ok, departures} ->
-            %{type: :normal_section, departures: departures}
+            %{type: :normal_section, rows: departures}
           end)
 
         %DeparturesWidget{screen: config, section_data: sections}

--- a/lib/screens/v2/widget_instance/departures.ex
+++ b/lib/screens/v2/widget_instance/departures.ex
@@ -11,18 +11,16 @@ defmodule Screens.V2.WidgetInstance.Departures do
   defstruct screen: nil,
             section_data: []
 
-  @type normal_section :: %{
+  @type section :: %{
           type: :normal_section,
-          departures: list(Departure.t())
+          departures: list(Departure.t() | notice())
         }
 
-  @type notice_section :: %{
-          type: :notice_section,
-          icon: atom() | nil,
-          text: FreeText.t()
+  @type notice :: %{
+          destination: String.t(),
+          headway: non_neg_integer()
         }
 
-  @type section :: normal_section | notice_section
   @type t :: %__MODULE__{
           screen: Screen.t(),
           section_data: list(section)

--- a/lib/screens/v2/widget_instance/departures.ex
+++ b/lib/screens/v2/widget_instance/departures.ex
@@ -46,7 +46,7 @@ defmodule Screens.V2.WidgetInstance.Departures do
   end
 
   def serialize_section(%{type: :notice_section, icon: icon, text: text}, _screen) do
-    %{type: :notice_section, icon: icon, text: FreeTextLine.to_json(text)}
+    %{type: :notice_section, icon: icon, text: text}
   end
 
   def serialize_section(%{type: :normal_section, rows: departures}, screen) do

--- a/lib/screens/v2/widget_instance/departures.ex
+++ b/lib/screens/v2/widget_instance/departures.ex
@@ -18,7 +18,6 @@ defmodule Screens.V2.WidgetInstance.Departures do
 
   @type notice_section :: %{
           type: :notice_section,
-          icon: atom() | nil,
           text: FreeTextLine.t()
         }
 
@@ -45,8 +44,8 @@ defmodule Screens.V2.WidgetInstance.Departures do
     def valid_candidate?(_instance), do: true
   end
 
-  def serialize_section(%{type: :notice_section, icon: icon, text: text}, _screen) do
-    %{type: :notice_section, icon: icon, text: text}
+  def serialize_section(%{type: :notice_section, text: text}, _screen) do
+    %{type: :notice_section, text: text}
   end
 
   def serialize_section(%{type: :normal_section, rows: departures}, screen) do

--- a/lib/screens/v2/widget_instance/departures.ex
+++ b/lib/screens/v2/widget_instance/departures.ex
@@ -44,7 +44,7 @@ defmodule Screens.V2.WidgetInstance.Departures do
     %{type: :notice_section, icon: icon, text: FreeText.to_json(text)}
   end
 
-  def serialize_section(%{type: :normal_section, departures: departures}, screen) do
+  def serialize_section(%{type: :normal_section, rows: departures}, screen) do
     rows = group_departures(departures)
     %{type: :normal_section, rows: Enum.map(rows, &serialize_row(&1, screen))}
   end

--- a/lib/screens/v2/widget_instance/departures.ex
+++ b/lib/screens/v2/widget_instance/departures.ex
@@ -46,7 +46,7 @@ defmodule Screens.V2.WidgetInstance.Departures do
   end
 
   def serialize_section(%{type: :notice_section, icon: icon, text: text}, _screen) do
-    %{type: :notice_section, icon: icon, text: FreeText.to_json(text)}
+    %{type: :notice_section, icon: icon, text: FreeTextLine.to_json(text)}
   end
 
   def serialize_section(%{type: :normal_section, rows: departures}, screen) do

--- a/lib/screens/v2/widget_instance/departures.ex
+++ b/lib/screens/v2/widget_instance/departures.ex
@@ -2,7 +2,7 @@ defmodule Screens.V2.WidgetInstance.Departures do
   @moduledoc false
 
   alias Screens.Alerts.Alert
-  alias Screens.Config.Dup.Override.FreeText
+  alias Screens.Config.Dup.Override.FreeTextLine
   alias Screens.Config.Screen
   alias Screens.V2.Departure
   alias Screens.V2.WidgetInstance.Departures
@@ -13,12 +13,17 @@ defmodule Screens.V2.WidgetInstance.Departures do
 
   @type section :: %{
           type: :normal_section,
-          departures: list(Departure.t() | notice())
+          rows: list(Departure.t() | notice())
+        }
+
+  @type notice_section :: %{
+          type: :notice_section,
+          icon: atom() | nil,
+          text: FreeTextLine.t()
         }
 
   @type notice :: %{
-          destination: String.t(),
-          headway: non_neg_integer()
+          text: FreeTextLine.t()
         }
 
   @type t :: %__MODULE__{

--- a/test/screens/v2/candidate_generator/widgets/departures_test.exs
+++ b/test/screens/v2/candidate_generator/widgets/departures_test.exs
@@ -48,8 +48,8 @@ defmodule Screens.V2.CandidateGenerator.Widgets.DeparturesTest do
         %DeparturesWidget{
           screen: config,
           section_data: [
-            %{type: :normal_section, departures: ["departure A1", "departure A2"]},
-            %{type: :normal_section, departures: ["departure B1", "departure B2"]}
+            %{type: :normal_section, rows: ["departure A1", "departure A2"]},
+            %{type: :normal_section, rows: ["departure B1", "departure B2"]}
           ]
         }
       ]
@@ -71,8 +71,8 @@ defmodule Screens.V2.CandidateGenerator.Widgets.DeparturesTest do
         %DeparturesWidget{
           screen: config,
           section_data: [
-            %{type: :normal_section, departures: []},
-            %{type: :normal_section, departures: []}
+            %{type: :normal_section, rows: []},
+            %{type: :normal_section, rows: []}
           ]
         }
       ]

--- a/test/screens/v2/widget_instance/departures_test.exs
+++ b/test/screens/v2/widget_instance/departures_test.exs
@@ -20,7 +20,7 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
 
   describe "serialize_section/1" do
     test "returns serialized normal_section" do
-      section = %{type: :normal_section, departures: []}
+      section = %{type: :normal_section, rows: []}
       assert %{type: :normal_section, rows: []} == Departures.serialize_section(section, nil)
     end
 

--- a/test/screens/v2/widget_instance/departures_test.exs
+++ b/test/screens/v2/widget_instance/departures_test.exs
@@ -25,9 +25,9 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
     end
 
     test "returns serialized notice_section" do
-      section = %{type: :notice_section, icon: :warning, text: %{icon: nil, text: []}}
+      section = %{type: :notice_section, text: %{icon: :warning, text: []}}
 
-      assert %{type: :notice_section, icon: :warning, text: %{icon: nil, text: []}} ==
+      assert %{type: :notice_section, text: %{icon: :warning, text: []}} ==
                Departures.serialize_section(section, nil)
     end
   end

--- a/test/screens/v2/widget_instance/departures_test.exs
+++ b/test/screens/v2/widget_instance/departures_test.exs
@@ -25,9 +25,9 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
     end
 
     test "returns serialized notice_section" do
-      section = %{type: :notice_section, icon: :warning, text: []}
+      section = %{type: :notice_section, icon: :warning, text: %{icon: nil, text: []}}
 
-      assert %{type: :notice_section, icon: :warning, text: []} ==
+      assert %{type: :notice_section, icon: :warning, text: %{icon: nil, text: []}} ==
                Departures.serialize_section(section, nil)
     end
   end


### PR DESCRIPTION
**Asana task**: [Update type defs to support "notice rows" in departures list](https://app.asana.com/0/0/1201067686861561/f)

Changed up typedefs. This will allow the front end to display a single `section` with a list of objects that will either be one `notice`, one `notice` and one `departure`, or two `departures`.

A couple of discussions to start here:

1. The section attribute name `departures` doesn't make sense anymore. What would be a better name? `data`? `rows`?
2. Is `type` necessary anymore? Could there be a future need for it? I don't think so but wanted to double check. I know there are conditionals in the front-end that check for it, but they may need to be removed because of the typedefs changes anyway.

- [ ] Needs version bump?
