### PR TITLE
feat: Alerts outro audio-only widget

### DIFF
--- a/lib/screens/v2/candidate_generator/pre_fare.ex
+++ b/lib/screens/v2/candidate_generator/pre_fare.ex
@@ -9,7 +9,7 @@ defmodule Screens.V2.CandidateGenerator.PreFare do
   alias Screens.V2.CandidateGenerator
   alias Screens.V2.CandidateGenerator.Widgets
   alias Screens.V2.Template.Builder
-  alias Screens.V2.WidgetInstance.AudioOnly.{AlertsIntro, ContentSummary}
+  alias Screens.V2.WidgetInstance.AudioOnly.{AlertsIntro, AlertsOutro, ContentSummary}
   alias Screens.V2.WidgetInstance.{NormalHeader, Placeholder}
 
   @behaviour CandidateGenerator
@@ -83,7 +83,8 @@ defmodule Screens.V2.CandidateGenerator.PreFare do
       ) do
     [
       fn -> content_summary_instances(widgets, config, fetch_routes_by_stop_fn) end,
-      fn -> alerts_intro_instances(widgets, config) end
+      fn -> alerts_intro_instances(widgets, config) end,
+      fn -> alerts_outro_instances(widgets, config) end
     ]
     |> Task.async_stream(& &1.(), ordered: false, timeout: :infinity)
     |> Enum.flat_map(fn {:ok, instances} -> instances end)
@@ -129,6 +130,10 @@ defmodule Screens.V2.CandidateGenerator.PreFare do
 
   defp alerts_intro_instances(widgets, config) do
     [%AlertsIntro{screen: config, widgets_snapshot: widgets}]
+  end
+
+  defp alerts_outro_instances(widgets, config) do
+    [%AlertsOutro{screen: config, widgets_snapshot: widgets}]
   end
 
   defp placeholder_instances do

--- a/lib/screens/v2/widget_instance/audio_only/alerts_intro.ex
+++ b/lib/screens/v2/widget_instance/audio_only/alerts_intro.ex
@@ -64,7 +64,7 @@ defmodule Screens.V2.WidgetInstance.AudioOnly.AlertsIntro do
         %__MODULE__{screen: %Screen{app_id: :pre_fare_v2}} = t,
         slot_names_fn
       ) do
-    # On pre-fare screens, we only include an alerts intro when
+    # On pre-fare screens, we only include this widget when
     # there's no takeover content and at least one service alert widget in the readout queue.
     takeover_slots = MapSet.new(~w[full_body_left full_body_right full_body full_screen]a)
 

--- a/lib/screens/v2/widget_instance/audio_only/alerts_outro.ex
+++ b/lib/screens/v2/widget_instance/audio_only/alerts_outro.ex
@@ -50,7 +50,7 @@ defmodule Screens.V2.WidgetInstance.AudioOnly.AlertsOutro do
         slot_names_fn
       ) do
     # On pre-fare screens, we only include this widget when
-    # there's no takeover content and at least alert widget in the readout queue.
+    # there's no takeover content and at least one alert widget in the readout queue.
     takeover_slots = MapSet.new(~w[full_body_left full_body_right full_body full_screen]a)
 
     no_takeover_content? =

--- a/lib/screens/v2/widget_instance/audio_only/alerts_outro.ex
+++ b/lib/screens/v2/widget_instance/audio_only/alerts_outro.ex
@@ -5,7 +5,7 @@ defmodule Screens.V2.WidgetInstance.AudioOnly.AlertsOutro do
 
   alias Screens.Config.Screen
   alias Screens.V2.WidgetInstance
-  alias Screens.V2.WidgetInstance.{Alert, ReconstructedAlert}
+  alias Screens.V2.WidgetInstance.ReconstructedAlert
 
   require Logger
 
@@ -72,7 +72,6 @@ defmodule Screens.V2.WidgetInstance.AudioOnly.AlertsOutro do
 
   def audio_view(_instance), do: ScreensWeb.V2.Audio.AlertsOutroView
 
-  defp alert_widget?(%Alert{}), do: true
   defp alert_widget?(%ReconstructedAlert{}), do: true
   defp alert_widget?(%_other_widget_instance{}), do: false
 

