### PR TITLE
fix: Prevent null headway in front-end

### DIFF
--- a/assets/src/components/eink/green_line/departures.tsx
+++ b/assets/src/components/eink/green_line/departures.tsx
@@ -71,7 +71,7 @@ const DepartureList = ({
     <Departure time={time} currentTimeString={currentTimeString} key={id} />
   ));
 
-  if (renderedDepartures.length < 2) {
+  if (renderedDepartures.length < 2 && headway) {
     renderedDepartures.push(
       <HeadwayMessage
         destination={destination}


### PR DESCRIPTION
**Asana task**: [Invalid headway values on some GL e-ink screens](https://app.asana.com/0/1185117109217413/1201342811286106/f)

This scenario shouldn't happen any time but early morning, but just in case we will check for null.

- [ ] Needs version bump?
