### PR TITLE
tweak: Elevator Alert header variable text size

### DIFF
--- a/assets/css/v2/pre_fare/elevator_status.scss
+++ b/assets/css/v2/pre_fare/elevator_status.scss
@@ -221,10 +221,18 @@
 
     .detail-page__closure-header {
       font-family: Inter, sans-serif;
-      font-size: 32px;
       font-weight: 500;
-      line-height: 40px;
       padding-bottom: 32px;
+
+      &--small {
+        font-size: 32px;
+        line-height: 40px;
+      }
+
+      &--large {
+        font-size: 36px;
+        line-height: 48px;
+      }
     }
 
     .detail-page__timeframe {

--- a/assets/src/components/v2/elevator_status.tsx
+++ b/assets/src/components/v2/elevator_status.tsx
@@ -197,10 +197,17 @@ const DetailPageComponent: ComponentType<DetailPage> = ({
   },
 }) => {
   const DESCRIPTION_SIZES = ["extra-small", "small", "large", "extra-large"];
+  const HEADER_SIZES = ["small", "large"];
   const { ref: descriptionRef, size: descriptionSize } = useTextResizer({
     sizes: DESCRIPTION_SIZES,
     maxHeight: 450,
     resetDependencies: [description],
+  });
+
+  const { ref: headerRef, size: headerSize } = useTextResizer({
+    sizes: HEADER_SIZES,
+    maxHeight: 144,
+    resetDependencies: [headerText],
   });
 
   return (
@@ -222,7 +229,15 @@ const DetailPageComponent: ComponentType<DetailPage> = ({
             {isAtHomeStop ? null : <RouteModeIcons icons={icons} />}
           </div>
         </div>
-        <div className="detail-page__closure-header">{headerText}</div>
+        <div
+          className={classWithModifier(
+            "detail-page__closure-header",
+            headerSize
+          )}
+          ref={headerRef}
+        >
+          {headerText}
+        </div>
         <div className={"detail-page__timeframe"}>
           <div className="detail-page__closure-alert-icon-container">
             <TimeframeHeadingIcon happeningNow={happeningNow} />


### PR DESCRIPTION
**Asana task**: [[Elevator Detail page] Use variable text sizes for the alert header](https://app.asana.com/0/1185117109217413/1201901724848537/f)

Only two size options for header. [Design spec](https://app.abstract.com/projects/c04b5940-4805-11e8-8262-510af7fd49fe/branches/f6705d99-fa8b-4115-a97f-188ea9e01a11/commits/034d0d23528534baf767a758d27d7ff4157657d0/files/898fa222-8d26-4cae-b816-2678d1aeba53/layers/8E829759-D03F-4505-861B-3A0B31658265?collectionId=91521734-0e0f-434b-bf25-13516d47b1f3&collectionLayerId=49adba0f-1109-48c5-81e2-8e59d15b2e83&mode=build&selected=root-5AA37D8F-FD00-48A0-8251-A73A530FAC99&sha=latest)

- [ ] Needs version bump?
