### PR TITLE
tweak: Change audio_sort_key return value

### DIFF
--- a/lib/screens/v2/widget_instance.ex
+++ b/lib/screens/v2/widget_instance.ex
@@ -27,7 +27,7 @@ defprotocol Screens.V2.WidgetInstance do
   @spec audio_serialize(t) :: map()
   def audio_serialize(instance)
 
-  @spec audio_sort_key(t) :: integer()
+  @spec audio_sort_key(t) :: priority()
   def audio_sort_key(instance)
 
   @spec audio_valid_candidate?(t) :: boolean()

--- a/lib/screens/v2/widget_instance/alert.ex
+++ b/lib/screens/v2/widget_instance/alert.ex
@@ -546,7 +546,7 @@ defmodule Screens.V2.WidgetInstance.Alert do
 
   def audio_serialize(_instance), do: %{}
 
-  def audio_sort_key(_instance), do: 0
+  def audio_sort_key(_instance), do: [0]
 
   def audio_valid_candidate?(_instance), do: false
 

--- a/lib/screens/v2/widget_instance/alert_header.ex
+++ b/lib/screens/v2/widget_instance/alert_header.ex
@@ -44,7 +44,7 @@ defmodule Screens.V2.WidgetInstance.AlertHeader do
 
     def audio_serialize(_instance), do: %{}
 
-    def audio_sort_key(_instance), do: 0
+    def audio_sort_key(_instance), do: [0]
 
     def audio_valid_candidate?(_instance), do: false
 

--- a/lib/screens/v2/widget_instance/bottom_screen_filler.ex
+++ b/lib/screens/v2/widget_instance/bottom_screen_filler.ex
@@ -24,7 +24,7 @@ defmodule Screens.V2.WidgetInstance.BottomScreenFiller do
   def valid_candidate?(_instance), do: true
 
   def audio_serialize(_instance), do: %{}
-  def audio_sort_key(_instance), do: 0
+  def audio_sort_key(_instance), do: [0]
   def audio_valid_candidate?(_instance), do: false
   def audio_view(_instance), do: ScreensWeb.V2.Audio.BottomScreenFillerView
 

--- a/lib/screens/v2/widget_instance/departures.ex
+++ b/lib/screens/v2/widget_instance/departures.ex
@@ -48,7 +48,7 @@ defmodule Screens.V2.WidgetInstance.Departures do
       %{sections: Enum.map(section_data, &Departures.audio_serialize_section(&1, screen))}
     end
 
-    def audio_sort_key(_instance), do: 1
+    def audio_sort_key(_instance), do: [1]
 
     def audio_valid_candidate?(_instance), do: true
 

--- a/lib/screens/v2/widget_instance/departures_no_data.ex
+++ b/lib/screens/v2/widget_instance/departures_no_data.ex
@@ -37,7 +37,7 @@ defmodule Screens.V2.WidgetInstance.DeparturesNoData do
     def widget_type(instance), do: DeparturesNoData.widget_type(instance)
     def valid_candidate?(instance), do: DeparturesNoData.valid_candidate?(instance)
     def audio_serialize(_instance), do: %{}
-    def audio_sort_key(_instance), do: 0
+    def audio_sort_key(_instance), do: [0]
     def audio_valid_candidate?(_instance), do: false
     def audio_view(_instance), do: ScreensWeb.V2.Audio.DeparturesNoDataView
   end

--- a/lib/screens/v2/widget_instance/elevator_status.ex
+++ b/lib/screens/v2/widget_instance/elevator_status.ex
@@ -489,7 +489,7 @@ defmodule Screens.V2.WidgetInstance.ElevatorStatus do
 
   def audio_serialize(_instance), do: %{}
 
-  def audio_sort_key(_instance), do: 0
+  def audio_sort_key(_instance), do: [0]
 
   def audio_valid_candidate?(_instance), do: false
 

