### PR TITLE
fix: Ensure screen API requests receive 404 for nonexistent screen IDs

### DIFF
--- a/lib/screens/v2/screen_data.ex
+++ b/lib/screens/v2/screen_data.ex
@@ -26,24 +26,15 @@ defmodule Screens.V2.ScreenData do
             {page_index :: non_neg_integer(), num_pages :: pos_integer()}
         }
 
-  @spec by_screen_id(screen_id(), String.t()) :: response_map()
-  def by_screen_id(screen_id, last_refresh) do
-    cond do
-      outdated?(screen_id, last_refresh) ->
-        outdated_response()
+  @spec by_screen_id(screen_id()) :: response_map()
+  def by_screen_id(screen_id) do
+    config = get_config(screen_id)
+    refresh_rate = Parameters.get_refresh_rate(config)
 
-      disabled?(screen_id) ->
-        disabled_response()
-
-      true ->
-        config = get_config(screen_id)
-        refresh_rate = Parameters.get_refresh_rate(config)
-
-        config
-        |> fetch_data()
-        |> resolve_paging(refresh_rate)
-        |> serialize()
-    end
+    config
+    |> fetch_data()
+    |> resolve_paging(refresh_rate)
+    |> serialize()
   end
 
   @spec fetch_data(Screens.Config.Screen.t()) :: {Template.layout(), selected_instances_map()}
@@ -338,22 +329,8 @@ defmodule Screens.V2.ScreenData do
     |> Map.merge(%{type: WidgetInstance.widget_type(instance)})
   end
 
-  defp outdated?(screen_id, client_refresh_timestamp) do
-    {:ok, client_refresh_time, _} = DateTime.from_iso8601(client_refresh_timestamp)
-    refresh_if_loaded_before_time = Screens.Config.State.refresh_if_loaded_before(screen_id)
-
-    case refresh_if_loaded_before_time do
-      nil -> false
-      _ -> DateTime.compare(client_refresh_time, refresh_if_loaded_before_time) == :lt
-    end
-  end
-
-  defp disabled?(screen_id) do
-    Screens.Config.State.disabled?(screen_id)
-  end
-
-  defp outdated_response, do: response(force_reload: true)
-  defp disabled_response, do: response(disabled: true)
+  def outdated_response, do: response(force_reload: true)
+  def disabled_response, do: response(disabled: true)
 
   @spec response(keyword()) :: response_map()
   defp response(fields) do


### PR DESCRIPTION
**Asana task**: [Properly handle screen API requests for nonexistent IDs](https://app.asana.com/0/1185117109217413/1201885776028177/f)