### PR TITLE
feat: Add configurable audio offset

### DIFF
--- a/assets/src/apps/v2/bus_shelter.tsx
+++ b/assets/src/apps/v2/bus_shelter.tsx
@@ -89,6 +89,9 @@ const blinkConfig: BlinkConfig = {
 };
 
 const audioConfig: AudioConfig = {
+  intervalOffsetSeconds: parseInt(
+    document.getElementById("app").dataset.audioIntervalOffsetSeconds
+  ),
   readoutIntervalMinutes: parseInt(
     document.getElementById("app").dataset.audioReadoutInterval
   ),

--- a/assets/src/components/v2/screen_container.tsx
+++ b/assets/src/components/v2/screen_container.tsx
@@ -52,6 +52,7 @@ const BlinkConfigContext = createContext<BlinkConfig | null>(
 );
 
 interface AudioConfig {
+  intervalOffsetSeconds: number;
   readoutIntervalMinutes: number;
 }
 

--- a/assets/src/hooks/use_interval.tsx
+++ b/assets/src/hooks/use_interval.tsx
@@ -4,22 +4,27 @@ import { useEffect, useRef } from "react";
 
 const noop = () => {};
 
-const useInterval = (callback: () => void, delay: number) => {
+const useInterval = (callback: () => void, delay: number, skipInterval?: boolean) => {
   const savedCallback = useRef<() => void>(noop);
 
   // Remember the latest callback.
   useEffect(() => {
-    savedCallback.current = callback;
-  }, [callback]);
+    if (!skipInterval && delay) {
+      savedCallback.current = callback;
+    }
+  }, [callback, delay, skipInterval]);
 
   // Set up the interval.
   useEffect(() => {
-    const tick = () => {
-      savedCallback.current();
-    };
-    const id = setInterval(tick, delay);
-    return () => clearInterval(id);
-  }, [delay]);
+    if (!skipInterval && delay) {
+      const tick = () => {
+        savedCallback.current();
+      };
+      const id = setInterval(tick, delay);
+      return () => clearInterval(id);
+    }
+    return noop;
+  }, [delay, skipInterval]);
 };
 
 export default useInterval;

--- a/lib/screens/config/v2/audio.ex
+++ b/lib/screens/config/v2/audio.ex
@@ -8,7 +8,8 @@ defmodule Screens.Config.V2.Audio do
           daytime_stop_time: Time.t(),
           days_active: list(Calendar.day_of_week()),
           daytime_volume: float(),
-          nighttime_volume: float()
+          nighttime_volume: float(),
+          interval_offset_seconds: non_neg_integer()
         }
 
   defstruct start_time: ~T[00:00:00],
@@ -17,7 +18,8 @@ defmodule Screens.Config.V2.Audio do
             daytime_stop_time: ~T[00:00:00],
             days_active: [],
             daytime_volume: 0.0,
-            nighttime_volume: 0.0
+            nighttime_volume: 0.0,
+            interval_offset_seconds: 0
 
   use Screens.Config.Struct, with_default: true
 

--- a/lib/screens/v2/screen_data/parameters.ex
+++ b/lib/screens/v2/screen_data/parameters.ex
@@ -55,4 +55,9 @@ defmodule Screens.V2.ScreenData.Parameters do
   def get_audio_readout_interval(app_id) do
     Map.get(@app_id_to_audio_readout_interval, app_id)
   end
+
+  @spec get_audio_interval_offset_seconds(Screens.Config.Screen.t()) :: pos_integer()
+  def get_audio_interval_offset_seconds(%Screens.Config.Screen{app_params: %Screens.Config.V2.BusShelter{audio: %Screens.Config.V2.Audio{interval_offset_seconds: interval_offset_seconds}}}) do
+    interval_offset_seconds
+  end
 end

--- a/lib/screens/v2/screen_data/parameters.ex
+++ b/lib/screens/v2/screen_data/parameters.ex
@@ -29,6 +29,14 @@ defmodule Screens.V2.ScreenData.Parameters do
     solari_large_v2: 0
   }
 
+  @app_id_to_audio_interval_offset_seconds %{
+    bus_eink_v2: 0,
+    bus_shelter_v2: 0,
+    gl_eink_v2: 0,
+    solari_v2: 0,
+    solari_large_v2: 0
+  }
+
   @spec get_candidate_generator(Screens.Config.Screen.t() | atom()) :: candidate_generator()
   def get_candidate_generator(%Screens.Config.Screen{app_id: app_id}) do
     get_candidate_generator(app_id)
