### PR TITLE
feat: Added endpoint that returns a Polly audio file given a static string.

### DIFF
--- a/lib/screens/audio.ex
+++ b/lib/screens/audio.ex
@@ -20,10 +20,10 @@ defmodule Screens.Audio do
 
   @type departure_group :: {departure_group_key(), [map()]}
 
-  def synthesize(ssml_string, is_screen) do
+  def synthesize(ssml_string, is_screen, text_type) do
     result =
       ssml_string
-      |> ExAws.Polly.synthesize_speech(lexicon_names: @lexicon_names, text_type: "ssml")
+      |> ExAws.Polly.synthesize_speech(lexicon_names: @lexicon_names, text_type: text_type)
       |> ExAws.request()
 
     case result do

--- a/lib/screens_web/controllers/audio_controller.ex
+++ b/lib/screens_web/controllers/audio_controller.ex
@@ -37,7 +37,7 @@ defmodule ScreensWeb.AudioController do
            Screens.ScreenData.by_screen_id(screen_id, is_screen, check_disabled: true),
          template_assigns <- Screens.Audio.from_api_data(data, screen_id),
          ssml <- render_ssml(template_assigns),
-         {:ok, audio_data} <- Screens.Audio.synthesize(ssml, is_screen) do
+         {:ok, audio_data} <- Screens.Audio.synthesize(ssml, is_screen, "ssml") do
       send_audio(conn, {:binary, audio_data}, disposition)
     else
       _ -> send_fallback_audio(conn, is_screen, screen_id, disposition)

--- a/lib/screens_web/controllers/audio_controller.ex
+++ b/lib/screens_web/controllers/audio_controller.ex
@@ -55,6 +55,18 @@ defmodule ScreensWeb.AudioController do
     end
   end
 
+  def text_to_speech(conn, %{"text" => text} = params) do
+    disposition =
+      params
+      |> Map.get("disposition")
+      |> disposition_atom()
+
+      case Screens.Audio.synthesize(text, false, "text") do
+        {:ok, audio_data} -> send_audio(conn, {:binary, audio_data}, disposition)
+        :error -> send_fallback_audio(conn, false, nil, disposition)
+      end
+  end
+
   defp render_ssml(template_assigns) do
     View.render_to_string(ScreensWeb.AudioView, "index.ssml", template_assigns)
   end

--- a/lib/screens_web/controllers/audio_controller.ex
+++ b/lib/screens_web/controllers/audio_controller.ex
@@ -55,18 +55,6 @@ defmodule ScreensWeb.AudioController do
     end
   end
 
-  def text_to_speech(conn, %{"text" => text} = params) do
-    disposition =
-      params
-      |> Map.get("disposition")
-      |> disposition_atom()
-
-      case Screens.Audio.synthesize(text, false, "text") do
-        {:ok, audio_data} -> send_audio(conn, {:binary, audio_data}, disposition)
-        :error -> send_fallback_audio(conn, false, nil, disposition)
-      end
-  end
-
   defp render_ssml(template_assigns) do
     View.render_to_string(ScreensWeb.AudioView, "index.ssml", template_assigns)
   end

--- a/lib/screens_web/controllers/v2/audio_controller.ex
+++ b/lib/screens_web/controllers/v2/audio_controller.ex
@@ -1,0 +1,27 @@
+defmodule ScreensWeb.V2.AudioController do
+  use ScreensWeb, :controller
+  require Logger
+  alias Phoenix.View
+  alias Screens.Config.State
+
+  @fallback_audio_path "assets/static/audio/readout_fallback.mp3"
+
+  plug(:check_config)
+
+  defp check_config(conn, _) do
+    if State.ok?() do
+      conn
+    else
+      conn
+      |> put_status(:not_found)
+      |> halt()
+    end
+  end
+
+  def text_to_speech(conn, %{"text" => text}) do
+    case Screens.Audio.synthesize(text, false, "text") do
+        {:ok, audio_data} -> send_download(conn, {:binary, audio_data}, filename: "readout.mp3", disposition: :inline)
+        :error -> send_download(conn, {:file, @fallback_audio_path}, filename: "readout.mp3", disposition: :inline)
+      end
+  end
+end

