### PR TITLE
[Subway Status] Adjust footer text and color

### DIFF
--- a/assets/css/pre_fare_v2.scss
+++ b/assets/css/pre_fare_v2.scss
@@ -30,7 +30,7 @@
 @import "v2/pre_fare/flex/paging_indicator";
 @import "v2/pre_fare/full_line_map";
 
-@import "v2/lcd_common_styles/subway_status";
+@import "v2/pre_fare/subway_status.scss";
 @import "v2/lcd_common_styles/route_pill";
 
 body {

--- a/assets/css/pre_fare_v2.scss
+++ b/assets/css/pre_fare_v2.scss
@@ -30,7 +30,7 @@
 @import "v2/pre_fare/flex/paging_indicator";
 @import "v2/pre_fare/full_line_map";
 
-@import "v2/pre_fare/subway_status.scss";
+@import "v2/pre_fare/subway_status";
 @import "v2/lcd_common_styles/route_pill";
 
 body {

--- a/assets/css/v2/lcd_common_styles/subway_status.scss
+++ b/assets/css/v2/lcd_common_styles/subway_status.scss
@@ -166,5 +166,5 @@
   font-weight: 800;
   font-size: 40px;
   line-height: 40px;
-  color: white;
+  color: #171f26;
 }

--- a/assets/css/v2/lcd_common_styles/subway_status.scss
+++ b/assets/css/v2/lcd_common_styles/subway_status.scss
@@ -152,7 +152,7 @@
 .subway-status-footer {
   position: absolute;
   bottom: 0;
-  background-color: #cccbc8;
+  background-color: #737373;
   width: 100%;
   height: 80px;
 }
@@ -163,7 +163,8 @@
   top: 18px;
 
   font-family: Inter;
+  font-weight: 800;
   font-size: 40px;
   line-height: 40px;
-  color: #171f26;
+  color: white;
 }

--- a/assets/css/v2/lcd_common_styles/subway_status.scss
+++ b/assets/css/v2/lcd_common_styles/subway_status.scss
@@ -152,7 +152,7 @@
 .subway-status-footer {
   position: absolute;
   bottom: 0;
-  background-color: #737373;
+  background-color: #cccbc8;
   width: 100%;
   height: 80px;
 }

--- a/assets/css/v2/lcd_common_styles/subway_status.scss
+++ b/assets/css/v2/lcd_common_styles/subway_status.scss
@@ -163,7 +163,6 @@
   top: 18px;
 
   font-family: Inter;
-  font-weight: 800;
   font-size: 40px;
   line-height: 40px;
   color: #171f26;

--- a/assets/css/v2/pre_fare/subway_status.scss
+++ b/assets/css/v2/pre_fare/subway_status.scss
@@ -1,10 +1,10 @@
 @import "../lcd_common_styles/subway_status.scss";
 
 .subway-status-footer {
-  background-color: #cccbc8 !important;
+  background-color: #cccbc8;
 }
 
 .subway-status-footer__link {
-  font-weight: unset !important;
-  color: #171f26 !important;
+  font-weight: unset;
+  color: #171f26;
 }

--- a/assets/css/v2/pre_fare/subway_status.scss
+++ b/assets/css/v2/pre_fare/subway_status.scss
@@ -1,0 +1,10 @@
+@import "../lcd_common_styles/subway_status.scss";
+
+.subway-status-footer {
+  background-color: #cccbc8 !important;
+}
+
+.subway-status-footer__link {
+  font-weight: unset !important;
+  color: #171f26 !important;
+}


### PR DESCRIPTION
**Asana task**: [[Subway Status] Adjust footer text and color](https://app.asana.com/0/0/1201914758246007/f)

Adjust the background and text colors for the Subway status widget footer. Also change the font to be unbolded.

Pre-fare:
![Screen Shot 2022-03-11 at 10 27 05 AM](https://user-images.githubusercontent.com/16074540/157897652-06daef35-b311-4230-a352-696d0755579c.png)

Bus Shelter:
![Screen Shot 2022-03-11 at 10 27 20 AM](https://user-images.githubusercontent.com/16074540/157897692-35219a5a-7b7f-4707-ad4d-1e7b778d26df.png)


- [ ] Needs version bump?
