### PR TITLE
refactor: Improve parent station fetch performance

### DIFF
--- a/lib/screens/route_patterns/route_pattern.ex
+++ b/lib/screens/route_patterns/route_pattern.ex
@@ -55,21 +55,65 @@ defmodule Screens.RoutePatterns.RoutePattern do
 
     case get_json_fn.("route_patterns", params) do
       {:ok, result} ->
-        stop_sequences =
-          get_in(result, [
-            "included",
-            Access.filter(&(&1["type"] == "trip")),
-            "relationships",
-            "stops",
-            "data",
-            Access.all(),
-            "id"
-          ])
-
-        {:ok, stop_sequences}
+        {:ok, get_stop_sequences_from_result(result)}
 
       _ ->
         :error
     end
+  end
+
+  @doc """
+  Gets the list of stop sequences for stop and creates a map of platform IDs to parent station name.
+  Assumes that all stop sequences in result are platforms.
+  """
+  @spec fetch_parent_station_sequences_through_stop(Stop.id(), list(String.t())) ::
+          {:ok, list(list(Stop.id())), map()} | :error
+  def fetch_parent_station_sequences_through_stop(
+        stop_id,
+        route_filters,
+        get_json_fn \\ &V3Api.get_json/2
+      ) do
+    params = %{
+      "include" => "representative_trip.stops,route",
+      "filter[stop]" => stop_id,
+      "filter[route]" => Enum.join(route_filters, ",")
+    }
+
+    case get_json_fn.("route_patterns", params) do
+      {:ok, result} ->
+        {:ok, get_stop_sequences_from_result(result),
+         get_platform_to_station_map_from_result(result)}
+
+      _ ->
+        :error
+    end
+  end
+
+  defp get_stop_sequences_from_result(result) do
+    get_in(result, [
+      "included",
+      Access.filter(&(&1["type"] == "trip")),
+      "relationships",
+      "stops",
+      "data",
+      Access.all(),
+      "id"
+    ])
+  end
+
+  defp get_platform_to_station_map_from_result(result) do
+    get_in(result, [
+      "included",
+      Access.filter(&(&1["type"] == "stop"))
+    ])
+    |> Enum.map(fn %{
+                     "relationships" => %{
+                       "parent_station" => %{"data" => %{"id" => parent_station_name}}
+                     },
+                     "id" => platform_id
+                   } ->
+      {platform_id, parent_station_name}
+    end)
+    |> Enum.into(%{})
   end
 end

--- a/lib/screens/route_patterns/route_pattern.ex
+++ b/lib/screens/route_patterns/route_pattern.ex
@@ -102,7 +102,8 @@ defmodule Screens.RoutePatterns.RoutePattern do
   end
 
   defp get_platform_to_station_map_from_result(result) do