--- a/lib/screens/v2/widget_instance/evergreen_content.ex
+++ b/lib/screens/v2/widget_instance/evergreen_content.ex
@@ -56,7 +56,7 @@ defmodule Screens.V2.WidgetInstance.EvergreenContent do
     def widget_type(instance), do: EvergreenContent.widget_type(instance)
     def valid_candidate?(instance), do: EvergreenContent.valid_candidate?(instance)
     def audio_serialize(_instance), do: %{}
-    def audio_sort_key(_instance), do: 0
+    def audio_sort_key(_instance), do: [0]
     def audio_valid_candidate?(_instance), do: false
     def audio_view(_instance), do: ScreensWeb.V2.Audio.EvergreenContentView
   end

--- a/lib/screens/v2/widget_instance/fare_info_footer.ex
+++ b/lib/screens/v2/widget_instance/fare_info_footer.ex
@@ -37,7 +37,7 @@ defmodule Screens.V2.WidgetInstance.FareInfoFooter do
 
     def audio_serialize(_instance), do: %{}
 
-    def audio_sort_key(_instance), do: 0
+    def audio_sort_key(_instance), do: [0]
 
     def audio_valid_candidate?(_instance), do: false
 

--- a/lib/screens/v2/widget_instance/full_line_map.ex
+++ b/lib/screens/v2/widget_instance/full_line_map.ex
@@ -24,7 +24,7 @@ defmodule Screens.V2.WidgetInstance.FullLineMap do
 
   def audio_serialize(_instance), do: %{}
 
-  def audio_sort_key(_instance), do: 0
+  def audio_sort_key(_instance), do: [0]
 
   def audio_valid_candidate?(_instance), do: false
 

--- a/lib/screens/v2/widget_instance/line_map.ex
+++ b/lib/screens/v2/widget_instance/line_map.ex
@@ -74,7 +74,7 @@ defmodule Screens.V2.WidgetInstance.LineMap do
 
     def audio_serialize(_instance), do: %{}
 
-    def audio_sort_key(_instance), do: 0
+    def audio_sort_key(_instance), do: [0]
 
     def audio_valid_candidate?(_instance), do: false
 

--- a/lib/screens/v2/widget_instance/link_footer.ex
+++ b/lib/screens/v2/widget_instance/link_footer.ex
@@ -28,7 +28,7 @@ defmodule Screens.V2.WidgetInstance.LinkFooter do
 
     def audio_serialize(_instance), do: %{}
 
-    def audio_sort_key(_instance), do: 0
+    def audio_sort_key(_instance), do: [0]
 
     def audio_valid_candidate?(_instance), do: false
 

--- a/lib/screens/v2/widget_instance/normal_header.ex
+++ b/lib/screens/v2/widget_instance/normal_header.ex
@@ -47,7 +47,7 @@ defmodule Screens.V2.WidgetInstance.NormalHeader do
 
     def audio_serialize(%NormalHeader{text: text}), do: %{text: text}
 
-    def audio_sort_key(_instance), do: 0
+    def audio_sort_key(_instance), do: [0]
 
     def audio_valid_candidate?(_instance), do: true
 

--- a/lib/screens/v2/widget_instance/overnight_departures.ex
+++ b/lib/screens/v2/widget_instance/overnight_departures.ex
@@ -24,7 +24,7 @@ defmodule Screens.V2.WidgetInstance.OvernightDepartures do
     def widget_type(instance), do: OvernightDepartures.widget_type(instance)
     def valid_candidate?(instance), do: OvernightDepartures.valid_candidate?(instance)
     def audio_serialize(_instance), do: %{}
-    def audio_sort_key(_instance), do: 0
+    def audio_sort_key(_instance), do: [0]
     def audio_valid_candidate?(_instance), do: false
     def audio_view(_instance), do: ScreensWeb.V2.Audio.OvernightDeparturesView
   end

--- a/lib/screens/v2/widget_instance/placeholder.ex
+++ b/lib/screens/v2/widget_instance/placeholder.ex
@@ -22,7 +22,7 @@ defmodule Screens.V2.WidgetInstance.Placeholder do
     def widget_type(_), do: :placeholder
     def valid_candidate?(_instance), do: true
     def audio_serialize(_instance), do: %{}
