### PR TITLE
Cm/subway status gl direction error

### DIFF
--- a/lib/screens/v2/widget_instance/subway_status.ex
+++ b/lib/screens/v2/widget_instance/subway_status.ex
@@ -22,7 +22,8 @@ defmodule Screens.V2.WidgetInstance.SubwayStatus do
     "Green-B" => ["Westbound", "Eastbound"],
     "Green-C" => ["Westbound", "Eastbound"],
     "Green-D" => ["Westbound", "Eastbound"],
-    "Green-E" => ["Westbound", "Eastbound"]
+    "Green-E" => ["Westbound", "Eastbound"],
+    "Green" => ["Westbound", "Eastbound"]
   }
 
   @blue_line_stops [

--- a/test/screens/v2/widget_instance/subway_status_test.exs
+++ b/test/screens/v2/widget_instance/subway_status_test.exs
@@ -344,6 +344,33 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
                type: :single
              } = SubwayStatus.serialize_green_line(grouped_alerts)
     end
+
+    test "handles directional delay alert" do
+      alert = [
+        %Alert{
+          effect: :delay,
+          severity: 9,
+          informed_entities: [
+            %{route: "Green-B", direction_id: 1, stop: nil},
+            %{route: "Green-C", direction_id: 1, stop: nil},
+            %{route: "Green-D", direction_id: 1, stop: nil},
+            %{route: "Green-E", direction_id: 1, stop: nil}
+          ]
+        }
+      ]
+
+      grouped_alerts = %{
+        "Green-B" => alert,
+        "Green-C" => alert,
+        "Green-D" => alert,
+        "Green-E" => alert
+      }
+
+      assert %{
+               status: "Delays over 60 minutes",
+               location: %{full: "Eastbound", abbrev: "Eastbound"}
+             } = SubwayStatus.serialize_green_line(grouped_alerts)
+    end
   end
 
   describe "slot_names/1" do


### PR DESCRIPTION
**Asana task**: [Subway status errors](https://app.asana.com/0/1185117109217413/1201897942452378/f)

This bug occurs when a GL alert affects the whole GL in one direction (See screenshot below). There wasn't a mapping for the whole GL in `@route_directions` so `Map.get` was returning `nil`. After adding the mapping, everything looks good.

![Screen Shot 2022-03-09 at 11 21 35 AM](https://user-images.githubusercontent.com/10713153/157484262-630af131-39ef-46ea-be80-fd80b7514200.png)

![Screen Shot 2022-03-09 at 11 21 53 AM](https://user-images.githubusercontent.com/10713153/157484317-93c2360d-cdd7-4fac-844a-5596a7a9d22d.png)


- [ ] Needs version bump?