--- a/lib/screens/v2/widget_instance/audio_only/alerts_outro.ex
+++ b/lib/screens/v2/widget_instance/audio_only/alerts_outro.ex
@@ -1,0 +1,94 @@
+defmodule Screens.V2.WidgetInstance.AudioOnly.AlertsOutro do
+  @moduledoc """
+  An audio-only widget that follows the section of the readout describing service alerts.
+  """
+
+  alias Screens.Config.Screen
+  alias Screens.V2.WidgetInstance
+  alias Screens.V2.WidgetInstance.{Alert, ReconstructedAlert}
+
+  require Logger
+
+  @type t :: %__MODULE__{
+          screen: Screen.t(),
+          widgets_snapshot: list(WidgetInstance.t())
+        }
+
+  @enforce_keys [:screen, :widgets_snapshot]
+  defstruct @enforce_keys
+
+  # This value is appended to the target widget's sort key in order to insert this one
+  # immediately after the target, and is unique among other audio-only widgets'
+  # sort keys so that there is a definite ordering should two audio-only widgets
+  # end up adjacent to each other.
+  @audio_sort_key_part [2]
+
+  def audio_serialize(%__MODULE__{screen: %Screen{app_id: :pre_fare_v2}}) do
+    %{}
+  end
+
+  def audio_sort_key(%__MODULE__{} = t, audio_sort_key_fn \\ &WidgetInstance.audio_sort_key/1) do
+    last_alert_widget =
+      t.widgets_snapshot
+      |> Enum.sort_by(audio_sort_key_fn, :desc)
+      |> Enum.find(&alert_widget?/1)
+
+    case last_alert_widget do
+      nil ->
+        Logger.warn("Failed to find an alert widget in the audio readout queue")
+        [100]
+
+      widget ->
+        audio_sort_key_fn.(widget) ++ @audio_sort_key_part
+    end
+  end
+
+  def audio_valid_candidate?(t, slot_names_fn \\ &WidgetInstance.slot_names/1)
+
+  def audio_valid_candidate?(
+        %__MODULE__{screen: %Screen{app_id: :pre_fare_v2}} = t,
+        slot_names_fn
+      ) do
+    # On pre-fare screens, we only include this widget when
+    # there's no takeover content and at least alert widget in the readout queue.
+    takeover_slots = MapSet.new(~w[full_body_left full_body_right full_body full_screen]a)
+
+    no_takeover_content? =
+      Enum.all?(t.widgets_snapshot, fn widget ->
+        widget
+        |> slot_names_fn.()
+        |> MapSet.new()
+        |> MapSet.disjoint?(takeover_slots)
+      end)
+
+    at_least_one_alert_widget? = Enum.any?(t.widgets_snapshot, &alert_widget?/1)
+
+    no_takeover_content? and at_least_one_alert_widget?
+  end
+
+  def audio_valid_candidate?(_t, _slot_names_fn) do
+    false
+  end
+
+  def audio_view(_instance), do: ScreensWeb.V2.Audio.AlertsOutroView
+
+  defp alert_widget?(%Alert{}), do: true
+  defp alert_widget?(%ReconstructedAlert{}), do: true
+  defp alert_widget?(%_other_widget_instance{}), do: false
+
+  defimpl Screens.V2.WidgetInstance do
+    alias Screens.V2.WidgetInstance.AudioOnly.AlertsOutro
+
+    # Since this is an audio-only widget, these functions will never be called.
+    def priority(_instance), do: :no_render
+    def serialize(_instance), do: %{}
+    def slot_names(_instance), do: :no_render
+    def widget_type(_instance), do: :no_render
+    def valid_candidate?(_instance), do: false
+
+    def audio_serialize(instance), do: AlertsOutro.audio_serialize(instance)
+    def audio_sort_key(instance), do: AlertsOutro.audio_sort_key(instance)
+    def audio_valid_candidate?(instance), do: AlertsOutro.audio_valid_candidate?(instance)
+    def audio_view(instance), do: AlertsOutro.audio_view(instance)
+  end
+end

