### PR TITLE
feat: Support .ogv and .webm filetypes for video content

### DIFF
--- a/assets/src/components/v2/evergreen_content.tsx
+++ b/assets/src/components/v2/evergreen_content.tsx
@@ -3,7 +3,7 @@ import React, { ComponentType } from "react";
 import LoopingVideoPlayer from "Components/v2/looping_video_player";
 
 const IMAGE_EXTENSIONS = ["png", "jpg", "jpeg", "svg"];
-const VIDEO_EXTENSIONS = ["mp4", "ogg"];
+const VIDEO_EXTENSIONS = ["mp4", "ogg", "ogv", "webm"];
 
 interface Props {
   asset_url: string;


### PR DESCRIPTION
**Asana task**: ad hoc

Going to try using one of these formats, since they work on Ubuntu Firefox out of the box and generally take up much less disk space than the equivalent mp4.

- [ ] Needs version bump?
