### PR TITLE
feat: Alerts intro audio-only widget

### DIFF
--- a/lib/screens/v2/candidate_generator/pre_fare.ex
+++ b/lib/screens/v2/candidate_generator/pre_fare.ex
@@ -9,7 +9,7 @@ defmodule Screens.V2.CandidateGenerator.PreFare do
   alias Screens.V2.CandidateGenerator
   alias Screens.V2.CandidateGenerator.Widgets
   alias Screens.V2.Template.Builder
-  alias Screens.V2.WidgetInstance.AudioOnly.ContentSummary
+  alias Screens.V2.WidgetInstance.AudioOnly.{AlertsIntro, ContentSummary}
   alias Screens.V2.WidgetInstance.{NormalHeader, Placeholder}
 
   @behaviour CandidateGenerator
@@ -82,7 +82,8 @@ defmodule Screens.V2.CandidateGenerator.PreFare do
         fetch_routes_by_stop_fn \\ &Route.fetch_routes_by_stop/1
       ) do
     [
-      fn -> content_summary_instances(widgets, config, fetch_routes_by_stop_fn) end
+      fn -> content_summary_instances(widgets, config, fetch_routes_by_stop_fn) end,
+      fn -> alerts_intro_instances(widgets, config) end
     ]
     |> Task.async_stream(& &1.(), ordered: false, timeout: :infinity)
     |> Enum.flat_map(fn {:ok, instances} -> instances end)
@@ -124,6 +125,10 @@ defmodule Screens.V2.CandidateGenerator.PreFare do
         nil
     end
     |> List.wrap()
+  end
+
+  defp alerts_intro_instances(widgets, config) do
+    [%AlertsIntro{screen: config, widgets_snapshot: widgets}]
   end
 
   defp placeholder_instances do

--- a/lib/screens/v2/widget_instance/audio_only/alerts_intro.ex
+++ b/lib/screens/v2/widget_instance/audio_only/alerts_intro.ex
@@ -1,0 +1,110 @@
+defmodule Screens.V2.WidgetInstance.AudioOnly.AlertsIntro do
+  @moduledoc """
+  An audio-only widget that introduces the section of the readout describing service alerts.
+  """
+
+  alias Screens.Config.Screen
+  alias Screens.V2.WidgetInstance
+  alias Screens.V2.WidgetInstance.{Alert, ReconstructedAlert, SubwayStatus}
+
+  require Logger
+
+  @type t :: %__MODULE__{
+          screen: Screen.t(),
+          widgets_snapshot: list(WidgetInstance.t())
+        }
+
+  @enforce_keys [:screen, :widgets_snapshot]
+  defstruct @enforce_keys
+
+  # This value is appended to the target widget's sort key in order to insert this one
+  # immediately after the target, and is unique among other audio-only widgets'
+  # sort keys so that there is a definite ordering should two audio-only widgets
+  # end up adjacent to each other.
+  @audio_sort_key_part [1]
+
+  def audio_serialize(%__MODULE__{screen: %Screen{app_id: :pre_fare_v2}}) do
+    %{}
+  end
+
+  def audio_sort_key(%__MODULE__{} = t, audio_sort_key_fn \\ &WidgetInstance.audio_sort_key/1) do
+    # After sorting, attempt to find the first subway status or alert widget,
+    # and insert this widget immediately before it.
+    # (Technically, immediately after the preceding widget)
+
+    sorted_widgets = Enum.sort_by(t.widgets_snapshot, audio_sort_key_fn)
+
+    first_service_alert_index = Enum.find_index(sorted_widgets, &service_alert_widget?/1)
+
+    case first_service_alert_index do
+      nil ->
+        Logger.warn("Failed to find a service alert widget in the audio readout queue")
+        [0]
+
+      0 ->
+        Logger.warn(
+          "Unexpectedly found a service alert widget at the start of the audio readout queue"
+        )
+
+        [0]
+
+      i ->
+        preceding_widget_sort_key =
+          sorted_widgets
+          |> Enum.at(i - 1)
+          |> audio_sort_key_fn.()
+
+        preceding_widget_sort_key ++ @audio_sort_key_part
+    end
+  end
+
+  def audio_valid_candidate?(t, slot_names_fn \\ &WidgetInstance.slot_names/1)
+
+  def audio_valid_candidate?(
+        %__MODULE__{screen: %Screen{app_id: :pre_fare_v2}} = t,
+        slot_names_fn
+      ) do
+    # On pre-fare screens, we only include a content summary when
+    # there's no takeover content and at least one service alert widget in the readout queue.
+    takeover_slots = MapSet.new(~w[full_body_left full_body_right full_body full_screen]a)
+
+    no_takeover_content? =
+      Enum.all?(t.widgets_snapshot, fn widget ->
+        widget
+        |> slot_names_fn.()
+        |> MapSet.new()
+        |> MapSet.disjoint?(takeover_slots)
+      end)
+
+    at_least_one_service_alert_widget? = Enum.any?(t.widgets_snapshot, &service_alert_widget?/1)
+
+    no_takeover_content? and at_least_one_service_alert_widget?
+  end
+
+  def audio_valid_candidate?(_t, _slot_names_fn) do
+    false
+  end
+
+  def audio_view(_instance), do: ScreensWeb.V2.Audio.AlertsIntroView
+
+  defp service_alert_widget?(%Alert{}), do: true
+  defp service_alert_widget?(%ReconstructedAlert{}), do: true
+  defp service_alert_widget?(%SubwayStatus{}), do: true
+  defp service_alert_widget?(%_other_widget_instance{}), do: false
+
+  defimpl Screens.V2.WidgetInstance do
+    alias Screens.V2.WidgetInstance.AudioOnly.AlertsIntro
+
+    # Since this is an audio-only widget, these functions will never be called.
+    def priority(_instance), do: :no_render
+    def serialize(_instance), do: %{}
+    def slot_names(_instance), do: :no_render
+    def widget_type(_instance), do: :no_render
+    def valid_candidate?(_instance), do: false
+
+    def audio_serialize(instance), do: AlertsIntro.audio_serialize(instance)
+    def audio_sort_key(instance), do: AlertsIntro.audio_sort_key(instance)
+    def audio_valid_candidate?(instance), do: AlertsIntro.audio_valid_candidate?(instance)
+    def audio_view(instance), do: AlertsIntro.audio_view(instance)
+  end
+end

