### PR TITLE
fix: Add an attribute to <vdeo> tags to make caching work

### DIFF
--- a/assets/src/components/v2/looping_video_player.tsx
+++ b/assets/src/components/v2/looping_video_player.tsx
@@ -15,6 +15,8 @@ interface Props {
  * - `loop`: video loops indefinitely
  * - `playsInline`: video plays within the element, not fullscreen
  * - `muted`: any audio on the file is muted
+ * - `preload="auto"`: tells the browser that the video is expected to play through and should be fully downloaded
+ *                     (this helps it choose an appropriate caching strategy instead of downloading anew every time)
  *
  * Playback can be paused by flipping `isPlaying` to false.
  *
@@ -47,10 +49,11 @@ const LoopingVideoPlayer: ComponentType<Props> = ({
   return (
     <video
       src={src}
-      className={"looping-video"}
+      className="looping-video"
       onCanPlay={handleCanPlay}
       ref={ref}
       poster={poster}
+      preload="auto"
       loop
       playsInline
       muted


### PR DESCRIPTION
**Asana task**: Investigate browser caching for video assets](https://app.asana.com/0/1185117109217422/1201071596205552/f)

The reasoning behind it is involved, but long story short, this gets Firefox to properly cache video assets so that they aren't downloaded anew every time they reappear on screen.

Thanks to Cora for helping me find this fix!

- [ ] Needs version bump?
