### PR TITLE
feat: Elevator status widget page-splitting/fitting logic

### DIFF
--- a/assets/css/v2/pre_fare/elevator_status.scss
+++ b/assets/css/v2/pre_fare/elevator_status.scss
@@ -62,7 +62,7 @@
   &__station-row {
     width: 1024px;
     border-top: 4px solid rgb(217, 214, 208);
-    padding-top: 16px;
+    padding-top: 24px;
     padding-left: 32px;
     padding-bottom: 20px;
     box-sizing: border-box;
@@ -71,11 +71,17 @@
       background-color: rgba(255, 255, 255, 0.68);
     }
 
+    &__header {
+      height: 44px;
+      margin-bottom: 16px;
+    }
+
     &__icons {
       display: inline-block;
       height: 44px;
+      line-height: 44px;
+      vertical-align: top;
       margin-right: 16px;
-      transform: translateY(8px);
     }
 
     &__station-name {
@@ -86,7 +92,8 @@
       font-family: Inter, sans-serif;
       font-weight: 700;
       letter-spacing: 0px;
-      line-height: 36px;
+      line-height: 44px;
+      vertical-align: top;
       margin-bottom: 12px;
     }
 
@@ -98,14 +105,18 @@
       font-family: Inter, sans-serif;
       font-weight: 500;
       letter-spacing: 0px;
-      line-height: 32px;
+      line-height: 44px;
+      vertical-align: text-top;
       margin-left: 16px;
     }
 
     &__you-are-here-icon {
       display: inline-block;
+      height: 44px;
       margin-left: 24px;
       transform: translateY(4px);
+      line-height: 44px;
+      vertical-align: top;
 
       .elevator-status__closure-you-are-here-icon {
         width: 34px;

--- a/assets/css/v2/pre_fare/elevator_status.scss
+++ b/assets/css/v2/pre_fare/elevator_status.scss
@@ -107,6 +107,8 @@
       letter-spacing: 0px;
       line-height: 44px;
       vertical-align: text-top;
+      // needs a tiiiiny nudge to align with station name
+      transform: translateY(1px);
       margin-left: 16px;
     }
 

--- a/assets/css/v2/pre_fare/elevator_status.scss
+++ b/assets/css/v2/pre_fare/elevator_status.scss
@@ -1,3 +1,15 @@
+// *** HEADS UP ***
+// The backend logic that fits list view rows onto pages
+// makes assumptions based on styles defined here.
+//
+// Currently, each row for a station in the list view has its height
+// calculated as:
+//     100px + (48px * length(station.closures))
+//
+// If any changes to this stylesheet affect that, be sure to update
+// the backend page-fitting logic as well.
+// *** HEADS UP ***
+
 .elevator-status {
   width: 1024px;
   height: 1000px;

--- a/lib/screens/v2/candidate_generator/widgets/elevator_closures.ex
+++ b/lib/screens/v2/candidate_generator/widgets/elevator_closures.ex
@@ -19,8 +19,9 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ElevatorClosures do
     with {:ok, stop_sequences} <-
            RoutePattern.fetch_stop_sequences_through_stop(parent_station_id),
          {:ok, parent_station_map} <- Stop.fetch_parent_station_name_map(),
-         {:ok, elevator_closures, facility_id_to_name} <- fetch_elevator_closures(),
-         icon_map <- get_icon_map(elevator_closures) do
+         {:ok, elevator_closures, facility_id_to_name} <- fetch_elevator_closures() do
+      icon_map = get_icon_map(elevator_closures, parent_station_id)
+
       [
         %ElevatorStatusWidget{
           alerts: elevator_closures,
@@ -32,6 +33,8 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ElevatorClosures do
           station_id_to_icons: icon_map
         }
       ]
+    else
+      :error -> []
     end
   end
 
@@ -64,9 +67,11 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ElevatorClosures do
     end
   end
 
-  defp get_icon_map(elevator_closures) do
+  defp get_icon_map(elevator_closures, home_parent_station_id) do
     elevator_closures
     |> get_parent_station_ids_from_entities()
+    |> MapSet.new()
+    |> MapSet.put(home_parent_station_id)
     |> Enum.map(fn station_id ->
       {station_id, station_id |> Stop.create_station_with_routes_map() |> routes_to_icons()}
     end)

--- a/lib/screens/v2/widget_instance/elevator_status.ex
+++ b/lib/screens/v2/widget_instance/elevator_status.ex
@@ -29,10 +29,28 @@ defmodule Screens.V2.WidgetInstance.ElevatorStatus do
     defstruct stations: nil
   end
 
-  @subway_icons ~w[red blue orange green silver]a
+  defmodule AnnotatedStationRow do
+    alias Screens.V2.WidgetInstance.ElevatorStatus
 
-  # To be replaced by more detailed values for fitting rows in the list view
-  @max_rows_per_page 4
+    @type t :: %__MODULE__{
+            station: ElevatorStatus.station(),
+            height: non_neg_integer()
+          }
+
+    @enforce_keys ~w[station height]a
+    defstruct @enforce_keys
+
+    @station_row_base_height 100
+    @closure_height 48
+
+    def new(station), do: %__MODULE__{station: station, height: height(station)}
+
+    defp height({_station_id, alerts}) do
+      @station_row_base_height + @closure_height * length(alerts)
+    end
+  end
+
+  @subway_icons ~w[red blue orange green silver]a
 
   alias Screens.Alerts.Alert
   alias Screens.Config.Screen
@@ -189,23 +207,24 @@ defmodule Screens.V2.WidgetInstance.ElevatorStatus do
          %Alert{effect: :elevator_closure, informed_entities: entities} = alert,
          %__MODULE__{now: now, stop_sequences: stop_sequences} = t
        ) do
+    # This assumes platform-level stop IDs are always numeric strings, e.g. "70045"
     informed_platforms =
       for %{stop: stop} when is_binary(stop) <- entities,
           match?({_n, ""}, Integer.parse(stop)),
           do: stop
 
-    parent_station_id = parent_station_id(t)
-    platform_stop_ids = platform_stop_ids(t)
-
-    flat_stop_sequences =
+    connecting_platform_ids =
       stop_sequences
       |> List.flatten()
+      |> MapSet.new()
+      |> MapSet.difference(
+        t
+        |> platform_stop_ids()
+        |> MapSet.new()
+      )
 
     Alert.happening_now?(alert, now) and
-      Enum.any?(informed_platforms, fn platform ->
-        platform != parent_station_id and platform not in platform_stop_ids and
-          platform in flat_stop_sequences
-      end)
+      Enum.any?(informed_platforms, &(&1 in connecting_platform_ids))
   end
 
   defp sort_elsewhere(e1, _e2, %__MODULE__{stop_sequences: stop_sequences}) do
@@ -215,6 +234,8 @@ defmodule Screens.V2.WidgetInstance.ElevatorStatus do
       stop_sequences
       |> List.flatten()
 
+    # TODO: fix this, stop sequences never contain parent station IDs
+    # https://app.asana.com/0/1185117109217422/1202001224916109/f
     Enum.any?(stations, fn station ->
       station in flat_stop_sequences
     end)
@@ -222,24 +243,6 @@ defmodule Screens.V2.WidgetInstance.ElevatorStatus do
 
   defp get_stations_from_entities(entities) do
     for %{stop: "place-" <> _ = stop_id} <- entities, do: stop_id
-  end
-
-  defp trim_and_page_alerts(pages) do
-    pages
-    |> Enum.flat_map(fn
-      %ListPage{} = page ->
-        split_list_page(page)
-
-      %DetailPage{} = page ->
-        [page]
-    end)
-    |> Enum.take(4)
-  end
-
-  defp split_list_page(%ListPage{stations: stations}) do
-    stations
-    |> Enum.chunk_every(@max_rows_per_page)
-    |> Enum.map(&%ListPage{stations: &1})
   end
 
   defp get_informed_facility(entities, facilities) do
@@ -276,6 +279,7 @@ defmodule Screens.V2.WidgetInstance.ElevatorStatus do
 
     closures =
       alerts
+      |> Enum.sort_by(&get_informed_facility(&1.informed_entities, facility_id_to_name))
       |> Enum.map(fn %Alert{
                        informed_entities: entities
                      } = alert ->
@@ -308,10 +312,25 @@ defmodule Screens.V2.WidgetInstance.ElevatorStatus do
     }
   end
 
-  # produces %{parent_station_id => [%Alert{}, ...]}
-  defp alerts_by_station(alerts) do
+  # Groups alerts by their informed parent station ID, and then sorts the station groups
+  # by number of subway routes shared between that station and the home station, descending.
+  defp sorted_alerts_by_station(alerts, t) do
+    subway_routes_at_home_station =
+      t.station_id_to_icons[parent_station_id(t)]
+      |> Enum.filter(&(&1 in @subway_icons))
+      |> MapSet.new()
+
     alerts
     |> Enum.group_by(&get_parent_station_id_from_informed_entities(&1.informed_entities))
+    |> Enum.sort_by(
+      fn {station_id, _} ->
+        routes_at_alerted_station = MapSet.new(t.station_id_to_icons[station_id])
+
+        MapSet.intersection(routes_at_alerted_station, subway_routes_at_home_station)
+        |> MapSet.size()
+      end,
+      :desc
+    )
   end
 
   defp get_parent_station_id_from_informed_entities(entities) do
@@ -328,7 +347,7 @@ defmodule Screens.V2.WidgetInstance.ElevatorStatus do
        ) do
     station =
       [alert]