-    def audio_sort_key(_instance), do: 0
+    def audio_sort_key(_instance), do: [0]
     def audio_valid_candidate?(_instance), do: false
     def audio_view(_instance), do: ScreensWeb.V2.Audio.PlaceholderView
   end

--- a/lib/screens/v2/widget_instance/reconstructed_alert.ex
+++ b/lib/screens/v2/widget_instance/reconstructed_alert.ex
@@ -52,7 +52,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
     def widget_type(_instance), do: :reconstructed_alert
     def valid_candidate?(_instance), do: true
     def audio_serialize(_instance), do: %{}
-    def audio_sort_key(_instance), do: 0
+    def audio_sort_key(_instance), do: [0]
     def audio_valid_candidate?(_instance), do: false
     def audio_view(_instance), do: ScreensWeb.V2.Audio.ReconstructedAlertView
   end

--- a/lib/screens/v2/widget_instance/static_image.ex
+++ b/lib/screens/v2/widget_instance/static_image.ex
@@ -37,7 +37,7 @@ defmodule Screens.V2.WidgetInstance.StaticImage do
 
     def audio_serialize(_instance), do: %{}
 
-    def audio_sort_key(_instance), do: 0
+    def audio_sort_key(_instance), do: [0]
 
     def audio_valid_candidate?(_instance), do: false
 

--- a/lib/screens/v2/widget_instance/subway_status.ex
+++ b/lib/screens/v2/widget_instance/subway_status.ex
@@ -240,7 +240,7 @@ defmodule Screens.V2.WidgetInstance.SubwayStatus do
 
     def audio_serialize(_instance), do: %{}
 
-    def audio_sort_key(_instance), do: 0
+    def audio_sort_key(_instance), do: [0]
 
     def audio_valid_candidate?(_instance), do: false
 

--- a/lib/screens/v2/widget_instance/survey.ex
+++ b/lib/screens/v2/widget_instance/survey.ex
@@ -43,7 +43,7 @@ defmodule Screens.V2.WidgetInstance.Survey do
     def widget_type(instance), do: Survey.widget_type(instance)
     def valid_candidate?(instance), do: Survey.valid_candidate?(instance)
     def audio_serialize(_instance), do: %{}
-    def audio_sort_key(_instance), do: 0
+    def audio_sort_key(_instance), do: [0]
     def audio_valid_candidate?(_instance), do: false
     def audio_view(_instance), do: ScreensWeb.V2.Audio.SurveyView
   end

--- a/test/screens/v2/screen_audio_data_test.exs
+++ b/test/screens/v2/screen_audio_data_test.exs
@@ -87,19 +87,19 @@ defmodule Screens.V2.ScreenAudioDataTest do
         {0, :medium_left} => %MockWidget{
           slot_names: [:medium_left, :medium_right],
           audio_valid_candidate?: false,
-          audio_sort_key: 2,
+          audio_sort_key: [2],
           content: "Alert"
         },
         :main_content => %MockWidget{
           slot_names: [:main_content],
           audio_valid_candidate?: true,
-          audio_sort_key: 1,
+          audio_sort_key: [1],
           content: "Departures"
         },
         :header => %MockWidget{
           slot_names: [:header],
           audio_valid_candidate?: true,
-          audio_sort_key: 0,
+          audio_sort_key: [0],
           content: "Header"
         }
       }
@@ -126,19 +126,19 @@ defmodule Screens.V2.ScreenAudioDataTest do
         {0, :medium_left} => %MockWidget{
           slot_names: [:medium_left, :medium_right],
           audio_valid_candidate?: false,
-          audio_sort_key: 2,
+          audio_sort_key: [2],
           content: "Alert"
         },
         :main_content => %MockWidget{
           slot_names: [:main_content],
           audio_valid_candidate?: true,
-          audio_sort_key: 1,
+          audio_sort_key: [1],
           content: "Departures"
         },
         :header => %MockWidget{
           slot_names: [:header],
           audio_valid_candidate?: true,
-          audio_sort_key: 0,
+          audio_sort_key: [0],
           content: "Header"
         }
       }
