### PR TITLE
fix: remove border-radius from evergreen content container

### DIFF
--- a/assets/css/v2/bus_eink/evergreen/image.scss
+++ b/assets/css/v2/bus_eink/evergreen/image.scss
@@ -4,7 +4,6 @@
 
 .screen-normal__medium-flex {
   .evergreen-content-image__container {
-    border-radius: 32px;
     width: 1200px;
     height: 1164px;
   }

--- a/assets/css/v2/gl_eink/evergreen/image.scss
+++ b/assets/css/v2/gl_eink/evergreen/image.scss
@@ -4,7 +4,6 @@
 
 .screen-normal__medium-flex {
   .evergreen-content-image__container {
-    border-radius: 32px;
     width: 1200px;
     height: 1164px;
   }


### PR DESCRIPTION
**Asana task**: [Margins on evergreen content](https://app.asana.com/0/1185117109217413/1201221301197679)

We decided to build the margins into the images themselves (for greater flexibility), so we don't need to change the sizes of these containers, but we should remove the border-radius so we have the flexibility to display content anywhere in this region.