### PR TITLE
Handle "no elevator closures" state

### DIFF
--- a/lib/screens/v2/candidate_generator/widgets/elevator_closures.ex
+++ b/lib/screens/v2/candidate_generator/widgets/elevator_closures.ex
@@ -105,6 +105,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ElevatorClosures do
     |> Enum.uniq()
   end
 
+  defp parse_facility_data(nil), do: %{}
   defp parse_facility_data(facilities) do
     facilities
     |> Enum.map(fn %{"attributes" => %{"short_name" => short_name}, "id" => id} ->

--- a/lib/screens/v2/candidate_generator/widgets/elevator_closures.ex
+++ b/lib/screens/v2/candidate_generator/widgets/elevator_closures.ex
@@ -106,6 +106,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ElevatorClosures do
   end
 
   defp parse_facility_data(nil), do: %{}
+
   defp parse_facility_data(facilities) do
     facilities
     |> Enum.map(fn %{"attributes" => %{"short_name" => short_name}, "id" => id} ->


### PR DESCRIPTION
**Asana task**: [Elevator status breaks when there are no elevator alerts](https://app.asana.com/0/1185117109217422/1202101532752129)

When there are no elevator closures, the app breaks. This handles the "nil" value.

- [ ] Needs version bump?
