### PR TITLE
fix: Subway Status with GL alert affecting whole line

### DIFF
--- a/lib/screens/v2/widget_instance/subway_status.ex
+++ b/lib/screens/v2/widget_instance/subway_status.ex
@@ -542,7 +542,6 @@ defmodule Screens.V2.WidgetInstance.SubwayStatus do
     alert_whole_line_stops =
       informed_entities
       |> Enum.map(fn e -> Map.get(e, :route) end)
-      |> Enum.reject(&is_nil/1)
       |> Enum.filter(fn
         "Green-" <> _ -> true
         _ -> false

--- a/lib/screens/v2/widget_instance/subway_status.ex
+++ b/lib/screens/v2/widget_instance/subway_status.ex
@@ -215,6 +215,8 @@ defmodule Screens.V2.WidgetInstance.SubwayStatus do
     "Green" => [@green_line_trunk_stops]
   }
 
+  @green_line_branches ["Green-B", "Green-C", "Green-D", "Green-E"]
+
   defimpl Screens.V2.WidgetInstance do
     def priority(_instance), do: [2, 1]
 
@@ -525,7 +527,7 @@ defmodule Screens.V2.WidgetInstance.SubwayStatus do
     |> Enum.sort_by(fn [[first_route | _other_routes], _status] -> first_route end)
   end
 
-  defp alert_affects_gl_trunk?(%Alert{informed_entities: informed_entities}) do
+  defp alert_affects_gl_trunk_or_whole_line?(%Alert{informed_entities: informed_entities}) do
     gl_trunk_stops =
       @route_stop_sequences |> Map.get("Green") |> hd() |> Enum.map(&elem(&1, 0)) |> MapSet.new()
 
@@ -537,7 +539,19 @@ defmodule Screens.V2.WidgetInstance.SubwayStatus do
       |> Enum.into(MapSet.new())
       |> MapSet.intersection(gl_trunk_stops)
 
-    MapSet.size(alert_trunk_stops) > 0
+    alert_whole_line_stops =
+      informed_entities
+      |> Enum.map(fn e -> Map.get(e, :route) end)
+      |> Enum.reject(&is_nil/1)
+      |> Enum.filter(fn
+        "Green-" <> _ -> true
+        _ -> false
+      end)
+      |> Enum.uniq()
+      |> Enum.sort()
+
+    MapSet.size(alert_trunk_stops) > 0 or
+      alert_whole_line_stops == @green_line_branches
   end
 
   defp is_multi_route?(alert) do
@@ -546,13 +560,13 @@ defmodule Screens.V2.WidgetInstance.SubwayStatus do
 
   def serialize_green_line(grouped_alerts) do
     green_line_alerts =
-      ["Green-B", "Green-C", "Green-D", "Green-E"]
+      @green_line_branches
       |> Enum.flat_map(fn route -> Map.get(grouped_alerts, route, []) end)
       |> Enum.uniq()
 
     multi_route_alerts = Enum.filter(green_line_alerts, &is_multi_route?/1)
     single_route_alerts = Enum.reject(green_line_alerts, &is_multi_route?/1)
-    trunk_alerts = Enum.filter(multi_route_alerts, &alert_affects_gl_trunk?/1)
+    trunk_alerts = Enum.filter(multi_route_alerts, &alert_affects_gl_trunk_or_whole_line?/1)
     alert_count = length(green_line_alerts)
 
     statuses =

--- a/test/screens/v2/widget_instance/subway_status_test.exs
+++ b/test/screens/v2/widget_instance/subway_status_test.exs
@@ -316,6 +316,34 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
       assert %{status: "Normal Service", type: :single} =
                SubwayStatus.serialize_green_line(grouped_alerts)
     end
+
+    test "handles alert affecting all branches" do
+      alert = [
+        %Alert{
+          effect: :delay,
+          severity: 3,
+          informed_entities: [
+            %{route: "Green-B", direction_id: nil, stop: nil},
+            %{route: "Green-C", direction_id: nil, stop: nil},
+            %{route: "Green-D", direction_id: nil, stop: nil},
+            %{route: "Green-E", direction_id: nil, stop: nil}
+          ]
+        }
+      ]
+
+      grouped_alerts = %{
+        "Green-B" => alert,
+        "Green-C" => alert,
+        "Green-D" => alert,
+        "Green-E" => alert
+      }
+
+      assert %{
+               location: nil,
+               status: "Delays up to 10 minutes",
+               type: :single
+             } = SubwayStatus.serialize_green_line(grouped_alerts)
+    end
   end
 
   describe "slot_names/1" do


### PR DESCRIPTION
**Asana task**: [[bug] Subway status ignores GL alerts which affect the entire Green Line](https://app.asana.com/0/1185117109217413/1201804054848498/f)

When an alert that affecting the whole GL exists, the subway status was ignoring it. This was because we only looked for trunk vs. branch alerts. Now, when an alert comes through with all 4 branches in its informed entities, we treat it as a trunk alert. 

![Screen Shot 2022-02-22 at 8 52 38 AM](https://user-images.githubusercontent.com/10713153/155146027-27bf4e09-1c36-4b98-89b9-4f7b2e8d0acc.png)

![Screen Shot 2022-02-22 at 8 52 43 AM](https://user-images.githubusercontent.com/10713153/155146052-2fcf2ed9-7de5-4812-8b9a-20f0463c97bf.png)

- [ ] Needs version bump?
