### PR TITLE
fix: Pre-Fare body takeover height

### DIFF
--- a/assets/css/v2/pre_fare/body_left/takeover.scss
+++ b/assets/css/v2/pre_fare/body_left/takeover.scss
@@ -9,6 +9,6 @@
   top: 0px;
   left: 0px;
   width: 1080px;
-  height: 1648px;
+  height: 1724px;
   overflow: hidden;
 }

--- a/assets/css/v2/pre_fare/body_right/takeover.scss
+++ b/assets/css/v2/pre_fare/body_right/takeover.scss
@@ -9,6 +9,6 @@
   top: 0px;
   left: 0px;
   width: 1080px;
-  height: 1648px;
+  height: 1724px;
   overflow: hidden;
 }


### PR DESCRIPTION
**Asana task**: [[Evergreen Takeover] Takeover images not full height](https://app.asana.com/0/0/1201896247257218/f)

Height values match design now.

- [ ] Needs version bump?