@@ -162,19 +162,19 @@ defmodule Screens.V2.ScreenAudioDataTest do
         {0, :medium_left} => %MockWidget{
           slot_names: [:medium_left, :medium_right],
           audio_valid_candidate?: false,
-          audio_sort_key: 2,
+          audio_sort_key: [2],
           content: "Alert"
         },
         :main_content => %MockWidget{
           slot_names: [:main_content],
           audio_valid_candidate?: true,
-          audio_sort_key: 1,
+          audio_sort_key: [1],
           content: "Departures"
         },
         :header => %MockWidget{
           slot_names: [:header],
           audio_valid_candidate?: true,
-          audio_sort_key: 0,
+          audio_sort_key: [0],
           content: "Header"
         }
       }
@@ -198,19 +198,19 @@ defmodule Screens.V2.ScreenAudioDataTest do
         {0, :medium_left} => %MockWidget{
           slot_names: [:medium_left, :medium_right],
           audio_valid_candidate?: false,
-          audio_sort_key: 2,
+          audio_sort_key: [2],
           content: "Alert"
         },
         :main_content => %MockWidget{
           slot_names: [:main_content],
           audio_valid_candidate?: true,
-          audio_sort_key: 1,
+          audio_sort_key: [1],
           content: "Departures"
         },
         :header => %MockWidget{
           slot_names: [:header],
           audio_valid_candidate?: true,
-          audio_sort_key: 0,
+          audio_sort_key: [0],
           content: "Header"
         }
       }

--- a/test/screens/v2/widget_instance/alert_header_test.exs
+++ b/test/screens/v2/widget_instance/alert_header_test.exs
@@ -72,12 +72,12 @@ defmodule Screens.V2.WidgetInstance.AlertHeaderTest do
   end
 
   describe "audio_sort_key/1" do
-    test "returns 0 for header with time", %{instance_with_time: instance} do
-      assert 0 == WidgetInstance.audio_sort_key(instance)
+    test "returns [0] for header with time", %{instance_with_time: instance} do
+      assert [0] == WidgetInstance.audio_sort_key(instance)
     end
 
-    test "returns 0 for header without time", %{instance_no_time: instance} do
-      assert 0 == WidgetInstance.audio_sort_key(instance)
+    test "returns [0] for header without time", %{instance_no_time: instance} do
+      assert [0] == WidgetInstance.audio_sort_key(instance)
     end
   end
 

--- a/test/screens/v2/widget_instance/alert_test.exs
+++ b/test/screens/v2/widget_instance/alert_test.exs
@@ -854,8 +854,8 @@ defmodule Screens.V2.WidgetInstance.AlertTest do
   end
 
   describe "audio_sort_key/1" do
-    test "returns 0", %{widget: widget} do
-      assert 0 == AlertWidget.audio_sort_key(widget)
+    test "returns [0]", %{widget: widget} do
+      assert [0] == AlertWidget.audio_sort_key(widget)
     end
   end
 

--- a/test/screens/v2/widget_instance/bottom_screen_filler_test.exs
+++ b/test/screens/v2/widget_instance/bottom_screen_filler_test.exs
@@ -48,8 +48,8 @@ defmodule Screens.V2.WidgetInstance.BottomScreenFillerTest do
   end
 
   describe "audio_sort_key/1" do
-    test "returns 0", %{instance: instance} do
-      assert 0 == WidgetInstance.audio_sort_key(instance)
+    test "returns [0]", %{instance: instance} do
+      assert [0] == WidgetInstance.audio_sort_key(instance)
     end
   end
 

--- a/test/screens/v2/widget_instance/departures_no_data_test.exs
+++ b/test/screens/v2/widget_instance/departures_no_data_test.exs
@@ -42,8 +42,8 @@ defmodule Screens.V2.WidgetInstance.DeparturesNoDataTest do
   end
 
   describe "audio_sort_key/1" do
