### PR TITLE
tweak: Increased header title width

### DIFF
--- a/assets/css/v2/pre_fare/normal_header.scss
+++ b/assets/css/v2/pre_fare/normal_header.scss
@@ -16,7 +16,7 @@
 }
 
 .normal-header-title {
-  width: 824px;
+  width: 1040px;
   position: absolute;
   left: 40px;
   bottom: 40px;

--- a/assets/css/v2/pre_fare/normal_header.scss
+++ b/assets/css/v2/pre_fare/normal_header.scss
@@ -16,7 +16,7 @@
 }
 
 .normal-header-title {
-  width: 1040px;
+  width: 1000px;
   position: absolute;
   left: 40px;
   bottom: 40px;


### PR DESCRIPTION
**Asana task**: [[Header] "Downtown Crossing" is wrapping](https://app.asana.com/0/0/1201896247257224/f)

I picked 1040 to give title the illusion of `padding-right: 40px`. Can't set padding now that one screen uses width of both screens.

- [ ] Needs version bump?
