### PR TITLE
fix: Add GLX stops to GL-E lists

### DIFF
--- a/lib/screens/stops/stop.ex
+++ b/lib/screens/stops/stop.ex
@@ -159,6 +159,9 @@ defmodule Screens.Stops.Stop do
   ]
 
   @green_line_e_stops [
+    {"place-unsqu", {"Union Square", "Union Sq"}},
+    {"place-lech", {"Lechmere", "Lechmere"}},
+    {"place-spmnl", {"Science Park/West End", "Science Pk"}},
     {"place-north", {"North Station", "North Sta"}},
     {"place-haecl", {"Haymarket", "Haymarket"}},
     {"place-gover", {"Government Center", "Gov't Ctr"}},

--- a/lib/screens/v2/widget_instance/reconstructed_alert.ex
+++ b/lib/screens/v2/widget_instance/reconstructed_alert.ex
@@ -35,7 +35,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
     "Green-B" => ["Boston College", "Government Center"],
     "Green-C" => ["Cleveland Circle", "Government Center"],
     "Green-D" => ["Riverside", "North Station"],
-    "Green-E" => ["Heath Street", "North Station"]
+    "Green-E" => ["Heath Street", "Union Square"]
   }
 
   @alert_cause_mapping %{


### PR DESCRIPTION
**Asana task**: [Add Lechmere and Union Square to hard-coded stop sequences](https://app.asana.com/0/1185117109217413/1202042701703726/f)

The DUP at Haymarket actually shows "Northbound", so nothing to change there.

<img width="1048" alt="Screen Shot 2022-04-06 at 2 15 40 PM" src="https://user-images.githubusercontent.com/10713153/162041401-61389b48-fd64-408e-8bf2-2a96c3b1490f.png">


- [ ] Needs version bump?
