### PR TITLE
cleanup: Remove placeholder instances from v2 eink screens.

### DIFF
--- a/lib/screens/v2/candidate_generator/bus_eink.ex
+++ b/lib/screens/v2/candidate_generator/bus_eink.ex
@@ -7,7 +7,7 @@ defmodule Screens.V2.CandidateGenerator.BusEink do
   alias Screens.V2.CandidateGenerator
   alias Screens.V2.CandidateGenerator.Widgets
   alias Screens.V2.Template.Builder
-  alias Screens.V2.WidgetInstance.{FareInfoFooter, NormalHeader, Placeholder}
+  alias Screens.V2.WidgetInstance.{FareInfoFooter, NormalHeader}
 
   @behaviour CandidateGenerator
 
@@ -46,7 +46,6 @@ defmodule Screens.V2.CandidateGenerator.BusEink do
       fn -> departures_instances_fn.(config) end,
       fn -> alert_instances_fn.(config) end,
       fn -> footer_instances(config) end,
-      fn -> placeholder_instances() end,
       fn -> evergreen_content_instances_fn.(config) end
     ]
     |> Task.async_stream(& &1.(), ordered: false, timeout: :infinity)
@@ -84,12 +83,5 @@ defmodule Screens.V2.CandidateGenerator.BusEink do
       _ ->
         nil
     end
-  end
-
-  defp placeholder_instances do
-    [
-      %Placeholder{color: :green, slot_names: [:main_content]},
-      %Placeholder{color: :red, slot_names: [:medium_flex]}
-    ]
   end
 end

--- a/lib/screens/v2/candidate_generator/gl_eink.ex
+++ b/lib/screens/v2/candidate_generator/gl_eink.ex
@@ -10,8 +10,7 @@ defmodule Screens.V2.CandidateGenerator.GlEink do
   alias Screens.V2.WidgetInstance.{
     FareInfoFooter,
     LineMap,
-    NormalHeader,
-    Placeholder
+    NormalHeader
   }
 
   @scheduled_terminal_departure_lookback_seconds 180
@@ -53,7 +52,6 @@ defmodule Screens.V2.CandidateGenerator.GlEink do
       fn -> departures_instances_fn.(config) end,
       fn -> alert_instances_fn.(config) end,
       fn -> footer_instances(config) end,
-      fn -> placeholder_instances() end,
       fn -> line_map_instances(config) end,
       fn -> evergreen_content_instances_fn.(config) end
     ]
@@ -127,13 +125,6 @@ defmodule Screens.V2.CandidateGenerator.GlEink do
         text: "For real-time predictions and fare purchase locations:",
         url: "mbta.com/stops/#{stop_id}"
       }
-    ]
-  end
-
-  defp placeholder_instances do
-    [
-      %Placeholder{color: :blue, slot_names: [:main_content]},
-      %Placeholder{color: :green, slot_names: [:medium_flex]}
     ]
   end
 end


### PR DESCRIPTION
**Asana task**: [Remove placeholder instances from v2 E-Ink screens](https://app.asana.com/0/1185117109217413/1201089427060782/f)

Removed placeholder instances from eink screens.

Question: Should we also go ahead and remove these instances for v2 solari?

- [ ] Needs version bump?
