### PR TITLE
tweak: Initialize Sentry only on real screens

### DIFF
--- a/assets/src/apps/bus_eink.tsx
+++ b/assets/src/apps/bus_eink.tsx
@@ -15,10 +15,8 @@ import {
   MultiScreenPage,
   ScreenPage,
 } from "Components/eink/screen_page";
-import useSentry from "Hooks/use_sentry";
 
 const App = (): JSX.Element => {
-  useSentry();
   return (
     <Router>
       <Switch>

--- a/assets/src/apps/dup.tsx
+++ b/assets/src/apps/dup.tsx
@@ -14,10 +14,8 @@ import {
   MultiRotationPage,
 } from "Components/dup/dup_screen_page";
 import { isDup } from "Util/util";
-import useSentry from "Hooks/use_sentry";
 
 const App = (): JSX.Element => {
-  useSentry();
   if (isDup()) {
     return <ScreenPage screenContainer={ScreenContainer} />;
   } else {

--- a/assets/src/apps/v2/bus_eink.tsx
+++ b/assets/src/apps/v2/bus_eink.tsx
@@ -25,9 +25,11 @@ import {
   ResponseMapperContext,
 } from "Components/v2/screen_container";
 import NoData from "Components/v2/eink/no_data";
-import { MediumFlexAlert, FullBodyTopScreenAlert } from "Components/v2/eink/alert";
+import {
+  MediumFlexAlert,
+  FullBodyTopScreenAlert,
+} from "Components/v2/eink/alert";
 import BottomScreenFiller from "Components/v2/eink/bottom_screen_filler";
-import useSentry from "Hooks/use_sentry";
 
 const TYPE_TO_COMPONENT = {
   screen_normal: NormalScreen,
@@ -44,7 +46,7 @@ const TYPE_TO_COMPONENT = {
   full_body_alert: FullBodyTopScreenAlert,
   evergreen_content: EvergreenContent,
   no_data: NoData,
-  bottom_screen_filler: BottomScreenFiller
+  bottom_screen_filler: BottomScreenFiller,
 };
 
 const DISABLED_LAYOUT = {
@@ -68,7 +70,6 @@ const responseMapper: ResponseMapper = (apiResponse) => {
 };
 
 const App = (): JSX.Element => {
-  useSentry();
   return (
     <Router>
       <Switch>

--- a/assets/src/apps/v2/bus_shelter.tsx
+++ b/assets/src/apps/v2/bus_shelter.tsx
@@ -39,7 +39,6 @@ import NoData from "Components/v2/bus_shelter/no_data";
 import DeparturesNoData from "Components/v2/bus_shelter/departures_no_data";
 
 import { FlexZoneAlert, FullBodyAlert } from "Components/v2/bus_shelter/alert";
-import useSentry from "Hooks/use_sentry";
 
 const TYPE_TO_COMPONENT = {
   screen_normal: NormalScreen,
@@ -98,7 +97,6 @@ const audioConfig: AudioConfig = {
 };
 
 const App = (): JSX.Element => {
-  useSentry();
   return (
     <Router>
       <Switch>

--- a/assets/src/apps/v2/dup.tsx
+++ b/assets/src/apps/v2/dup.tsx
@@ -13,7 +13,6 @@ import TakeoverScreen from "Components/v2/takeover_screen";
 import Placeholder from "Components/v2/placeholder";
 import NormalHeader from "Components/v2/dup/normal_header";
 import NormalDepartures from "Components/v2/departures/normal_departures";
-import useSentry from "Hooks/use_sentry";
 
 const TYPE_TO_COMPONENT = {
   normal: NormalScreen,
@@ -24,7 +23,6 @@ const TYPE_TO_COMPONENT = {
 };
 
 const App = (): JSX.Element => {
-  useSentry();
   return (
     <Router>
       <Switch>

--- a/assets/src/apps/v2/gl_eink.tsx
+++ b/assets/src/apps/v2/gl_eink.tsx
@@ -21,11 +21,16 @@ import NormalDepartures from "Components/v2/departures/normal_departures";
 import LineMap from "Components/v2/gl_eink_double/line_map";
 import EvergreenContent from "Components/v2/evergreen_content";
 import NoData from "Components/v2/eink/no_data";
-import { ResponseMapper, ResponseMapperContext } from "Components/v2/screen_container";
-import { MediumFlexAlert, FullBodyTopScreenAlert } from "Components/v2/eink/alert";
+import {
+  ResponseMapper,
+  ResponseMapperContext,
+} from "Components/v2/screen_container";
+import {
+  MediumFlexAlert,
+  FullBodyTopScreenAlert,
+} from "Components/v2/eink/alert";
 import BottomScreenFiller from "Components/v2/eink/bottom_screen_filler";
 import OvernightDepartures from "Components/v2/eink/overnight_departures";
-import useSentry from "Hooks/use_sentry";
 
 const TYPE_TO_COMPONENT = {
   screen_normal: NormalScreen,
@@ -68,7 +73,6 @@ const responseMapper: ResponseMapper = (apiResponse) => {
 };
 
 const App = (): JSX.Element => {
-  useSentry();
   return (
     <Router>
       <Switch>

--- a/assets/src/apps/v2/gl_eink_single.tsx
+++ b/assets/src/apps/v2/gl_eink_single.tsx
@@ -13,7 +13,6 @@ import TakeoverScreen from "Components/v2/takeover_screen";
 import Placeholder from "Components/v2/placeholder";
 import LinkFooter from "Components/v2/eink/link_footer";
 import NormalHeader from "Components/v2/eink/normal_header";
-import useSentry from "Hooks/use_sentry";
 
 const TYPE_TO_COMPONENT = {
   normal: NormalScreen,
@@ -24,7 +23,6 @@ const TYPE_TO_COMPONENT = {
 };
 
 const App = (): JSX.Element => {
-  useSentry();
   return (
     <Router>
       <Switch>

--- a/assets/src/apps/v2/solari.tsx
+++ b/assets/src/apps/v2/solari.tsx
@@ -13,7 +13,6 @@ import TakeoverScreen from "Components/v2/takeover_screen";
 import Placeholder from "Components/v2/placeholder";
 import NormalHeader from "Components/v2/lcd/normal_header";
 import NormalDepartures from "Components/v2/departures/normal_departures";
-import useSentry from "Hooks/use_sentry";
 
 const TYPE_TO_COMPONENT = {
   normal: NormalScreen,
@@ -24,7 +23,6 @@ const TYPE_TO_COMPONENT = {
 };
 
 const App = (): JSX.Element => {
-  useSentry();
   return (
     <Router>
       <Switch>

--- a/assets/src/apps/v2/solari_large.tsx
+++ b/assets/src/apps/v2/solari_large.tsx
@@ -13,7 +13,6 @@ import TakeoverScreen from "Components/v2/takeover_screen";
 import Placeholder from "Components/v2/placeholder";
 import NormalHeader from "Components/v2/lcd/normal_header";
 import NormalDepartures from "Components/v2/departures/normal_departures";
-import useSentry from "Hooks/use_sentry";
 
 const TYPE_TO_COMPONENT = {
   normal: NormalScreen,
@@ -24,7 +23,6 @@ const TYPE_TO_COMPONENT = {
 };
 
 const App = (): JSX.Element => {
-  useSentry();
   return (
     <Router>
       <Switch>

--- a/assets/src/components/dup/screen_container.tsx
+++ b/assets/src/components/dup/screen_container.tsx
@@ -10,6 +10,7 @@ import useOutfrontStation from "Hooks/use_outfront_station";
 import useCurrentPage from "Hooks/use_current_dup_page";
 
 import { formatTimeString, classWithModifier, imagePath } from "Util/util";
+import useSentry from "Hooks/use_sentry";
 
 const LinkArrow = ({ width, color }) => {
   const height = 40;
@@ -191,6 +192,7 @@ const ScreenLayout = ({ apiResponse }): JSX.Element => {
 
 const ScreenContainer = ({ id, rotationIndex }): JSX.Element => {
   const apiResponse = useApiResponse({ id, rotationIndex });
+  useSentry();
 
   return <ScreenLayout apiResponse={apiResponse} />;
 };

--- a/assets/src/components/eink/bus/screen_container.tsx
+++ b/assets/src/components/eink/bus/screen_container.tsx
@@ -14,6 +14,7 @@ import useApiResponse from "Hooks/use_api_response";
 import useFitDepartures from "Hooks/use_fit_departures";
 
 import { EINK_REFRESH_MS } from "Constants";
+import useSentry from "Hooks/use_sentry";
 
 const TopScreenLayout = forwardRef(
   ({ currentTimeString, stopName, departures }, ref): JSX.Element => {
@@ -124,6 +125,7 @@ const NoConnectionScreenLayout = (): JSX.Element => {
 
 const ScreenLayout = ({ apiResponse }): JSX.Element => {
   const noDepartures = (apiResponse?.departures?.length ?? 0) === 0;
+  useSentry();
 
   switch (true) {
     case !apiResponse || apiResponse.success === false:

--- a/assets/src/components/eink/green_line/double/screen_container.tsx
+++ b/assets/src/components/eink/green_line/double/screen_container.tsx
@@ -16,6 +16,7 @@ import TakeoverScreenLayout from "Components/eink/takeover_screen_layout";
 import useApiResponse from "Hooks/use_api_response";
 
 import { EINK_REFRESH_MS } from "Constants";
+import useSentry from "Hooks/use_sentry";
 
 const TopScreenLayout = ({
   currentTimeString,
@@ -138,6 +139,7 @@ const NoConnectionScreenLayout = (): JSX.Element => {
 };
 
 const ScreenLayout = ({ apiResponse }): JSX.Element => {
+  useSentry();
   switch (true) {
     case !apiResponse || apiResponse.success === false:
       return <NoConnectionScreenLayout />;

--- a/assets/src/components/eink/green_line/single/screen_container.tsx
+++ b/assets/src/components/eink/green_line/single/screen_container.tsx
@@ -12,6 +12,7 @@ import TakeoverScreenLayout from "Components/eink/takeover_screen_layout";
 import useApiResponse from "Hooks/use_api_response";
 
 import { EINK_REFRESH_MS } from "Constants";
+import useSentry from "Hooks/use_sentry";
 
 const TopScreenLayout = ({
   currentTimeString,
@@ -95,6 +96,7 @@ const NoConnectionScreenLayout = (): JSX.Element => {
 };
 
 const ScreenLayout = ({ apiResponse }): JSX.Element => {
+  useSentry();
   switch (true) {
     case !apiResponse || apiResponse.success === false:
       return <NoConnectionScreenLayout />;

--- a/assets/src/components/solari/screen_container.tsx
+++ b/assets/src/components/solari/screen_container.tsx
@@ -10,6 +10,7 @@ import useApiResponse from "Hooks/use_api_response";
 
 import { SOLARI_REFRESH_MS } from "Constants";
 import { useLocation } from "react-router-dom";
+import useSentry from "Hooks/use_sentry";
 
 const DefaultScreenLayout = ({ apiResponse }): JSX.Element => {
   const sizeModifier = apiResponse.overhead ? "size-large" : "size-normal";
@@ -56,6 +57,7 @@ const TakeoverScreenLayout = ({ apiResponse }): JSX.Element => {
 };
 
 const ScreenLayout = ({ apiResponse }): JSX.Element => {
+  useSentry();
   if (!apiResponse || apiResponse.success === false) {
     return <NoConnectionScreenLayout />;
   }

--- a/assets/src/components/v2/screen_page.tsx
+++ b/assets/src/components/v2/screen_page.tsx
@@ -1,9 +1,11 @@
 import React from "react";
 import { useParams } from "react-router-dom";
 import ScreenContainer from "Components/v2/screen_container";
+import useSentry from "Hooks/use_sentry";
 
 const ScreenPage = () => {
   const { id } = useParams();
+  useSentry();
   return <ScreenContainer id={id} />;
 };
 

--- a/assets/src/hooks/use_sentry.tsx
+++ b/assets/src/hooks/use_sentry.tsx
@@ -1,10 +1,13 @@
 import * as Sentry from "@sentry/react";
 import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
 
 const useSentry = () => {
   const sentryDsn = document.getElementById("app")?.dataset.sentry;
+  const query = new URLSearchParams(useLocation().search);
+  const isRealScreen = query.get("is_real_screen");
   useEffect(() => {
-    if (sentryDsn) {
+    if (sentryDsn && isRealScreen) {
       Sentry.init({
         dsn: sentryDsn,
       });


### PR DESCRIPTION
**Asana task**: [Only set Sentry DSN data attribute on page requests from real screens](https://app.asana.com/0/1185117109217413/1201465640055315/f)

Biggest change here was moving the hook call for each app. Needed to be in the Router in order to grab the param.

- [ ] Needs version bump?