--- a/lib/screens/v2/widget_instance/audio_only/alerts_intro.ex
+++ b/lib/screens/v2/widget_instance/audio_only/alerts_intro.ex
@@ -87,7 +87,6 @@ defmodule Screens.V2.WidgetInstance.AudioOnly.AlertsIntro do
 
   def audio_view(_instance), do: ScreensWeb.V2.Audio.AlertsIntroView
 
-  defp service_alert_widget?(%Alert{}), do: true
   defp service_alert_widget?(%ReconstructedAlert{}), do: true
   defp service_alert_widget?(%SubwayStatus{}), do: true
   defp service_alert_widget?(%_other_widget_instance{}), do: false

--- a/lib/screens/v2/widget_instance/audio_only/alerts_intro.ex
+++ b/lib/screens/v2/widget_instance/audio_only/alerts_intro.ex
@@ -5,7 +5,7 @@ defmodule Screens.V2.WidgetInstance.AudioOnly.AlertsIntro do
 
   alias Screens.Config.Screen
   alias Screens.V2.WidgetInstance
-  alias Screens.V2.WidgetInstance.{Alert, ReconstructedAlert, SubwayStatus}
+  alias Screens.V2.WidgetInstance.{ReconstructedAlert, SubwayStatus}
 
   require Logger
 

--- a/lib/screens/v2/widget_instance/audio_only/alerts_intro.ex
+++ b/lib/screens/v2/widget_instance/audio_only/alerts_intro.ex
@@ -64,7 +64,7 @@ defmodule Screens.V2.WidgetInstance.AudioOnly.AlertsIntro do
         %__MODULE__{screen: %Screen{app_id: :pre_fare_v2}} = t,
         slot_names_fn
       ) do
-    # On pre-fare screens, we only include a content summary when
+    # On pre-fare screens, we only include an alerts intro when
     # there's no takeover content and at least one service alert widget in the readout queue.
     takeover_slots = MapSet.new(~w[full_body_left full_body_right full_body full_screen]a)
 

--- a/lib/screens/v2/widget_instance/audio_only/content_summary.ex
+++ b/lib/screens/v2/widget_instance/audio_only/content_summary.ex
@@ -20,6 +20,12 @@ defmodule Screens.V2.WidgetInstance.AudioOnly.ContentSummary do
   @enforce_keys [:screen, :widgets_snapshot, :lines_at_station]
   defstruct @enforce_keys
 
