### PR TITLE
fix: Shift `now` to Eastern time for all time-based config checking in ScreenAudioData

### DIFF
--- a/lib/screens/v2/screen_audio_data.ex
+++ b/lib/screens/v2/screen_audio_data.ex
@@ -16,6 +16,7 @@ defmodule Screens.V2.ScreenAudioData do
         now \\ DateTime.utc_now()
       ) do
     config = get_config_fn.(screen_id)
+    {:ok, now} = DateTime.shift_zone(now, "America/New_York")
 
     case config do
       %Screen{app_params: %app{}} when app not in [BusShelter] ->
@@ -43,6 +44,7 @@ defmodule Screens.V2.ScreenAudioData do
         now \\ DateTime.utc_now()
       ) do
     config = get_config_fn.(screen_id)
+    {:ok, now} = DateTime.shift_zone(now, "America/New_York")
 
     case config do
       %Screen{app_params: %app{}} when app not in [BusShelter] ->
@@ -73,15 +75,13 @@ defmodule Screens.V2.ScreenAudioData do
            stop_time: stop_time,
            days_active: days_active
          },
-         now
+         dt
        ) do
-    {:ok, now_eastern} = DateTime.shift_zone(now, "America/New_York")
-
-    Date.day_of_week(now_eastern) in days_active and
-      time_in_range?(now_eastern, start_time, stop_time)
+    Date.day_of_week(dt) in days_active and
+      time_in_range?(DateTime.to_time(dt), start_time, stop_time)
   end
 
-  defp time_in_range?(t, start_time, stop_time) do
+  def time_in_range?(t, start_time, stop_time) do
     if Time.compare(start_time, stop_time) in [:lt, :eq] do
       # The range exists within a single day starting/ending at midnight
       Time.compare(start_time, t) in [:lt, :eq] and Time.compare(stop_time, t) == :gt

--- a/test/screens/v2/screen_audio_data_test.exs
+++ b/test/screens/v2/screen_audio_data_test.exs
@@ -225,4 +225,88 @@ defmodule Screens.V2.ScreenAudioDataTest do
                ScreenAudioData.by_screen_id(screen_id, get_config_fn, fetch_data_fn)
     end
   end
+
+  describe "time_in_range?/1" do
+    test "returns false for a time before a normal range" do
+      t = ~T[01:00:00]
+      start_time = ~T[05:00:00]
+      stop_time = ~T[07:00:00]
+
+      refute ScreenAudioData.time_in_range?(t, start_time, stop_time)
+    end
+
+    test "returns false for a time after a normal range" do
+      t = ~T[09:00:00]
+      start_time = ~T[05:00:00]
+      stop_time = ~T[07:00:00]
+
+      refute ScreenAudioData.time_in_range?(t, start_time, stop_time)
+    end
+
+    test "returns true for a time at start of a normal range" do
+      t = ~T[05:00:00]
+      start_time = ~T[05:00:00]
+      stop_time = ~T[07:00:00]
+
+      assert ScreenAudioData.time_in_range?(t, start_time, stop_time)
+    end
+
+    test "returns false for a time at end of a normal range" do
+      t = ~T[07:00:00]
+      start_time = ~T[05:00:00]
+      stop_time = ~T[07:00:00]
+
+      refute ScreenAudioData.time_in_range?(t, start_time, stop_time)
+    end
+
+    test "returns true for a time within a normal range" do
+      t = ~T[06:00:00]
+      start_time = ~T[05:00:00]
+      stop_time = ~T[07:00:00]
+
+      assert ScreenAudioData.time_in_range?(t, start_time, stop_time)
+    end
+
+    #############################
+
+    test "returns false for a time outside an inverted range" do
+      t = ~T[06:00:00]
+      start_time = ~T[07:00:00]
+      stop_time = ~T[05:00:00]
+
+      refute ScreenAudioData.time_in_range?(t, start_time, stop_time)
+    end
+
+    test "returns true for a time at start of an inverted range" do
+      t = ~T[07:00:00]
+      start_time = ~T[07:00:00]
+      stop_time = ~T[05:00:00]
+
+      assert ScreenAudioData.time_in_range?(t, start_time, stop_time)
+    end
+
+    test "returns false for a time at end of an inverted range" do
+      t = ~T[05:00:00]
+      start_time = ~T[07:00:00]
+      stop_time = ~T[05:00:00]
+
+      refute ScreenAudioData.time_in_range?(t, start_time, stop_time)
+    end
+
+    test "returns true for a time within an inverted range (after start/before midnight)" do
+      t = ~T[08:00:00]
+      start_time = ~T[07:00:00]
+      stop_time = ~T[05:00:00]
+
+      assert ScreenAudioData.time_in_range?(t, start_time, stop_time)
+    end
+
+    test "returns true for a time within an inverted range (before end/after midnight)" do
+      t = ~T[04:00:00]
+      start_time = ~T[07:00:00]
+      stop_time = ~T[05:00:00]
+
+      assert ScreenAudioData.time_in_range?(t, start_time, stop_time)
+    end
+  end
 end


### PR DESCRIPTION
**Asana task**: ad hoc

`now` was not being shifted to Eastern when computing the current audio volume from config. 🤦

- [ ] Needs version bump?
