### PR TITLE
Elevator status list view + factor out persistent carousel logic

### DIFF
--- a/assets/css/v2/pre_fare/elevator_status.scss
+++ b/assets/css/v2/pre_fare/elevator_status.scss
@@ -41,6 +41,103 @@
       padding-top: 20px;
     }
   }
+
+  &__closure-you-are-here-icon {
+    object-fit: contain;
+  }
+
+  &__closure-route-mode-icon {
+    width: 45px;
+    height: 45px;
+    &:not(:last-child) {
+      padding-right: 12px;
+    }
+  }
+
+  &__list-view {
+    width: 1024px;
+    height: 760px;
+    overflow: hidden;
+  }
+
+  &__station-row {
+    width: 1024px;
+    border-top: 4px solid rgb(217, 214, 208);
+    padding-top: 16px;
+    padding-left: 32px;
+    padding-bottom: 20px;
+    box-sizing: border-box;
+
+    &--home-stop {
+      background-color: rgba(255, 255, 255, 0.68);
+    }
+
+    &__icons {
+      display: inline-block;
+      height: 44px;
+      margin-right: 16px;
+      transform: translateY(8px);
+    }
+
+    &__station-name {
+      display: inline-block;
+      height: 44px;
+      color: rgb(23, 31, 38);
+      font-size: 40px;
+      font-family: Inter, sans-serif;
+      font-weight: 700;
+      letter-spacing: 0px;
+      line-height: 36px;
+      margin-bottom: 12px;
+    }
+
+    &__ids {
+      display: inline-block;
+      height: 44px;
+      color: rgb(115, 115, 115);
+      font-size: 32px;
+      font-family: Inter, sans-serif;
+      font-weight: 500;
+      letter-spacing: 0px;
+      line-height: 32px;
+      margin-left: 16px;
+    }
+
+    &__you-are-here-icon {
+      display: inline-block;
+      margin-left: 24px;
+      transform: translateY(4px);
+
+      .elevator-status__closure-you-are-here-icon {
+        width: 34px;
+        height: 34px;
+      }
+    }
+
+    &__closures {
+      width: 960px;
+    }
+
+    &__closure {
+      width: 960px;
+      height: 40px;
+
+      color: rgb(23, 31, 38);
+      font-size: 32px;
+      font-family: Inter, sans-serif;
+      font-weight: 400;
+      letter-spacing: 0px;
+      line-height: 32px;
+
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+
+      &:not(:last-child) {
+        margin-bottom: 8px;
+      }
+    }
+  }
 }
 
 .detail-page {
@@ -85,15 +182,9 @@
         display: inline-block;
         padding-left: 30px;
 
-        .detail-page__closure-you-are-here-icon {
+        .elevator-status__closure-you-are-here-icon {
           width: 45px;
           height: 45px;
-        }
-
-        .detail-page__closure-route-mode-icons {
-          width: 45px;
-          height: 45px;
-          padding-right: 12px;
         }
       }
     }

--- a/assets/src/components/v2/elevator_status.tsx
+++ b/assets/src/components/v2/elevator_status.tsx
@@ -2,7 +2,7 @@ import moment from "moment";
 import React, { ComponentType, useEffect, useState } from "react";
 import { classWithModifier, imagePath } from "Util/util";
 import FlexZonePageIndicator from "./flex/page_indicator";
-import makePersistentCarousel from "./persistent_carousel";
+import makePersistentCarousel, { PageRendererProps } from "./persistent_carousel";
 
 const subwayIcons = ["red", "blue", "orange", "green", "silver"];
 
@@ -49,10 +49,8 @@ type Icon =
   | "bus"
   | "mattapan";
 
