### PR TITLE
fix: Text resizing issue for some detail pages.

### DIFF
--- a/assets/src/components/v2/elevator_status.tsx
+++ b/assets/src/components/v2/elevator_status.tsx
@@ -200,7 +200,7 @@ const DetailPageComponent: ComponentType<DetailPage> = ({
   const HEADER_SIZES = ["small", "large"];
   const { ref: descriptionRef, size: descriptionSize } = useTextResizer({
     sizes: DESCRIPTION_SIZES,
-    maxHeight: 450,
+    maxHeight: 425,
     resetDependencies: [description],
   });
 

--- a/assets/src/hooks/v2/use_text_resizer.tsx
+++ b/assets/src/hooks/v2/use_text_resizer.tsx
@@ -34,7 +34,7 @@ const useTextResizer = ({
     setSizeIndex(sizes.length - 1);
   }, resetDependencies);
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     if (ref.current !== null) {
       const height = ref.current.clientHeight;
       if (height > maxHeight && sizeIndex > 0) {


### PR DESCRIPTION
**Asana task**: ad-hoc

Text was not resizing properly for some detail pages that show after list pages. Changing the hook used helps with this issue.

- [ ] Needs version bump?
