### PR TITLE
feat: Add client_ip metadata to endpoint logs

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -17,7 +17,7 @@ config :screens, ScreensWeb.Endpoint,
 # Configures Elixir's Logger
 config :logger, :console,
   format: "$time $metadata[$level] $message\n",
-  metadata: [:request_id]
+  metadata: [:client_ip, :request_id]
 
 # Use Jason for JSON parsing in Phoenix
 config :phoenix, :json_library, Jason

--- a/lib/screens_web/endpoint.ex
+++ b/lib/screens_web/endpoint.ex
@@ -23,6 +23,7 @@ defmodule ScreensWeb.Endpoint do
     plug Phoenix.CodeReloader
   end
 
+  plug ScreensWeb.Plugs.Metadata
   plug Plug.RequestId
   plug Plug.Telemetry, event_prefix: [:phoenix, :endpoint]
 

--- a/lib/screens_web/plugs/metadata.ex
+++ b/lib/screens_web/plugs/metadata.ex
@@ -1,0 +1,20 @@
+defmodule ScreensWeb.Plugs.Metadata do
+  require Logger
+
+  def init(default), do: default
+
+  def call(conn, _default) do
+    log_client_ip(conn)
+
+    conn
+  end
+
+  defp log_client_ip(conn) do
+    forwarded_for =
+      conn
+      |> Plug.Conn.get_req_header("x-forwarded-for")
+      |> List.first()
+
+    Logger.metadata(client_ip: forwarded_for || conn.remote_ip)
+  end
+end

--- a/lib/screens_web/plugs/metadata.ex
+++ b/lib/screens_web/plugs/metadata.ex
@@ -1,4 +1,6 @@
 defmodule ScreensWeb.Plugs.Metadata do
+  @moduledoc false
+
   require Logger
 
   def init(default), do: default

--- a/lib/screens_web/plugs/metadata.ex
+++ b/lib/screens_web/plugs/metadata.ex
@@ -16,7 +16,11 @@ defmodule ScreensWeb.Plugs.Metadata do
       conn
       |> Plug.Conn.get_req_header("x-forwarded-for")
       |> List.first()
+    remote_ip = 
+      conn.remote_ip
+      |> :inet_parse.ntoa()
+      |> to_string()
 
-    Logger.metadata(client_ip: forwarded_for || conn.remote_ip)
+    Logger.metadata(client_ip: forwarded_for || remote_ip)
   end
 end

--- a/lib/screens_web/plugs/metadata.ex
+++ b/lib/screens_web/plugs/metadata.ex
@@ -16,7 +16,8 @@ defmodule ScreensWeb.Plugs.Metadata do
       conn
       |> Plug.Conn.get_req_header("x-forwarded-for")
       |> List.first()
-    remote_ip = 
+
+    remote_ip =
       conn.remote_ip
       |> :inet_parse.ntoa()
       |> to_string()


### PR DESCRIPTION
**Asana task**: [Add IP address to screen data request logging (both v1 and v2)](https://app.asana.com/0/1185117109217413/1201396741870851/f)

Add custom plug to add request client ip to logger metadata
