### PR TITLE
fix: Adjusted bus eInk dept headsign alignement for wrapped names

### DIFF
--- a/assets/css/v2/bus_eink/departures/row.scss
+++ b/assets/css/v2/bus_eink/departures/row.scss
@@ -17,16 +17,16 @@
 
 .departure-row__route {
   display: inline-block;
-  vertical-align: top;
+  vertical-align: middle;
   margin-left: 32px;
   margin-top: 32px;
 }
 
 .departure-row__destination {
   display: inline-block;
-  vertical-align: top;
+  vertical-align: middle;
   margin-left: 32px;
-  margin-top: 68px;
+  margin-top: 32px;
 }
 
 .departure-row__time {


### PR DESCRIPTION
**Asana task**: [[Bus e-Ink] Fix vertical position of headsigns which wrap](https://app.asana.com/0/1185117109217413/1201520511503438/f)

<img width="1300" alt="Screen Shot 2022-01-05 at 9 47 33 AM" src="https://user-images.githubusercontent.com/10713153/148237092-f40cd511-397b-473f-a7bf-ca14d48de34b.png">

- [ ] Needs version bump?
