### PR TITLE
fix: Register the :medium_flex atom

### DIFF
--- a/lib/screens/config/state/s3_fetch.ex
+++ b/lib/screens/config/state/s3_fetch.ex
@@ -9,6 +9,11 @@ defmodule Screens.Config.State.S3Fetch do
 
   @impl true
   def fetch_config(current_version) do
+    # Temp fix: "bring into existence" a slot ID that has been renamed,
+    # so that the app doesn't crash when using `String.to_existing_atom/1`
+    # during parsing of old config.
+    _ = :medium_flex
+
     with {:ok, body, new_version} <- get_config(current_version),
          {:ok, parsed} <- Jason.decode(body) do
       {:ok, Config.from_json(parsed), new_version}


### PR DESCRIPTION
**Asana task**: ad hoc

Register `:medium_flex` so that the app doesn't crash when parsing old config that still uses that slot name, which has since been renamed to `:medium` since it lives inside a flex zone now.

- [ ] Needs version bump?
