### PR TITLE
feat: Log successful API responses

### DIFF
--- a/lib/screens/log_screen_data.ex
+++ b/lib/screens/log_screen_data.ex
@@ -55,8 +55,7 @@ defmodule Screens.LogScreenData do
       data = %{
         screen_id: screen_id,
         screen_name: screen_name_for_id(screen_id),
-        last_refresh: last_refresh,
-        status: status
+        last_refresh: last_refresh
       }
 
       log_message("[screen api response #{status}]", data)

--- a/lib/screens/log_screen_data.ex
+++ b/lib/screens/log_screen_data.ex
@@ -33,29 +33,34 @@ defmodule Screens.LogScreenData do
     end
   end
 
-  def log_api_response(%{force_reload: true}, screen_id, last_refresh, is_screen) do
-    log_api_response_success(screen_id, last_refresh, is_screen)
+  def log_api_response(%{force_reload: true, status: status}, screen_id, last_refresh, is_screen) do
+    log_api_response_success(screen_id, last_refresh, is_screen, status)
   end
 
-  def log_api_response(%{success: true}, screen_id, last_refresh, is_screen) do
-    log_api_response_success(screen_id, last_refresh, is_screen)
+  def log_api_response(%{success: true, status: status}, screen_id, last_refresh, is_screen) do
+    log_api_response_success(screen_id, last_refresh, is_screen, status)
+  end
+
+  def log_api_response(status, screen_id, last_refresh, is_screen)
+      when is_atom(status) do
+    log_api_response_success(screen_id, last_refresh, is_screen, status)
   end
 
   def log_api_response(_response, _screen_id, _last_refresh, _is_screen) do
     :ok
   end
 
-  defp log_api_response_success(screen_id, last_refresh, is_screen) do
-    _ =
-      if is_screen do
-        data = %{
-          screen_id: screen_id,
-          screen_name: screen_name_for_id(screen_id),
-          last_refresh: last_refresh
-        }
+  defp log_api_response_success(screen_id, last_refresh, is_screen, status) do
+    if is_screen do
+      data = %{
+        screen_id: screen_id,
+        screen_name: screen_name_for_id(screen_id),
+        last_refresh: last_refresh,
+        status: status
+      }
 
-        log_message("[screen api response success]", data)
-      end
+      log_message("[screen api response #{status}]", data)
+    end
 
     :ok
   end

--- a/lib/screens/log_screen_data.ex
+++ b/lib/screens/log_screen_data.ex
@@ -41,13 +41,8 @@ defmodule Screens.LogScreenData do
     log_api_response_success(screen_id, last_refresh, is_screen, status)
   end
 
-  def log_api_response(status, screen_id, last_refresh, is_screen)
-      when is_atom(status) do
+  def log_api_response(status, screen_id, last_refresh, is_screen) do
     log_api_response_success(screen_id, last_refresh, is_screen, status)
-  end
-
-  def log_api_response(_response, _screen_id, _last_refresh, _is_screen) do
-    :ok
   end
 
   defp log_api_response_success(screen_id, last_refresh, is_screen, status) do

--- a/lib/screens/screen_data.ex
+++ b/lib/screens/screen_data.ex
@@ -12,9 +12,9 @@ defmodule Screens.ScreenData do
     dup: Screens.DupScreenData
   }
 
-  @disabled_response %{force_reload: false, success: false}
+  @disabled_response %{force_reload: false, success: false, status: :disabled}
 
-  @outdated_response %{force_reload: true}
+  @outdated_response %{force_reload: true, status: :outdated}
 
   def by_screen_id(screen_id, is_screen, opts \\ []) do
     check_disabled = Keyword.get(opts, :check_disabled, false)
@@ -26,7 +26,7 @@ defmodule Screens.ScreenData do
       cond do
         check_outdated and outdated?(screen_id, last_refresh) -> @outdated_response
         check_disabled and disabled?(screen_id) -> @disabled_response
-        true -> fetch_data(screen_id, is_screen)
+        true -> screen_id |> fetch_data(is_screen) |> Map.put(:status, :success)
       end
 
     _ = LogScreenData.log_api_response(response, screen_id, last_refresh, is_screen)

--- a/lib/screens_web/controllers/screen_api_controller.ex
+++ b/lib/screens_web/controllers/screen_api_controller.ex
@@ -32,6 +32,8 @@ defmodule ScreensWeb.ScreenApiController do
     _ = Screens.LogScreenData.log_data_request(screen_id, last_refresh, is_screen)
 
     if nonexistent_screen?(screen_id) do
+      Screens.LogScreenData.log_api_response(:nonexistent, screen_id, last_refresh, is_screen)
+
       not_found_response(conn)
     else
       data =

--- a/lib/screens_web/controllers/v2/screen_api_controller.ex
+++ b/lib/screens_web/controllers/v2/screen_api_controller.ex
@@ -23,15 +23,19 @@ defmodule ScreensWeb.V2.ScreenApiController do
 
     cond do
       nonexistent_screen?(screen_id) ->
+        Screens.LogScreenData.log_api_response(:nonexistent, screen_id, last_refresh, is_screen)
         not_found_response(conn)
 
       outdated?(screen_id, last_refresh) ->
+        Screens.LogScreenData.log_api_response(:outdated, screen_id, last_refresh, is_screen)
         json(conn, ScreenData.outdated_response())
 
       disabled?(screen_id) ->
+        Screens.LogScreenData.log_api_response(:disabled, screen_id, last_refresh, is_screen)
         json(conn, ScreenData.disabled_response())
 
       true ->
+        Screens.LogScreenData.log_api_response(:success, screen_id, last_refresh, is_screen)
         json(conn, ScreenData.by_screen_id(screen_id))
     end
   end


### PR DESCRIPTION
**Asana task**: [Log successful API responses](https://app.asana.com/0/1185117109217413/1202116831580950/f)

v1 was already _kinda_ doing this, but was always logging responses with message `[screen api response success]`. I changed that to say the status of the response instead. 

v2 was not doing response logging at all so that was a straightforward addition to the controller logic.

- [ ] Needs version bump?
