### PR TITLE
fix: Elevator Status connecting lines logic

### DIFF
--- a/lib/screens/route_patterns/route_pattern.ex
+++ b/lib/screens/route_patterns/route_pattern.ex
@@ -67,7 +67,7 @@ defmodule Screens.RoutePatterns.RoutePattern do
   Assumes that all stop sequences in result are platforms.
   """
   @spec fetch_parent_station_sequences_through_stop(Stop.id(), list(String.t())) ::
-          {:ok, list(list(Stop.id())), map()} | :error
+          {:ok, list(list(Stop.id()))} | :error
   def fetch_parent_station_sequences_through_stop(
         stop_id,
         route_filters,

--- a/lib/screens/v2/candidate_generator/widgets/elevator_closures.ex
+++ b/lib/screens/v2/candidate_generator/widgets/elevator_closures.ex
@@ -5,6 +5,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ElevatorClosures do
   alias Screens.Config.Screen
   alias Screens.Config.V2.{ElevatorStatus, PreFare}
   alias Screens.RoutePatterns.RoutePattern
+  alias Screens.Routes.Route
   alias Screens.Stops.Stop
   alias Screens.V2.WidgetInstance.ElevatorStatus, as: ElevatorStatusWidget
 
@@ -16,8 +17,13 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ElevatorClosures do
         } = config,
         now
       ) do
-    with {:ok, stop_sequences} <-
-           RoutePattern.fetch_stop_sequences_through_stop(parent_station_id),
+    with {:ok, routes_at_stop} <- Route.fetch_routes_by_stop(parent_station_id, now, [0, 1]),
+         route_ids_at_stop = Enum.map(routes_at_stop, & &1.route_id),
+         {:ok, stop_sequences} <-
+           RoutePattern.fetch_parent_station_sequences_through_stop(
+             parent_station_id,
+             route_ids_at_stop
+           ),
          {:ok, parent_station_map} <- Stop.fetch_parent_station_name_map(),
          {:ok, elevator_closures, facility_id_to_name} <- fetch_elevator_closures() do
       icon_map = get_icon_map(elevator_closures, parent_station_id)

--- a/lib/screens/v2/widget_instance/elevator_status.ex
+++ b/lib/screens/v2/widget_instance/elevator_status.ex
@@ -212,18 +212,11 @@ defmodule Screens.V2.WidgetInstance.ElevatorStatus do
     # This assumes platform-level stop IDs are always numeric strings, e.g. "70045"
     informed_platforms =
       for %{stop: stop} when is_binary(stop) <- entities,
-          match?({_n, ""}, Integer.parse(stop)),
+          match?("place-" <> _, stop),
           do: stop
 
     connecting_platform_ids =
-      stop_sequences
-      |> List.flatten()
-      |> MapSet.new()
-      |> MapSet.difference(
-        t
-        |> platform_stop_ids()
-        |> MapSet.new()
-      )
+      stop_sequences |> List.flatten() |> List.delete(parent_station_id(t))
 
     Alert.happening_now?(alert, now) and
       Enum.any?(informed_platforms, &(&1 in connecting_platform_ids))

--- a/lib/screens/v2/widget_instance/elevator_status.ex
+++ b/lib/screens/v2/widget_instance/elevator_status.ex
@@ -209,7 +209,6 @@ defmodule Screens.V2.WidgetInstance.ElevatorStatus do
          %Alert{effect: :elevator_closure, informed_entities: entities} = alert,
          %__MODULE__{now: now, stop_sequences: stop_sequences} = t
        ) do
-    # This assumes platform-level stop IDs are always numeric strings, e.g. "70045"
     informed_platforms =
       for %{stop: stop} when is_binary(stop) <- entities,
           match?("place-" <> _, stop),

--- a/lib/screens/v2/widget_instance/elevator_status.ex
+++ b/lib/screens/v2/widget_instance/elevator_status.ex
@@ -214,6 +214,7 @@ defmodule Screens.V2.WidgetInstance.ElevatorStatus do
           match?("place-" <> _, stop),
           do: stop
 
+    # Remove parent station so it does not show up as on a connecting line.
     connecting_platform_ids =
       stop_sequences |> List.flatten() |> List.delete(parent_station_id(t))
 

--- a/test/screens/v2/widget_instance/elevator_status_test.exs
+++ b/test/screens/v2/widget_instance/elevator_status_test.exs
@@ -56,8 +56,8 @@ defmodule WidgetInstance.ElevatorStatusTest do
     }
 
     stop_sequences = [
-      ["1001", "1003", "1005"],
-      ["1002", "1004", "1006"]
+      ["place-foo", "place-bar"],
+      ["place-foo", "place-bar"]
     ]
 
     station_id_to_icons = %{
@@ -1258,8 +1258,8 @@ defmodule WidgetInstance.ElevatorStatusTest do
               elevator_closures: [
                 %{
                   description: nil,
-                  elevator_id: "6",
-                  elevator_name: "Elevator 6",
+                  elevator_id: "2",
+                  elevator_name: "Elevator 2",
                   header_text: nil,
                   timeframe: %{
                     active_period: %{
@@ -1280,8 +1280,8 @@ defmodule WidgetInstance.ElevatorStatusTest do
               elevator_closures: [
                 %{
                   description: nil,
-                  elevator_id: "2",
-                  elevator_name: "Elevator 2",
+                  elevator_id: "6",
+                  elevator_name: "Elevator 6",
                   header_text: nil,
                   timeframe: %{
                     active_period: %{


### PR DESCRIPTION
**Asana task**: [[Bug] Elevator Status is not showing active alerts on connecting lines ](https://app.asana.com/0/1185117109217422/1202081351164230/f)

`informed_entities` does not always contain the platforms we expected. I changed `stop_sequences` to be a list of parent station ids. This is an ID that is always in a closure alert. Using that, we can reliably tell what alerts are on a connecting line.

- [ ] Needs version bump?
