### PR TITLE
fix: Prevent build_text from breaking when passed an ~E value

### DIFF
--- a/lib/screens_web/views/v2/audio/departures_view.ex
+++ b/lib/screens_web/views/v2/audio/departures_view.ex
@@ -65,8 +65,8 @@ defmodule ScreensWeb.V2.Audio.DeparturesView do
 
     prefix =
       case time.type do
-        :timestamp -> ~E|A later|
-        _ -> ~E|The following|
+        :timestamp -> "A later"
+        _ -> "The following"
       end
 
     content =
@@ -151,11 +151,11 @@ defmodule ScreensWeb.V2.Audio.DeparturesView do
   defp build_text(value_renderers) do
     value_renderers
     |> Enum.reject(fn
-      {value, _renderer} -> is_nil(value)
+      {value, renderer} when is_function(renderer) -> is_nil(value)
       value -> is_nil(value)
     end)
     |> Enum.map(fn
-      {value, renderer} -> renderer.(value)
+      {value, renderer} when is_function(renderer) -> renderer.(value)
       value -> identity_render(value)
     end)
     |> Enum.intersperse(~E| |)


### PR DESCRIPTION
**Asana task**: ad hoc

Small fix! My utility function was breaking when passed an `~E` value because those are internally represented as 2-tuples of the structure `{:safe, content}`. A change I made during cleanup/just before merging ran into this.

- [ ] Needs version bump?