-      |> alerts_by_station()
+      |> sorted_alerts_by_station(t)
       |> Enum.map(&serialize_station(&1, t))
       |> hd()
 
@@ -337,75 +356,134 @@ defmodule Screens.V2.WidgetInstance.ElevatorStatus do
     }
   end
 
-  defp serialize_list_page(
-         alerts,
-         %__MODULE__{} = t
-       ) do
-    stations =
-      alerts
-      |> alerts_by_station()
-      |> Enum.map(&serialize_station(&1, t))
-      # This sort_by does a last minute sort to put home station alerts at the top.
-      # Eventually, this will need to be more complex to properly sort elsewhere.
-      |> Enum.sort_by(
-        fn %{
-             is_at_home_stop: is_at_home_stop
-           } ->
-          is_at_home_stop
-        end,
-        fn s1, _s2 ->
-          s1
-        end
-      )
+  defp serialize_list_pages(alerts, pinned_alerts \\ [], t) do
+    pinned_stations = sorted_alerts_by_station(pinned_alerts, t)
 
-    %ListPage{
-      stations: stations
-    }
+    stations = sorted_alerts_by_station(alerts, t)
+
+    pages = split_station_pages(stations, pinned_stations)
+
+    Enum.map(pages, fn stations ->
+      %ListPage{stations: Enum.map(stations, &serialize_station(&1, t))}
+    end)
   end
 
-  def priority(_instance), do: [2]
+  @max_page_height 760
 
-  @spec serialize(t()) :: %{pages: list(DetailPage.t() | ListPage.t())}
-  def serialize(%__MODULE__{} = t) do
-    active_at_home =
+  # Splits a list of station rows into several lists, each small enough to fit on a page.
+  # list(station_row) -> list(list(station_row))
+  defp split_station_pages(stations, pinned_stations) do
+    annotated_stations = Enum.map(stations, &AnnotatedStationRow.new/1)
+
+    annotated_pinned_stations = Enum.map(pinned_stations, &AnnotatedStationRow.new/1)
+
+    split_station_pages(
+      annotated_stations,
+      annotated_pinned_stations,
+      [annotated_pinned_stations]
+    )
+    |> Enum.map(fn annotated_stations ->
+      Enum.map(annotated_stations, & &1.station)
+    end)
+  end
+
+  defp split_station_pages([], _pinned_stations, acc), do: Enum.reverse(acc)
+
+  defp split_station_pages(
+         [station | rest_stations] = stations,
+         pinned_stations,
+         [acc_page | rest_acc_pages] = acc_pages
+       ) do
+    # If the station row fits on the page we're populating,
+    if page_height(acc_page) + station.height <= @max_page_height do
+      # Append it on the page and continue fitting the rest of the station rows
+      split_station_pages(rest_stations, pinned_stations, [acc_page ++ [station] | rest_acc_pages])
+    else
+      # Create a new page populated with the pinned station rows, and try again
+      split_station_pages(stations, pinned_stations, [pinned_stations | acc_pages])
+    end
+  end
+
+  defp page_height(annotated_station_rows) do
+    annotated_station_rows
+    |> Enum.map(& &1.height)
+    |> Enum.sum()
+  end
+
+  @max_page_count 3
+
+  # To be un-stubbed when this widget is updated to support appearing on elevator screens
+  defp scenario_a_pages(_t), do: []
+
+  defp scenario_b_pages(t) do
+    active_at_home = get_active_at_home_station(t)
+
+    active_at_home_detail_pages = Enum.map(active_at_home, &serialize_detail_page(&1, t))
+
+    pages =
+      if length(active_at_home_detail_pages) >= @max_page_count do
+        # Skip the extra work to populate list view pages if they're completely displaced by detail pages
+        active_at_home_detail_pages
+      else
+        active_elsewhere = get_active_elsewhere(t)
+
+        list_pages = serialize_list_pages(active_elsewhere, active_at_home, t)
+
+        active_at_home_detail_pages ++ list_pages
+      end
+
+    Enum.take(pages, @max_page_count)
+  end
+
+  defp scenario_c_pages(t) do
+    list_pages =
       t
-      |> get_active_at_home_station()
-      |> Enum.map(&serialize_detail_page(&1, t))
+      |> get_active_elsewhere()
+      |> serialize_list_pages(t)
 
-    active_elsewhere =
-      t
-      |> get_active_at_home_station()
-      |> Enum.concat(get_active_elsewhere(t))
-      |> serialize_list_page(t)
-
-    upcoming_at_home =
+    upcoming_at_home_detail_pages =
       t
       |> get_upcoming_at_home_station()
       |> Enum.map(&serialize_detail_page(&1, t))
 
-    active_on_connecting_lines =
+    active_on_connecting_lines_detail_pages =
       t
       |> get_active_on_connecting_lines()
       |> Enum.map(&serialize_detail_page(&1, t))
 
-    # first show detail pages for each closure at this station
-    # then if there is still space, show list pages for _all_ active closures across the system
-    # then if there is still space, show detail pages for upcoming closures at this station
-    # then if there is still space, show detail pages for active closures along lines serving this station
+    (list_pages ++ upcoming_at_home_detail_pages ++ active_on_connecting_lines_detail_pages)
+    |> Enum.take(@max_page_count)
+  end
 
+  # Determines the scenario we're currently in, as defined at
+  # https://app.abstract.com/projects/c04b5940-4805-11e8-8262-510af7fd49fe/branches/f6705d99-fa8b-4115-a97f-188ea9e01a11/collections/91521734-0e0f-434b-bf25-13516d47b1f3
+  #
+  # To summarize:
+  # Scenario A: This screen's "home elevator" is closed. (Only possible on elevator screens)
+  # Scenario B: One or more elevators at this screen's home station are closed.
+  # Scenario C: All elevators at this screen's home station are operational.
+  defp scenario(%__MODULE__{alerts: alerts} = t) do
+    cond do
+      has_closure_at_home_elevator?(t) -> :a
+      Enum.any?(alerts, &active_at_home_station?(&1, t)) -> :b
+      true -> :c
+    end
+  end
+
+  # To be un-stubbed when this widget is updated to support appearing on elevator screens
+  defp has_closure_at_home_elevator?(_t), do: false
+
+  def priority(_instance), do: [2]
+
+  def serialize(%__MODULE__{} = t) do
     pages =
-      [
-        active_at_home,
-        [active_elsewhere],
-        upcoming_at_home,
-        active_on_connecting_lines
-      ]
-      |> Enum.concat()
-      |> trim_and_page_alerts()
+      case scenario(t) do
+        :a -> scenario_a_pages(t)
+        :b -> scenario_b_pages(t)
+        :c -> scenario_c_pages(t)
+      end
 
-    %{
-      pages: pages
-    }
+    %{pages: pages}
   end
 
   def slot_names(_instance), do: [:lower_right]

--- a/test/screens/v2/candidate_generator/widgets/reconstructed_alert_test.exs
+++ b/test/screens/v2/candidate_generator/widgets/reconstructed_alert_test.exs
@@ -9,7 +9,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlertTest do
   alias Screens.Config.V2.{PreFare, Solari}
   alias Screens.V2.WidgetInstance.ReconstructedAlert, as: ReconstructedAlertWidget
 
-  defp ie(opts \\ []) do
+  defp ie(opts) do
     %{stop: opts[:stop], route: opts[:route], route_type: opts[:route_type]}
   end
 

