### PR TITLE
tweak: Add screen_side to request logs

### DIFF
--- a/assets/src/hooks/v2/use_api_response.tsx
+++ b/assets/src/hooks/v2/use_api_response.tsx
@@ -69,6 +69,13 @@ const useIsRealScreenParam = () => {
   return isRealScreen === "true" ? "&is_real_screen=true" : "";
 };
 
+const useScreenSideParam = () => {
+  const query = useQuery();
+  const screenSide = query.get("screen_side");
+
+  return screenSide ? `&screen_side=${screenSide}` : "";
+};
+
 interface UseApiResponseArgs {
   id: string;
   failureModeElapsedMs?: number;
@@ -85,6 +92,7 @@ const useApiResponse = ({
   failureModeElapsedMs = MINUTE_IN_MS,
 }: UseApiResponseArgs): UseApiResponseReturn => {
   const isRealScreenParam = useIsRealScreenParam();
+  const screenSideParam = useScreenSideParam();
   const [apiResponse, setApiResponse] = useState<ApiResponse>(FAILURE_RESPONSE);
   const [requestCount, setRequestCount] = useState<number>(0);
   const [lastSuccess, setLastSuccess] = useState<number | null>(null);
@@ -92,7 +100,7 @@ const useApiResponse = ({
     document.getElementById("app").dataset;
   const refreshMs = parseInt(refreshRate, 10) * 1000;
   const refreshRateOffsetMs = parseInt(refreshRateOffset, 10) * 1000;
-  const apiPath = `/v2/api/screen/${id}?last_refresh=${lastRefresh}${isRealScreenParam}`;
+  const apiPath = `/v2/api/screen/${id}?last_refresh=${lastRefresh}${isRealScreenParam}${screenSideParam}`;
 
   const fetchData = async () => {
     try {

--- a/lib/screens/log_screen_data.ex
+++ b/lib/screens/log_screen_data.ex
@@ -3,20 +3,29 @@ defmodule Screens.LogScreenData do
   require Logger
   alias Screens.Config.{Screen, State}
 
-  def log_page_load(screen_id, is_screen) do
+  def log_page_load(screen_id, is_screen, screen_side \\ nil) do
     if is_screen do
       data = %{screen_id: screen_id, screen_name: screen_name_for_id(screen_id)}
+
+      if not is_nil(screen_side) do
+        Map.put(data, :screen_side, screen_side)
+      end
+
       log_message("[screen page load]", data)
     end
   end
 
-  def log_data_request(screen_id, last_refresh, is_screen) do
+  def log_data_request(screen_id, last_refresh, is_screen, screen_side \\ nil) do
     if is_screen do
       data = %{
         screen_id: screen_id,
         screen_name: screen_name_for_id(screen_id),
         last_refresh: last_refresh
       }
+
+      if not is_nil(screen_side) do
+        Map.put(data, :screen_side, screen_side)
+      end
 
       log_message("[screen data request]", data)
     end
@@ -33,19 +42,27 @@ defmodule Screens.LogScreenData do
     end
   end
 
-  def log_api_response(%{force_reload: true}, screen_id, last_refresh, is_screen) do
-    log_api_response_success(screen_id, last_refresh, is_screen)
+  def log_api_response(response, screen_id, last_refresh, is_screen, screen_side \\ nil)
+
+  def log_api_response(
+        %{force_reload: true},
+        screen_id,
+        last_refresh,
+        is_screen,
+        screen_side
+      ) do
+    log_api_response_success(screen_id, last_refresh, is_screen, screen_side)
   end
 
-  def log_api_response(%{success: true}, screen_id, last_refresh, is_screen) do
-    log_api_response_success(screen_id, last_refresh, is_screen)
+  def log_api_response(%{success: true}, screen_id, last_refresh, is_screen, screen_side) do
+    log_api_response_success(screen_id, last_refresh, is_screen, screen_side)
   end
 
-  def log_api_response(_response, _screen_id, _last_refresh, _is_screen) do
+  def log_api_response(_response, _screen_id, _last_refresh, _is_screen, _screen_side) do
     :ok
   end
 
-  defp log_api_response_success(screen_id, last_refresh, is_screen) do
+  defp log_api_response_success(screen_id, last_refresh, is_screen, screen_side) do
     _ =
       if is_screen do
         data = %{
@@ -53,6 +70,10 @@ defmodule Screens.LogScreenData do
           screen_name: screen_name_for_id(screen_id),
           last_refresh: last_refresh
         }
+
+        if not is_nil(screen_side) do
+          Map.put(data, :screen_side, screen_side)
+        end
 
         log_message("[screen api response success]", data)
       end

--- a/lib/screens/log_screen_data.ex
+++ b/lib/screens/log_screen_data.ex
@@ -7,9 +7,10 @@ defmodule Screens.LogScreenData do
     if is_screen do
       data = %{screen_id: screen_id, screen_name: screen_name_for_id(screen_id)}
 
-      if not is_nil(screen_side) do
-        Map.put(data, :screen_side, screen_side)
-      end
+      _ =
+        if not is_nil(screen_side) do
+          Map.put(data, :screen_side, screen_side)
+        end
 
       log_message("[screen page load]", data)
     end
@@ -23,9 +24,10 @@ defmodule Screens.LogScreenData do
         last_refresh: last_refresh
       }
 
-      if not is_nil(screen_side) do
-        Map.put(data, :screen_side, screen_side)
-      end
+      _ =
+        if not is_nil(screen_side) do
+          Map.put(data, :screen_side, screen_side)
+        end
 
       log_message("[screen data request]", data)
     end
@@ -71,9 +73,10 @@ defmodule Screens.LogScreenData do
           last_refresh: last_refresh
         }
 
-        if not is_nil(screen_side) do
-          Map.put(data, :screen_side, screen_side)
-        end
+        _ =
+          if not is_nil(screen_side) do
+            Map.put(data, :screen_side, screen_side)
+          end
 
         log_message("[screen api response success]", data)
       end

--- a/lib/screens_web/controllers/v2/screen_api_controller.ex
+++ b/lib/screens_web/controllers/v2/screen_api_controller.ex
@@ -16,7 +16,7 @@ defmodule ScreensWeb.V2.ScreenApiController do
     end
   end
 
-  def show(%{params: params} = conn, %{"id" => screen_id, "last_refresh" => last_refresh}) do
+  def show(conn, %{"id" => screen_id, "last_refresh" => last_refresh} = params) do
     is_screen = ScreensWeb.UserAgent.is_screen_conn?(conn, screen_id)
     screen_side = get_screen_side(params)
 

--- a/lib/screens_web/controllers/v2/screen_api_controller.ex
+++ b/lib/screens_web/controllers/v2/screen_api_controller.ex
@@ -16,10 +16,11 @@ defmodule ScreensWeb.V2.ScreenApiController do
     end
   end
 
-  def show(conn, %{"id" => screen_id, "last_refresh" => last_refresh}) do
+  def show(%{params: params} = conn, %{"id" => screen_id, "last_refresh" => last_refresh}) do
     is_screen = ScreensWeb.UserAgent.is_screen_conn?(conn, screen_id)
+    screen_side = get_screen_side(params)
 
-    _ = Screens.LogScreenData.log_data_request(screen_id, last_refresh, is_screen)
+    _ = Screens.LogScreenData.log_data_request(screen_id, last_refresh, is_screen, screen_side)
 
     cond do
       nonexistent_screen?(screen_id) ->
@@ -59,4 +60,7 @@ defmodule ScreensWeb.V2.ScreenApiController do
     |> put_status(:not_found)
     |> text("Not found")
   end
+
+  defp get_screen_side(%{"screen_side" => screen_side}), do: screen_side
+  defp get_screen_side(_), do: nil
 end

--- a/lib/screens_web/controllers/v2/screen_api_controller.ex
+++ b/lib/screens_web/controllers/v2/screen_api_controller.ex
@@ -18,9 +18,13 @@ defmodule ScreensWeb.V2.ScreenApiController do
 
   def show(conn, %{"id" => screen_id, "last_refresh" => last_refresh} = params) do
     is_screen = ScreensWeb.UserAgent.is_screen_conn?(conn, screen_id)
-    screen_side = get_screen_side(params)
 
-    _ = Screens.LogScreenData.log_data_request(screen_id, last_refresh, is_screen, screen_side)
+    Screens.LogScreenData.log_data_request(
+      screen_id,
+      last_refresh,
+      is_screen,
+      params["screen_side"]
+    )
 
     cond do
       nonexistent_screen?(screen_id) ->
@@ -60,7 +64,4 @@ defmodule ScreensWeb.V2.ScreenApiController do
     |> put_status(:not_found)
     |> text("Not found")
   end
-
-  defp get_screen_side(%{"screen_side" => screen_side}), do: screen_side
-  defp get_screen_side(_), do: nil
 end

--- a/lib/screens_web/controllers/v2/screen_controller.ex
+++ b/lib/screens_web/controllers/v2/screen_controller.ex
@@ -35,7 +35,7 @@ defmodule ScreensWeb.V2.ScreenController do
     put_layout(conn, {ScreensWeb.V2.LayoutView, "app.html"})
   end
 
-  def index(%{params: params} = conn, %{"id" => screen_id}) do
+  def index(conn, %{"id" => screen_id} = params) do
     is_screen = ScreensWeb.UserAgent.is_screen_conn?(conn, screen_id)
     screen_side = get_screen_side(params)
 

--- a/lib/screens_web/controllers/v2/screen_controller.ex
+++ b/lib/screens_web/controllers/v2/screen_controller.ex
@@ -37,9 +37,8 @@ defmodule ScreensWeb.V2.ScreenController do
 
   def index(conn, %{"id" => screen_id} = params) do
     is_screen = ScreensWeb.UserAgent.is_screen_conn?(conn, screen_id)
-    screen_side = get_screen_side(params)
 
-    _ = Screens.LogScreenData.log_page_load(screen_id, is_screen, screen_side)
+    _ = Screens.LogScreenData.log_page_load(screen_id, is_screen, params["screen_side"])
 
     config = State.screen(screen_id)
 
@@ -82,7 +81,4 @@ defmodule ScreensWeb.V2.ScreenController do
     |> put_view(ScreensWeb.ErrorView)
     |> render("404.html")
   end
-
-  defp get_screen_side(%{"screen_side" => screen_side}), do: screen_side
-  defp get_screen_side(_), do: nil
 end

--- a/lib/screens_web/controllers/v2/screen_controller.ex
+++ b/lib/screens_web/controllers/v2/screen_controller.ex
@@ -35,10 +35,11 @@ defmodule ScreensWeb.V2.ScreenController do
     put_layout(conn, {ScreensWeb.V2.LayoutView, "app.html"})
   end
 
-  def index(conn, %{"id" => screen_id}) do
+  def index(%{params: params} = conn, %{"id" => screen_id}) do
     is_screen = ScreensWeb.UserAgent.is_screen_conn?(conn, screen_id)
+    screen_side = get_screen_side(params)
 
-    _ = Screens.LogScreenData.log_page_load(screen_id, is_screen)
+    _ = Screens.LogScreenData.log_page_load(screen_id, is_screen, screen_side)
 
     config = State.screen(screen_id)
 
@@ -81,4 +82,7 @@ defmodule ScreensWeb.V2.ScreenController do
     |> put_view(ScreensWeb.ErrorView)
     |> render("404.html")
   end
+
+  defp get_screen_side(%{"screen_side" => screen_side}), do: screen_side
+  defp get_screen_side(_), do: nil
 end


### PR DESCRIPTION
**Asana task**: [Log screen side (left vs right) for Pre-fare screens](https://app.asana.com/0/1185117109217413/1202116831580952/f)

Added `screen_side` to the map we log for requests. Will only exist if `screen_side` is a param in the request, so Pre-Fare will be the only screen that logs it at the moment.

- [ ] Needs version bump?
