### PR TITLE
Update screens repo readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 1. Import the Node.js release team's OpenPGP keys to main keyring (this is required by asdf-nodejs):
    `bash ~/.asdf/plugins/nodejs/bin/import-release-team-keyring`
 1. Install versions specified in `.tool-versions` with `asdf install`
-   - If you see an error along the lines of 
+   If you see an error along the lines of 
       ```
       configure: error: 
 
@@ -29,7 +29,7 @@
       tar zxvf OTP-<version>.tar.gz
       ```
 
-      Next, modify **~/.asdf/plugins/erlang/kerl-home/archives/otp-OTP-<version>/make/configure.in** near line 415 by adding `&& false` (exact line # may vary based on OTP version)
+      Next, modify **~/.asdf/plugins/erlang/kerl-home/archives/otp-OTP-{version}/make/configure.in** near line 415 by adding `&& false` (exact line # may vary based on OTP version)
       ```
       #if __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ > $int_macosx_version && false
       ```

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 1. Clone this repo
 1. Install the [asdf package manager](https://github.com/asdf-vm/asdf)
 1. Install dependencies:
-   `brew install autoconf coreutils gnupg`
+   `brew install autoconf@2.69 coreutils gnupg`
 1. Add `asdf` plugins:
    1. `asdf plugin-add erlang`
    1. `asdf plugin-add elixir`
@@ -13,6 +13,36 @@
 1. Import the Node.js release team's OpenPGP keys to main keyring (this is required by asdf-nodejs):
    `bash ~/.asdf/plugins/nodejs/bin/import-release-team-keyring`
 1. Install versions specified in `.tool-versions` with `asdf install`
+   - If you see an error along the lines of 
+      ```
+      configure: error: 
+
+         You are natively building Erlang/OTP for a later version of MacOSX
+         than current version (11.0). You either need to
+         cross-build Erlang/OTP, or set the environment variable
+         MACOSX_DEPLOYMENT_TARGET to 11.0 (or a lower version).
+      ```
+      you can try modifying the source downloaded by `asdf` to get around it.
+
+      ```
+      cd ~/.asdf/plugins/erlang/kerl-home/archives
+      tar zxvf OTP-<version>.tar.gz
+      ```
+
+      Next, modify **~/.asdf/plugins/erlang/kerl-home/archives/otp-OTP-<version>/make/configure.in** near line 415 by adding `&& false` (exact line # may vary based on OTP version)
+      ```
+      #if __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ > $int_macosx_version && false
+      ```
+
+      Re-tar the directory:
+      ```
+      tar cfz OTP-<version>.tar otp-OTP-<version>
+      rm -rf otp-OTP-<version>
+      ```
+      More context can be found on [this Github issue](https://github.com/asdf-vm/asdf-erlang/issues/161#issuecomment-731477842)
+
+      Return to your screens repo and try running `asdf install` again.
+
 1. Install Elixir dependencies with `mix deps.get`
 1. Install Node.js dependencies with `npm install --prefix assets`
 1. Get access to our S3 bucket from DevOps and/or a teammate and save the JSON found at mbta-ctd-config/screens/screens-prod.json as `priv/local.json` to supply your local server with config values.

--- a/README.md
+++ b/README.md
@@ -25,18 +25,18 @@
       ```
       you can try modifying the OTP source downloaded by `asdf` to get around it (More context can be found on [this Github issue](https://github.com/asdf-vm/asdf-erlang/issues/161#issuecomment-731477842)):
 
-      ```
+      ```sh
       cd ~/.asdf/plugins/erlang/kerl-home/archives
       tar zxvf OTP-<version>.tar.gz
       ```
 
       Next, modify **~/.asdf/plugins/erlang/kerl-home/archives/otp-OTP-{version}/make/configure.in** near line 415 by adding `&& false` (exact line # may vary based on OTP version):
-      ```
+      ```sh
       #if __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ > $int_macosx_version && false
       ```
 
       Re-tar the directory:
-      ```
+      ```sh
       tar cfz OTP-<version>.tar otp-OTP-<version>
       rm -rf otp-OTP-<version>
       ```

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@
 1. Import the Node.js release team's OpenPGP keys to main keyring (this is required by asdf-nodejs):
    `bash ~/.asdf/plugins/nodejs/bin/import-release-team-keyring`
 1. Install versions specified in `.tool-versions` with `asdf install`
-   If you see an error along the lines of 
+
+   **If** you see an error along the lines of 
       ```
       configure: error: 
 
@@ -22,7 +23,7 @@
          cross-build Erlang/OTP, or set the environment variable
          MACOSX_DEPLOYMENT_TARGET to 11.0 (or a lower version).
       ```
-      you can try modifying the source downloaded by `asdf` to get around it.
+      you can try modifying the OTP source downloaded by `asdf` to get around it (More context can be found on [this Github issue](https://github.com/asdf-vm/asdf-erlang/issues/161#issuecomment-731477842)):
 
       ```
       cd ~/.asdf/plugins/erlang/kerl-home/archives
@@ -39,8 +40,6 @@
       tar cfz OTP-<version>.tar otp-OTP-<version>
       rm -rf otp-OTP-<version>
       ```
-      More context can be found on [this Github issue](https://github.com/asdf-vm/asdf-erlang/issues/161#issuecomment-731477842)
-
       Return to your screens repo and try running `asdf install` again.
 
 1. Install Elixir dependencies with `mix deps.get`

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 1. Install versions specified in `.tool-versions` with `asdf install`
 
    **If** you see an error along the lines of 
-      ```
+      ```sh
       configure: error: 
 
          You are natively building Erlang/OTP for a later version of MacOSX
@@ -30,7 +30,7 @@
       tar zxvf OTP-<version>.tar.gz
       ```
 
-      Next, modify **~/.asdf/plugins/erlang/kerl-home/archives/otp-OTP-{version}/make/configure.in** near line 415 by adding `&& false` (exact line # may vary based on OTP version)
+      Next, modify **~/.asdf/plugins/erlang/kerl-home/archives/otp-OTP-{version}/make/configure.in** near line 415 by adding `&& false` (exact line # may vary based on OTP version):
       ```
       #if __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ > $int_macosx_version && false
       ```
@@ -44,7 +44,7 @@
 
 1. Install Elixir dependencies with `mix deps.get`
 1. Install Node.js dependencies with `npm install --prefix assets`
-1. Get access to our S3 bucket from DevOps and/or a teammate and save the JSON found at mbta-ctd-config/screens/screens-prod.json as `priv/local.json` to supply your local server with config values.
+1. Get access to our S3 bucket from DevOps and/or a teammate and save the JSON found at mbta-ctd-config/screens/screens-prod.json as `priv/local.json` to supply your local server with config values. You will also need to grab the signs_ui_config JSON and save it at `priv/signs_ui_config.json`.
 1. Visit [AWS security credentials](https://console.aws.amazon.com/iam/home#/security_credentials) and create an access key if you don't already have it. Save the access key ID and secret access key as environment variables:
 
    ```sh


### PR DESCRIPTION
Description:

Encountered a few hurdles when setting up and running the screens application locally for the first time. This PR contains some amendments to the readme that should help future engineers get past those hurdles quickly.

Quick summary of the changes:
- Specify install of autoconf version 2.69 as it looks like latest versions of autoconf are preventing asdf from building erlang
- Include a workaround (a bit hacky) for MacOSX and Erlang configure error
- Include mention of `signs_ui_config.json` file needed for running the app

View a preview of the rendered readme [here](https://github.com/mbta/screens/tree/pk/update-readme#readme)
