### PR TITLE
fix: Sort departure times correctly

### DIFF
--- a/lib/screens/v2/departure/builder.ex
+++ b/lib/screens/v2/departure/builder.ex
@@ -66,7 +66,7 @@ defmodule Screens.V2.Departure.Builder do
 
     departures_without_trip
     |> Kernel.++(deduplicated_predictions_with_trip)
-    |> Enum.sort_by(& &1.departure_time)
+    |> Enum.sort_by(& &1.departure_time, DateTime)
   end
 
   def merge_predictions_and_schedules(predictions, schedules) do

--- a/lib/screens/v2/departure/builder.ex
+++ b/lib/screens/v2/departure/builder.ex
@@ -62,11 +62,13 @@ defmodule Screens.V2.Departure.Builder do
     deduplicated_predictions_with_trip =
       departures_with_trip
       |> Enum.group_by(fn %{trip: %Trip{id: trip_id}} -> trip_id end)
-      |> Enum.map(fn {_trip_id, departures} -> Enum.min_by(departures, & &1.departure_time) end)
+      |> Enum.map(fn {_trip_id, departures} ->
+        Enum.min_by(departures, &(&1.departure_time || &1.arrival_time), DateTime)
+      end)
 
     departures_without_trip
     |> Kernel.++(deduplicated_predictions_with_trip)
-    |> Enum.sort_by(& &1.departure_time, DateTime)
+    |> Enum.sort_by(&(&1.departure_time || &1.arrival_time), DateTime)
   end
 
   def merge_predictions_and_schedules(predictions, schedules) do


### PR DESCRIPTION
**Asana task**: [Explore time sorting error on V2 apps](https://app.asana.com/0/1185117109217413/1201453209353026/f)

https://hexdocs.pm/elixir/Enum.html#sort/2-sorting-structs

I've created a [separate task](https://app.asana.com/0/1185117109217422/1201894802937869/f) to check out other spots where we use `Enum.sort` and make sure they don't need a similar fix.

- [ ] Needs version bump?
