### PR TITLE
fix: Prevent text wrapping on DUP partial alert

### DIFF
--- a/assets/css/dup/free_text.scss
+++ b/assets/css/dup/free_text.scss
@@ -133,6 +133,9 @@
 
   .free-text__line {
     width: 1608px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .free-text__icon-container {

--- a/lib/screens/dup_screen_data/response.ex
+++ b/lib/screens/dup_screen_data/response.ex
@@ -60,8 +60,16 @@ defmodule Screens.DupScreenData.Response do
     end
   end
 
+  defp partial_alert_specifier(%{headsign: {:adj, "Ashmont/Braintree" = headsign}}) do
+    {headsign, ""}
+  end
+
   defp partial_alert_specifier(%{headsign: {:adj, headsign}}) do
     {headsign, "trains"}
+  end
+
+  defp partial_alert_specifier(%{headsign: "Ashmont/Braintree" = headsign}) do
+    {headsign, ""}
   end
 
   defp partial_alert_specifier(%{headsign: headsign}) do


### PR DESCRIPTION
**Asana task**: [DUP partial alert text for Ashmont/Braintree suspension and shuttle](https://app.asana.com/0/1185117109217413/1201010702999849/f)

The word `trains` caused bad wrapping for Ashmont/Braintree alerts. That word has been removed for that case. Also added CSS to prevent other cases from causing the same issue.

- [ ] Needs version bump?
