### PR TITLE
chore: Re-add BU West and Babcock St to subway status widget stop list

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -13404,8 +13404,7 @@
     "tslib": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
-      "dev": true
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
     },
     "tslint": {
       "version": "6.1.3",

--- a/lib/screens/v2/widget_instance/subway_status.ex
+++ b/lib/screens/v2/widget_instance/subway_status.ex
@@ -106,6 +106,8 @@ defmodule Screens.V2.WidgetInstance.SubwayStatus do
     {"place-buest", {"Boston University East", "BU East"}},
     {"place-bucen", {"Boston University Central", "BU Central"}},
     {"place-amory", {"Amory Street", "Amory St"}},
+    {"place-buwst", {"Boston University West", "BU West"}},
+    {"place-stplb", {"Saint Paul Street", "St. Paul St"}},
     {"place-babck", {"Babcock Street", "Babcock St"}},
     {"place-brico", {"Packards Corner", "Packards Cn"}},
     {"place-harvd", {"Harvard Avenue", "Harvard Ave"}},


### PR DESCRIPTION
**Asana task**: [Subway status handling of long term stop closure](https://app.asana.com/0/1185117109217413/1201374936544476/f)

Temporarily re-adding the stops that have been consolidated to the new Amory St stop, so that the subway status widget's presentation of the change aligns with dotcom's.

We will remove these stops from the list again once the alert that mentions them is deleted.

- [ ] Needs version bump?