--- a/lib/screens_web/views/v2/audio/alerts_outro_view.ex
+++ b/lib/screens_web/views/v2/audio/alerts_outro_view.ex
@@ -1,0 +1,7 @@
+defmodule ScreensWeb.V2.Audio.AlertsOutroView do
+  use ScreensWeb, :view
+
+  def render("_widget.ssml", _data) do
+    ~E|<p><s>For more information, go to <say-as interpret-as="spell-out">MBTA</say-as> dot com slash <break /> alerts</s></p>|
+  end
+end

--- a/test/screens/v2/candidate_generator/pre_fare_test.exs
+++ b/test/screens/v2/candidate_generator/pre_fare_test.exs
@@ -4,7 +4,7 @@ defmodule Screens.V2.CandidateGenerator.PreFareTest do
   alias Screens.Config.{Screen, V2}
   alias Screens.V2.CandidateGenerator.PreFare
   alias Screens.V2.WidgetInstance.NormalHeader
-  alias Screens.V2.WidgetInstance.AudioOnly.{AlertsIntro, ContentSummary}
+  alias Screens.V2.WidgetInstance.AudioOnly.{AlertsIntro, AlertsOutro, ContentSummary}
 
   setup do
     config = %Screen{
@@ -155,6 +155,17 @@ defmodule Screens.V2.CandidateGenerator.PreFareTest do
       assert Enum.any?(
                PreFare.audio_only_instances(widgets, config, fetch_routes_by_stop_fn),
                &match?(%AlertsIntro{}, &1)
+             )
+    end
+
+    test "always returns list containing alerts outro", %{config: config} do
+      widgets = []
+
+      fetch_routes_by_stop_fn = fn "place-foo" -> {:ok, []} end
+
+      assert Enum.any?(
+               PreFare.audio_only_instances(widgets, config, fetch_routes_by_stop_fn),
+               &match?(%AlertsOutro{}, &1)
              )
     end
   end

--- a/test/screens/v2/widget_instance/audio_only/alerts_outro_test.exs
+++ b/test/screens/v2/widget_instance/audio_only/alerts_outro_test.exs
@@ -1,0 +1,157 @@
+defmodule Screens.V2.WidgetInstance.AudioOnly.AlertsOutroTest do
+  use ExUnit.Case, async: true
+  import ExUnit.CaptureLog
+
+  alias Screens.Config.Screen
+  alias Screens.V2.WidgetInstance
+  alias Screens.V2.WidgetInstance.AudioOnly.AlertsOutro
+  alias Screens.V2.WidgetInstance.{MockWidget, SubwayStatus, ReconstructedAlert}
+
+  setup do
+    pre_fare_config = struct(Screen, %{app_id: :pre_fare_v2})
+    other_config = struct(Screen, %{app_id: :bus_e_ink_v2})
+
+    subway_status = struct(SubwayStatus)
+    alert = struct(ReconstructedAlert)
+
+    other_widget = %MockWidget{
+      slot_names: [:header],
+      audio_sort_key: [0],
+      audio_valid_candidate?: true
+    }
+
+    takeover_widget = %MockWidget{
+      slot_names: [:full_body],
+      audio_sort_key: [0],
+      audio_valid_candidate?: true
+    }
+
+    audio_sort_key_fn = fn
+      %MockWidget{} = mock_widget -> WidgetInstance.audio_sort_key(mock_widget)
+      %SubwayStatus{} -> [1]
+      %ReconstructedAlert{} -> [2]
+    end
+
+    slot_names_fn = fn
+      %MockWidget{} = mock_widget -> WidgetInstance.slot_names(mock_widget)
+      %SubwayStatus{} -> [:large]
+      %ReconstructedAlert{} -> [:large]
+    end
+
+    instance_without_alert_widgets = %AlertsOutro{
+      screen: nil,
+      widgets_snapshot: [subway_status, other_widget]
+    }
+
+    instance_with_alerts = %AlertsOutro{
+      screen: nil,
+      widgets_snapshot: [subway_status, alert, other_widget]
+    }
+
+    instance_with_takeover_content = %AlertsOutro{
+      screen: nil,
+      widgets_snapshot: [takeover_widget, subway_status, alert, other_widget]
+    }
+
+    %{
+      pre_fare_config: pre_fare_config,
+      other_config: other_config,
+      audio_sort_key_fn: audio_sort_key_fn,
+      slot_names_fn: slot_names_fn,
+      instance_without_alert_widgets: instance_without_alert_widgets,
+      instance_with_alerts: instance_with_alerts,
+      instance_with_takeover_content: instance_with_takeover_content
+    }
+  end
+
+  defp put_config(widget, config), do: %{widget | screen: config}
+
+  describe "audio_serialize/1" do
+    test "returns an empty map for pre-fare", %{
+      pre_fare_config: pre_fare_config,
+      instance_with_alerts: widget
+    } do
+      widget = put_config(widget, pre_fare_config)
+
+      assert %{} == WidgetInstance.audio_serialize(widget)
+    end
+
+    test "fails for other screen type", %{
+      other_config: other_config,
+      instance_with_alerts: widget
+    } do
+      widget = put_config(widget, other_config)
+
+      assert_raise FunctionClauseError, fn -> WidgetInstance.audio_serialize(widget) end
+    end
+  end
+
+  describe "audio_sort_key/1" do
+    # NOTE: need to call `AlertsOutro.audio_sort_key/2` in order to inject a stubbed function for testing purposes.
+    # This is otherwise equivalent to `WidgetInstance.audio_sort_key/1`.
+    test "returns audio sort key ++ [2] of last alert widget in the readout queue",
+         %{audio_sort_key_fn: audio_sort_key_fn, instance_with_alerts: widget} do
+      assert [2, 2] == AlertsOutro.audio_sort_key(widget, audio_sort_key_fn)
+    end
+
+    test "logs a warning and returns [100] if there's no alert widget in the readout queue",
+         %{audio_sort_key_fn: audio_sort_key_fn, instance_without_alert_widgets: widget} do
+      {result, log} = with_log(fn -> AlertsOutro.audio_sort_key(widget, audio_sort_key_fn) end)
+
+      assert [100] == result
+
+      assert String.contains?(
+               log,
+               "Failed to find an alert widget in the audio readout queue"
+             )
+    end
+  end
+
+  describe "audio_valid_candidate?/1" do
+    # NOTE: need to call `AlertsOutro.audio_valid_candidate?/2` in order to inject a stubbed function
+    # for testing purposes. This is otherwise equivalent to `WidgetInstance.audio_valid_candidate?/1`.
+    test "for pre-fare, returns true if there's at least one alert widget and no takeover content",
+         %{
+           slot_names_fn: slot_names_fn,
+           pre_fare_config: pre_fare_config,
+           instance_with_alerts: widget
+         } do
+      widget = put_config(widget, pre_fare_config)
+
+      assert AlertsOutro.audio_valid_candidate?(widget, slot_names_fn)
+    end
+
+    test "for pre-fare, returns false if there's no alert widget",
+         %{
+           slot_names_fn: slot_names_fn,
+           pre_fare_config: pre_fare_config,
+           instance_without_alert_widgets: widget
+         } do
+      widget = put_config(widget, pre_fare_config)
+
+      refute AlertsOutro.audio_valid_candidate?(widget, slot_names_fn)
+    end
+
+    test "for pre-fare, returns false if there's any takeover content",
+         %{
+           slot_names_fn: slot_names_fn,
+           pre_fare_config: pre_fare_config,
+           instance_with_takeover_content: widget
+         } do
+      widget = put_config(widget, pre_fare_config)
+
+      refute AlertsOutro.audio_valid_candidate?(widget, slot_names_fn)
+    end
+
+    test "returns false for other screen type",
+         %{
+           slot_names_fn: slot_names_fn,
+           other_config: other_config,
+           instance_with_alerts: widget
+         } do
+      widget = put_config(widget, other_config)
+
+      refute AlertsOutro.audio_valid_candidate?(widget, slot_names_fn)
+    end
+  end
+end


### PR DESCRIPTION
**Asana task**: [Audio implementation: Audio-only widgets](https://app.asana.com/0/1185117109217413/1202035304691540/f) (Part 3 of a 3-part trilogy)

This branch is off of the alerts intro widget branch. Will re-point at the master branch once that one is merged (or maybe GitHub does that automatically?)