### PR TITLE
test: Reconstructed alerts candidate generator filters out non-active alerts

### DIFF
--- a/lib/screens/v2/candidate_generator/widgets/reconstructed_alert.ex
+++ b/lib/screens/v2/candidate_generator/widgets/reconstructed_alert.ex
@@ -32,7 +32,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlert do
          {:ok, station_sequences} <-
            fetch_stop_sequences_by_stop_fn.(stop_id, route_ids_at_stop) do
       alerts
-      |> Enum.filter(&relevant?(&1, config, station_sequences, routes_at_stop))
+      |> Enum.filter(&relevant?(&1, config, station_sequences, routes_at_stop, now))
       |> Enum.map(fn alert ->
         %ReconstructedAlert{
           screen: config,
@@ -51,17 +51,18 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlert do
          %Alert{effect: effect} = alert,
          config,
          stop_sequences,
-         routes_at_stop
+         routes_at_stop,
+         now
        ) do
     reconstructed_alert = %ReconstructedAlert{
       screen: config,
       alert: alert,
       stop_sequences: stop_sequences,
       routes_at_stop: routes_at_stop,
-      now: DateTime.utc_now()
+      now: now
     }
 
-    relevant_effect?(effect) and relevant_location?(reconstructed_alert) and active?(alert)
+    relevant_effect?(effect) and relevant_location?(reconstructed_alert) and active?(alert, now)
   end
 
   defp relevant_effect?(effect) do
@@ -84,7 +85,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlert do
     end
   end
 
-  defp active?(alert) do
-    Alert.happening_now?(alert)
+  defp active?(alert, now) do
+    Alert.happening_now?(alert, now)
   end
 end

--- a/lib/screens/v2/candidate_generator/widgets/reconstructed_alert.ex
+++ b/lib/screens/v2/candidate_generator/widgets/reconstructed_alert.ex
@@ -62,7 +62,8 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlert do
       now: now
     }
 
-    relevant_effect?(effect) and relevant_location?(reconstructed_alert) and active?(alert, now)
+    relevant_effect?(effect) and relevant_location?(reconstructed_alert) and
+      Alert.happening_now?(alert, now)
   end
 
   defp relevant_effect?(effect) do
@@ -83,9 +84,5 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlert do
       _ ->
         false
     end
-  end
-
-  defp active?(alert, now) do
-    Alert.happening_now?(alert, now)
   end
 end

--- a/test/screens/v2/candidate_generator/widgets/reconstructed_alert_test.exs
+++ b/test/screens/v2/candidate_generator/widgets/reconstructed_alert_test.exs
@@ -67,12 +67,46 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlertTest do
         }
       ]
 
+      happening_now_active_period = [{~U[2020-12-31T00:00:00Z], ~U[2021-01-02T00:00:00Z]}]
+      upcoming_active_period = [{~U[2021-01-02T00:00:00Z], ~U[2021-01-03T00:00:00Z]}]
+
       alerts = [
-        %Alert{id: "1", effect: :station_closure, informed_entities: [ie(stop: "place-hsmnl")]},
-        %Alert{id: "2", effect: :station_closure, informed_entities: [ie(stop: "place-bckhl")]},
-        %Alert{id: "3", effect: :delay, informed_entities: [ie(stop: "place-hsmnl")]},
-        %Alert{id: "4", effect: :station_closure, informed_entities: []},
-        %Alert{id: "5", effect: :stop_closure, informed_entities: [ie(stop: "place-rvrwy")]}
+        %Alert{
+          id: "1",
+          effect: :station_closure,
+          informed_entities: [ie(stop: "place-hsmnl")],
+          active_period: happening_now_active_period
+        },
+        %Alert{
+          id: "2",
+          effect: :station_closure,
+          informed_entities: [ie(stop: "place-bckhl")],
+          active_period: happening_now_active_period
+        },
+        %Alert{
+          id: "3",
+          effect: :delay,
+          informed_entities: [ie(stop: "place-hsmnl")],
+          active_period: happening_now_active_period
+        },
+        %Alert{
+          id: "4",
+          effect: :station_closure,
+          informed_entities: [],
+          active_period: happening_now_active_period
+        },
+        %Alert{
+          id: "5",
+          effect: :stop_closure,
+          informed_entities: [ie(stop: "place-rvrwy")],
+          active_period: happening_now_active_period
+        },
+        %Alert{
+          id: "6",
+          effect: :station_closure,
+          informed_entities: [ie(stop: "place-hsmnl")],
+          active_period: upcoming_active_period
+        }
       ]
 
       station_sequences = [
@@ -121,7 +155,8 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlertTest do
             alert: %Alert{
               id: "1",
               effect: :station_closure,
-              informed_entities: [ie(stop: "place-hsmnl")]
+              informed_entities: [ie(stop: "place-hsmnl")],
+              active_period: [{~U[2020-12-31T00:00:00Z], ~U[2021-01-02T00:00:00Z]}]
             }
           },
           expected_common_data
@@ -131,14 +166,20 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlertTest do
             alert: %Alert{
               id: "2",
               effect: :station_closure,
-              informed_entities: [ie(stop: "place-bckhl")]
+              informed_entities: [ie(stop: "place-bckhl")],
+              active_period: [{~U[2020-12-31T00:00:00Z], ~U[2021-01-02T00:00:00Z]}]
             }
           },
           expected_common_data
         ),
         struct(
           %ReconstructedAlertWidget{
-            alert: %Alert{id: "3", effect: :delay, informed_entities: [ie(stop: "place-hsmnl")]}
+            alert: %Alert{
+              id: "3",
+              effect: :delay,
+              informed_entities: [ie(stop: "place-hsmnl")],
+              active_period: [{~U[2020-12-31T00:00:00Z], ~U[2021-01-02T00:00:00Z]}]
+            }
           },
           expected_common_data
         )

--- a/test/screens/v2/widget_instance/reconstructed_alert_test.exs
+++ b/test/screens/v2/widget_instance/reconstructed_alert_test.exs
@@ -73,7 +73,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
     %{widget | alert: %{widget.alert | severity: severity}}
   end
 
-  defp ie(opts \\ []) do
+  defp ie(opts) do
     %{
       stop: opts[:stop],
       route: opts[:route],


### PR DESCRIPTION
**Asana task**: [Restrict reconstructed alert widgets to active alerts only](https://app.asana.com/0/1185117109217413/1202112353590269/f)