### PR TITLE
fix: Filter audio-only widgets by `audio_valid_candidate?`

### DIFF
--- a/lib/screens/v2/screen_audio_data.ex
+++ b/lib/screens/v2/screen_audio_data.ex
@@ -26,12 +26,19 @@ defmodule Screens.V2.ScreenAudioData do
 
       %Screen{app_params: %_app{audio: audio}} ->
         if date_in_range?(audio, now) do
-          config
-          |> fetch_data_fn.()
-          |> elem(1)
-          |> Map.values()
-          |> Enum.filter(&WidgetInstance.audio_valid_candidate?/1)
-          |> then(&(&1 ++ get_audio_only_instances_fn.(&1, config)))
+          visual_widgets_with_audio_equivalence =
+            config
+            |> fetch_data_fn.()
+            |> elem(1)
+            |> Map.values()
+            |> Enum.filter(&WidgetInstance.audio_valid_candidate?/1)
+
+          audio_only_widgets =
+            visual_widgets_with_audio_equivalence
+            |> get_audio_only_instances_fn.(config)
+            |> Enum.filter(&WidgetInstance.audio_valid_candidate?/1)
+
+          (visual_widgets_with_audio_equivalence ++ audio_only_widgets)
           |> Enum.sort_by(&WidgetInstance.audio_sort_key/1)
           |> Enum.map(&{WidgetInstance.audio_view(&1), WidgetInstance.audio_serialize(&1)})
         else

--- a/test/screens/v2/screen_audio_data_test.exs
+++ b/test/screens/v2/screen_audio_data_test.exs
@@ -302,6 +302,12 @@ defmodule Screens.V2.ScreenAudioDataTest do
             audio_valid_candidate?: true,
             audio_sort_key: [1, 1],
             content: "Alerts Summary"
+          },
+          %MockWidget{
+            slot_names: [:nothing],
+            audio_valid_candidate?: false,
+            audio_sort_key: [0],
+            content: "SoundOfNailsOnChalkboard Widget"
           }
         ]
       end


### PR DESCRIPTION
**Asana task**: ad hoc

I made a small oversight in the original PR and didn't filter audio-only instances by their `audio_valid_candidate?/1` return value. This fixes that.

I also took the opportunity to make the code hopefully more readable.

- [ ] Needs version bump?
