### PR TITLE
fix: Only create reconstructed alert widgets for active service alerts

### DIFF
--- a/lib/screens/v2/candidate_generator/widgets/reconstructed_alert.ex
+++ b/lib/screens/v2/candidate_generator/widgets/reconstructed_alert.ex
@@ -48,30 +48,43 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlert do
   end
 
   defp relevant?(
-         %Alert{severity: severity, effect: effect} = alert,
+         %Alert{effect: effect} = alert,
          config,
          stop_sequences,
          routes_at_stop
        ) do
-    Enum.member?(@relevant_effects, effect) and
-      case BaseAlert.location(%ReconstructedAlert{
-             screen: config,
-             alert: alert,
-             stop_sequences: stop_sequences,
-             routes_at_stop: routes_at_stop,
-             now: DateTime.utc_now()
-           }) do
-        location when location in [:downstream, :upstream] ->
-          true
+    reconstructed_alert = %ReconstructedAlert{
+      screen: config,
+      alert: alert,
+      stop_sequences: stop_sequences,
+      routes_at_stop: routes_at_stop,
+      now: DateTime.utc_now()
+    }
 
-        :inside ->
-          effect != :delay or severity > 3
+    relevant_effect?(effect) and relevant_location?(reconstructed_alert) and active?(alert)
+  end
 
-        location when location in [:boundary_upstream, :boundary_downstream] ->
-          effect != :station_closure and (effect != :delay or severity > 3)
+  defp relevant_effect?(effect) do
+    Enum.member?(@relevant_effects, effect)
+  end
 
-        _ ->
-          false
-      end
+  defp relevant_location?(%ReconstructedAlert{alert: alert} = reconstructed_alert) do
+    case BaseAlert.location(reconstructed_alert) do
+      location when location in [:downstream, :upstream] ->
+        true
+
+      :inside ->
+        alert.effect != :delay or alert.severity > 3
+
+      location when location in [:boundary_upstream, :boundary_downstream] ->
+        alert.effect != :station_closure and (alert.effect != :delay or alert.severity > 3)
+
+      _ ->
+        false
+    end
+  end
+
+  defp active?(alert) do
+    Alert.happening_now?(alert)
   end
 end


### PR DESCRIPTION
**Asana task**: ad hoc

This adds an additional check to the `relevant?` predicate to filter out alerts that aren't currently active.