### PR TITLE
feat: Support configurable daytime/nighttime periods, with different readout volumes

### DIFF
--- a/assets/src/apps/v2/bus_shelter.tsx
+++ b/assets/src/apps/v2/bus_shelter.tsx
@@ -88,8 +88,7 @@ const blinkConfig: BlinkConfig = {
 };
 
 const audioConfig: AudioConfig = {
-  readoutIntervalMinutes: parseInt(document.getElementById("app").dataset.audioReadoutInterval),
-  volume: parseFloat(document.getElementById("app").dataset.volume)
+  readoutIntervalMinutes: parseInt(document.getElementById("app").dataset.audioReadoutInterval)
 }
 
 const App = (): JSX.Element => {

--- a/assets/src/components/v2/screen_container.tsx
+++ b/assets/src/components/v2/screen_container.tsx
@@ -53,7 +53,6 @@ const BlinkConfigContext = createContext<BlinkConfig | null>(
 
 interface AudioConfig {
   readoutIntervalMinutes: number;
-  volume: number;
 }
 
 const defaultAudioConfig = null;

--- a/assets/src/hooks/v2/use_audio_readout.tsx
+++ b/assets/src/hooks/v2/use_audio_readout.tsx
@@ -4,7 +4,7 @@ import { useEffect } from "react";
 
 interface UseAudioReadoutArgs {
   id: string;
-  config: AudioConfig;
+  config: AudioConfig | null;
 }
 
 const useAudioReadout = ({
@@ -16,18 +16,24 @@ const useAudioReadout = ({
   }
 
   const readoutInterval = config.readoutIntervalMinutes * 60000;
-  const apiPath = `/v2/audio/${id}/readout.mp3`;
+  const readoutPath = `/v2/audio/${id}/readout.mp3`;
+  const volumePath = `/v2/audio/${id}/volume`;
 
   const fetchAudio = async () => {
     try {
-      const result = await fetch(apiPath);
-      const blob = await result.blob();
+      const readoutData = await fetch(readoutPath);
+      const volumeData = await fetch(volumePath);
+
+      const { volume } = await volumeData.json();
+
+      const blob = await readoutData.blob();
       const url = URL.createObjectURL(blob);
       const audio = new Audio(url);
       audio.onended = (_e) => {
         URL.revokeObjectURL(url);
       };
-      audio.volume = config.volume;
+
+      audio.volume = volume;
       audio.play();
     } catch (err) {
       console.log(err);

--- a/lib/screens/config/v2/audio.ex
+++ b/lib/screens/config/v2/audio.ex
@@ -4,25 +4,30 @@ defmodule Screens.Config.V2.Audio do
   @type t :: %__MODULE__{
           start_time: Time.t(),
           stop_time: Time.t(),
+          daytime_start_time: Time.t(),
+          daytime_stop_time: Time.t(),
           days_active: list(Calendar.day_of_week()),
-          volume: float()
+          daytime_volume: float(),
+          nighttime_volume: float()
         }
 
   defstruct start_time: ~T[00:00:00],
             stop_time: ~T[00:00:00],
+            daytime_start_time: ~T[00:00:00],
+            daytime_stop_time: ~T[00:00:00],
             days_active: [],
-            volume: 0.0
+            daytime_volume: 0.0,
+            nighttime_volume: 0.0
 
   use Screens.Config.Struct, with_default: true
 
-  defp value_from_json("start_time", iso_string) do
-    {:ok, t} = Time.from_iso8601(iso_string)
-    t
-  end
+  for time_key <- ~w[start_time stop_time daytime_start_time daytime_stop_time]a do
+    time_key_string = Atom.to_string(time_key)
 
-  defp value_from_json("stop_time", iso_string) do
-    {:ok, t} = Time.from_iso8601(iso_string)
-    t
+    defp value_from_json(unquote(time_key_string), iso_string) do
+      {:ok, t} = Time.from_iso8601(iso_string)
+      t
+    end
   end
 
   defp value_from_json(_, value), do: value

--- a/lib/screens_web/controllers/v2/audio_controller.ex
+++ b/lib/screens_web/controllers/v2/audio_controller.ex
@@ -23,6 +23,20 @@ defmodule ScreensWeb.V2.AudioController do
     end
   end
 
+  def show_volume(conn, %{"id" => screen_id}) do
+    cond do
+      not screen_exists?(screen_id) ->
+        not_found(conn)
+
+      State.disabled?(screen_id) ->
+        json(conn, %{volume: 0.0})
+
+      true ->
+        {:ok, volume} = ScreenAudioData.volume_by_screen_id(screen_id)
+        json(conn, %{volume: volume})
+    end
+  end
+
   def debug(conn, %{"id" => screen_id}) do
     cond do
       not screen_exists?(screen_id) -> not_found(conn)

--- a/lib/screens_web/controllers/v2/screen_controller.ex
+++ b/lib/screens_web/controllers/v2/screen_controller.ex
@@ -2,7 +2,6 @@ defmodule ScreensWeb.V2.ScreenController do
   use ScreensWeb, :controller
 
   alias Screens.Config.{Screen, State}
-  alias Screens.Config.V2.Audio
   alias Screens.V2.ScreenData.Parameters
 
   @default_app_id :bus_eink
@@ -36,16 +35,6 @@ defmodule ScreensWeb.V2.ScreenController do
     put_layout(conn, {ScreensWeb.V2.LayoutView, "app.html"})
   end
 
-  defp assign_volume(conn, config) do
-    case config do
-      %Screen{app_params: %_app{audio: %Audio{volume: volume}}} ->
-        assign(conn, :volume, volume)
-
-      %Screen{} ->
-        assign(conn, :volume, 0.0)
-    end
-  end
-
   def index(conn, %{"id" => screen_id}) do
     is_screen = ScreensWeb.UserAgent.is_screen_conn?(conn, screen_id)
 
@@ -59,7 +48,6 @@ defmodule ScreensWeb.V2.ScreenController do
         |> assign(:app_id, app_id)
         |> assign(:refresh_rate, Parameters.get_refresh_rate(app_id))
         |> assign(:audio_readout_interval, Parameters.get_audio_readout_interval(app_id))
-        |> assign_volume(config)
         |> put_view(ScreensWeb.V2.ScreenView)
         |> render("index.html")
 

--- a/lib/screens_web/router.ex
+++ b/lib/screens_web/router.ex
@@ -91,6 +91,8 @@ defmodule ScreensWeb.Router do
 
       get "/:id/readout.mp3", AudioController, :show
 
+      get "/:id/volume", AudioController, :show_volume
+
       get "/:id/debug", AudioController, :debug
 
       get "/text_to_speech/:text", AudioController, :text_to_speech

--- a/lib/screens_web/templates/v2/screen/index.html.eex
+++ b/lib/screens_web/templates/v2/screen/index.html.eex
@@ -3,6 +3,5 @@
   data-last-refresh="<%= @last_refresh %>"
   data-environment-name="<%= @environment_name %>"
   data-refresh-rate="<%= @refresh_rate %>"
-  data-volume="<%= @volume %>"
   data-audio-readout-interval="<%= @audio_readout_interval %>"
 ></div>

--- a/test/screens/v2/screen_audio_data_test.exs
+++ b/test/screens/v2/screen_audio_data_test.exs
@@ -24,8 +24,11 @@ defmodule Screens.V2.ScreenAudioDataTest do
           audio: %V2.Audio{
             start_time: ~T[00:00:00],
             stop_time: ~T[01:00:00],
-            days_active: [0, 1, 2, 3, 4, 5, 6],
-            volume: 0.1
+            daytime_start_time: ~T[00:00:00],
+            daytime_stop_time: ~T[01:00:00],
+            days_active: [1, 2, 3, 4, 5, 6, 7],
+            daytime_volume: 0.1,
+            nighttime_volume: 0.1
           },
           departures: %V2.Departures{sections: []},
           footer: %V2.Footer{},
@@ -42,8 +45,11 @@ defmodule Screens.V2.ScreenAudioDataTest do
           audio: %V2.Audio{
             start_time: ~T[00:00:00],
             stop_time: ~T[02:00:00],
-            days_active: [0, 1, 2, 3, 4, 5, 6],
-            volume: 0.1
+            daytime_start_time: ~T[00:00:00],
+            daytime_stop_time: ~T[01:00:00],
+            days_active: [1, 2, 3, 4, 5, 6, 7],
+            daytime_volume: 0.1,
+            nighttime_volume: 0.1
           },
           departures: %V2.Departures{sections: []},
           footer: %V2.Footer{},


### PR DESCRIPTION
**Asana task**: ad hoc

This adds some new audio config values and makes it possible to set different volumes daytime and nighttime.
The client now gets its readout volume value from the server every time it requests a new readout, rather than getting a "constant" value on initial page load.

- [ ] Needs version bump?
