### PR TITLE
fix: Fixed text cutoff on some letters.

### DIFF
--- a/assets/css/v2/bus_shelter/departures/destination.scss
+++ b/assets/css/v2/bus_shelter/departures/destination.scss
@@ -11,7 +11,7 @@
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
-  padding-bottom: 5px;
+  padding-bottom: 6px;
 }
 
 .departure-destination__variation {


### PR DESCRIPTION
**Asana task**: [Fix cut off text on bus shelter screens](https://app.asana.com/0/1185117109217413/1201141511273727/f)

Before:

<img width="280" alt="Screen Shot 2021-10-19 at 10 57 59 AM" src="https://user-images.githubusercontent.com/10713153/137937453-fc46adc7-227a-443c-b66b-ab511b257de2.png">

After:

<img width="278" alt="Screen Shot 2021-10-19 at 10 58 17 AM" src="https://user-images.githubusercontent.com/10713153/137937518-f7daca6c-1014-440f-b0d8-7b89527984e8.png">

- [ ] Needs version bump?
