### PR TITLE
Added key to top level of normal_departures for v2

### DIFF
--- a/assets/src/components/v2/departures/normal_departures.tsx
+++ b/assets/src/components/v2/departures/normal_departures.tsx
@@ -4,10 +4,12 @@ import React, {
   useLayoutEffect,
   useRef,
   useEffect,
+  useContext,
 } from "react";
 
 import NormalSection from "Components/v2/departures/normal_section";
 import NoticeSection from "Components/v2/departures/notice_section";
+import { LastFetchContext } from "../screen_container";
 
 const NormalDeparturesRenderer = forwardRef(
   ({ sections, sectionSizes }, ref) => {
@@ -116,6 +118,7 @@ const NormalDeparturesSizer = ({ sections, onDoneSizing }) => {
 
 const NormalDepartures = ({ sections }) => {
   const [sectionSizes, setSectionSizes] = useState([]);
+  const lastFetch = useContext(LastFetchContext);
 
   // Reset state each time we receive new props,
   // so that section sizes are recalculated from scratch.
@@ -128,6 +131,7 @@ const NormalDepartures = ({ sections }) => {
       <NormalDeparturesRenderer
         sections={sections}
         sectionSizes={sectionSizes}
+        key={lastFetch}
       />
     );
   } else {
@@ -135,6 +139,7 @@ const NormalDepartures = ({ sections }) => {
       <NormalDeparturesSizer
         sections={sections}
         onDoneSizing={setSectionSizes}
+        key={lastFetch}
       />
     );
   }


### PR DESCRIPTION
**Asana task**: [Explore time sorting error on V2 apps](https://app.asana.com/0/1185117109217413/1201453209353026)

Setting React keys on the top-level of the Departures Widget should force a re-mount with each data fetch, preventing wonky departure data from hanging around