+  # This value is appended to the target widget in order to insert this one
+  # immediately after the target, and is unique among other audio-only widgets'
+  # sort keys so that there is a definite ordering should two audio-only widgets
+  # end up adjacent to each other.
+  @audio_sort_key_part [0]
+
   def audio_serialize(%__MODULE__{screen: %Screen{app_id: :pre_fare_v2}} = t) do
     %{lines_at_station: t.lines_at_station}
   end
@@ -32,7 +38,7 @@ defmodule Screens.V2.WidgetInstance.AudioOnly.ContentSummary do
         [0]
 
       header ->
-        WidgetInstance.audio_sort_key(header) ++ [0]
+        WidgetInstance.audio_sort_key(header) ++ @audio_sort_key_part
     end
   end
 

--- a/lib/screens_web/views/v2/audio/alerts_intro_view.ex
+++ b/lib/screens_web/views/v2/audio/alerts_intro_view.ex
@@ -1,0 +1,7 @@
+defmodule ScreensWeb.V2.Audio.AlertsIntroView do
+  use ScreensWeb, :view
+
+  def render("_widget.ssml", _data) do
+    ~E|<p><s>Current service alerts are also available at <say-as interpret-as="spell-out">MBTA</say-as> dot com slash <break /> alerts</s></p>|
+  end
+end