-    test "returns 0" do
-      assert 0 == WidgetInstance.audio_sort_key(@instance)
+    test "returns [0]" do
+      assert [0] == WidgetInstance.audio_sort_key(@instance)
     end
   end
 

--- a/test/screens/v2/widget_instance/departures_test.exs
+++ b/test/screens/v2/widget_instance/departures_test.exs
@@ -561,9 +561,9 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
   end
 
   describe "audio_sort_key/1" do
-    test "returns 1" do
+    test "returns [1]" do
       instance = %Departures{}
-      assert 1 == WidgetInstance.audio_sort_key(instance)
+      assert [1] == WidgetInstance.audio_sort_key(instance)
     end
   end
 

--- a/test/screens/v2/widget_instance/elevator_status_test.exs
+++ b/test/screens/v2/widget_instance/elevator_status_test.exs
@@ -1443,8 +1443,8 @@ defmodule WidgetInstance.ElevatorStatusTest do
   end
 
   describe "audio_sort_key/1" do
-    test "returns 0", %{one_active_at_home_instance: instance} do
-      assert 0 == WidgetInstance.audio_sort_key(instance)
+    test "returns [0]", %{one_active_at_home_instance: instance} do
+      assert [0] == WidgetInstance.audio_sort_key(instance)
     end
   end
 

--- a/test/screens/v2/widget_instance/evergreen_content_test.exs
+++ b/test/screens/v2/widget_instance/evergreen_content_test.exs
@@ -73,8 +73,8 @@ defmodule Screens.V2.WidgetInstance.EvergreenContentTest do
   end
 
   describe "audio_sort_key/1" do
-    test "returns 0", %{widget: widget} do
-      assert 0 == WidgetInstance.audio_sort_key(widget)
+    test "returns [0]", %{widget: widget} do
+      assert [0] == WidgetInstance.audio_sort_key(widget)
     end
   end
 

--- a/test/screens/v2/widget_instance/fare_info_footer_test.exs
+++ b/test/screens/v2/widget_instance/fare_info_footer_test.exs
@@ -69,12 +69,12 @@ defmodule Screens.V2.WidgetInstance.FareInfoFooterTest do
   end
 
   describe "audio_sort_key/1" do
-    test "returns 0 for bus", %{bus_instance: instance} do
-      assert 0 == WidgetInstance.audio_sort_key(instance)
+    test "returns [0] for bus", %{bus_instance: instance} do
+      assert [0] == WidgetInstance.audio_sort_key(instance)
     end
 
-    test "returns 0 for subway", %{subway_instance: instance} do
-      assert 0 == WidgetInstance.audio_sort_key(instance)
+    test "returns [0] for subway", %{subway_instance: instance} do
+      assert [0] == WidgetInstance.audio_sort_key(instance)
     end
   end
 

--- a/test/screens/v2/widget_instance/line_map_test.exs
+++ b/test/screens/v2/widget_instance/line_map_test.exs
@@ -338,9 +338,9 @@ defmodule Screens.V2.WidgetInstance.LineMapTest do
   end
 
   describe "audio_sort_key/1" do
-    test "returns 0" do
+    test "returns [0]" do
       instance = %LineMap{}
-      assert 0 == WidgetInstance.audio_sort_key(instance)
+      assert [0] == WidgetInstance.audio_sort_key(instance)
     end
   end
 

--- a/test/screens/v2/widget_instance/link_footer_test.exs
+++ b/test/screens/v2/widget_instance/link_footer_test.exs
@@ -46,8 +46,8 @@ defmodule Screens.V2.WidgetInstance.LinkFooterTest do
   end
 
   describe "audio_sort_key/1" do
-    test "returns 0", %{instance: instance} do
-      assert 0 == WidgetInstance.audio_sort_key(instance)
+    test "returns [0]", %{instance: instance} do
+      assert [0] == WidgetInstance.audio_sort_key(instance)
     end
   end
 

--- a/test/screens/v2/widget_instance/normal_header_test.exs
+++ b/test/screens/v2/widget_instance/normal_header_test.exs
@@ -49,8 +49,8 @@ defmodule Screens.V2.WidgetInstance.NormalHeaderTest do
   end
 
   describe "audio_sort_key/1" do
