### PR TITLE
feat: Allow CurrentStopName config for bus shelter screens

### DIFF
--- a/lib/screens/config/v2/bus_shelter.ex
+++ b/lib/screens/config/v2/bus_shelter.ex
@@ -3,12 +3,12 @@ defmodule Screens.Config.V2.BusShelter do
   # credo:disable-for-this-file Credo.Check.Design.DuplicatedCode
 
   alias Screens.Config.V2.{Alerts, Departures, EvergreenContentItem, Footer, Survey}
-  alias Screens.Config.V2.Header.CurrentStopId
+  alias Screens.Config.V2.Header.{CurrentStopId, CurrentStopName}
 
   @type t :: %__MODULE__{
           departures: Departures.t(),
           footer: Footer.t(),
-          header: CurrentStopId.t(),
+          header: CurrentStopId.t() | CurrentStopName.t(),
           alerts: Alerts.t(),
           evergreen_content: list(EvergreenContentItem.t()),
           survey: Survey.t()
@@ -26,9 +26,34 @@ defmodule Screens.Config.V2.BusShelter do
     children: [
       departures: Departures,
       footer: Footer,
-      header: CurrentStopId,
       alerts: Alerts,
       evergreen_content: {:list, EvergreenContentItem},
       survey: Survey
     ]
+
+  defp value_from_json("header", %{"type" => "current_stop_id"} = header) do
+    CurrentStopId.from_json(header)
+  end
+
+  defp value_from_json("header", %{"type" => "current_stop_name"} = header) do
+    CurrentStopName.from_json(header)
+  end
+
+  # Fallback for previous config definition that only allowed CurrentStopId
+  # and did not specify header type
+  defp value_from_json("header", header) do
+    CurrentStopId.from_json(header)
+  end
+
+  defp value_to_json(:header, %CurrentStopId{} = header) do
+    header
+    |> CurrentStopId.to_json()
+    |> Map.put(:type, :current_stop_id)
+  end
+
+  defp value_to_json(:header, %CurrentStopName{} = header) do
+    header
+    |> CurrentStopName.to_json()
+    |> Map.put(:type, :current_stop_name)
+  end
 end

--- a/lib/screens/v2/candidate_generator/bus_shelter.ex
+++ b/lib/screens/v2/candidate_generator/bus_shelter.ex
@@ -3,7 +3,7 @@ defmodule Screens.V2.CandidateGenerator.BusShelter do
 
   alias Screens.Config.Screen
   alias Screens.Config.V2.{BusShelter, Footer, Survey}
-  alias Screens.Config.V2.Header.CurrentStopId
+  alias Screens.Config.V2.Header.{CurrentStopId, CurrentStopName}
   alias Screens.Util.Assets
   alias Screens.V2.CandidateGenerator
   alias Screens.V2.CandidateGenerator.Widgets
@@ -77,11 +77,17 @@ defmodule Screens.V2.CandidateGenerator.BusShelter do
   end
 
   defp header_instances(config, now, fetch_stop_name_fn) do
-    %Screen{app_params: %BusShelter{header: %CurrentStopId{stop_id: stop_id}}} = config
+    %Screen{app_params: %BusShelter{header: header_config}} = config
 
-    case fetch_stop_name_fn.(stop_id) do
-      nil -> []
-      stop_name -> [%NormalHeader{screen: config, text: stop_name, time: now}]
+    case header_config do
+      %CurrentStopId{stop_id: stop_id} ->
+        case fetch_stop_name_fn.(stop_id) do
+          nil -> []
+          stop_name -> [%NormalHeader{screen: config, text: stop_name, time: now}]
+        end
+
+      %CurrentStopName{stop_name: stop_name} ->
+        [%NormalHeader{screen: config, text: stop_name, time: now}]
     end
   end
 

--- a/test/screens/v2/candidate_generator/bus_shelter_test.exs
+++ b/test/screens/v2/candidate_generator/bus_shelter_test.exs
@@ -102,5 +102,35 @@ defmodule Screens.V2.CandidateGenerator.BusShelterTest do
       assert expected_header in actual_instances
       assert expected_footer in actual_instances
     end
+
+    test "supports CurrentStopName header config", %{config: config} do
+      config =
+        put_in(config.app_params.header, %V2.Header.CurrentStopName{stop_name: "Walnut Ave"})
+
+      departures_instances_fn = fn _ -> [] end
+      alert_instances_fn = fn _ -> [] end
+      fetch_stop_fn = fn "1216" -> raise "This should not be called!" end
+      now = ~U[2020-04-06T10:00:00Z]
+      evergreen_content_instances_fn = fn _ -> [] end
+
+      expected_header = %NormalHeader{
+        screen: config,
+        icon: nil,
+        text: "Walnut Ave",
+        time: ~U[2020-04-06T10:00:00Z]
+      }
+
+      actual_instances =
+        BusShelter.candidate_instances(
+          config,
+          now,
+          fetch_stop_fn,
+          departures_instances_fn,
+          alert_instances_fn,
+          evergreen_content_instances_fn
+        )
+
+      assert expected_header in actual_instances
+    end
   end
 end


### PR DESCRIPTION
**Asana task**: ad hoc

This change was needed in order to let us set bus shelter screen headers directly from config. (So that we can match the stop names Wayfinding has chosen for the physical signage, which don't currently match up with the names the API returns for each stop ID. E.g. 1743 -> "Columbus Ave @ Walnut Ave" ≠ Wayfinding's "Walnut Ave")

An extra `value_from_json/2` clause was temporarily included to prevent the current config from breaking the app, since it's missing the newly-added `type` key that we use to determine which type of header config the screen is using.

- [ ] Needs version bump?
