### PR TITLE
fix: Add sorter for Enum functions with DateTimes

### DIFF
--- a/lib/screens/audio.ex
+++ b/lib/screens/audio.ex
@@ -71,7 +71,7 @@ defmodule Screens.Audio do
   defp merge_section_departures(sections) do
     sections
     |> Enum.flat_map(& &1.departures)
-    |> Enum.sort_by(& &1.time)
+    |> Enum.sort_by(& &1.time, DateTime)
     |> Util.group_by_with_order(&{&1.route, &1.route_id, &1.destination})
     |> Enum.map(fn {key, departures} ->
       {key,

--- a/lib/screens/departures/departure.ex
+++ b/lib/screens/departures/departure.ex
@@ -7,6 +7,7 @@ defmodule Screens.Departures.Departure do
   alias Screens.Schedules.Schedule
   alias Screens.Trips.Trip
   alias Screens.Vehicles.Vehicle
+  alias Screens.Util
 
   defstruct id: nil,
             stop_name: nil,
@@ -190,7 +191,7 @@ defmodule Screens.Departures.Departure do
 
     merged =
       (predicted_departures ++ scheduled_departures)
-      |> Enum.sort_by(& &1.time)
+      |> Enum.sort_by(&Util.parse_time_string(&1.time), DateTime)
 
     {:ok, merged}
   end
@@ -429,11 +430,13 @@ defmodule Screens.Departures.Departure do
       predictions_with_trip
       |> Enum.group_by(fn %{trip: %Trip{id: trip_id}} -> trip_id end)
       |> log_unexpected_groups()
-      |> Enum.map(fn {_trip_id, predictions} -> Enum.min_by(predictions, & &1.departure_time) end)
+      |> Enum.map(fn {_trip_id, predictions} ->
+        Enum.min_by(predictions, & &1.departure_time, DateTime)
+      end)
 
     deduplicated_predictions =
       (predictions_without_trip ++ deduplicated_predictions_with_trip)
-      |> Enum.sort_by(& &1.departure_time)
+      |> Enum.sort_by(& &1.departure_time, DateTime)
 
     {:ok, deduplicated_predictions}
   end

--- a/lib/screens/departures/departure.ex
+++ b/lib/screens/departures/departure.ex
@@ -6,8 +6,8 @@ defmodule Screens.Departures.Departure do
   alias Screens.Predictions.Prediction
   alias Screens.Schedules.Schedule
   alias Screens.Trips.Trip
-  alias Screens.Vehicles.Vehicle
   alias Screens.Util
+  alias Screens.Vehicles.Vehicle
 
   defstruct id: nil,
             stop_name: nil,

--- a/lib/screens/dup_screen_data/request.ex
+++ b/lib/screens/dup_screen_data/request.ex
@@ -9,6 +9,7 @@ defmodule Screens.DupScreenData.Request do
   alias Screens.Departures.Departure
   alias Screens.DupScreenData.Response
   alias Screens.SignsUiConfig
+  alias Screens.Util
 
   # Filters for the types of alerts we care about
   @alert_route_types ~w[light_rail subway]a
@@ -174,7 +175,7 @@ defmodule Screens.DupScreenData.Request do
         section_departures =
           departures
           |> Enum.map(&Map.from_struct/1)
-          |> Enum.sort_by(& &1.time)
+          |> Enum.sort_by(&Util.parse_time_string(&1.time), DateTime)
           |> Enum.take(num_rows)
           |> Enum.map(&replace_long_headsigns/1)
 

--- a/lib/screens/nearby_departures.ex
+++ b/lib/screens/nearby_departures.ex
@@ -22,7 +22,7 @@ defmodule Screens.NearbyDepartures do
         predictions
         |> Enum.group_by(& &1.stop.id)
         |> Enum.map(fn {stop_id, prediction_list} ->
-          {stop_id, Enum.min_by(prediction_list, & &1.departure_time, fn -> nil end)}
+          {stop_id, Enum.min_by(prediction_list, & &1.departure_time, DateTime, fn -> nil end)}
         end)
         |> Enum.map(fn {_stop_id, prediction} -> format_prediction(prediction) end)
 

--- a/lib/screens/solari_screen_data.ex
+++ b/lib/screens/solari_screen_data.ex
@@ -7,8 +7,7 @@ defmodule Screens.SolariScreenData do
   alias Screens.Config.Solari.Section.{Headway, Layout}
   alias Screens.Config.Solari.Section.Layout.{Bidirectional, Upcoming}
   alias Screens.Departures.Departure
-  alias Screens.LogScreenData
-  alias Screens.SignsUiConfig
+  alias Screens.{LogScreenData, SignsUiConfig, Util}
 
   def by_screen_id(screen_id, is_screen, at_historical_datetime \\ nil) do
     if State.mode_disabled?(:bus) do
@@ -199,7 +198,10 @@ defmodule Screens.SolariScreenData do
     query_data
     |> filter_by_routes(layout_opts)
     |> filter_by_minutes(layout_opts)
-    |> Enum.sort_by(& &1.time)
+    |> Enum.sort_by(
+      &Util.parse_time_string(&1.time),
+      DateTime
+    )
     |> take_rows(num_rows)
     |> Enum.map(&Map.from_struct/1)
   end
@@ -209,11 +211,17 @@ defmodule Screens.SolariScreenData do
     query_data
     |> filter_by_routes(layout_opts)
     |> filter_by_minutes(layout_opts)
-    |> Enum.sort_by(& &1.time)
+    |> Enum.sort_by(
+      &Util.parse_time_string(&1.time),
+      DateTime
+    )
     |> Enum.split_with(fn %{direction_id: direction_id} -> direction_id == 0 end)
     |> Tuple.to_list()
     |> Enum.flat_map(&Enum.slice(&1, 0, 1))
-    |> Enum.sort_by(& &1.time)
+    |> Enum.sort_by(
+      &Util.parse_time_string(&1.time),
+      DateTime
+    )
     |> Enum.map(&Map.from_struct/1)
   end
 

--- a/lib/screens/util.ex
+++ b/lib/screens/util.ex
@@ -111,4 +111,14 @@ defmodule Screens.Util do
       i -> Enum.drop(list, i + 1)
     end
   end
+
+  @doc """
+  Returns a DateTime object parsed from the given string.
+  String must already be in ISO8601 format.
+  """
+  @spec parse_time_string(String.t()) :: DateTime.t()
+  def parse_time_string(time) do
+    {:ok, dt, _} = DateTime.from_iso8601(time)
+    dt
+  end
 end


### PR DESCRIPTION
**Asana task**: [Check usages of `Enum.sort` for cases where we're incorrectly sorting a list of structs](https://app.asana.com/0/1185117109217413/1201894802937869/f)

Tested all of these after adding the sorter. The new Util function was added because some objects were strings in ISO8601 format. Those need to be converted before the sorter can work.

- [ ] Needs version bump?