--- a/lib/screens_web/controllers/v2/audio_controller.ex
+++ b/lib/screens_web/controllers/v2/audio_controller.ex
@@ -1,7 +1,6 @@
 defmodule ScreensWeb.V2.AudioController do
   use ScreensWeb, :controller
   require Logger
-  alias Phoenix.View
   alias Screens.Config.State
 
   @fallback_audio_path "assets/static/audio/readout_fallback.mp3"
@@ -20,8 +19,14 @@ defmodule ScreensWeb.V2.AudioController do
 
   def text_to_speech(conn, %{"text" => text}) do
     case Screens.Audio.synthesize(text, false, "text") do
-        {:ok, audio_data} -> send_download(conn, {:binary, audio_data}, filename: "readout.mp3", disposition: :inline)
-        :error -> send_download(conn, {:file, @fallback_audio_path}, filename: "readout.mp3", disposition: :inline)
-      end
+      {:ok, audio_data} ->
+        send_download(conn, {:binary, audio_data}, filename: "readout.mp3", disposition: :inline)
+
+      :error ->
+        send_download(conn, {:file, @fallback_audio_path},
+          filename: "readout.mp3",
+          disposition: :inline
+        )
+    end
   end
 end

--- a/lib/screens_web/controllers/v2/audio_controller.ex
+++ b/lib/screens_web/controllers/v2/audio_controller.ex
@@ -3,8 +3,6 @@ defmodule ScreensWeb.V2.AudioController do
   require Logger
   alias Screens.Config.State
 
-  @fallback_audio_path "assets/static/audio/readout_fallback.mp3"
-
   plug(:check_config)
 
   defp check_config(conn, _) do
@@ -23,10 +21,7 @@ defmodule ScreensWeb.V2.AudioController do
         send_download(conn, {:binary, audio_data}, filename: "readout.mp3", disposition: :inline)
 
       :error ->
-        send_download(conn, {:file, @fallback_audio_path},
-          filename: "readout.mp3",
-          disposition: :inline
-        )
+        send_resp(conn, 404, "Not found")
     end
   end
 end

--- a/lib/screens_web/router.ex
+++ b/lib/screens_web/router.ex
@@ -89,7 +89,7 @@ defmodule ScreensWeb.Router do
     scope "/audio" do
       pipe_through [:redirect_prod_http, :browser]
 
-      get "/text_to_speech/:text", AudioController, :text_to_speech
+      post "/text_to_speech", AudioController, :text_to_speech
     end
   end
 

--- a/lib/screens_web/router.ex
+++ b/lib/screens_web/router.ex
@@ -112,6 +112,8 @@ defmodule ScreensWeb.Router do
     get "/:id/readout.mp3", AudioController, :show
 
     get "/:id/debug", AudioController, :debug
+
+    get "/text_to_speech/:text", AudioController, :text_to_speech
   end
 
   scope "/alert_priority", ScreensWeb do

--- a/lib/screens_web/router.ex
+++ b/lib/screens_web/router.ex
@@ -85,6 +85,12 @@ defmodule ScreensWeb.Router do
 
       get "/:id", ScreenApiController, :show
     end
+
+    scope "/audio" do
+      pipe_through [:redirect_prod_http, :browser]
+
+      get "/text_to_speech/:text", AudioController, :text_to_speech
+    end
   end
 
   scope "/image", ScreensWeb do
@@ -112,8 +118,6 @@ defmodule ScreensWeb.Router do
     get "/:id/readout.mp3", AudioController, :show
 
     get "/:id/debug", AudioController, :debug
-
-    get "/text_to_speech/:text", AudioController, :text_to_speech
   end
 
   scope "/alert_priority", ScreensWeb do


### PR DESCRIPTION
**Asana task**: [Add v2 audio endpoint (send a static file from string)](https://app.asana.com/0/1185117109217413/1201071462192293/f)

Endpoint will be used to help us test audio on bus shelter screens.

NOTE: I still do not have Polly access (Ian will work on it this next sprint). I am confident this works, but if you feel more comfortable, we can hold off merging until I am able to test locally.

- [ ] Needs version bump?
