### PR TITLE
fix: PreFare header text size

### DIFF
--- a/assets/css/v2/pre_fare/normal_header.scss
+++ b/assets/css/v2/pre_fare/normal_header.scss
@@ -36,7 +36,7 @@
 
   &--small {
     font-size: 72px;
-    line-height: 80px;
+    line-height: 72px;
   }
 
   &--with-icon {

--- a/assets/src/apps/v2/pre_fare.tsx
+++ b/assets/src/apps/v2/pre_fare.tsx
@@ -21,7 +21,7 @@ import NormalBody from "Components/v2/pre_fare/normal_body";
 import NormalBodyLeft from "Components/v2/pre_fare/normal_body_left";
 import NormalBodyRight from "Components/v2/pre_fare/normal_body_right";
 import EvergreenContent from "Components/v2/evergreen_content";
-import NormalHeader from "Components/v2/lcd/normal_header";
+import NormalHeader from "Components/v2/pre_fare/normal_header";
 import OneLarge from "Components/v2/pre_fare/flex/one_large";
 import TwoMedium from "Components/v2/pre_fare/flex/two_medium";
 import BodyLeftTakeover from "Components/v2/pre_fare/body_left_takeover";

--- a/assets/src/components/v2/lcd/normal_header.tsx
+++ b/assets/src/components/v2/lcd/normal_header.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 
 import DefaultNormalHeader from "Components/v2/normal_header";
-import { DUP_VERSION } from "Components/dup/version";
 
 const NormalHeader = ({ icon, text, time }) => {
   return (

--- a/assets/src/components/v2/normal_header.tsx
+++ b/assets/src/components/v2/normal_header.tsx
@@ -1,3 +1,4 @@
+import useTextResizer from "Hooks/v2/use_text_resizer";
 import React, {
   forwardRef,
   useEffect,
@@ -35,27 +36,29 @@ const NormalHeaderIcon = ({ icon }) => {
   );
 };
 
-const NormalHeaderTitle = forwardRef(({ icon, text, size, showTo, fullName }, ref) => {
-  const modifiers = [size];
-  if (icon) {
-    modifiers.push("with-icon");
-  }
+const NormalHeaderTitle = forwardRef(
+  ({ icon, text, size, showTo, fullName }, ref) => {
+    const modifiers = [size];
+    if (icon) {
+      modifiers.push("with-icon");
+    }
 
-  const abbreviatedText = fullName ? text : abbreviateText(text);
+    const abbreviatedText = fullName ? text : abbreviateText(text);
 
-  return (
-    <div className="normal-header-title">
-      {showTo && <div className="normal-header-to__text">TO</div>}
-      {icon && <NormalHeaderIcon icon={icon} />}
-      <div
-        className={classWithModifiers("normal-header-title__text", modifiers)}
-        ref={ref}
-      >
-        {abbreviatedText}
+    return (
+      <div className="normal-header-title">
+        {showTo && <div className="normal-header-to__text">TO</div>}
+        {icon && <NormalHeaderIcon icon={icon} />}
+        <div
+          className={classWithModifiers("normal-header-title__text", modifiers)}
+          ref={ref}
+        >
+          {abbreviatedText}
+        </div>
       </div>
-    </div>
-  );
-});
+    );
+  }
+);
 
 const NormalHeaderTime = ({ time }) => {
   const currentTime = formatTimeString(time);
@@ -90,32 +93,21 @@ const NormalHeader = ({
   versionNumber,
   maxHeight,
   showTo,
-  fullName
+  fullName,
 }) => {
   const SIZES = ["small", "large"];
-  const ref = useRef(null);
-  const [stopSize, setStopSize] = useState(1);
-
-  // Reset state when relevant props change,
-  // so that we recalculate size from scratch.
-  useEffect(() => {
-    setStopSize(1);
-  }, [icon, text]);
-
-  useLayoutEffect(() => {
-    const height = ref.current.clientHeight;
-    if (height > maxHeight) {
-      setStopSize(stopSize - 1);
-    }
+  const { ref: headerRef, size: headerSize } = useTextResizer({
+    sizes: SIZES,
+    maxHeight: maxHeight,
+    resetDependencies: [text],
   });
-
   return (
     <div className="normal-header">
       <NormalHeaderTitle
         icon={icon}
         text={text}
-        size={SIZES[stopSize]}
-        ref={ref}
+        size={headerSize}
+        ref={headerRef}
         showTo={showTo}
         fullName={fullName}
       />


### PR DESCRIPTION
**Asana task**: [[Bug] Pre-fare screen header text not auto-resizing](https://app.asana.com/0/1185117109217413/1201945334732260/f)

Header was actually working. The wrong `NormalHeader` component was being rendered for Pre-Fare so the `maxHeight` was greater than it should have been. I went ahead and change the header to use the text resizer hook.

<img width="1144" alt="Screen Shot 2022-04-06 at 1 25 29 PM" src="https://user-images.githubusercontent.com/10713153/162033006-d5a90af1-5502-47fc-87a2-55e1456b5b5c.png">


- [ ] Needs version bump?