@@ -59,5 +67,9 @@ defmodule Screens.V2.ScreenData.Parameters do
   @spec get_audio_interval_offset_seconds(Screens.Config.Screen.t()) :: pos_integer()
   def get_audio_interval_offset_seconds(%Screens.Config.Screen{app_params: %Screens.Config.V2.BusShelter{audio: %Screens.Config.V2.Audio{interval_offset_seconds: interval_offset_seconds}}}) do
     interval_offset_seconds
+  end
+
+  def get_audio_interval_offset_seconds(%Screens.Config.Screen{app_id: app_id}) do
+    Map.get(@app_id_to_audio_interval_offset_seconds, app_id)
   end
 end

--- a/lib/screens/v2/screen_data/parameters.ex
+++ b/lib/screens/v2/screen_data/parameters.ex
@@ -65,7 +65,11 @@ defmodule Screens.V2.ScreenData.Parameters do
   end
 
   @spec get_audio_interval_offset_seconds(Screens.Config.Screen.t()) :: pos_integer()
-  def get_audio_interval_offset_seconds(%Screens.Config.Screen{app_params: %Screens.Config.V2.BusShelter{audio: %Screens.Config.V2.Audio{interval_offset_seconds: interval_offset_seconds}}}) do
+  def get_audio_interval_offset_seconds(%Screens.Config.Screen{
+        app_params: %Screens.Config.V2.BusShelter{
+          audio: %Screens.Config.V2.Audio{interval_offset_seconds: interval_offset_seconds}
+        }
+      }) do
     interval_offset_seconds
   end
 

--- a/lib/screens_web/controllers/v2/screen_controller.ex
+++ b/lib/screens_web/controllers/v2/screen_controller.ex
@@ -1,6 +1,6 @@
 defmodule ScreensWeb.V2.ScreenController do
   use ScreensWeb, :controller
-
+  require Logger
   alias Screens.Config.{Screen, State}
   alias Screens.V2.ScreenData.Parameters
 
@@ -48,6 +48,7 @@ defmodule ScreensWeb.V2.ScreenController do
         |> assign(:app_id, app_id)
         |> assign(:refresh_rate, Parameters.get_refresh_rate(app_id))
         |> assign(:audio_readout_interval, Parameters.get_audio_readout_interval(app_id))
+        |> assign(:audio_interval_offset_seconds, Parameters.get_audio_interval_offset_seconds(config))
         |> assign(:sentry_frontend_dsn, Application.get_env(:screens, :sentry_frontend_dsn))
         |> put_view(ScreensWeb.V2.ScreenView)
         |> render("index.html")

--- a/lib/screens_web/controllers/v2/screen_controller.ex
+++ b/lib/screens_web/controllers/v2/screen_controller.ex
@@ -48,7 +48,10 @@ defmodule ScreensWeb.V2.ScreenController do
         |> assign(:app_id, app_id)
         |> assign(:refresh_rate, Parameters.get_refresh_rate(app_id))
         |> assign(:audio_readout_interval, Parameters.get_audio_readout_interval(app_id))
-        |> assign(:audio_interval_offset_seconds, Parameters.get_audio_interval_offset_seconds(config))
+        |> assign(
+          :audio_interval_offset_seconds,
+          Parameters.get_audio_interval_offset_seconds(config)
+        )
         |> assign(:sentry_frontend_dsn, Application.get_env(:screens, :sentry_frontend_dsn))
         |> put_view(ScreensWeb.V2.ScreenView)
         |> render("index.html")

--- a/lib/screens_web/templates/v2/screen/index.html.eex
+++ b/lib/screens_web/templates/v2/screen/index.html.eex
@@ -4,6 +4,7 @@
   data-environment-name="<%= @environment_name %>"
   data-refresh-rate="<%= @refresh_rate %>"
   data-audio-readout-interval="<%= @audio_readout_interval %>"
+  data-audio-interval-offset-seconds="<%= @audio_interval_offset_seconds %>"
   <%= if record_sentry?() do %>
     data-sentry="<%= @sentry_frontend_dsn %>"
   <% end %>


### PR DESCRIPTION
**Asana task**: [Audio Plays at different times for Walnut NB/SB](https://app.asana.com/0/1185117109217413/1201341796500854/f)

- Updated backend config to be handle `interval_offset_seconds` audio config value
- Pass config value to frontend as data attribute
- Update initial audio readout logic to wait until the next 5m interval (plus offset if present) rather than initial page load
- Continue readouts at normal interval after that
