### PR TITLE
fix: DeparturesNoData server error

### DIFF
--- a/lib/screens/v2/widget_instance/departures_no_data.ex
+++ b/lib/screens/v2/widget_instance/departures_no_data.ex
@@ -2,8 +2,7 @@ defmodule Screens.V2.WidgetInstance.DeparturesNoData do
   @moduledoc false
 
   alias Screens.Config.Screen
-  alias Screens.Config.V2.BusShelter
-  alias Screens.Config.V2.Header.CurrentStopId
+  alias Screens.Config.V2.Alerts
 
   defstruct screen: nil, show_alternatives?: nil
 
@@ -23,7 +22,7 @@ defmodule Screens.V2.WidgetInstance.DeparturesNoData do
   def valid_candidate?(_instance), do: true
 
   defp stop_id(%__MODULE__{
-         screen: %Screen{app_params: %BusShelter{header: %CurrentStopId{stop_id: stop_id}}}
+         screen: %Screen{app_params: %_app{alerts: %Alerts{stop_id: stop_id}}}
        }) do
     stop_id
   end

--- a/test/screens/v2/widget_instance/departures_no_data_test.exs
+++ b/test/screens/v2/widget_instance/departures_no_data_test.exs
@@ -2,12 +2,10 @@ defmodule Screens.V2.WidgetInstance.DeparturesNoDataTest do
   use ExUnit.Case, async: true
   alias Screens.V2.WidgetInstance
   alias Screens.Config.Screen
-  alias Screens.Config.V2.BusShelter
-  alias Screens.Config.V2.Header.CurrentStopId
+  alias Screens.Config.V2.{Alerts, BusShelter}
 
   @instance %WidgetInstance.DeparturesNoData{
-    screen:
-      struct(Screen, %{app_params: struct(BusShelter, %{header: %CurrentStopId{stop_id: "1"}})}),
+    screen: struct(Screen, %{app_params: struct(BusShelter, %{alerts: %Alerts{stop_id: "1"}})}),
     show_alternatives?: true
   }
 


### PR DESCRIPTION
**Asana task**: [[Bug] DeparturesNoData throwing error for Bus Shelter screens](https://app.asana.com/0/1185117109217413/1202123170003797/f)

The DeparturesNoData widget was looking for `stop_id` in the header but we do not always put it there. In each V2 config, we place a `stop_id` in the `alerts` section, so I changed it to look there instead.

This solution does fix backend issues for eInk apps, but this widget is still not registered to those components in the front-end. That will be fixed in [this task](https://app.asana.com/0/1185117109217422/1202131702864644/f).

- [ ] Needs version bump?
