### PR TITLE
fix: Make bus shelter blink length 34ms to accomodate 30Hz screens

### DIFF
--- a/assets/src/apps/v2/bus_shelter.tsx
+++ b/assets/src/apps/v2/bus_shelter.tsx
@@ -82,7 +82,7 @@ const responseMapper: ResponseMapper = (apiResponse) => {
 
 const blinkConfig: BlinkConfig = {
   refreshesPerBlink: 15,
-  durationMs: 16,
+  durationMs: 34,
 };
 
 const App = (): JSX.Element => {


### PR DESCRIPTION
**Asana task**: ad hoc

Bumping the blink time for bus shelter screens to just over 1/30 sec to accomodate 30Hz screens.

- [ ] Needs version bump?
