### PR TITLE
fix: sort departure strings, not DateTimes

### DIFF
--- a/lib/screens/audio.ex
+++ b/lib/screens/audio.ex
@@ -71,7 +71,7 @@ defmodule Screens.Audio do
   defp merge_section_departures(sections) do
     sections
     |> Enum.flat_map(& &1.departures)
-    |> Enum.sort_by(& &1.time, DateTime)
+    |> Enum.sort_by(& &1.time)
     |> Util.group_by_with_order(&{&1.route, &1.route_id, &1.destination})
     |> Enum.map(fn {key, departures} ->
       {key,


### PR DESCRIPTION
**Asana task**: ad hoc

We've gotten some errors because these are actually strings, not DateTime structs. Sorry to distract from pre-fare work, but I want to sneak this in since I think it's breaking Solari audio.

Representative stacktrace:
```
** (exit) an exception was raised: ** (FunctionClauseError) no function clause matching in DateTime.compare/2 (elixir 1.13.1)
lib/calendar/datetime.ex:1319: DateTime.compare("2022-04-07T15:47:23Z", "2022-04-07T15:55:04Z") (elixir 1.13.1)
lib/enum.ex:3109: anonymous fn/3 in Enum.to_sort_by_fun/1 (stdlib 3.17)
lists.erl:973: :lists.sort/2 (elixir 1.13.1)
lib/enum.ex:3095: Enum.sort_by/3 (screens 0.1.0)
lib/screens/audio.ex:74: Screens.Audio.merge_section_departures/1 (screens 0.1.0)
lib/screens/audio.ex:64: anonymous fn/1 in Screens.Audio.group_departures_by_pill/2(elixir 1.13.1)
lib/enum.ex:1593: Enum."-map/2-lists^map/1-0-"/2 (screens 0.1.0)
lib/screens/audio.ex:53: Screens.Audio.from_api_data/2
```