### PR TITLE
fix: Include alerts outro in readout even for takeover alerts

### DIFF
--- a/lib/screens/v2/widget_instance/audio_only/alerts_outro.ex
+++ b/lib/screens/v2/widget_instance/audio_only/alerts_outro.ex
@@ -1,6 +1,6 @@
 defmodule Screens.V2.WidgetInstance.AudioOnly.AlertsOutro do
   @moduledoc """
-  An audio-only widget that follows the section of the readout describing service alerts.
+  An audio-only widget that follows the section of the readout describing alerts.
   """
 
   alias Screens.Config.Screen
@@ -43,30 +43,11 @@ defmodule Screens.V2.WidgetInstance.AudioOnly.AlertsOutro do
     end
   end
 
-  def audio_valid_candidate?(t, slot_names_fn \\ &WidgetInstance.slot_names/1)
-
-  def audio_valid_candidate?(
-        %__MODULE__{screen: %Screen{app_id: :pre_fare_v2}} = t,
-        slot_names_fn
-      ) do
-    # On pre-fare screens, we only include this widget when
-    # there's no takeover content and at least one alert widget in the readout queue.
-    takeover_slots = MapSet.new(~w[full_body_left full_body_right full_body full_screen]a)
-
-    no_takeover_content? =
-      Enum.all?(t.widgets_snapshot, fn widget ->
-        widget
-        |> slot_names_fn.()
-        |> MapSet.new()
-        |> MapSet.disjoint?(takeover_slots)
-      end)
-
-    at_least_one_alert_widget? = Enum.any?(t.widgets_snapshot, &alert_widget?/1)
-
-    no_takeover_content? and at_least_one_alert_widget?
+  def audio_valid_candidate?(%__MODULE__{screen: %Screen{app_id: :pre_fare_v2}} = t) do
+    Enum.any?(t.widgets_snapshot, &alert_widget?/1)
   end
 
-  def audio_valid_candidate?(_t, _slot_names_fn) do
+  def audio_valid_candidate?(_t) do
     false
   end
 

--- a/test/screens/v2/widget_instance/audio_only/alerts_outro_test.exs
+++ b/test/screens/v2/widget_instance/audio_only/alerts_outro_test.exs
@@ -32,12 +32,6 @@ defmodule Screens.V2.WidgetInstance.AudioOnly.AlertsOutroTest do
       %ReconstructedAlert{} -> [2]
     end
 
-    slot_names_fn = fn
-      %MockWidget{} = mock_widget -> WidgetInstance.slot_names(mock_widget)
-      %SubwayStatus{} -> [:large]
-      %ReconstructedAlert{} -> [:large]
-    end
-
     instance_without_alert_widgets = %AlertsOutro{
       screen: nil,
       widgets_snapshot: [subway_status, other_widget]
@@ -57,7 +51,6 @@ defmodule Screens.V2.WidgetInstance.AudioOnly.AlertsOutroTest do
       pre_fare_config: pre_fare_config,
       other_config: other_config,
       audio_sort_key_fn: audio_sort_key_fn,
-      slot_names_fn: slot_names_fn,
       instance_without_alert_widgets: instance_without_alert_widgets,
       instance_with_alerts: instance_with_alerts,
       instance_with_takeover_content: instance_with_takeover_content
@@ -108,50 +101,34 @@ defmodule Screens.V2.WidgetInstance.AudioOnly.AlertsOutroTest do
   end
 
   describe "audio_valid_candidate?/1" do
-    # NOTE: need to call `AlertsOutro.audio_valid_candidate?/2` in order to inject a stubbed function
-    # for testing purposes. This is otherwise equivalent to `WidgetInstance.audio_valid_candidate?/1`.
     test "for pre-fare, returns true if there's at least one alert widget and no takeover content",
          %{
-           slot_names_fn: slot_names_fn,
            pre_fare_config: pre_fare_config,
            instance_with_alerts: widget
          } do
       widget = put_config(widget, pre_fare_config)
 
-      assert AlertsOutro.audio_valid_candidate?(widget, slot_names_fn)
+      assert WidgetInstance.audio_valid_candidate?(widget)
     end
 
     test "for pre-fare, returns false if there's no alert widget",
          %{
-           slot_names_fn: slot_names_fn,
            pre_fare_config: pre_fare_config,
            instance_without_alert_widgets: widget
          } do
       widget = put_config(widget, pre_fare_config)
 
-      refute AlertsOutro.audio_valid_candidate?(widget, slot_names_fn)
-    end
-
-    test "for pre-fare, returns false if there's any takeover content",
-         %{
-           slot_names_fn: slot_names_fn,
-           pre_fare_config: pre_fare_config,
-           instance_with_takeover_content: widget
-         } do
-      widget = put_config(widget, pre_fare_config)
-
-      refute AlertsOutro.audio_valid_candidate?(widget, slot_names_fn)
+      refute WidgetInstance.audio_valid_candidate?(widget)
     end
 
     test "returns false for other screen type",
          %{
-           slot_names_fn: slot_names_fn,
            other_config: other_config,
            instance_with_alerts: widget
          } do
       widget = put_config(widget, other_config)
 
-      refute AlertsOutro.audio_valid_candidate?(widget, slot_names_fn)
+      refute WidgetInstance.audio_valid_candidate?(widget)
     end
   end
 end


### PR DESCRIPTION
**Asana task**: [Add CTA to end of full-screen takeover audio](https://app.asana.com/0/1185117109217413/1202101941603426/f)