--- a/test/screens/v2/widget_instance/elevator_status_test.exs
+++ b/test/screens/v2/widget_instance/elevator_status_test.exs
@@ -1,208 +1,341 @@
-defmodule Screens.V2.WidgetInstance.ElevatorStatusTest do
+defmodule WidgetInstance.ElevatorStatusTest do
   use ExUnit.Case, async: true
 
   alias Screens.V2.WidgetInstance
   alias Screens.Alerts.Alert
   alias Screens.Config.Screen
-  alias Screens.Config.V2.{ElevatorStatus, FullLineMap, PreFare}
-  alias Screens.Config.V2.Header.CurrentStopName
+  alias Screens.Config.V2.{ElevatorStatus, PreFare}
+
+  # Convenience function to build an elevator alert
+  defp alert(opts) do
+    %Alert{
+      effect: :elevator_closure,
+      informed_entities: opts[:informed_entities] || [],
+      active_period: opts[:active_period] || []
+    }
+  end
+
+  # Convenience function to build an informed entity
+  defp ie(opts), do: %{stop: opts[:stop], facility: opts[:facility]}
 
   setup do
-    %{
-      instance: %WidgetInstance.ElevatorStatus{
-        screen: %Screen{
-          app_params: %PreFare{
+    home_station_id = "place-foo"
+    home_platform_ids = ["1001", "1002"]
+
+    connecting_station_id = "place-bar"
+    connecting_platform_ids = ["1003", "1004"]
+
+    elsewhere_station_id = "place-baz"
+    elsewhere_platform_ids = ["2001", "2002"]
+
+    other_elsewhere_station_id = "place-qux"
+    other_elsewhere_platform_ids = ["2003", "2004"]
+
+    screen_config =
+      struct(Screen, %{
+        app_params:
+          struct(PreFare, %{
             elevator_status: %ElevatorStatus{
-              parent_station_id: "place-foo",
-              platform_stop_ids: []
-            },
-            header: %CurrentStopName{stop_name: "Test Station"},
-            full_line_map: [
-              %FullLineMap{
-                asset_path: "test/path"
-              }
-            ]
-          },
-          vendor: nil,
-          device_id: nil,
-          name: nil,
-          app_id: nil
-        },
-        alerts: [
-          %Alert{
-            effect: :elevator_closure,
-            informed_entities: [
-              %{stop: "place-bar", facility: "1"}
-            ],
-            active_period: [{~U[2022-01-01T00:00:00Z], ~U[2022-01-01T22:00:00Z]}]
-          },
-          %Alert{
-            effect: :elevator_closure,
-            informed_entities: [
-              %{stop: "place-foo", facility: "1"}
-            ],
-            active_period: [{~U[2022-01-01T00:00:00Z], ~U[2022-01-01T22:00:00Z]}]
-          }
-        ],
-        facility_id_to_name: %{"1" => "Elevator 1"},
-        station_id_to_name: %{"place-foo" => "Foo Station", "place-bar" => "Bar Station"},
-        station_id_to_icons: %{"place-foo" => [:red], "place-bar" => [:red]},
-        now: ~U[2022-01-01T10:00:00Z],
-        stop_sequences: [["place-foo"]]
-      },
-      one_active_at_home_instance: %WidgetInstance.ElevatorStatus{
-        screen: %Screen{
-          app_params: %PreFare{
-            elevator_status: %ElevatorStatus{
-              parent_station_id: "place-foo",
-              platform_stop_ids: []
-            },
-            header: %CurrentStopName{stop_name: "Test Station"},
-            full_line_map: [
-              %FullLineMap{
-                asset_path: "test/path"
-              }
-            ]
-          },
-          vendor: nil,
-          device_id: nil,
-          name: nil,
-          app_id: nil
-        },
-        alerts: [
-          %Alert{
-            effect: :elevator_closure,
-            informed_entities: [
-              %{stop: "place-foo", facility: "1"}
-            ],
-            active_period: [{~U[2022-01-01T00:00:00Z], ~U[2022-01-01T22:00:00Z]}]
-          }
-        ],
-        facility_id_to_name: %{"1" => "Elevator 1"},
-        station_id_to_name: %{"place-foo" => "Foo Station"},
-        station_id_to_icons: %{"place-foo" => [:red]},
-        now: ~U[2022-01-01T10:00:00Z],
-        stop_sequences: [["place-foo"]]
-      },
-      one_active_elsewhere_instance: %WidgetInstance.ElevatorStatus{
-        screen: %Screen{
-          app_params: %PreFare{
-            elevator_status: %ElevatorStatus{
-              parent_station_id: "place-foo",
-              platform_stop_ids: []
-            },
-            header: %CurrentStopName{stop_name: "Test Station"},
-            full_line_map: [
-              %FullLineMap{
-                asset_path: "test/path"
-              }
-            ]
-          },
-          vendor: nil,
-          device_id: nil,
-          name: nil,
-          app_id: nil
-        },
-        alerts: [
-          %Alert{
-            effect: :elevator_closure,
-            informed_entities: [
-              %{stop: "place-bar", facility: "1"}
-            ],
-            active_period: [{~U[2022-01-01T00:00:00Z], ~U[2022-01-01T22:00:00Z]}]
-          }
-        ],
-        facility_id_to_name: %{"1" => "Elevator 1"},
-        station_id_to_name: %{"place-bar" => "Bar Station"},
-        station_id_to_icons: %{"place-bar" => [:red]},
-        now: ~U[2022-01-01T10:00:00Z],
-        stop_sequences: [["place-foo"]]
-      },
-      one_upcoming_at_home_instance: %WidgetInstance.ElevatorStatus{
-        screen: %Screen{
-          app_params: %PreFare{
-            elevator_status: %ElevatorStatus{
-              parent_station_id: "place-foo",
-              platform_stop_ids: []
-            },
-            header: %CurrentStopName{stop_name: "Test Station"},
-            full_line_map: [
-              %FullLineMap{
-                asset_path: "test/path"
-              }
-            ]
-          },
-          vendor: nil,
-          device_id: nil,
-          name: nil,
-          app_id: nil
-        },
-        alerts: [
-          %Alert{
-            effect: :elevator_closure,
-            informed_entities: [
-              %{stop: "place-foo", facility: "1"}
-            ],
-            active_period: [{~U[2022-02-01T00:00:00Z], ~U[2022-02-01T22:00:00Z]}]
-          }
-        ],
-        facility_id_to_name: %{"1" => "Elevator 1"},
-        station_id_to_name: %{"place-foo" => "Foo Station"},
-        station_id_to_icons: %{"place-foo" => [:red]},
-        now: ~U[2022-01-01T10:00:00Z],
-        stop_sequences: [["place-foo"]]
-      },
-      one_active_on_connecting_line_instance: %WidgetInstance.ElevatorStatus{
-        screen: %Screen{
-          app_params: %PreFare{
-            elevator_status: %ElevatorStatus{
-              parent_station_id: "place-foo",
-              platform_stop_ids: []
-            },
-            header: %CurrentStopName{stop_name: "Test Station"},
-            full_line_map: [
-              %FullLineMap{
-                asset_path: "test/path"
-              }
-            ]
-          },
-          vendor: nil,
-          device_id: nil,
-          name: nil,
-          app_id: nil
-        },
-        alerts: [
-          %Alert{
-            effect: :elevator_closure,
-            informed_entities: [
-              %{stop: "place-bar", facility: "1"},
-              %{stop: "123", facility: "1"}
-            ],
-            active_period: [{~U[2022-01-01T00:00:00Z], ~U[2022-01-01T22:00:00Z]}]
-          }
-        ],
-        facility_id_to_name: %{"1" => "Elevator 1"},
-        station_id_to_name: %{"place-bar" => "Bar Station", "place-foo" => "Foo Station"},
-        station_id_to_icons: %{"place-bar" => [:red], "place-foo" => [:red]},
-        now: ~U[2022-01-01T10:00:00Z],
-        stop_sequences: [["place-foo", "place-bar", "123"]]
+              parent_station_id: home_station_id,
+              platform_stop_ids: home_platform_ids
+            }
+          })
+      })
+
+    now = ~U[2022-01-01T10:00:00Z]
+    happening_now_active_period = [{~U[2022-01-01T00:00:00Z], ~U[2022-01-01T22:00:00Z]}]
+    upcoming_active_period = [{~U[2022-02-01T00:00:00Z], ~U[2022-02-01T22:00:00Z]}]
+
+    facility_id_to_name = for id <- 1..9, into: %{}, do: {to_string(id), "Elevator #{id}"}
+
+    station_id_to_name = %{
+      "place-foo" => "Foo Station",
+      "place-bar" => "Bar Station",
+      "place-baz" => "Baz Station",
+      "place-qux" => "Qux Station"
+    }
+
+    stop_sequences = [
+      ["1001", "1003", "1005"],
+      ["1002", "1004", "1006"]
+    ]
+
+    station_id_to_icons = %{
+      "place-foo" => [:red],
+      "place-bar" => [:red, :orange, :bus],
+      "place-baz" => [:green],
+      "place-qux" => [:green]
+    }
+
+    home_ies = fn facility ->
+      [ie(stop: home_station_id, facility: facility)] ++
+        Enum.map(home_platform_ids, &ie(stop: &1, facility: facility))
+    end
+
+    connecting_ies = fn facility ->
+      [ie(stop: connecting_station_id, facility: facility)] ++
+        Enum.map(connecting_platform_ids, &ie(stop: &1, facility: facility))
+    end
+
+    elsewhere_ies = fn facility ->
+      [ie(stop: elsewhere_station_id, facility: facility)] ++
+        Enum.map(elsewhere_platform_ids, &ie(stop: &1, facility: facility))
+    end
+
+    other_elsewhere_ies = fn facility ->
+      [ie(stop: other_elsewhere_station_id, facility: facility)] ++
+        Enum.map(other_elsewhere_platform_ids, &ie(stop: &1, facility: facility))
+    end
+
+    alert_active_home1 =
+      alert(
+        informed_entities: home_ies.("1"),
+        active_period: happening_now_active_period
+      )
+
+    alert_active_home2 =
+      alert(
+        informed_entities: home_ies.("5"),
+        active_period: happening_now_active_period
+      )
+
+    alert_upcoming_home1 =
+      alert(
+        informed_entities: home_ies.("1"),
+        active_period: upcoming_active_period
+      )
+
+    alert_upcoming_home2 =
+      alert(
+        informed_entities: home_ies.("5"),
+        active_period: upcoming_active_period
+      )
+
+    alert_active_connecting_station1 =
+      alert(
+        informed_entities: connecting_ies.("2"),
+        active_period: happening_now_active_period
+      )
+
+    alert_active_connecting_station2 =
+      alert(
+        informed_entities: connecting_ies.("6"),
+        active_period: happening_now_active_period
+      )
+
+    alert_upcoming_connecting_station1 =
+      alert(
+        informed_entities: connecting_ies.("2"),
+        active_period: upcoming_active_period
+      )
+
+    alert_upcoming_connecting_station2 =
+      alert(
+        informed_entities: connecting_ies.("6"),
+        active_period: upcoming_active_period
+      )
+
+    alert_active_elsewhere1 =
+      alert(
+        informed_entities: elsewhere_ies.("3"),
+        active_period: happening_now_active_period
+      )
+
+    alert_active_elsewhere2 =
+      alert(
+        informed_entities: elsewhere_ies.("7"),
+        active_period: happening_now_active_period
+      )
+
+    alert_upcoming_elsewhere1 =
+      alert(
+        informed_entities: elsewhere_ies.("3"),
+        active_period: upcoming_active_period
+      )
+
+    alert_upcoming_elsewhere2 =
+      alert(
+        informed_entities: elsewhere_ies.("7"),
+        active_period: upcoming_active_period
+      )
+
+    alert_active_other_elsewhere1 =
+      alert(
+        informed_entities: other_elsewhere_ies.("4"),
+        active_period: happening_now_active_period
+      )
+
+    alert_active_other_elsewhere2 =
+      alert(
+        informed_entities: other_elsewhere_ies.("8"),
+        active_period: happening_now_active_period
+      )
+
+    alert_active_other_elsewhere3 =
+      alert(
+        informed_entities: other_elsewhere_ies.("9"),
+        active_period: happening_now_active_period
+      )
+
+    alert_upcoming_other_elsewhere1 =
+      alert(
+        informed_entities: other_elsewhere_ies.("4"),
+        active_period: upcoming_active_period
+      )
+
+    alert_upcoming_other_elsewhere2 =
+      alert(
+        informed_entities: other_elsewhere_ies.("8"),
+        active_period: upcoming_active_period
+      )
+
+    alert_upcoming_other_elsewhere3 =
+      alert(
+        informed_entities: other_elsewhere_ies.("9"),
+        active_period: upcoming_active_period
+      )
+
+    widget = fn opts ->
+      %WidgetInstance.ElevatorStatus{
+        screen: screen_config,
+        alerts: opts[:alerts] || [],
+        facility_id_to_name: facility_id_to_name,
+        station_id_to_name: station_id_to_name,
+        station_id_to_icons: station_id_to_icons,
+        now: now,
+        stop_sequences: stop_sequences
       }
+    end
+
+    %{
+      no_alerts_instance: widget.(alerts: []),
+
+      # Scenario A: closure at home elevator
+      # (not possible until we implement elevator screens)
+
+      # Scenario B: one or more active closure at home station
+      one_active_at_home_instance: widget.(alerts: [alert_active_home1]),
+      two_active_at_home_instance: widget.(alerts: [alert_active_home1, alert_active_home2]),
+      all_active_instance:
+        widget.(
+          alerts: [
+            alert_active_home1,
+            alert_active_home2,
+            alert_active_connecting_station1,
+            alert_active_connecting_station2,
+            alert_active_elsewhere1,
+            alert_active_elsewhere2,
+            alert_active_other_elsewhere1,
+            alert_active_other_elsewhere2,
+            alert_active_other_elsewhere3
+          ]
+        ),
+      all_mixed_instance:
+        widget.(
+          alerts: [
+            alert_active_home1,
+            alert_upcoming_home2,
+            alert_active_connecting_station1,
+            alert_upcoming_connecting_station2,
+            alert_active_elsewhere1,
+            alert_upcoming_elsewhere2,
+            alert_active_other_elsewhere1,
+            alert_upcoming_other_elsewhere2,
+            alert_upcoming_other_elsewhere3
+          ]
+        ),
+      one_active_at_home_many_active_elsewhere_instance:
+        widget.(
+          alerts: [
+            alert_active_home1,
+            alert_active_connecting_station1,
+            alert_active_connecting_station2,
+            alert_active_elsewhere1,
+            alert_active_elsewhere2,
+            alert_active_other_elsewhere1,
+            alert_active_other_elsewhere2,
+            alert_active_other_elsewhere3
+          ]
+        ),
+
+      # Scenario C: no active closures at home station
+      one_upcoming_at_home_instance: widget.(alerts: [alert_upcoming_home1]),
+      all_upcoming_instance:
+        widget.(
+          alerts: [
+            alert_upcoming_home1,
+            alert_upcoming_home2,
+            alert_upcoming_connecting_station1,
+            alert_upcoming_connecting_station2,
+            alert_upcoming_elsewhere1,
+            alert_upcoming_elsewhere2,
+            alert_upcoming_other_elsewhere1,
+            alert_upcoming_other_elsewhere2,
+            alert_upcoming_other_elsewhere3
+          ]
+        ),
+      one_active_on_connecting_line_instance: widget.(alerts: [alert_active_connecting_station1]),
+      one_active_elsewhere_instance: widget.(alerts: [alert_active_elsewhere1]),
+      non_home_active_instance:
+        widget.(
+          alerts: [
+            alert_active_connecting_station1,
+            alert_active_connecting_station2,
+            alert_active_elsewhere1,
+            alert_active_elsewhere2,
+            alert_active_other_elsewhere1,
+            alert_active_other_elsewhere2,
+            alert_active_other_elsewhere3
+          ]
+        ),
+      non_home_upcoming_instance:
+        widget.(
+          alerts: [
+            alert_upcoming_connecting_station1,
+            alert_upcoming_connecting_station2,
+            alert_upcoming_elsewhere1,
+            alert_upcoming_elsewhere2,
+            alert_upcoming_other_elsewhere1,
+            alert_upcoming_other_elsewhere2,
+            alert_upcoming_other_elsewhere3
+          ]
+        ),
+      non_home_mixed_instance:
+        widget.(
+          alerts: [
+            alert_active_connecting_station1,
+            alert_upcoming_connecting_station2,
+            alert_active_elsewhere1,
+            alert_upcoming_elsewhere2,
+            alert_active_other_elsewhere1,
+            alert_upcoming_other_elsewhere2,
+            alert_active_other_elsewhere3
+          ]
+        )
     }
   end
 
   describe "priority/1" do
-    test "returns 2", %{instance: instance} do
+    test "returns 2", %{one_active_at_home_instance: instance} do
       assert [2] == WidgetInstance.priority(instance)
     end
   end
 
   describe "serialize/1" do
+    test "returns an empty list page when there are no alerts", %{no_alerts_instance: instance} do
+      expected_result = %{
+        pages: [%WidgetInstance.ElevatorStatus.ListPage{stations: []}]
+      }
+
+      assert expected_result == WidgetInstance.serialize(instance)
+    end
+
     test "returns a detail and list page for one active at-home", %{
       one_active_at_home_instance: instance
     } do
       expected_result = %{
         pages: [
-          %Screens.V2.WidgetInstance.ElevatorStatus.DetailPage{
+          %WidgetInstance.ElevatorStatus.DetailPage{
             station: %{
               name: "Foo Station",
               icons: [:red],
@@ -224,7 +357,7 @@ defmodule Screens.V2.WidgetInstance.ElevatorStatusTest do
               ]
             }
           },
-          %Screens.V2.WidgetInstance.ElevatorStatus.ListPage{
+          %WidgetInstance.ElevatorStatus.ListPage{
             stations: [
               %{
                 name: "Foo Station",
@@ -254,22 +387,79 @@ defmodule Screens.V2.WidgetInstance.ElevatorStatusTest do
       assert expected_result == WidgetInstance.serialize(instance)
     end
 
-    test "returns a list page for one active elsewhere", %{
-      one_active_elsewhere_instance: instance
+    test "returns two detail and one list page for two active at home", %{
+      two_active_at_home_instance: instance
     } do
       expected_result = %{
         pages: [
-          %Screens.V2.WidgetInstance.ElevatorStatus.ListPage{
+          %WidgetInstance.ElevatorStatus.DetailPage{
+            station: %{
+              name: "Foo Station",
+              icons: [:red],
+              is_at_home_stop: true,
+              elevator_closures: [
+                %{
+                  description: nil,
+                  elevator_id: "1",
+                  elevator_name: "Elevator 1",
+                  timeframe: %{
+                    active_period: %{
+                      "start" => "2022-01-01T00:00:00Z",
+                      "end" => "2022-01-01T22:00:00Z"
+                    },
+                    happening_now: true
+                  },
+                  header_text: nil
+                }
+              ]
+            }
+          },
+          %WidgetInstance.ElevatorStatus.DetailPage{
+            station: %{
+              name: "Foo Station",
+              icons: [:red],
+              is_at_home_stop: true,
+              elevator_closures: [
+                %{
+                  description: nil,
+                  elevator_id: "5",
+                  elevator_name: "Elevator 5",
+                  timeframe: %{
+                    active_period: %{
+                      "start" => "2022-01-01T00:00:00Z",
+                      "end" => "2022-01-01T22:00:00Z"
+                    },
+                    happening_now: true
+                  },
+                  header_text: nil
+                }
+              ]
+            }
+          },
+          %WidgetInstance.ElevatorStatus.ListPage{
             stations: [
               %{
-                name: "Bar Station",
+                name: "Foo Station",
                 icons: [:red],
-                is_at_home_stop: false,
+                is_at_home_stop: true,
                 elevator_closures: [
                   %{
                     description: nil,
                     elevator_id: "1",
                     elevator_name: "Elevator 1",
+                    timeframe: %{
+                      active_period: %{
+                        "start" => "2022-01-01T00:00:00Z",
+                        "end" => "2022-01-01T22:00:00Z"
+                      },
+                      happening_now: true
+                    },
+                    header_text: nil
+                  },
+                  %{
+                    description: nil,
+                    elevator_id: "5",
+                    elevator_name: "Elevator 5",
                     timeframe: %{
                       active_period: %{
                         "start" => "2022-01-01T00:00:00Z",
@@ -289,12 +479,482 @@ defmodule Screens.V2.WidgetInstance.ElevatorStatusTest do
       assert expected_result == WidgetInstance.serialize(instance)
     end
 
-    test "returns a detail page for one upcoming at-home", %{
+    test "returns two detail pages and one list page for two active each at home + connecting, 4 active at elsewhere stations",
+         %{all_active_instance: instance} do
+      # Note: some content would appear on an additional list page, which gets truncated
+      expected_result = %{
+        pages: [
+          %WidgetInstance.ElevatorStatus.DetailPage{
+            station: %{
+              name: "Foo Station",
+              icons: [:red],
+              is_at_home_stop: true,
+              elevator_closures: [
+                %{
+                  description: nil,
+                  elevator_id: "1",
+                  elevator_name: "Elevator 1",
+                  timeframe: %{
+                    active_period: %{
+                      "start" => "2022-01-01T00:00:00Z",
+                      "end" => "2022-01-01T22:00:00Z"
+                    },
+                    happening_now: true
+                  },
+                  header_text: nil
+                }
+              ]
+            }
+          },
+          %WidgetInstance.ElevatorStatus.DetailPage{
+            station: %{
+              name: "Foo Station",
+              icons: [:red],
+              is_at_home_stop: true,
+              elevator_closures: [
+                %{
+                  description: nil,
+                  elevator_id: "5",
+                  elevator_name: "Elevator 5",
+                  timeframe: %{
+                    active_period: %{
+                      "start" => "2022-01-01T00:00:00Z",
+                      "end" => "2022-01-01T22:00:00Z"
+                    },
+                    happening_now: true
+                  },
+                  header_text: nil
+                }
+              ]
+            }
+          },
+          %WidgetInstance.ElevatorStatus.ListPage{
+            stations: [
+              %{
+                name: "Foo Station",
+                icons: [:red],
+                is_at_home_stop: true,
+                elevator_closures: [
+                  %{
+                    description: nil,
+                    elevator_id: "1",
+                    elevator_name: "Elevator 1",
+                    timeframe: %{
+                      active_period: %{
+                        "start" => "2022-01-01T00:00:00Z",
+                        "end" => "2022-01-01T22:00:00Z"
+                      },
+                      happening_now: true
+                    },
+                    header_text: nil
+                  },
+                  %{
+                    description: nil,
+                    elevator_id: "5",
+                    elevator_name: "Elevator 5",
+                    timeframe: %{
+                      active_period: %{
+                        "start" => "2022-01-01T00:00:00Z",
+                        "end" => "2022-01-01T22:00:00Z"
+                      },
+                      happening_now: true
+                    },
+                    header_text: nil
+                  }
+                ]
+              },
+              %{
+                name: "Bar Station",
+                icons: [:red, :orange, :bus],
+                is_at_home_stop: false,
+                elevator_closures: [
+                  %{
+                    description: nil,
+                    elevator_id: "2",
+                    elevator_name: "Elevator 2",
+                    timeframe: %{
+                      active_period: %{
+                        "start" => "2022-01-01T00:00:00Z",
+                        "end" => "2022-01-01T22:00:00Z"
+                      },
+                      happening_now: true
+                    },
+                    header_text: nil
+                  },
+                  %{
+                    description: nil,
+                    elevator_id: "6",
+                    elevator_name: "Elevator 6",
+                    timeframe: %{
+                      active_period: %{
+                        "start" => "2022-01-01T00:00:00Z",
+                        "end" => "2022-01-01T22:00:00Z"
+                      },
+                      happening_now: true
+                    },
+                    header_text: nil
+                  }
+                ]
+              },
+              %{
+                name: "Baz Station",
+                icons: [:green],
+                is_at_home_stop: false,
+                elevator_closures: [
+                  %{
+                    description: nil,
+                    elevator_id: "3",
+                    elevator_name: "Elevator 3",
+                    timeframe: %{
+                      active_period: %{
+                        "start" => "2022-01-01T00:00:00Z",
+                        "end" => "2022-01-01T22:00:00Z"
+                      },
+                      happening_now: true
+                    },
+                    header_text: nil
+                  },
+                  %{
+                    description: nil,
+                    elevator_id: "7",
+                    elevator_name: "Elevator 7",
+                    timeframe: %{
+                      active_period: %{
+                        "start" => "2022-01-01T00:00:00Z",
+                        "end" => "2022-01-01T22:00:00Z"
+                      },
+                      happening_now: true
+                    },
+                    header_text: nil
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+
+      assert expected_result == WidgetInstance.serialize(instance)
+    end
+
+    test "returns one detail and one list page for a mix of active/upcoming at home, connecting, elsewhere",
+         %{
+           all_mixed_instance: instance
+         } do
+      expected_result = %{
+        pages: [
+          %WidgetInstance.ElevatorStatus.DetailPage{
+            station: %{
+              name: "Foo Station",
+              icons: [:red],
+              is_at_home_stop: true,
+              elevator_closures: [
+                %{
+                  description: nil,
+                  elevator_id: "1",
+                  elevator_name: "Elevator 1",
+                  header_text: nil,
+                  timeframe: %{
+                    active_period: %{
+                      "end" => "2022-01-01T22:00:00Z",
+                      "start" => "2022-01-01T00:00:00Z"
+                    },
+                    happening_now: true
+                  }
+                }
+              ]
+            }
+          },
+          %WidgetInstance.ElevatorStatus.ListPage{
+            stations: [
+              %{
+                name: "Foo Station",
+                icons: [:red],
+                is_at_home_stop: true,
+                elevator_closures: [
+                  %{
+                    description: nil,
+                    elevator_id: "1",
+                    elevator_name: "Elevator 1",
+                    header_text: nil,
+                    timeframe: %{
+                      active_period: %{
+                        "end" => "2022-01-01T22:00:00Z",
+                        "start" => "2022-01-01T00:00:00Z"
+                      },
+                      happening_now: true
+                    }
+                  }
+                ]
+              },
+              %{
+                name: "Bar Station",
+                icons: [:red, :orange, :bus],
+                is_at_home_stop: false,
+                elevator_closures: [
+                  %{
+                    description: nil,
+                    elevator_id: "2",
+                    elevator_name: "Elevator 2",
+                    header_text: nil,
+                    timeframe: %{
+                      active_period: %{
+                        "end" => "2022-01-01T22:00:00Z",
+                        "start" => "2022-01-01T00:00:00Z"
+                      },
+                      happening_now: true
+                    }
+                  }
+                ]
+              },
+              %{
+                name: "Baz Station",
+                icons: [:green],
+                is_at_home_stop: false,
+                elevator_closures: [
+                  %{
+                    description: nil,
+                    elevator_id: "3",
+                    elevator_name: "Elevator 3",
+                    header_text: nil,
+                    timeframe: %{
+                      active_period: %{
+                        "end" => "2022-01-01T22:00:00Z",
+                        "start" => "2022-01-01T00:00:00Z"
+                      },
+                      happening_now: true
+                    }
+                  }
+                ]
+              },
+              %{
+                name: "Qux Station",
+                icons: [:green],
+                is_at_home_stop: false,
+                elevator_closures: [
+                  %{
+                    description: nil,
+                    elevator_id: "4",
+                    elevator_name: "Elevator 4",
+                    header_text: nil,
+                    timeframe: %{
+                      active_period: %{
+                        "end" => "2022-01-01T22:00:00Z",
+                        "start" => "2022-01-01T00:00:00Z"
+                      },
+                      happening_now: true
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+
+      assert expected_result == WidgetInstance.serialize(instance)
+    end
+
+    test "returns one detail and two list pages for one active at home and many active on connecting + elsewhere",
+         %{one_active_at_home_many_active_elsewhere_instance: instance} do
+      # List view content spills onto a second page
+      expected_result = %{
+        pages: [
+          %WidgetInstance.ElevatorStatus.DetailPage{
+            station: %{
+              elevator_closures: [
+                %{
+                  description: nil,
+                  elevator_id: "1",
+                  elevator_name: "Elevator 1",
+                  header_text: nil,
+                  timeframe: %{
+                    active_period: %{
+                      "end" => "2022-01-01T22:00:00Z",
+                      "start" => "2022-01-01T00:00:00Z"
+                    },
+                    happening_now: true
+                  }
+                }
+              ],
+              icons: [:red],
+              is_at_home_stop: true,
+              name: "Foo Station"
+            }
+          },
+          %WidgetInstance.ElevatorStatus.ListPage{
+            stations: [
+              %{
+                elevator_closures: [
+                  %{
+                    description: nil,
+                    elevator_id: "1",
+                    elevator_name: "Elevator 1",
+                    header_text: nil,
+                    timeframe: %{
+                      active_period: %{
+                        "end" => "2022-01-01T22:00:00Z",
+                        "start" => "2022-01-01T00:00:00Z"
+                      },
+                      happening_now: true
+                    }
+                  }
+                ],
+                icons: [:red],
+                is_at_home_stop: true,
+                name: "Foo Station"
+              },
+              %{
+                elevator_closures: [
+                  %{
+                    description: nil,
+                    elevator_id: "2",
+                    elevator_name: "Elevator 2",
+                    header_text: nil,
+                    timeframe: %{
+                      active_period: %{
+                        "end" => "2022-01-01T22:00:00Z",
+                        "start" => "2022-01-01T00:00:00Z"
+                      },
+                      happening_now: true
+                    }
+                  },
+                  %{
+                    description: nil,
+                    elevator_id: "6",
+                    elevator_name: "Elevator 6",
+                    header_text: nil,
+                    timeframe: %{
+                      active_period: %{
+                        "end" => "2022-01-01T22:00:00Z",
+                        "start" => "2022-01-01T00:00:00Z"
+                      },
+                      happening_now: true
+                    }
+                  }
+                ],
+                icons: [:red, :orange, :bus],
+                is_at_home_stop: false,
+                name: "Bar Station"
+              },
+              %{
+                elevator_closures: [
+                  %{
+                    description: nil,
+                    elevator_id: "3",
+                    elevator_name: "Elevator 3",
+                    header_text: nil,
+                    timeframe: %{
+                      active_period: %{
+                        "end" => "2022-01-01T22:00:00Z",
+                        "start" => "2022-01-01T00:00:00Z"
+                      },
+                      happening_now: true
+                    }
+                  },
+                  %{
+                    description: nil,
+                    elevator_id: "7",
+                    elevator_name: "Elevator 7",
+                    header_text: nil,
+                    timeframe: %{
+                      active_period: %{
+                        "end" => "2022-01-01T22:00:00Z",
+                        "start" => "2022-01-01T00:00:00Z"
+                      },
+                      happening_now: true
+                    }
+                  }
+                ],
+                icons: [:green],
+                is_at_home_stop: false,
+                name: "Baz Station"
+              }
+            ]
+          },
+          %WidgetInstance.ElevatorStatus.ListPage{
+            stations: [
+              %{
+                elevator_closures: [
+                  %{
+                    description: nil,
+                    elevator_id: "1",
+                    elevator_name: "Elevator 1",
+                    header_text: nil,
+                    timeframe: %{
+                      active_period: %{
+                        "end" => "2022-01-01T22:00:00Z",
+                        "start" => "2022-01-01T00:00:00Z"
+                      },
+                      happening_now: true
+                    }
+                  }
+                ],
+                icons: [:red],
+                is_at_home_stop: true,
+                name: "Foo Station"
+              },
+              %{
+                elevator_closures: [
+                  %{
+                    description: nil,
+                    elevator_id: "4",
+                    elevator_name: "Elevator 4",
+                    header_text: nil,
+                    timeframe: %{
+                      active_period: %{
+                        "end" => "2022-01-01T22:00:00Z",
+                        "start" => "2022-01-01T00:00:00Z"
+                      },
+                      happening_now: true
+                    }
+                  },
+                  %{
+                    description: nil,
+                    elevator_id: "8",
+                    elevator_name: "Elevator 8",
+                    header_text: nil,
+                    timeframe: %{
+                      active_period: %{
+                        "end" => "2022-01-01T22:00:00Z",
+                        "start" => "2022-01-01T00:00:00Z"
+                      },
+                      happening_now: true
+                    }
+                  },
+                  %{
+                    description: nil,
+                    elevator_id: "9",
+                    elevator_name: "Elevator 9",
+                    header_text: nil,
+                    timeframe: %{
+                      active_period: %{
+                        "end" => "2022-01-01T22:00:00Z",
+                        "start" => "2022-01-01T00:00:00Z"
+                      },
+                      happening_now: true
+                    }
+                  }
+                ],
+                icons: [:green],
+                is_at_home_stop: false,
+                name: "Qux Station"
+              }
+            ]
+          }
+        ]
+      }
+
+      assert expected_result == WidgetInstance.serialize(instance)
+    end
+
+    test "returns a list page (empty) and a detail page for one upcoming at home", %{
       one_upcoming_at_home_instance: instance
     } do
       expected_result = %{
         pages: [
-          %Screens.V2.WidgetInstance.ElevatorStatus.DetailPage{
+          %WidgetInstance.ElevatorStatus.ListPage{stations: []},
+          %WidgetInstance.ElevatorStatus.DetailPage{
             station: %{
               name: "Foo Station",
               icons: [:red],
@@ -322,67 +982,15 @@ defmodule Screens.V2.WidgetInstance.ElevatorStatusTest do
       assert expected_result == WidgetInstance.serialize(instance)
     end
 
-    test "returns a detail page for one active on connecting line", %{
-      one_active_on_connecting_line_instance: instance
+    test "returns list page (empty) followed by detail pages for several upcoming alerts", %{
+      all_upcoming_instance: instance
     } do
       expected_result = %{
         pages: [
-          %Screens.V2.WidgetInstance.ElevatorStatus.ListPage{
-            stations: [
-              %{
-                name: "Bar Station",
-                icons: [:red],
-                is_at_home_stop: false,
-                elevator_closures: [
-                  %{
-                    description: nil,
-                    elevator_id: "1",
-                    elevator_name: "Elevator 1",
-                    timeframe: %{
-                      active_period: %{
-                        "start" => "2022-01-01T00:00:00Z",
-                        "end" => "2022-01-01T22:00:00Z"
-                      },
-                      happening_now: true
-                    },
-                    header_text: nil
-                  }
-                ]
-              }
-            ]
+          %WidgetInstance.ElevatorStatus.ListPage{
+            stations: []
           },
-          %Screens.V2.WidgetInstance.ElevatorStatus.DetailPage{
-            station: %{
-              name: "Bar Station",
-              icons: [:red],
-              is_at_home_stop: false,
-              elevator_closures: [
-                %{
-                  description: nil,
-                  elevator_id: "1",
-                  elevator_name: "Elevator 1",
-                  timeframe: %{
-                    active_period: %{
-                      "start" => "2022-01-01T00:00:00Z",
-                      "end" => "2022-01-01T22:00:00Z"
-                    },
-                    happening_now: true
-                  },
-                  header_text: nil
-                }
-              ]
-            }
-          }
-        ]
-      }
-
-      assert expected_result == WidgetInstance.serialize(instance)
-    end
-
-    test "returns ordered list of pages", %{instance: instance} do
-      expected_result = %{
-        pages: [
-          %Screens.V2.WidgetInstance.ElevatorStatus.DetailPage{
+          %WidgetInstance.ElevatorStatus.DetailPage{
             station: %{
               name: "Foo Station",
               icons: [:red],
@@ -392,6 +1000,85 @@ defmodule Screens.V2.WidgetInstance.ElevatorStatusTest do
                   description: nil,
                   elevator_id: "1",
                   elevator_name: "Elevator 1",
+                  header_text: nil,
+                  timeframe: %{
+                    active_period: %{
+                      "end" => "2022-02-01T22:00:00Z",
+                      "start" => "2022-02-01T00:00:00Z"
+                    },
+                    happening_now: false
+                  }
+                }
+              ]
+            }
+          },
+          %WidgetInstance.ElevatorStatus.DetailPage{
+            station: %{
+              name: "Foo Station",
+              icons: [:red],
+              is_at_home_stop: true,
+              elevator_closures: [
+                %{
+                  description: nil,
+                  elevator_id: "5",
+                  elevator_name: "Elevator 5",
+                  header_text: nil,
+                  timeframe: %{
+                    active_period: %{
+                      "end" => "2022-02-01T22:00:00Z",
+                      "start" => "2022-02-01T00:00:00Z"
+                    },
+                    happening_now: false
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+
+      assert expected_result == WidgetInstance.serialize(instance)
+    end
+
+    test "returns a detail page for one active on connecting line", %{
+      one_active_on_connecting_line_instance: instance
+    } do
+      expected_result = %{
+        pages: [
+          %WidgetInstance.ElevatorStatus.ListPage{
+            stations: [
+              %{
+                name: "Bar Station",
+                icons: [:red, :orange, :bus],
+                is_at_home_stop: false,
+                elevator_closures: [
+                  %{
+                    description: nil,
+                    elevator_id: "2",
+                    elevator_name: "Elevator 2",
+                    timeframe: %{
+                      active_period: %{
+                        "start" => "2022-01-01T00:00:00Z",
+                        "end" => "2022-01-01T22:00:00Z"
+                      },
+                      happening_now: true
+                    },
+                    header_text: nil
+                  }
+                ]
+              }
+            ]
+          },
+          %WidgetInstance.ElevatorStatus.DetailPage{
+            station: %{
+              name: "Bar Station",
+              icons: [:red, :orange, :bus],
+              is_at_home_stop: false,
+              elevator_closures: [
+                %{
+                  description: nil,
+                  elevator_id: "2",
+                  elevator_name: "Elevator 2",
                   timeframe: %{
                     active_period: %{
                       "start" => "2022-01-01T00:00:00Z",
@@ -403,38 +1090,29 @@ defmodule Screens.V2.WidgetInstance.ElevatorStatusTest do
                 }
               ]
             }
-          },
-          %Screens.V2.WidgetInstance.ElevatorStatus.ListPage{
+          }
+        ]
+      }
+
+      assert expected_result == WidgetInstance.serialize(instance)
+    end
+
+    test "returns a list page for one active elsewhere", %{
+      one_active_elsewhere_instance: instance
+    } do
+      expected_result = %{
+        pages: [
+          %WidgetInstance.ElevatorStatus.ListPage{
             stations: [
               %{
-                name: "Foo Station",
-                icons: [:red],
-                is_at_home_stop: true,
-                elevator_closures: [
-                  %{
-                    description: nil,
-                    elevator_id: "1",
-                    elevator_name: "Elevator 1",
-                    timeframe: %{
-                      active_period: %{
-                        "start" => "2022-01-01T00:00:00Z",
-                        "end" => "2022-01-01T22:00:00Z"
-                      },
-                      happening_now: true
-                    },
-                    header_text: nil
-                  }
-                ]
-              },
-              %{
-                name: "Bar Station",
-                icons: [:red],
+                name: "Baz Station",
+                icons: [:green],
                 is_at_home_stop: false,
                 elevator_closures: [
                   %{
                     description: nil,
-                    elevator_id: "1",
-                    elevator_name: "Elevator 1",
+                    elevator_id: "3",
+                    elevator_name: "Elevator 3",
                     timeframe: %{
                       active_period: %{
                         "start" => "2022-01-01T00:00:00Z",
@@ -453,40 +1131,331 @@ defmodule Screens.V2.WidgetInstance.ElevatorStatusTest do
 
       assert expected_result == WidgetInstance.serialize(instance)
     end
+
+    test "returns one list and two detail pages for active on connecting lines + elsewhere", %{
+      non_home_active_instance: instance
+    } do
+      expected_result = %{
+        pages: [
+          %WidgetInstance.ElevatorStatus.ListPage{
+            stations: [
+              %{
+                elevator_closures: [
+                  %{
+                    description: nil,
+                    elevator_id: "2",
+                    elevator_name: "Elevator 2",
+                    header_text: nil,
+                    timeframe: %{
+                      active_period: %{
+                        "end" => "2022-01-01T22:00:00Z",
+                        "start" => "2022-01-01T00:00:00Z"
+                      },
+                      happening_now: true
+                    }
+                  },
+                  %{
+                    description: nil,
+                    elevator_id: "6",
+                    elevator_name: "Elevator 6",
+                    header_text: nil,
+                    timeframe: %{
+                      active_period: %{
+                        "end" => "2022-01-01T22:00:00Z",
+                        "start" => "2022-01-01T00:00:00Z"
+                      },
+                      happening_now: true
+                    }
+                  }
+                ],
+                icons: [:red, :orange, :bus],
+                is_at_home_stop: false,
+                name: "Bar Station"
+              },
+              %{
+                elevator_closures: [
+                  %{
+                    description: nil,
+                    elevator_id: "3",
+                    elevator_name: "Elevator 3",
+                    header_text: nil,
+                    timeframe: %{
+                      active_period: %{
+                        "end" => "2022-01-01T22:00:00Z",
+                        "start" => "2022-01-01T00:00:00Z"
+                      },
+                      happening_now: true
+                    }
+                  },
+                  %{
+                    description: nil,
+                    elevator_id: "7",
+                    elevator_name: "Elevator 7",
+                    header_text: nil,
+                    timeframe: %{
+                      active_period: %{
+                        "end" => "2022-01-01T22:00:00Z",
+                        "start" => "2022-01-01T00:00:00Z"
+                      },
+                      happening_now: true
+                    }
+                  }
+                ],
+                icons: [:green],
+                is_at_home_stop: false,
+                name: "Baz Station"
+              },
+              %{
+                elevator_closures: [
+                  %{
+                    description: nil,
+                    elevator_id: "4",
+                    elevator_name: "Elevator 4",
+                    header_text: nil,
+                    timeframe: %{
+                      active_period: %{
+                        "end" => "2022-01-01T22:00:00Z",
+                        "start" => "2022-01-01T00:00:00Z"
+                      },
+                      happening_now: true
+                    }
+                  },
+                  %{
+                    description: nil,
+                    elevator_id: "8",
+                    elevator_name: "Elevator 8",
+                    header_text: nil,
+                    timeframe: %{
+                      active_period: %{
+                        "end" => "2022-01-01T22:00:00Z",
+                        "start" => "2022-01-01T00:00:00Z"
+                      },
+                      happening_now: true
+                    }
+                  },
+                  %{
+                    description: nil,
+                    elevator_id: "9",
+                    elevator_name: "Elevator 9",
+                    header_text: nil,
+                    timeframe: %{
+                      active_period: %{
+                        "end" => "2022-01-01T22:00:00Z",
+                        "start" => "2022-01-01T00:00:00Z"
+                      },
+                      happening_now: true
+                    }
+                  }
+                ],
+                icons: [:green],
+                is_at_home_stop: false,
+                name: "Qux Station"
+              }
+            ]
+          },
+          %WidgetInstance.ElevatorStatus.DetailPage{
+            station: %{
+              elevator_closures: [
+                %{
+                  description: nil,
+                  elevator_id: "6",
+                  elevator_name: "Elevator 6",
+                  header_text: nil,
+                  timeframe: %{
+                    active_period: %{
+                      "end" => "2022-01-01T22:00:00Z",
+                      "start" => "2022-01-01T00:00:00Z"
+                    },
+                    happening_now: true
+                  }
+                }
+              ],
+              icons: [:red, :orange, :bus],
+              is_at_home_stop: false,
+              name: "Bar Station"
+            }
+          },
+          %WidgetInstance.ElevatorStatus.DetailPage{
+            station: %{
+              elevator_closures: [
+                %{
+                  description: nil,
+                  elevator_id: "2",
+                  elevator_name: "Elevator 2",
+                  header_text: nil,
+                  timeframe: %{
+                    active_period: %{
+                      "end" => "2022-01-01T22:00:00Z",
+                      "start" => "2022-01-01T00:00:00Z"
+                    },
+                    happening_now: true
+                  }
+                }
+              ],
+              icons: [:red, :orange, :bus],
+              is_at_home_stop: false,
+              name: "Bar Station"
+            }
+          }
+        ]
+      }
+
+      assert expected_result == WidgetInstance.serialize(instance)
+    end
+
+    test "returns one list page for upcoming on connecting lines + elsewhere", %{
+      non_home_upcoming_instance: instance
+    } do
+      # (We only include upcoming at home, no other upcoming closures)
+      expected_result = %{
+        pages: [%WidgetInstance.ElevatorStatus.ListPage{stations: []}]
+      }
+
+      assert expected_result == WidgetInstance.serialize(instance)
+    end
+
+    test "returns one list page and one detail page for a mix of active/upcoming on connecting lines + elsewhere",
+         %{non_home_mixed_instance: instance} do
+      expected_result = %{
+        pages: [
+          %WidgetInstance.ElevatorStatus.ListPage{
+            stations: [
+              %{
+                elevator_closures: [
+                  %{
+                    description: nil,
+                    elevator_id: "2",
+                    elevator_name: "Elevator 2",
+                    header_text: nil,
+                    timeframe: %{
+                      active_period: %{
+                        "end" => "2022-01-01T22:00:00Z",
+                        "start" => "2022-01-01T00:00:00Z"
+                      },
+                      happening_now: true
+                    }
+                  }
+                ],
+                icons: [:red, :orange, :bus],
+                is_at_home_stop: false,
+                name: "Bar Station"
+              },
+              %{
+                elevator_closures: [
+                  %{
+                    description: nil,
+                    elevator_id: "3",
+                    elevator_name: "Elevator 3",
+                    header_text: nil,
+                    timeframe: %{
+                      active_period: %{
+                        "end" => "2022-01-01T22:00:00Z",
+                        "start" => "2022-01-01T00:00:00Z"
+                      },
+                      happening_now: true
+                    }
+                  }
+                ],
+                icons: [:green],
+                is_at_home_stop: false,
+                name: "Baz Station"
+              },
+              %{
+                elevator_closures: [
+                  %{
+                    description: nil,
+                    elevator_id: "4",
+                    elevator_name: "Elevator 4",
+                    header_text: nil,
+                    timeframe: %{
+                      active_period: %{
+                        "end" => "2022-01-01T22:00:00Z",
+                        "start" => "2022-01-01T00:00:00Z"
+                      },
+                      happening_now: true
+                    }
+                  },
+                  %{
+                    description: nil,
+                    elevator_id: "9",
+                    elevator_name: "Elevator 9",
+                    header_text: nil,
+                    timeframe: %{
+                      active_period: %{
+                        "end" => "2022-01-01T22:00:00Z",
+                        "start" => "2022-01-01T00:00:00Z"
+                      },
+                      happening_now: true
+                    }
+                  }
+                ],
+                icons: [:green],
+                is_at_home_stop: false,
+                name: "Qux Station"
+              }
+            ]
+          },
+          %WidgetInstance.ElevatorStatus.DetailPage{
+            station: %{
+              elevator_closures: [
+                %{
+                  description: nil,
+                  elevator_id: "2",
+                  elevator_name: "Elevator 2",
+                  header_text: nil,
+                  timeframe: %{
+                    active_period: %{
+                      "end" => "2022-01-01T22:00:00Z",
+                      "start" => "2022-01-01T00:00:00Z"
+                    },
+                    happening_now: true
+                  }
+                }
+              ],
+              icons: [:red, :orange, :bus],
+              is_at_home_stop: false,
+              name: "Bar Station"
+            }
+          }
+        ]
+      }
+
+      assert expected_result == WidgetInstance.serialize(instance)
+    end
   end
 
   describe "slot_names/1" do
-    test "returns lower_right", %{instance: instance} do
+    test "returns lower_right", %{one_active_at_home_instance: instance} do
       assert [:lower_right] == WidgetInstance.slot_names(instance)
     end
   end
 
   describe "widget_type/1" do
-    test "returns elevator_status", %{instance: instance} do
+    test "returns elevator_status", %{one_active_at_home_instance: instance} do
       assert :elevator_status == WidgetInstance.widget_type(instance)
     end
   end
 
   describe "audio_serialize/1" do
-    test "returns empty string", %{instance: instance} do
+    test "returns empty map", %{one_active_at_home_instance: instance} do
       assert %{} == WidgetInstance.audio_serialize(instance)
     end
   end
 
   describe "audio_sort_key/1" do
-    test "returns 0", %{instance: instance} do
+    test "returns 0", %{one_active_at_home_instance: instance} do
       assert 0 == WidgetInstance.audio_sort_key(instance)
     end
   end
 
   describe "audio_valid_candidate?/1" do
-    test "returns false", %{instance: instance} do
+    test "returns false", %{one_active_at_home_instance: instance} do
       refute WidgetInstance.audio_valid_candidate?(instance)
     end
   end
 
   describe "audio_view/1" do
-    test "returns ElevatorStatusView", %{instance: instance} do
+    test "returns ElevatorStatusView", %{one_active_at_home_instance: instance} do
       assert ScreensWeb.V2.Audio.ElevatorStatusView == WidgetInstance.audio_view(instance)
     end
   end


### PR DESCRIPTION
**Asana task**: [Elevator status widget component - list view](https://app.asana.com/0/1185117109217413/1201621878856262/f)

This PR makes some small tweaks to the frontend styles to make the list view exactly match the designs, so that the backend can reliably calculate the height of each row as `100px + 48px * length(closures_at_station)`.

The rest of the code is the backend logic to achieve the page-splitting/fitting logic dictated by the [designs](https://app.abstract.com/projects/c04b5940-4805-11e8-8262-510af7fd49fe/branches/f6705d99-fa8b-4115-a97f-188ea9e01a11/collections/91521734-0e0f-434b-bf25-13516d47b1f3).

It took a lot of test cases to cover all the possible outputs of this logic—sorry for the gigantic test file!

- [ ] Needs version bump?