--- a/test/screens/v2/widget_instance/audio_only/alerts_intro_test.exs
+++ b/test/screens/v2/widget_instance/audio_only/alerts_intro_test.exs
@@ -1,0 +1,177 @@
+defmodule Screens.V2.WidgetInstance.AudioOnly.AlertsIntroTest do
+  use ExUnit.Case, async: true
+  import ExUnit.CaptureLog
+
+  alias Screens.Config.Screen
+  alias Screens.V2.WidgetInstance
+  alias Screens.V2.WidgetInstance.AudioOnly.AlertsIntro
+  alias Screens.V2.WidgetInstance.{MockWidget, SubwayStatus, ReconstructedAlert}
+
+  setup do
+    pre_fare_config = struct(Screen, %{app_id: :pre_fare_v2})
+    other_config = struct(Screen, %{app_id: :bus_e_ink_v2})
+
+    subway_status = struct(SubwayStatus)
+    alert = struct(ReconstructedAlert)
+
+    other_widget = %MockWidget{
+      slot_names: [:header],
+      audio_sort_key: [0],
+      audio_valid_candidate?: true
+    }
+
+    takeover_widget = %MockWidget{
+      slot_names: [:full_body],
+      audio_sort_key: [0],
+      audio_valid_candidate?: true
+    }
+
+    audio_sort_key_fn = fn
+      %MockWidget{} = mock_widget -> WidgetInstance.audio_sort_key(mock_widget)
+      %SubwayStatus{} -> [1]
+      %ReconstructedAlert{} -> [2]
+    end
+
+    slot_names_fn = fn
+      %MockWidget{} = mock_widget -> WidgetInstance.slot_names(mock_widget)
+      %SubwayStatus{} -> [:large]
+      %ReconstructedAlert{} -> [:large]
+    end
+
+    instance_without_service_alert_widgets = %AlertsIntro{
+      screen: nil,
+      widgets_snapshot: [other_widget]
+    }
+
+    instance_with_subway_status_and_alerts = %AlertsIntro{
+      screen: nil,
+      widgets_snapshot: [subway_status, alert, other_widget]
+    }
+
+    instance_with_alert_at_start = %AlertsIntro{
+      screen: nil,
+      widgets_snapshot: [subway_status, alert]
+    }
+
+    instance_with_takeover_content = %AlertsIntro{
+      screen: nil,
+      widgets_snapshot: [takeover_widget, subway_status, alert, other_widget]
+    }
+
+    %{
+      pre_fare_config: pre_fare_config,
+      other_config: other_config,
+      audio_sort_key_fn: audio_sort_key_fn,
+      slot_names_fn: slot_names_fn,
+      instance_without_service_alert_widgets: instance_without_service_alert_widgets,
+      instance_with_subway_status_and_alerts: instance_with_subway_status_and_alerts,
+      instance_with_alert_at_start: instance_with_alert_at_start,
+      instance_with_takeover_content: instance_with_takeover_content
+    }
+  end
+
+  defp put_config(widget, config), do: %{widget | screen: config}
+
+  describe "audio_serialize/1" do
+    test "returns an empty map for pre-fare", %{
+      pre_fare_config: pre_fare_config,
+      instance_with_subway_status_and_alerts: widget
+    } do
+      widget = put_config(widget, pre_fare_config)
+
+      assert %{} == WidgetInstance.audio_serialize(widget)
+    end
+
+    test "fails for other screen type", %{
+      other_config: other_config,
+      instance_with_subway_status_and_alerts: widget
+    } do
+      widget = put_config(widget, other_config)
+
+      assert_raise FunctionClauseError, fn -> WidgetInstance.audio_serialize(widget) end
+    end
+  end
+
+  describe "audio_sort_key/1" do
+    # NOTE: need to call `AlertsIntro.audio_sort_key/2` in order to inject a stubbed function for testing purposes.
+    # This is otherwise equivalent to `WidgetInstance.audio_sort_key/1`.
+
+    test "returns audio sort key ++ [1] of widget immediately preceding first service alert widget in the readout queue",
+         %{audio_sort_key_fn: audio_sort_key_fn, instance_with_subway_status_and_alerts: widget} do
+      assert [0, 1] == AlertsIntro.audio_sort_key(widget, audio_sort_key_fn)
+    end
+
+    test "logs a warning and returns [0] if there's no service alert widget in the readout queue",
+         %{audio_sort_key_fn: audio_sort_key_fn, instance_without_service_alert_widgets: widget} do
+      {result, log} = with_log(fn -> AlertsIntro.audio_sort_key(widget, audio_sort_key_fn) end)
+
+      assert [0] == result
+
+      assert String.contains?(
+               log,
+               "Failed to find a service alert widget in the audio readout queue"
+             )
+    end
+
+    test "logs a warning and returns [0] if service alert widget is first in the readout queue",
+         %{audio_sort_key_fn: audio_sort_key_fn, instance_with_alert_at_start: widget} do
+      {result, log} = with_log(fn -> AlertsIntro.audio_sort_key(widget, audio_sort_key_fn) end)
+
+      assert [0] == result
+
+      assert String.contains?(
+               log,
+               "Unexpectedly found a service alert widget at the start of the audio readout queue"
+             )
+    end
+  end
+
+  describe "audio_valid_candidate?/1" do
+    # NOTE: need to call `AlertsIntro.audio_valid_candidate?/2` in order to inject a stubbed function
+    # for testing purposes. This is otherwise equivalent to `WidgetInstance.audio_valid_candidate?/1`.
+
+    test "for pre-fare, returns true if there's at least one service alert widget and no takeover content",
+         %{
+           slot_names_fn: slot_names_fn,
+           pre_fare_config: pre_fare_config,
+           instance_with_subway_status_and_alerts: widget
+         } do
+      widget = put_config(widget, pre_fare_config)
+
+      assert AlertsIntro.audio_valid_candidate?(widget, slot_names_fn)
+    end
+
+    test "for pre-fare, returns false if there's no service alert widget",
+         %{
+           slot_names_fn: slot_names_fn,
+           pre_fare_config: pre_fare_config,
+           instance_without_service_alert_widgets: widget
+         } do
+      widget = put_config(widget, pre_fare_config)
+
+      refute AlertsIntro.audio_valid_candidate?(widget, slot_names_fn)
+    end
+
+    test "for pre-fare, returns false if there's any takeover content",
+         %{
+           slot_names_fn: slot_names_fn,
+           pre_fare_config: pre_fare_config,
+           instance_with_takeover_content: widget
+         } do
+      widget = put_config(widget, pre_fare_config)
+
+      refute AlertsIntro.audio_valid_candidate?(widget, slot_names_fn)
+    end
+
+    test "returns false for other screen type",
+         %{
+           slot_names_fn: slot_names_fn,
+           other_config: other_config,
+           instance_with_subway_status_and_alerts: widget
+         } do
+      widget = put_config(widget, other_config)
+
+      refute AlertsIntro.audio_valid_candidate?(widget, slot_names_fn)
+    end
+  end
+end


### PR DESCRIPTION
**Asana task**: [Audio implementation: Audio-only widgets](https://app.asana.com/0/1185117109217413/1202035304691540/f) (Part 2 of a 3-part trilogy)

This defines the alerts intro widget.

- [ ] Needs version bump?
