### PR TITLE
When fetching station sequences, get them in same direction

### DIFF
--- a/lib/screens/route_patterns/route_pattern.ex
+++ b/lib/screens/route_patterns/route_pattern.ex
@@ -76,6 +76,7 @@ defmodule Screens.RoutePatterns.RoutePattern do
     params = %{
       "include" => "representative_trip.stops,route",
       "filter[stop]" => stop_id,
+      "filter[direction_id]" => 0,
       "filter[route]" => Enum.join(route_filters, ",")
     }
 


### PR DESCRIPTION
**Asana task**: [Subway Status and Alert widgets don't handle Green Line suspension Lechmere - Government Center](https://app.asana.com/0/1185117109217422/1202101924522475)

- [ ] Needs version bump?
