### PR TITLE
fix: Single alert GL multi branch edge case

### DIFF
--- a/lib/screens/v2/widget_instance/subway_status.ex
+++ b/lib/screens/v2/widget_instance/subway_status.ex
@@ -348,10 +348,7 @@ defmodule Screens.V2.WidgetInstance.SubwayStatus do
   defp get_endpoints(informed_entities, route_id) do
     case get_stop_sequence(informed_entities, route_id) do
       nil ->
-        %{
-          full: "",
-          abbrev: ""
-        }
+        nil
 
       stop_sequence ->
         {min_index, max_index} =

--- a/lib/screens/v2/widget_instance/subway_status.ex
+++ b/lib/screens/v2/widget_instance/subway_status.ex
@@ -346,24 +346,31 @@ defmodule Screens.V2.WidgetInstance.SubwayStatus do
   end
 
   defp get_endpoints(informed_entities, route_id) do
-    stop_sequence = get_stop_sequence(informed_entities, route_id)
+    case get_stop_sequence(informed_entities, route_id) do
+      nil ->
+        %{
+          full: "",
+          abbrev: ""
+        }
 
-    {min_index, max_index} =
-      informed_entities
-      |> Enum.filter(&stop_on_route?(&1, stop_sequence))
-      |> Enum.map(&to_stop_index(&1, stop_sequence))
-      |> Enum.min_max()
+      stop_sequence ->
+        {min_index, max_index} =
+          informed_entities
+          |> Enum.filter(&stop_on_route?(&1, stop_sequence))
+          |> Enum.map(&to_stop_index(&1, stop_sequence))
+          |> Enum.min_max()
 
-    {_, min_station_name} = Enum.at(stop_sequence, min_index)
-    {_, max_station_name} = Enum.at(stop_sequence, max_index)
+        {_, min_station_name} = Enum.at(stop_sequence, min_index)
+        {_, max_station_name} = Enum.at(stop_sequence, max_index)
 
-    {min_full_name, min_abbreviated_name} = min_station_name
-    {max_full_name, max_abbreviated_name} = max_station_name
+        {min_full_name, min_abbreviated_name} = min_station_name
+        {max_full_name, max_abbreviated_name} = max_station_name
 
-    %{
-      full: "#{min_full_name} to #{max_full_name}",
-      abbrev: "#{min_abbreviated_name} to #{max_abbreviated_name}"
-    }
+        %{
+          full: "#{min_full_name} to #{max_full_name}",
+          abbrev: "#{min_abbreviated_name} to #{max_abbreviated_name}"
+        }
+    end
   end
 
   # Finds a stop sequence which contains all stations in informed_entities


### PR DESCRIPTION
**Asana task**: [[Subway Status] Handle case where a single alert affects multiple branches](https://app.asana.com/0/1185117109217413/1201514401502521/f)

A single alert on the GL with stops on multiple lines selected was causing the screen to crash. Added a case statement to handle this edge case.

![Screen Shot 2022-01-24 at 8 44 44 AM](https://user-images.githubusercontent.com/10713153/150793884-97f19c48-ce20-467b-8e41-e26e586584c6.png)
![Screen Shot 2022-01-24 at 8 44 49 AM](https://user-images.githubusercontent.com/10713153/150793894-25d8df31-8e72-438c-a59e-25f78b8caaaa.png)


- [ ] Needs version bump?
