### PR TITLE
fix: Use `makePersistentCarousel` to have line map widget update in sync with rest of the page

### DIFF
--- a/assets/src/components/v2/full_line_map.tsx
+++ b/assets/src/components/v2/full_line_map.tsx
@@ -1,34 +1,13 @@
-import React, { ComponentType, useState, useEffect } from "react";
+import makePersistentCarousel, { PageRendererProps } from "Components/v2/persistent_carousel";
+import React, { ComponentType } from "react";
 
-interface Props {
-  asset_urls: string[];
+interface Page {
+  asset_url: string;
 }
 
-const intervalInMs = 10000;
+type Props = PageRendererProps<Page>;
 
-const FullLineMap: ComponentType<Props> = ({ asset_urls }) => {
-  const [assetIndex, setAssetIndex] = useState(0);
-
-  useEffect(() => {
-    if (assetIndex === asset_urls.length - 1) {
-      setTimeout(() => {
-        setAssetIndex(0);
-      }, intervalInMs);
-    } else {
-      setTimeout(() => {
-        setAssetIndex((i) => i + 1);
-      }, intervalInMs);
-    }
-  }, [assetIndex]);
-
-  return <Image assetUrl={asset_urls[assetIndex]} />;
-};
-
-interface ImageProps {
-  assetUrl: string;
-}
-
-const Image: ComponentType<ImageProps> = ({ assetUrl }) => {
+const FullLineMapImagePage: ComponentType<Props> = ({ page: { asset_url: assetUrl } }) => {
   return (
     <div className="full-line-map-image__container">
       <img className="full-line-map-image__image" src={assetUrl} />
@@ -36,4 +15,4 @@ const Image: ComponentType<ImageProps> = ({ assetUrl }) => {
   );
 };
 
-export default FullLineMap;
+export default makePersistentCarousel(FullLineMapImagePage);

--- a/lib/screens/v2/widget_instance/full_line_map.ex
+++ b/lib/screens/v2/widget_instance/full_line_map.ex
@@ -10,7 +10,9 @@ defmodule Screens.V2.WidgetInstance.FullLineMap do
           screen: Screen.t(),
           asset_urls: list(String.t())
         }
-  def serialize(%__MODULE__{asset_urls: asset_urls}), do: %{asset_urls: asset_urls}
+  def serialize(%__MODULE__{asset_urls: asset_urls}) do
+    %{pages: Enum.map(asset_urls, &%{asset_url: &1})}
+  end
 
   def slot_names(_instance), do: [:main_content_left]
 


### PR DESCRIPTION
**Asana task**: [[Pre-Fare] Line map needs to render in-sync](https://app.asana.com/0/1185117109217413/1201995187651695/f)

This uses the `makePersistentCarousel` higher-order component to sync the FullLineMap widget component's updates with the rest of the components that update based on the `lastSuccess` timestamp.

- [ ] Needs version bump?
