### PR TITLE
fix: Elevator Status Silver Line icon

### DIFF
--- a/lib/screens/v2/candidate_generator/widgets/elevator_closures.ex
+++ b/lib/screens/v2/candidate_generator/widgets/elevator_closures.ex
@@ -93,6 +93,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ElevatorClosures do
       %Screens.Routes.Route{type: :subway, id: id} -> id |> String.downcase() |> String.to_atom()
       %Screens.Routes.Route{type: :light_rail, id: "Green-" <> _} -> :green
       %Screens.Routes.Route{type: :light_rail, id: "Mattapan" <> _} -> :mattapan
+      %Screens.Routes.Route{type: :bus, short_name: "SL" <> _} -> :silver
       %Screens.Routes.Route{type: type} -> type
     end)
     |> Enum.uniq()


### PR DESCRIPTION
**Asana task**: [[Pre-fare Elevator Polish] Silver Line is showing up as a bus route](https://app.asana.com/0/1185117109217413/1202019168003511/f)

We don't have a ton to go on in the data. This is one option. Another is looking at the `color` that is returned for routes in V3. Open to suggestions/opinions.

- [ ] Needs version bump?