-interface Props {
+interface Props extends PageRendererProps {
   page: Page;
-  pageIndex: number;
-  numPages: number;
 }
 
 const ElevatorStatus: ComponentType<Props> = ({ page, pageIndex, numPages }) => {

--- a/assets/src/components/v2/elevator_status.tsx
+++ b/assets/src/components/v2/elevator_status.tsx
@@ -2,7 +2,7 @@ import moment from "moment";
 import React, { ComponentType, useEffect, useState } from "react";
 import { classWithModifier, imagePath } from "Util/util";
 import FlexZonePageIndicator from "./flex/page_indicator";
-import makePersistent from "./persistent_wrapper";
+import makePersistentCarousel from "./persistent_carousel";
 
 const subwayIcons = ["red", "blue", "orange", "green", "silver"];
 
@@ -50,34 +50,12 @@ type Icon =
   | "mattapan";
 
 interface Props {
-  pages: Page[];
-  lastUpdate: number;
-  onFinish: Function;
+  page: Page;
+  pageIndex: number;
+  numPages: number;
 }
 
-const ElevatorStatus: ComponentType<Props> = ({
-  pages,
-  lastUpdate,
-  onFinish,
-}) => {
-  const [isFirstRender, setIsFirstRender] = useState(true);
-  const [pageIndex, setPageIndex] = useState(0);
-
-  useEffect(() => {
-    if (isFirstRender) {
-      setIsFirstRender(false);
-    } else {
-      setPageIndex((i) => i + 1);
-    }
-  }, [lastUpdate]);
-
-  useEffect(() => {
-    if (pageIndex === pages.length - 1) {
-      onFinish();
-    }
-  }, [pageIndex]);
-
-  const page = pages[pageIndex];
+const ElevatorStatus: ComponentType<Props> = ({ page, pageIndex, numPages }) => {
   let pageToRender;
   if (instanceOfDetailPage(page)) {
     pageToRender = <DetailPageComponent {...page} />;
@@ -102,7 +80,7 @@ const ElevatorStatus: ComponentType<Props> = ({
           </div>
         </div>
       </div>
-      <FlexZonePageIndicator numPages={pages.length} pageIndex={pageIndex} />
+      <FlexZonePageIndicator numPages={numPages} pageIndex={pageIndex} />
     </>
   );
 };
@@ -294,4 +272,4 @@ const ListPageComponent: ComponentType<ListPageProps> = ({ listPage }) => {
   return null;
 };
 
-export default makePersistent(ElevatorStatus);
+export default makePersistentCarousel(ElevatorStatus);

--- a/assets/src/components/v2/elevator_status.tsx
+++ b/assets/src/components/v2/elevator_status.tsx
@@ -4,12 +4,10 @@ import { classWithModifier, imagePath } from "Util/util";
 import FlexZonePageIndicator from "./flex/page_indicator";
 import makePersistentCarousel, { PageRendererProps } from "./persistent_carousel";
 
-const subwayIcons = ["red", "blue", "orange", "green", "silver"];
-
 type ElevatorStatusPage = ListPage | DetailPage;
 
 interface DetailPage {
-  station: Station;
+  station: DetailPageStation;
 }
 
 interface ListPage {
@@ -21,6 +19,10 @@ interface Station {
   icons: Icon[];
   elevator_closures: Closure[];
   is_at_home_stop: boolean;
+}
+
+interface DetailPageStation extends Station {
+  elevator_closures: [Closure];
 }
 
 interface Closure {
@@ -108,31 +110,24 @@ const LocationHeadingIcon = ({
     />
   );
 
-const RouteModeHereIcon = ({
-  isAtHomeStop,
-  icons,
-}: {
-  isAtHomeStop: boolean;
-  icons: Icon[];
-}): JSX.Element =>
-  isAtHomeStop ? (
-    <img
-      className="detail-page__closure-you-are-here-icon"
-      src={imagePath("elevator-status-you-are-here.svg")}
-    />
-  ) : (
-    <>
-      {icons
-        .sort((i1) => (subwayIcons.includes(i1) ? -1 : 1))
-        .map((icon) => (
-          <img
-            key={icon}
-            className="detail-page__closure-route-mode-icons"
-            src={imagePath(`elevator-status-${icon}.svg`)}
-          />
-        ))}
-    </>
-  );
+const HereIcon: ComponentType<{}> = ({ }) => (
+  <img
+    className="elevator-status__closure-you-are-here-icon"
+    src={imagePath("elevator-status-you-are-here.svg")}
+  />
+);
+
+const RouteModeIcons: ComponentType<{ icons: Icon[] }> = ({ icons }) => (
+  <>
+    {icons.map((icon) => (
+      <img
+        key={icon}
+        className="elevator-status__closure-route-mode-icon"
+        src={imagePath(`elevator-status-${icon}.svg`)}
+      />
+    ))}
+  </>
+);
 
 const TimeframeHeadingIcon = ({
   isAtHomeStop,
@@ -196,22 +191,16 @@ const getTimeframeEndText = (
   return endText;
 };
 
-const DetailPageComponent: ComponentType<DetailPage> = ({ station }) => {
-  const {
-    is_at_home_stop: isAtHomeStop,
-    name,
-    icons,
-    elevator_closures: elevatorClosures,
-  } = station;
-  const {
+const DetailPageComponent: ComponentType<DetailPage> = ({ station: {
+  is_at_home_stop: isAtHomeStop,
+  name,
+  icons,
+  elevator_closures: [{
     header_text: headerText,
     description,
-    timeframe,
-  } = elevatorClosures[0];
-
-  const { happening_now: happeningNow, active_period: activePeriod } =
-    timeframe;
-
+    timeframe: { happening_now: happeningNow, active_period: activePeriod },
+  }],
+} }) => {
   return (
     <div className="detail-page">
       <div
@@ -231,7 +220,7 @@ const DetailPageComponent: ComponentType<DetailPage> = ({ station }) => {
             {isAtHomeStop ? "At this station" : name}
           </div>
           <div className="detail-page__closure-route-mode-here-icon-container">
-            <RouteModeHereIcon isAtHomeStop={isAtHomeStop} icons={icons} />
+            {isAtHomeStop ? <HereIcon /> : <RouteModeIcons icons={icons} />}
           </div>
         </div>
         <div className="detail-page__closure-header">{headerText}</div>
@@ -261,7 +250,66 @@ const DetailPageComponent: ComponentType<DetailPage> = ({ station }) => {
 };
 
 const ListPageComponent: ComponentType<ListPage> = ({ stations }) => {
-  return null;
+  return (
+    <div className="elevator-status__list-view">
+      {stations.map((station) => (
+        <StationRow {...station} key={station.name} />
+      ))}
+    </div>
+  );
+};
+
+
+const StationRow: ComponentType<Station> = ({
+  name,
+  icons,
+  elevator_closures: elevatorClosures,
+  is_at_home_stop: isAtHomeStop,
+}) => {
+  let rowClass = "elevator-status__station-row";
+  if (isAtHomeStop) {
+    rowClass += " elevator-status__station-row--home-stop";
+  }
+
+  return (
+    <div className={rowClass}>
+      <div className="elevator-status__station-row__header">
+        <div className="elevator-status__station-row__icons"><RouteModeIcons icons={icons} /></div>
+        <div className="elevator-status__station-row__station-name">{name}</div>
+        <div className="elevator-status__station-row__ids">
+          {formatElevatorIds(elevatorClosures.map(({ elevator_id: id }) => id))}
+        </div>
+        {isAtHomeStop && (
+          <div className="elevator-status__station-row__you-are-here-icon">
+            <HereIcon />
+          </div>
+        )}
+      </div>
+      <div className="elevator-status__station-row__closures">
+        {elevatorClosures.map(({ elevator_name, elevator_id }) => (
+          <div className="elevator-status__station-row__closure" key={elevator_id}>
+            {elevator_name}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+const formatElevatorIds = (ids: string[]) => {
+  switch (ids.length) {
+    case 0:
+      return "";
+    case 1:
+      return `#${ids[0]}`;
+    case 2:
+      return `#${ids[0]} and ${ids[1]}`;
+    default:
+      // a, b, ..., m, and n
+      const allButLast = ids.slice(0, ids.length - 1);
+      const last = ids[ids.length - 1];
+      return `#${allButLast.join(", ")}, and ${last}`;
+  }
 };
 
 export default makePersistentCarousel(ElevatorStatus);

--- a/assets/src/components/v2/elevator_status.tsx
+++ b/assets/src/components/v2/elevator_status.tsx
@@ -1,12 +1,12 @@
 import moment from "moment";
-import React, { ComponentType, useEffect, useState } from "react";
+import React, { ComponentType } from "react";
 import { classWithModifier, imagePath } from "Util/util";
 import FlexZonePageIndicator from "./flex/page_indicator";
 import makePersistentCarousel, { PageRendererProps } from "./persistent_carousel";
 
 const subwayIcons = ["red", "blue", "orange", "green", "silver"];
 
-type Page = ListPage | DetailPage;
+type ElevatorStatusPage = ListPage | DetailPage;
 
 interface DetailPage {
   station: Station;
@@ -49,9 +49,7 @@ type Icon =
   | "bus"
   | "mattapan";
 
-interface Props extends PageRendererProps {
-  page: Page;
-}
+type Props = PageRendererProps<ElevatorStatusPage>;
 
 const ElevatorStatus: ComponentType<Props> = ({ page, pageIndex, numPages }) => {
   let pageToRender;
@@ -83,11 +81,11 @@ const ElevatorStatus: ComponentType<Props> = ({ page, pageIndex, numPages }) => 
   );
 };
 
-const instanceOfDetailPage = (page: Page): page is DetailPage => {
+const instanceOfDetailPage = (page: ElevatorStatusPage): page is DetailPage => {
   return (page as DetailPage).station !== undefined;
 };
 
-const instanceOfListPage = (page: Page): page is ListPage => {
+const instanceOfListPage = (page: ElevatorStatusPage): page is ListPage => {
   return (page as ListPage).stations !== undefined;
 };
 
@@ -262,11 +260,7 @@ const DetailPageComponent: ComponentType<DetailPage> = ({ station }) => {
   );
 };
 
-interface ListPageProps {
-  listPage: ListPage;
-}
-
-const ListPageComponent: ComponentType<ListPageProps> = ({ listPage }) => {
+const ListPageComponent: ComponentType<ListPage> = ({ stations }) => {
   return null;
 };
 

--- a/assets/src/components/v2/persistent_carousel.tsx
+++ b/assets/src/components/v2/persistent_carousel.tsx
@@ -1,11 +1,15 @@
 import React, { ComponentType, useEffect, useState } from "react";
-import makePersistent from "./persistent_wrapper";
+import makePersistent, { WrappedComponentProps } from "./persistent_wrapper";
 
-interface Props {
-  PageRenderer: ComponentType<any>;
+interface PageRendererProps {
+  page: any;
+  pageIndex: number;
+  numPages: number;
+}
+
+interface Props extends WrappedComponentProps {
+  PageRenderer: ComponentType<PageRendererProps>;
   pages: any[];
-  onFinish: () => void;
-  lastUpdate: number | null;
 }
 
 const Carousel: ComponentType<Props> = ({ PageRenderer, pages, onFinish, lastUpdate }) => {
@@ -33,12 +37,15 @@ const Carousel: ComponentType<Props> = ({ PageRenderer, pages, onFinish, lastUpd
   );
 }
 
-const PersistentCarousel = makePersistent(Carousel);
+const PersistentCarousel = makePersistent(Carousel as ComponentType<WrappedComponentProps>);
 
 /**
  * Call this function on a `PageRenderer` component to wrap it in a persistent component that
  * expects a `pages` prop containing an array of data, and passes one element of the array at a time to
  * `PageRenderer`.
+ *
+ * Consider extending the `PageRendererProps` type exported by this module when
+ * defining your `PageRenderer`'s props.
  *
  * Example:
  * ```tsx
@@ -55,8 +62,9 @@ const PersistentCarousel = makePersistent(Carousel);
  * ```
  */
 const makePersistentCarousel =
-  (Component) =>
+  (Component: ComponentType<PageRendererProps>) =>
     ({ ...data }) =>
       <PersistentCarousel {...data} PageRenderer={Component} />;
 
 export default makePersistentCarousel;
+export { PageRendererProps };

--- a/assets/src/components/v2/persistent_carousel.tsx
+++ b/assets/src/components/v2/persistent_carousel.tsx
@@ -1,0 +1,62 @@
+import React, { ComponentType, useEffect, useState } from "react";
+import makePersistent from "./persistent_wrapper";
+
+interface Props {
+  PageRenderer: ComponentType<any>;
+  pages: any[];
+  onFinish: () => void;
+  lastUpdate: number | null;
+}
+
+const Carousel: ComponentType<Props> = ({ PageRenderer, pages, onFinish, lastUpdate }) => {
+  const [isFirstRender, setIsFirstRender] = useState(true);
+  const [pageIndex, setPageIndex] = useState(0);
+
+  useEffect(() => {
+    if (lastUpdate != null) {
+      if (isFirstRender) {
+        setIsFirstRender(false);
+      } else {
+        setPageIndex((i) => i + 1);
+      }
+    }
+  }, [lastUpdate]);
+
+  useEffect(() => {
+    if (pageIndex === pages.length - 1) {
+      onFinish();
+    }
+  }, [pageIndex]);
+
+  return (
+    <PageRenderer page={pages[pageIndex]} pageIndex={pageIndex} numPages={pages.length} />
+  );
+}
+
+const PersistentCarousel = makePersistent(Carousel);
+
+/**
+ * Call this function on a `PageRenderer` component to wrap it in a persistent component that
+ * expects a `pages` prop containing an array of data, and passes one element of the array at a time to
+ * `PageRenderer`.
+ *
+ * Example:
+ * ```tsx
+ * const Image = ({ url }) => <img src={url} />;
+ * const PersistentImageCarousel = makePersistentCarousel(Image);
+ *
+ * // in some other component's render...
+ * const pages = [{url: "/psa.png"}, {url: "/squirrel.jpg"}, {url: "/survey.png"}];
+ * return (
+ *   <div>
+ *     <PersistentImageCarousel pages={pages} />
+ *   </div>
+ * );
+ * ```
+ */
+const makePersistentCarousel =
+  (Component) =>
+    ({ ...data }) =>
+      <PersistentCarousel {...data} PageRenderer={Component} />;
+
+export default makePersistentCarousel;

--- a/assets/src/components/v2/persistent_carousel.tsx
+++ b/assets/src/components/v2/persistent_carousel.tsx
@@ -1,18 +1,18 @@
-import React, { ComponentType, useEffect, useState } from "react";
+import React, { ComponentType, ReactNode, useEffect, useState } from "react";
 import makePersistent, { WrappedComponentProps } from "./persistent_wrapper";
 
-interface PageRendererProps {
-  page: any;
+interface PageRendererProps<T> {
+  page: T;
   pageIndex: number;
   numPages: number;
 }
 
-interface Props extends WrappedComponentProps {
-  PageRenderer: ComponentType<PageRendererProps>;
-  pages: any[];
+interface Props<T> extends WrappedComponentProps {
+  PageRenderer: ComponentType<PageRendererProps<T>>;
+  pages: T[];
 }
 
-const Carousel: ComponentType<Props> = ({ PageRenderer, pages, onFinish, lastUpdate }) => {
+const Carousel = <T,>({ PageRenderer, pages, onFinish, lastUpdate }: Props<T>): ReactNode => {
   const [isFirstRender, setIsFirstRender] = useState(true);
   const [pageIndex, setPageIndex] = useState(0);
 
@@ -40,20 +40,49 @@ const Carousel: ComponentType<Props> = ({ PageRenderer, pages, onFinish, lastUpd
 const PersistentCarousel = makePersistent(Carousel as ComponentType<WrappedComponentProps>);
 
 /**
- * Call this function on a `PageRenderer` component to wrap it in a persistent component that
- * expects a `pages` prop containing an array of data, and passes one element of the array at a time to
+ * Call this function on some `PageRenderer` component to wrap it in a persistent component that
+ * expects a `pages` prop containing an array of data, and will pass one element of the array at a time to
  * `PageRenderer`.
  *
- * Consider extending the `PageRendererProps` type exported by this module when
- * defining your `PageRenderer`'s props.
+ * Consider using the `PageRendererProps` type exported by this module when
+ * defining your `PageRenderer`'s prop types.
+ *
+ * `PageRenderer` must expect the following props (and no other props):
+ * - `page`: The data that the component needs to render. You supply the type for this value.
+ * - `pageIndex`: The index of the current page being shown.
+ * - `numPages`: The length of the current `pages` array.
  *
  * Example:
  * ```tsx
- * const Image = ({ url }) => <img src={url} />;
- * const PersistentImageCarousel = makePersistentCarousel(Image);
+ * // Define a type for the data our component requires in order to render one page of content.
+ * interface ImageData {
+ *   url: string;
+ *   caption: string;
+ * }
  *
- * // in some other component's render...
- * const pages = [{url: "/psa.png"}, {url: "/squirrel.jpg"}, {url: "/survey.png"}];
+ * // Pass as a parameter to PageRendererProps to get the type {page: ImageData, pageIndex: number, numPages: number}
+ * type Props = PageRendererProps<ImageData>;
+ *
+ * // This is our `PageRenderer` component.
+ * const Image: ComponentType<Props> = ({ page: {url, caption}, pageIndex, numPages }) => (
+ *   <div>
+ *     <figure>
+ *       <img src={url} />
+ *       <figcaption>{caption}</figcaption>
+ *     </figure>
+ *     <div>Page {pageIndex + 1} of {numPages}</div>
+ *   </div>
+ * );
+ *
+ * export default makePersistentCarousel(Image);
+ *
+ * // in some containing component's render...
+ * const pages = [
+ *   {url: "/psa.png", caption: "It's a PSA!"},
+ *   {url: "/squirrel.jpg", caption: "Beware."},
+ *   {url: "/survey.png", caption: "Penny for your thoughts?"}
+ * ];
+ *
  * return (
  *   <div>
  *     <PersistentImageCarousel pages={pages} />
@@ -62,7 +91,7 @@ const PersistentCarousel = makePersistent(Carousel as ComponentType<WrappedCompo
  * ```
  */
 const makePersistentCarousel =
-  (Component: ComponentType<PageRendererProps>) =>
+  <T,>(Component: ComponentType<PageRendererProps<T>>) =>
     ({ ...data }) =>
       <PersistentCarousel {...data} PageRenderer={Component} />;
 

--- a/assets/src/components/v2/persistent_carousel.tsx
+++ b/assets/src/components/v2/persistent_carousel.tsx
@@ -54,6 +54,7 @@ const PersistentCarousel = makePersistent(Carousel as ComponentType<WrappedCompo
  *
  * Example:
  * ```tsx
+ * //// in persistent_image_carousel.tsx
  * // Define a type for the data our component requires in order to render one page of content.
  * interface ImageData {
  *   url: string;
@@ -76,18 +77,23 @@ const PersistentCarousel = makePersistent(Carousel as ComponentType<WrappedCompo
  *
  * export default makePersistentCarousel(Image);
  *
- * // in some containing component's render...
- * const pages = [
- *   {url: "/psa.png", caption: "It's a PSA!"},
- *   {url: "/squirrel.jpg", caption: "Beware."},
- *   {url: "/survey.png", caption: "Penny for your thoughts?"}
- * ];
+ * //// in some other module...
+ * import PersistentImageCarousel from "persistent_image_carousel";
  *
- * return (
- *   <div>
- *     <PersistentImageCarousel pages={pages} />
- *   </div>
- * );
+ * const Container = ({}) => {
+ *   const pages = [
+ *     {url: "/psa.png", caption: "It's a PSA!"},
+ *     {url: "/squirrel.jpg", caption: "Beware."},
+ *     {url: "/survey.png", caption: "Penny for your thoughts?"}
+ *   ];
+ *
+ *   return (
+ *     <div>
+ *       <PersistentImageCarousel pages={pages} />
+ *       <OtherStuff  />
+ *     </div>
+ *   );
+ * };
  * ```
  */
 const makePersistentCarousel =

--- a/assets/src/components/v2/persistent_wrapper.tsx
+++ b/assets/src/components/v2/persistent_wrapper.tsx
@@ -1,7 +1,16 @@
-import React, { useContext, useEffect, useState } from "react";
+import React, { ComponentType, useContext, useEffect, useState } from "react";
 import { LastFetchContext } from "Components/v2/screen_container";
 
-const PersistentWrapper = ({ WrappedComponent, ...data }) => {
+interface WrappedComponentProps {
+  onFinish: () => void;
+  lastUpdate: number | null;
+}
+
+interface Props {
+  WrappedComponent: ComponentType<WrappedComponentProps>;
+}
+
+const PersistentWrapper: ComponentType<Props> = ({ WrappedComponent, ...data }) => {
   const lastFetch = useContext(LastFetchContext);
 
   const [visibleData, setVisibleData] = useState(data);
@@ -34,6 +43,9 @@ const PersistentWrapper = ({ WrappedComponent, ...data }) => {
  * Call this function on a `WrappedComponent` to allow it to persist across
  * data refreshes.
  *
+ * Consider extending the `WrappedComponentProps` type exported by this module when
+ * defining your `WrappedComponent`'s props.
+ *
  * `WrappedComponent` must expect the following props:
  * - `onFinish`: A callback that `WrappedComponent` can call to indicate that it is ready to receive
  *   fresh data on the next refresh.
@@ -43,7 +55,9 @@ const PersistentWrapper = ({ WrappedComponent, ...data }) => {
  * Any other props (e.g. data to be rendered) are passed through to `WrappedComponent` unchanged.
  */
 const makePersistent =
-  (Component) =>
+  (Component: ComponentType<WrappedComponentProps>) =>
     ({ ...data }) =>
       <PersistentWrapper {...data} WrappedComponent={Component} />;
+
 export default makePersistent;
+export { WrappedComponentProps };

--- a/assets/src/components/v2/persistent_wrapper.tsx
+++ b/assets/src/components/v2/persistent_wrapper.tsx
@@ -30,13 +30,20 @@ const PersistentWrapper = ({ WrappedComponent, ...data }) => {
   );
 };
 
+/**
+ * Call this function on a `WrappedComponent` to allow it to persist across
+ * data refreshes.
+ *
+ * `WrappedComponent` must expect the following props:
+ * - `onFinish`: A callback that `WrappedComponent` can call to indicate that it is ready to receive
+ *   fresh data on the next refresh.
+ * - `lastUpdate`: a **nullable** timestamp of the last successful data refresh, which `WrappedComponent` should use to
+ *   sync its re-renders with the rest of the page.
+ *
+ * Any other props (e.g. data to be rendered) are passed through to `WrappedComponent` unchanged.
+ */
 const makePersistent =
   (Component) =>
-  ({ ...data }) =>
-    <PersistentWrapper {...data} WrappedComponent={Component} />;
+    ({ ...data }) =>
+      <PersistentWrapper {...data} WrappedComponent={Component} />;
 export default makePersistent;
-
-const BufferedData = ({ data }) => {
-  console.log("buffered data: ", data);
-  return <div>Buffered Data ID: {data.id}</div>;
-};

--- a/assets/src/components/v2/persistent_wrapper.tsx
+++ b/assets/src/components/v2/persistent_wrapper.tsx
@@ -44,7 +44,7 @@ const PersistentWrapper: ComponentType<Props> = ({ WrappedComponent, ...data }) 
  * data refreshes.
  *
  * Consider extending the `WrappedComponentProps` type exported by this module when
- * defining your `WrappedComponent`'s props.
+ * defining your `WrappedComponent`'s prop types.
  *
  * `WrappedComponent` must expect the following props:
  * - `onFinish`: A callback that `WrappedComponent` can call to indicate that it is ready to receive

--- a/assets/src/components/v2/screen_container.tsx
+++ b/assets/src/components/v2/screen_container.tsx
@@ -62,7 +62,7 @@ const AudioConfigContext = createContext<AudioConfig | null>(
   defaultAudioConfig
 );
 
-const LastFetchContext = createContext<number>(0)
+const LastFetchContext = createContext<number | null>(null)
 
 interface ScreenLayoutProps {
   apiResponse: ApiResponse;

--- a/lib/screens/v2/widget_instance/elevator_status.ex
+++ b/lib/screens/v2/widget_instance/elevator_status.ex
@@ -29,6 +29,8 @@ defmodule Screens.V2.WidgetInstance.ElevatorStatus do
     defstruct stations: nil
   end
 
+  @subway_icons ~w[red blue orange green silver]a
+
   # To be replaced by more detailed values for fitting rows in the list view
   @max_rows_per_page 4
 
@@ -50,7 +52,6 @@ defmodule Screens.V2.WidgetInstance.ElevatorStatus do
           | :orange
           | :green
           | :silver
-          | :green
           | :rail
           | :bus
           | :mattapan
@@ -286,6 +287,8 @@ defmodule Screens.V2.WidgetInstance.ElevatorStatus do
     icons =
       station_id_to_icons
       |> Map.fetch!(parent_station_id)
+      # Prioritize subway (and Silver Line) route icons
+      |> Enum.sort_by(&if(&1 in @subway_icons, do: 0, else: 1))
       |> Enum.take(3)
 
     %{


### PR DESCRIPTION
**Asana task**: [Elevator status widget component - list view](https://app.asana.com/0/1185117109217413/1201621878856262/f)

This adds styles for the elevator status widget's list view. Logic to split up list view pages according to row heights will be added in a separate PR to keep the diff manageable.

I also split out the "persistent carousel" logic into its own HoC that builds on top of the `makePersistent` HoC, allowing the elevator status and other future frontend-paged widgets to skip the boilerplate and state management, and just pass a presentational component to the HoC.

Please let me know if the documentation makes sense!

Screenshots:
![Screenshot 2022-03-03 at 09-23-00 Screens](https://user-images.githubusercontent.com/63608771/156584819-7eeee174-ac12-4b2c-a1ba-34feaa9c2cf8.png)
![Screenshot 2022-03-03 at 09-22-46 Screens](https://user-images.githubusercontent.com/63608771/156584832-d0fcc0c0-2d58-48c5-a31f-e57ff9ba9065.png)

An example with multiple elevator closures at stations. Ignore the row overflow at the bottom for now; that will be prevented when we add the logic to properly fit content into pages.
![Screenshot 2022-03-03 at 09-47-12 Screens](https://user-images.githubusercontent.com/63608771/156592578-45c34c4d-2043-4db7-a635-f66a63c8b6cb.png)

