### PR TITLE
chore: Change URL that we fetch Mercury device logs from

### DIFF
--- a/lib/screens/mercury_data/fetch.ex
+++ b/lib/screens/mercury_data/fetch.ex
@@ -3,7 +3,7 @@ defmodule Screens.MercuryData.Fetch do
 
   import Screens.VendorData.Fetch, only: [make_and_parse_request: 5]
 
-  @api_url_base "https://cms.mercuryinnovation.com.au/ExtApi/devices"
+  @api_url_base "https://nexus.mercuryinnovation.com.au/ExtApi/devices"
   @vendor_request_opts [hackney: [pool: :mercury_api_pool]]
 
   def fetch_data do


### PR DESCRIPTION
**Asana task**: [Update Mercury API logging](https://app.asana.com/0/1185117109217413/1201449270360560/f)

`cms.*` -> `nexus.*`

Tested locally—the desired fields are missing from the new server's responses right now, but Kevin said he will check with Mercury and have them re-add the fields.

- [ ] Needs version bump?