-    get_in(result, [
+    result
+    |> get_in([
       "included",
       Access.filter(&(&1["type"] == "stop"))
     ])

--- a/lib/screens/v2/candidate_generator/widgets/reconstructed_alert.ex
+++ b/lib/screens/v2/candidate_generator/widgets/reconstructed_alert.ex
@@ -20,21 +20,21 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlert do
         %Screen{app_params: %PreFare{header: %CurrentStopId{stop_id: stop_id}}} = config,
         now \\ DateTime.utc_now(),
         fetch_routes_by_stop_fn \\ &Route.fetch_routes_by_stop/3,
-        fetch_stop_sequences_by_stop_fn \\ &RoutePattern.fetch_stop_sequences_through_stop/2,
-        fetch_alerts_fn \\ &Alert.fetch/1,
-        get_parent_station_id_fn \\ &get_parent_station/1
+        fetch_stop_sequences_by_stop_fn \\ &RoutePattern.fetch_parent_station_sequences_through_stop/2,
+        fetch_alerts_fn \\ &Alert.fetch/1
       ) do
     # Filtering by subway and light_rail types
     with {:ok, routes_at_stop} <- fetch_routes_by_stop_fn.(stop_id, now, [0, 1]),
          route_ids_at_stop = Enum.map(routes_at_stop, & &1.route_id),
          {:ok, alerts} <- fetch_alerts_fn.(route_ids: route_ids_at_stop),
-         {:ok, stop_sequences} <- fetch_stop_sequences_by_stop_fn.(stop_id, route_ids_at_stop) do
+         {:ok, stop_sequences, platform_to_station_map} <-
+           fetch_stop_sequences_by_stop_fn.(stop_id, route_ids_at_stop) do
       station_sequences =
         stop_sequences
         |> Enum.map(fn stop_sequence ->
           stop_sequence
           |> Enum.map(fn stop ->
-            case get_parent_station_id_fn.(stop) do
+            case Map.fetch(platform_to_station_map, stop) do
               {:ok, parent_stop} -> parent_stop
               :error -> nil
             end
@@ -85,26 +85,5 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlert do
         _ ->
           false
       end
-  end
-
-  # This slows things down... Should we store this like we do for elevator closures?
-  # Also, handle errors better
-  def get_parent_station(stop) do
-    case Screens.V3Api.get_json("stops/" <> stop) do
-      {:ok, result} ->
-        parent_stop =
-          get_in(result, [
-            "data",
-            "relationships",
-            "parent_station",
-            "data",
-            "id"
-          ])
-
-        {:ok, parent_stop}
-
-      _ ->
-        :error
-    end
   end
 end

--- a/lib/screens/v2/candidate_generator/widgets/reconstructed_alert.ex
+++ b/lib/screens/v2/candidate_generator/widgets/reconstructed_alert.ex
@@ -27,22 +27,8 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlert do
     with {:ok, routes_at_stop} <- fetch_routes_by_stop_fn.(stop_id, now, [0, 1]),
          route_ids_at_stop = Enum.map(routes_at_stop, & &1.route_id),
          {:ok, alerts} <- fetch_alerts_fn.(route_ids: route_ids_at_stop),
-         {:ok, stop_sequences, platform_to_station_map} <-
+         {:ok, station_sequences} <-
            fetch_stop_sequences_by_stop_fn.(stop_id, route_ids_at_stop) do
-      station_sequences =
-        stop_sequences
-        |> Enum.map(fn stop_sequence ->
-          stop_sequence
-          |> Enum.map(fn stop ->
-            case Map.fetch(platform_to_station_map, stop) do
-              {:ok, parent_stop} -> parent_stop
-              :error -> nil
-            end
-          end)
-        end)
-        # Dedup the stop sequences (both directions are listed, but we only need 1)
-        |> Enum.uniq_by(&MapSet.new/1)
-
       alerts
       |> Enum.filter(&relevant?(&1, config, station_sequences, routes_at_stop))
       |> Enum.map(fn alert ->

--- a/test/screens/v2/candidate_generator/widgets/reconstructed_alert_test.exs
+++ b/test/screens/v2/candidate_generator/widgets/reconstructed_alert_test.exs
@@ -74,24 +74,9 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlertTest do
         %Alert{id: "5", effect: :stop_closure, informed_entities: [ie(stop: "place-rvrwy")]}
       ]
 
-      stop_sequences = [
-        ["70260", "70258", "70256", "70254"],
-        ["70253", "70255", "70257", "70260"]
-      ]
-
       station_sequences = [
         ["place-hsmnl", "place-bckhl", "place-rvrwy", "place-mispk"]
       ]
-
-      platform_to_station_map = %{
-        "70260" => "place-hsmnl",
-        "70258" => "place-bckhl",
-        "70256" => "place-rvrwy",
-        "70254" => "place-mispk",
-        "70253" => "place-mispk",
-        "70255" => "place-rvrwy",
-        "70257" => "place-bckhl"
-      }
 
       %{
         config: config,
@@ -101,7 +86,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlertTest do
         now: ~U[2021-01-01T00:00:00Z],
         fetch_routes_by_stop_fn: fn _, _, _ -> {:ok, routes_at_stop} end,
         fetch_parent_station_sequences_through_stop_fn: fn _, _ ->
-          {:ok, stop_sequences, platform_to_station_map}
+          {:ok, station_sequences}
         end,
         fetch_alerts_fn: fn _ -> {:ok, alerts} end,
         x_fetch_routes_by_stop_fn: fn _, _, _ -> :error end,

--- a/test/screens/v2/candidate_generator/widgets/reconstructed_alert_test.exs
+++ b/test/screens/v2/candidate_generator/widgets/reconstructed_alert_test.exs
@@ -83,14 +83,15 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlertTest do
         ["place-hsmnl", "place-bckhl", "place-rvrwy", "place-mispk"]
       ]
 
-      stop_sequences = [
-        ["70260", "70258", "70256", "70254"],
-        ["70253", "70255", "70257", "70260"]
-      ]
-
-      station_sequences = [
-        ["place-hsmnl", "place-bckhl", "place-rvrwy", "place-mispk"]
-      ]
+      platform_to_station_map = %{
+        "70260" => "place-hsmnl",
+        "70258" => "place-bckhl",
+        "70256" => "place-rvrwy",
+        "70254" => "place-mispk",
+        "70253" => "place-mispk",
+        "70255" => "place-rvrwy",
+        "70257" => "place-bckhl"
+      }
 
       %{
         config: config,
@@ -99,19 +100,12 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlertTest do
         station_sequences: station_sequences,
         now: ~U[2021-01-01T00:00:00Z],
         fetch_routes_by_stop_fn: fn _, _, _ -> {:ok, routes_at_stop} end,
-        fetch_stop_sequences_by_stop_fn: fn _, _ -> {:ok, stop_sequences} end,
-        fetch_alerts_fn: fn _ -> {:ok, alerts} end,
-        get_parent_station_id_fn: fn
-          "70260" -> {:ok, "place-hsmnl"}
-          "70258" -> {:ok, "place-bckhl"}
-          "70257" -> {:ok, "place-bckhl"}
-          "70256" -> {:ok, "place-rvrwy"}
-          "70255" -> {:ok, "place-rvrwy"}
-          "70254" -> {:ok, "place-mispk"}
-          "70253" -> {:ok, "place-mispk"}
+        fetch_parent_station_sequences_through_stop_fn: fn _, _ ->
+          {:ok, stop_sequences, platform_to_station_map}
         end,
+        fetch_alerts_fn: fn _ -> {:ok, alerts} end,
         x_fetch_routes_by_stop_fn: fn _, _, _ -> :error end,
-        x_fetch_stop_sequences_by_stop_fn: fn _, _ -> :error end,
+        x_fetch_parent_station_sequences_through_stop_fn: fn _, _ -> :error end,
         x_fetch_alerts_fn: fn _ -> :error end
       }
     end
@@ -123,9 +117,9 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlertTest do
         station_sequences: station_sequences,
         now: now,
         fetch_routes_by_stop_fn: fetch_routes_by_stop_fn,
-        fetch_stop_sequences_by_stop_fn: fetch_stop_sequences_by_stop_fn,
-        fetch_alerts_fn: fetch_alerts_fn,
-        get_parent_station_id_fn: get_parent_station_id_fn
+        fetch_parent_station_sequences_through_stop_fn:
+          fetch_parent_station_sequences_through_stop_fn,
+        fetch_alerts_fn: fetch_alerts_fn
       } = context
 
       expected_common_data = %{
@@ -169,9 +163,8 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlertTest do
                  config,
                  now,
                  fetch_routes_by_stop_fn,
-                 fetch_stop_sequences_by_stop_fn,
-                 fetch_alerts_fn,
-                 get_parent_station_id_fn
+                 fetch_parent_station_sequences_through_stop_fn,
+                 fetch_alerts_fn
                )
     end
 
@@ -180,9 +173,9 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlertTest do
         bad_config: bad_config,
         now: now,
         fetch_routes_by_stop_fn: fetch_routes_by_stop_fn,
-        fetch_stop_sequences_by_stop_fn: fetch_stop_sequences_by_stop_fn,
-        fetch_alerts_fn: fetch_alerts_fn,
-        get_parent_station_id_fn: get_parent_station_id_fn
+        fetch_parent_station_sequences_through_stop_fn:
+          fetch_parent_station_sequences_through_stop_fn,
+        fetch_alerts_fn: fetch_alerts_fn
       } = context
 
       assert_raise FunctionClauseError, fn ->
@@ -190,9 +183,8 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlertTest do
           bad_config,
           now,
           fetch_routes_by_stop_fn,
-          fetch_stop_sequences_by_stop_fn,
-          fetch_alerts_fn,
-          get_parent_station_id_fn
+          fetch_parent_station_sequences_through_stop_fn,
+          fetch_alerts_fn
         )
       end
     end
