### PR TITLE
tweak: Allow variable paging on V2 apps

### DIFF
--- a/lib/screens/v2/screen_data.ex
+++ b/lib/screens/v2/screen_data.ex
@@ -239,19 +239,24 @@ defmodule Screens.V2.ScreenData do
     rem(periods_since_midnight, num_pages)
   end
 
+  # Function to remove slots from the layout if there are no candidates available to populate it
+  # Specifically added to help introduce variable paging
   defp filter_empty_slots({_slot_id, {_layout_type, children}}, selected_instances_slots) do
     children
     |> Enum.map(fn
+      # Static slots: :main_content, :header, etc.
       slot_id when is_atom(slot_id) ->
         if slot_id in selected_instances_slots do
           slot_id
         end
 
+      # Paged slots: :flex_zone
       nested_child when is_paged_slot_id(nested_child) ->
         if nested_child in selected_instances_slots do
           nested_child
         end
 
+      # A nested layout. Take the nested layout and feed it back into this function to process its children.
       {slot_id, {layout_type, _children}} = nested_layout ->
         case filter_empty_slots(nested_layout, selected_instances_slots) do
           [nil] ->
@@ -261,6 +266,7 @@ defmodule Screens.V2.ScreenData do
             {slot_id, {layout_type, child}}
         end
     end)
