### PR TITLE
fix: Move elevator closure alternate route description outside `<s>` tag to allow expected pronunciation of punctuation

### DIFF
--- a/lib/screens_web/views/v2/audio/elevator_status_view.ex
+++ b/lib/screens_web/views/v2/audio/elevator_status_view.ex
@@ -60,7 +60,7 @@ defmodule ScreensWeb.V2.Audio.ElevatorStatusView do
         "Upcoming elevator closure:"
       end
 
-    ~E|<s><%= upcoming_text %> At <%= station_text %>, <%= render_timeframe(timeframe) %>: Elevator Number <say-as interpret-as="address"><%= id %></say-as>, <%= name %>: <%= alternate_path_instructions %></s>|
+    ~E|<s><%= upcoming_text %> At <%= station_text %>, <%= render_timeframe(timeframe) %>: Elevator Number <say-as interpret-as="address"><%= id %></say-as>, <%= name %></s><%= alternate_path_instructions %>|
   end
 
   # List pages


### PR DESCRIPTION
**Asana task**: [Elevator alert audio not reading periods](https://app.asana.com/0/1185117109217413/1202110379846298/f)

Polly (or the SSML spec, really) does not allow for nested `<s>` (sentence) elements. Internally, Polly converts period-delimited text inside SSML to sentence elements. This means that if you drop a full paragraph of text into a sentence element, it would be interpreted something like `<s><s>first sentence</s><s>second sentence</s>...</s>` which is not valid SSML. To avoid this, Polly silently ignores periods inside of `<s>` elements and we end up with a crazy run-on: `<s>first sentence second sentence ...</s>`.

This means we need to avoid putting the PIO-provided alternate route text inside of an `<s>` element to have it get read out as expected. This change makes that fix.

- [ ] Needs version bump?