@@ -202,11 +194,12 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlertTest do
         config: config,
         now: now,
         fetch_routes_by_stop_fn: fetch_routes_by_stop_fn,
-        fetch_stop_sequences_by_stop_fn: fetch_stop_sequences_by_stop_fn,
-        get_parent_station_id_fn: get_parent_station_id_fn,
+        fetch_parent_station_sequences_through_stop_fn:
+          fetch_parent_station_sequences_through_stop_fn,
         fetch_alerts_fn: fetch_alerts_fn,
         x_fetch_routes_by_stop_fn: x_fetch_routes_by_stop_fn,
-        x_fetch_stop_sequences_by_stop_fn: x_fetch_stop_sequences_by_stop_fn,
+        x_fetch_parent_station_sequences_through_stop_fn:
+          x_fetch_parent_station_sequences_through_stop_fn,
         x_fetch_alerts_fn: x_fetch_alerts_fn
       } = context
 
@@ -215,9 +208,8 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlertTest do
                  config,
                  now,
                  x_fetch_routes_by_stop_fn,
-                 fetch_stop_sequences_by_stop_fn,
-                 fetch_alerts_fn,
-                 get_parent_station_id_fn
+                 fetch_parent_station_sequences_through_stop_fn,
+                 fetch_alerts_fn
                )
 
       assert [] ==
@@ -225,9 +217,8 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlertTest do
                  config,
                  now,
                  fetch_routes_by_stop_fn,
-                 x_fetch_stop_sequences_by_stop_fn,
-                 fetch_alerts_fn,
-                 get_parent_station_id_fn
+                 x_fetch_parent_station_sequences_through_stop_fn,
+                 fetch_alerts_fn
                )
 
       assert [] ==
@@ -235,9 +226,8 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlertTest do
                  config,
                  now,
                  fetch_routes_by_stop_fn,
-                 fetch_stop_sequences_by_stop_fn,
-                 x_fetch_alerts_fn,
-                 get_parent_station_id_fn
+                 fetch_parent_station_sequences_through_stop_fn,
+                 x_fetch_alerts_fn
                )
     end
   end


### PR DESCRIPTION
**Asana task**: [[PreFare] Improve performance of get_parent_station_id](https://app.asana.com/0/1185117109217413/1201950331696435/f)

I noticed that we already get the data we need when fetching `stop_sequences`. I took that result and made a map of platform IDs -> parent station name. We can then do a lookup and avoid individual V3 calls.

- [ ] Needs version bump?