+    # Remove all nil/empty pages from the original children.
     |> Enum.filter(fn
       nil -> false
       {_, {_, []}} -> false

--- a/lib/screens/v2/screen_data.ex
+++ b/lib/screens/v2/screen_data.ex
@@ -77,13 +77,17 @@ defmodule Screens.V2.ScreenData do
       |> Enum.map(fn t -> {t, %{}} end)
       |> Enum.into(%{})
 
-    {{_, selected_layout}, selected_instances} =
+    {{_, {slot_id, {layout_type, _children}} = selected_layout}, selected_instances} =
       prioritized_instances
       |> Enum.reduce(candidate_placements, &place_instance/2)
       |> log_mismatched_placement_widgets()
       |> select_best_placement()
 
-    {selected_layout, selected_instances}
+    filtered_children =
+      selected_layout
+      |> filter_empty_slots(Map.keys(selected_instances))
+
+    {{slot_id, {layout_type, filtered_children}}, selected_instances}
   end
 
   defp place_instance(instance, placements) do
@@ -233,6 +237,38 @@ defmodule Screens.V2.ScreenData do
     seconds_since_midnight = now.hour * 60 * 60 + now.minute * 60 + now.second
     periods_since_midnight = div(seconds_since_midnight, refresh_rate)
     rem(periods_since_midnight, num_pages)
+  end
+
+  defp filter_empty_slots({_slot_id, {_layout_type, children}}, selected_instances_slots) do
+    new_children =
+      children
+      |> Enum.map(fn
+        slot_id when is_atom(slot_id) ->
+          if slot_id in selected_instances_slots do
+            slot_id
+          end
+
+        nested_child when is_paged_slot_id(nested_child) ->
+          if nested_child in selected_instances_slots do
+            nested_child
+          end
+
+        {slot_id, {layout_type, _children}} = nested_layout ->
+          case filter_empty_slots(nested_layout, selected_instances_slots) do
+            [nil] ->
+              nil
+
+            child ->
+              {slot_id, {layout_type, child}}
+          end
+      end)
+
+    new_children
+    |> Enum.filter(fn
+      nil -> false
+      {_, {_, []}} -> false
+      _ -> true
+    end)
   end
 
   @spec choose_visible_slot_ids(Template.layout(), integer(), DateTime.t()) ::

--- a/lib/screens/v2/screen_data.ex
+++ b/lib/screens/v2/screen_data.ex
@@ -240,30 +240,27 @@ defmodule Screens.V2.ScreenData do
   end
 
   defp filter_empty_slots({_slot_id, {_layout_type, children}}, selected_instances_slots) do
-    new_children =
-      children
-      |> Enum.map(fn
-        slot_id when is_atom(slot_id) ->
-          if slot_id in selected_instances_slots do
-            slot_id
-          end
+    children
+    |> Enum.map(fn
+      slot_id when is_atom(slot_id) ->
+        if slot_id in selected_instances_slots do
+          slot_id
+        end
 
-        nested_child when is_paged_slot_id(nested_child) ->
-          if nested_child in selected_instances_slots do
-            nested_child
-          end
+      nested_child when is_paged_slot_id(nested_child) ->
+        if nested_child in selected_instances_slots do
+          nested_child
+        end
 
-        {slot_id, {layout_type, _children}} = nested_layout ->
-          case filter_empty_slots(nested_layout, selected_instances_slots) do
-            [nil] ->
-              nil
+      {slot_id, {layout_type, _children}} = nested_layout ->
+        case filter_empty_slots(nested_layout, selected_instances_slots) do
+          [nil] ->
+            nil
 
-            child ->
-              {slot_id, {layout_type, child}}
-          end
-      end)
-
-    new_children
+          child ->
+            {slot_id, {layout_type, child}}
+        end
+    end)
     |> Enum.filter(fn
       nil -> false
       {_, {_, []}} -> false

--- a/lib/screens/v2/template/builder.ex
+++ b/lib/screens/v2/template/builder.ex
@@ -19,10 +19,10 @@ defmodule Screens.V2.Template.Builder do
   Adds paging to a template or part of a template.
   Input must not already be paged or contain any paged elements.
   """
-  def with_paging(template, num_pages)
+  def with_paging(template, max_num_pages)
       when is_non_paged_slot_id(template)
       when is_non_paged_slot_id(elem(template, 0)) do
-    Enum.map(0..(num_pages - 1), &paged_template(template, &1))
+    Enum.map(0..(max_num_pages - 1), &paged_template(template, &1))
   end
 
   defp paged_template(template, page_index) when is_atom(template) do

--- a/test/screens/v2/screen_data_test.exs
+++ b/test/screens/v2/screen_data_test.exs
@@ -172,6 +172,57 @@ defmodule Screens.V2.ScreenDataTest do
                {1, :content2_large} => %MockWidget{content: "4"}
              } = actual_instance_placement
     end
+
+    test "filters out blank pages" do
+      candidate_template =
+        {:screen,
+         %{
+           normal: [
+             :header,
+             {{0, :flex_zone},
+              %{
+                one_large: [{0, :large}],
+                two_medium: [{0, :medium_left}, {0, :medium_right}],
+                one_medium_two_small: [
+                  {0, :medium_left},
+                  {0, :small_upper_right},
+                  {0, :small_lower_right}
+                ]
+              }},
+             {{1, :flex_zone},
+              %{
+                one_large: [{1, :large}],
+                two_medium: [{1, :medium_left}, {1, :medium_right}],
+                one_medium_two_small: [
+                  {1, :medium_left},
+                  {1, :small_upper_right},
+                  {1, :small_lower_right}
+                ]
+              }}
+           ],
+           takeover: [:full_screen]
+         }}
+
+      candidate_instances = [
+        %MockWidget{slot_names: [:large], priority: [2], content: "1"},
+        %MockWidget{slot_names: [:header], priority: [2], content: "header"}
+      ]
+
+      {actual_layout, actual_instance_placement} =
+        ScreenData.pick_instances(candidate_template, candidate_instances)
+
+      assert {:screen,
+              {:normal,
+               [
+                 :header,
+                 {{0, :flex_zone}, {:one_large, [{0, :large}]}}
+               ]}} == actual_layout
+
+      assert %{
+               :header => %MockWidget{content: "header"},
+               {0, :large} => %MockWidget{content: "1"}
+             } = actual_instance_placement
+    end
   end
 
   describe "serialize/1" do


### PR DESCRIPTION
**Asana task**: [Pre-Fare:  Allow flex zones to have a variable page number](https://app.asana.com/0/1185117109217413/1201812714325999/f)

This change looks through the selected candidates that are to be placed and removes slots from the layout if it does not have a matching candidate. This allows us to use a maximum page approach to paged slots that use `Screens.V2.Template`.

- [ ] Needs version bump?
