### PR TITLE
Fixed headsigns. Diverges from DUP headsigns

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -68,7 +68,7 @@ config :screens,
   # Maps alert informed entity contents to the appropriate headsign to show for that alert.
   # List elements must be of the shape {informed_stop_ids, not_informed_stop_ids, headsign}.
   # Each set of stop IDs can be either a single string or a list of strings.
-  reconstructed_alert_headsign_matchers: %{
+  dup_alert_headsign_matchers: %{
     # Kenmore
     "place-kencl" => [
       {"70149", ~w[70153 70211 70187], "Boston College"},
@@ -93,15 +93,6 @@ config :screens,
       # OL
       {"70027", "70023", "Oak Grove"},
       {"70022", "70026", "Forest Hills"}
-    ],
-    # Government Center
-    "place-gover" => [
-      # GL
-      {"70203", "70200", "Northbound"},
-      {"~w[70199 70198 70197 70196]", "70204", "Copley & West"},
-      # BL
-      {"70042", "70038", "Wonderland"},
-      {"70038", "70041", "Bowdoin"}
     ],
     # Back Bay
     "place-bbsta" => [
@@ -133,11 +124,6 @@ config :screens,
       {"70046", "70042", "Wonderland"},
       {"70041", "70045", "Bowdoin"}
     ],
-    # Maverick
-    "place-mvbcl" => [
-      {"70048", "70044", "Wonderland"},
-      {"70043", "70047", "Bowdoin"}
-    ],
     # Airport
     "place-aport" => [
       {"70050", "70046", "Wonderland"},
@@ -147,6 +133,27 @@ config :screens,
     "place-qnctr" => [
       {"70100", "70104", "Alewife"},
       {"70103", "70099", "Braintree"}
+    ]
+  },
+  prefare_alert_headsign_matchers: %{
+    # Government Center
+    "place-gover" => [
+      # GL
+      {"70203", "70200", "North Station & North"},
+      {"~w[70199 70198 70197 70196]", "70204", "Copley & West"},
+      # BL
+      {"70042", "70038", "Wonderland"},
+      {"70038", "70041", "Bowdoin"}
+    ],
+    # Tufts
+    "place-tumnl" => [
+      {"70019", "70015", "Oak Grove"},
+      {"70014", "70018", "Forest Hills"}
+    ],
+    # Maverick
+    "place-mvbcl" => [
+      {"70048", "70044", "Wonderland"},
+      {"70043", "70047", "Bowdoin"}
     ]
   },
   # Stop IDs at stations serviced by two subway lines, where we also have DUP screens.

--- a/config/test.exs
+++ b/config/test.exs
@@ -23,7 +23,7 @@ config :logger, level: :warn
 
 config :screens,
   # See config.exs for details
-  reconstructed_alert_headsign_matchers: %{
+  prefare_alert_headsign_matchers: %{
     # Downtown Crossing
     "place-dwnxg" => [
       # RL

--- a/lib/screens/dup_screen_data/data.ex
+++ b/lib/screens/dup_screen_data/data.ex
@@ -15,7 +15,7 @@ defmodule Screens.DupScreenData.Data do
 
     {region, headsign} =
       :screens
-      |> Application.get_env(:reconstructed_alert_headsign_matchers)
+      |> Application.get_env(:dup_alert_headsign_matchers)
       |> Map.get(parent_stop_id)
       |> Enum.find_value({:inside, nil}, fn {informed, not_informed, headsign} ->
         if alert_region_match?(to_set(informed), to_set(not_informed), informed_stop_ids),

--- a/lib/screens/v2/widget_instance/reconstructed_alert.ex
+++ b/lib/screens/v2/widget_instance/reconstructed_alert.ex
@@ -97,7 +97,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
       informed_stop_ids = Enum.into(informed_entities, MapSet.new(), & &1.stop)
 
       :screens
-      |> Application.get_env(:reconstructed_alert_headsign_matchers)
+      |> Application.get_env(:prefare_alert_headsign_matchers)
       |> Map.get(stop_id)
       |> Enum.find_value(nil, fn {informed, not_informed, headsign} ->
         if alert_region_match?(to_set(informed), to_set(not_informed), informed_stop_ids),


### PR DESCRIPTION
**Asana task**: Adhoc

Headsigns for Govt Center north should be "North Station & North" for PreFare but "Northbound" for DUPs. Split out the data into two config values.

- [ ] Needs version bump?
