### PR TITLE
chore: Update API dev-green URL

### DIFF
--- a/lib/screens/v3_api.ex
+++ b/lib/screens/v3_api.ex
@@ -77,7 +77,7 @@ defmodule Screens.V3Api do
     case environment_name do
       "screens-prod" -> "https://api-v3.mbta.com/"
       "screens-dev" -> "https://dev.api.mbtace.com/"
-      "screens-dev-green" -> "https://green.dev.api.mbtace.com/"
+      "screens-dev-green" -> "https://api-dev-green.mbtace.com/"
       _ -> Application.get_env(:screens, :default_api_v3_url)
     end
   end


### PR DESCRIPTION
**Asana task**: related to [💳 terraform-ize API and move to ECS](https://app.asana.com/0/584764604969369/1200732284152245)

As part of the ECS migration, we're moving the dev-green API to a new URL: https://api-dev-green.mbtace.com/ from https://green.dev.api.mbtace.com/. I did a search of CTD's repos and found the old URL hardcoded in a few places.

- [ ] Needs version bump?
