### PR TITLE
feat: Detail Page alert description variable text sizing

### DIFF
--- a/assets/css/v2/pre_fare/elevator_status.scss
+++ b/assets/css/v2/pre_fare/elevator_status.scss
@@ -238,9 +238,29 @@
 
     .detail-page__description {
       font-family: Inter, sans-serif;
-      font-size: 24px;
-      line-height: 32px;
       padding-right: 32px;
+
+      &--extra-large {
+        font-size: 36px;
+        line-height: 48px;
+      }
+
+      &--large {
+        font-size: 36px;
+        line-height: 44px;
+      }
+
+      &--small {
+        font-size: 28px;
+        line-height: 40px;
+        letter-spacing: -0.4px;
+      }
+
+      &--extra-small {
+        font-size: 24px;
+        line-height: 32px;
+        letter-spacing: -0.4px;
+      }
     }
   }
 }

--- a/assets/src/components/v2/elevator_status.tsx
+++ b/assets/src/components/v2/elevator_status.tsx
@@ -1,3 +1,4 @@
+import useTextResizer from "Hooks/v2/use_text_resizer";
 import moment from "moment";
 import React, { ComponentType } from "react";
 import { classWithModifier, imagePath } from "Util/util";
@@ -192,6 +193,13 @@ const DetailPageComponent: ComponentType<DetailPage> = ({
     ],
   },
 }) => {
+  const DESCRIPTION_SIZES = ["extra-small", "small", "large", "extra-large"];
+  const { ref: descriptionRef, size: descriptionSize } = useTextResizer({
+    sizes: DESCRIPTION_SIZES,
+    maxHeight: 450,
+    resetDependencies: [description],
+  });
+
   return (
     <div className="detail-page">
       <div
@@ -223,7 +231,15 @@ const DetailPageComponent: ComponentType<DetailPage> = ({
             {getTimeframeEndText(happeningNow, activePeriod)}
           </div>
         </div>
-        <div className="detail-page__description">{description}</div>
+        <div
+          className={classWithModifier(
+            "detail-page__description",
+            descriptionSize
+          )}
+          ref={descriptionRef}
+        >
+          {description}
+        </div>
       </div>
     </div>
   );

--- a/assets/src/hooks/v2/use_text_resizer.tsx
+++ b/assets/src/hooks/v2/use_text_resizer.tsx
@@ -24,9 +24,11 @@ const useTextResizer = ({
   }, resetDependencies);
 
   useLayoutEffect(() => {
-    const height = ref.current.clientHeight;
-    if (height > maxHeight && sizeIndex > 0) {
-      setSizeIndex(sizeIndex - 1);
+    if (ref.current !== null) {
+      const height = ref.current.clientHeight;
+      if (height > maxHeight && sizeIndex > 0) {
+        setSizeIndex(sizeIndex - 1);
+      }
     }
   });
 

--- a/assets/src/hooks/v2/use_text_resizer.tsx
+++ b/assets/src/hooks/v2/use_text_resizer.tsx
@@ -1,0 +1,38 @@
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+
+interface UseTextResizerArgs {
+  sizes: string[];
+  maxHeight: number;
+  resetDependencies: any[];
+}
+
+interface UseTextResizerReturn {
+  ref: React.MutableRefObject<null>;
+  size: string;
+}
+
+const useTextResizer = ({
+  sizes,
+  maxHeight,
+  resetDependencies,
+}: UseTextResizerArgs): UseTextResizerReturn => {
+  const [sizeIndex, setSizeIndex] = useState(sizes.length - 1);
+  const ref = useRef(null);
+
+  useEffect(() => {
+    setSizeIndex(sizes.length - 1);
+  }, resetDependencies);
+
+  useLayoutEffect(() => {
+    const height = ref.current.clientHeight;
+    if (height > maxHeight && sizeIndex > 0) {
+      setSizeIndex(sizeIndex - 1);
+    }
+  });
+
+  const size = sizes[sizeIndex];
+
+  return { ref, size };
+};
+
+export default useTextResizer;

--- a/assets/src/hooks/v2/use_text_resizer.tsx
+++ b/assets/src/hooks/v2/use_text_resizer.tsx
@@ -11,6 +11,17 @@ interface UseTextResizerReturn {
   size: string;
 }
 
+/**
+ * This hook creates a ref to be placed on an element with text and uses the `useLayoutEffect` hook
+ * to find the largest font size that still allows the text to fit in the element. If none of the sizes
+ * fit, the smallest size is selected. This hook should be used for text resizing in a single containing
+ * element with a single CSS class. It does not work well with containers that require more complicated
+ * resizing, e.g. Subway Status rows.
+ * @param sizes A list of CSS modifiers that represent the font size for the given element. Elements should be ordered smallest to largest.
+ * @param maxHeight The maximum height of the container in which the text will be placed.
+ * @param resetDependencies A list of dependencies that should be used to reset the sizeIndex.
+ * @returns A ref and the selected CSS modifier.
+ */
 const useTextResizer = ({
   sizes,
   maxHeight,


### PR DESCRIPTION
**Asana task**: [[Elevator Detail page] Use variable text sizes for the alert description](https://app.asana.com/0/0/1201901724848538/f)

This is a proposed general solution to variable text sizing for our v2 apps. Took the existing logic and put it in a custom hook. Definitely open to feedback on whether this is the solution we want going forward.

- [ ] Needs version bump?