-    test "returns 0", %{instance: instance} do
-      assert 0 == WidgetInstance.audio_sort_key(instance)
+    test "returns [0]", %{instance: instance} do
+      assert [0] == WidgetInstance.audio_sort_key(instance)
     end
   end
 

--- a/test/screens/v2/widget_instance/overnight_departures_test.exs
+++ b/test/screens/v2/widget_instance/overnight_departures_test.exs
@@ -40,8 +40,8 @@ defmodule Screens.V2.WidgetInstance.OvernightDeparturesTest do
   end
 
   describe "audio_sort_key/1" do
-    test "returns 0", %{instance: instance} do
-      assert 0 == WidgetInstance.audio_sort_key(instance)
+    test "returns [0]", %{instance: instance} do
+      assert [0] == WidgetInstance.audio_sort_key(instance)
     end
   end
 

--- a/test/screens/v2/widget_instance/reconstructed_alert_test.exs
+++ b/test/screens/v2/widget_instance/reconstructed_alert_test.exs
@@ -276,9 +276,9 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
   end
 
   describe "audio_sort_key/1" do
-    test "returns 0" do
+    test "returns [0]" do
       instance = %ReconstructedAlert{}
-      assert 0 == WidgetInstance.audio_sort_key(instance)
+      assert [0] == WidgetInstance.audio_sort_key(instance)
     end
   end
 

--- a/test/screens/v2/widget_instance/static_image_test.exs
+++ b/test/screens/v2/widget_instance/static_image_test.exs
@@ -67,8 +67,8 @@ defmodule Screens.V2.WidgetInstance.StaticImageTest do
   end
 
   describe "audio_sort_key/1" do
-    test "returns 0", %{instance: instance} do
-      assert 0 == WidgetInstance.audio_sort_key(instance)
+    test "returns [0]", %{instance: instance} do
+      assert [0] == WidgetInstance.audio_sort_key(instance)
     end
   end
 

--- a/test/screens/v2/widget_instance/subway_status_test.exs
+++ b/test/screens/v2/widget_instance/subway_status_test.exs
@@ -395,9 +395,9 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
   end
 
   describe "audio_sort_key/1" do
-    test "returns 0" do
+    test "returns [0]" do
       instance = %SubwayStatus{}
-      assert 0 == WidgetInstance.audio_sort_key(instance)
+      assert [0] == WidgetInstance.audio_sort_key(instance)
     end
   end
 

--- a/test/screens/v2/widget_instance/survey_test.exs
+++ b/test/screens/v2/widget_instance/survey_test.exs
@@ -74,8 +74,8 @@ defmodule Screens.V2.WidgetInstance.SurveyTest do
   end
 
   describe "audio_sort_key/1" do
-    test "returns 0", %{widget: widget} do
-      assert 0 == WidgetInstance.audio_sort_key(widget)
+    test "returns [0]", %{widget: widget} do
+      assert [0] == WidgetInstance.audio_sort_key(widget)
     end
   end
 

--- a/test/support/mock_widget.ex
+++ b/test/support/mock_widget.ex
@@ -7,7 +7,7 @@ defmodule Screens.V2.WidgetInstance.MockWidget do
             content: nil,
             slot_names: nil,
             valid_candidate?: true,
-            audio_sort_key: 0,
+            audio_sort_key: [0],
             audio_valid_candidate?: false
 
   @type t :: %__MODULE__{
@@ -16,7 +16,7 @@ defmodule Screens.V2.WidgetInstance.MockWidget do
           content: any(),
           slot_names: list(atom()),
           valid_candidate?: boolean(),
-          audio_sort_key: non_neg_integer(),
+          audio_sort_key: nonempty_list(integer()),
           audio_valid_candidate?: boolean()
         }
 


### PR DESCRIPTION
**Asana task**: ad-hoc

Engineers decided audio sorting logic should return a list of integers, similar to visual priority. This PR changes the return values to a list of whatever integer the sort key was before.

- [ ] Needs version bump?
