### PR TITLE
[fix] GL Line Map: tweak vehicle spacing

### DIFF
--- a/lib/screens/v2/widget_instance/line_map.ex
+++ b/lib/screens/v2/widget_instance/line_map.ex
@@ -170,7 +170,9 @@ defmodule Screens.V2.WidgetInstance.LineMap do
          %{index: current_index, label: current_label} = v,
          [%{index: prev_index, label: prev_label} | _] = acc
        ) do
-    if current_index <= prev_index do
+    minimum_index_difference = 0.4
+
+    if current_index - prev_index <= minimum_index_difference do
       adjustment = if current_label == prev_label, do: 0.4, else: 0.7
       [%{v | index: prev_index + adjustment} | acc]
     else


### PR DESCRIPTION
**Asana task**: [Increase space between overlapping trains](https://app.asana.com/0/1185117109217413/1201221301197680)

The positions of the vehicle icons (and associated departure prediction labels) are determined by their `index`. This change will guarantee that they differ by at least 0.4, which results in the labels not overlapping with what I hope is a sufficient margin.