### PR TITLE
Headsigns for new Pre-Fare screens

### DIFF
--- a/assets/src/components/v2/reconstructed_takeover.tsx
+++ b/assets/src/components/v2/reconstructed_takeover.tsx
@@ -16,7 +16,6 @@ interface ReconAlertProps {
 const ReconstructedTakeover: React.ComponentType<ReconAlertProps> = (alert) => {
   const {cause, effect, issue, location, remedy, routes} = alert
 
-  console.log('issue', issue)
   return (
     <>
       <div className={classWithModifiers("alert-container", ["takeover", "urgent", routes.length > 1 ? "yellow" : routes[0].color])}>

--- a/config/config.exs
+++ b/config/config.exs
@@ -150,10 +150,33 @@ config :screens,
       {"70019", "70015", "Oak Grove"},
       {"70014", "70018", "Forest Hills"}
     ],
+    # Back Bay
+    "place-bbsta" => [
+      {"70017", "70013", "Oak Grove"},
+      {"70012", "70016", "Forest Hills"}
+    ],
+    # Forest Hills
+    "place-forhl" => [
+      {"70003", nil, "Oak Grove"},
+    ],
     # Maverick
     "place-mvbcl" => [
       {"70048", "70044", "Wonderland"},
       {"70043", "70047", "Bowdoin"}
+    ],
+    # Ashmont
+    "place-asmnl" => [
+      {"70092", nil, "Alewife"},
+    ],
+    # Charles/MGH
+    "place-chmnl" => [
+      {"70072", "70076", "Alewife"},
+      {"70075", "70071", "Ashmont/Braintree"}
+    ],
+    # Porter
+    "place-portr" => [
+      {"70064", "70068", "Alewife"},
+      {"70067", "70063", "Ashmont/Braintree"}
     ]
   },
   # Stop IDs at stations serviced by two subway lines, where we also have DUP screens.

--- a/lib/screens/v2/candidate_generator/widgets/reconstructed_alert.ex
+++ b/lib/screens/v2/candidate_generator/widgets/reconstructed_alert.ex
@@ -30,18 +30,21 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlert do
       ) do
     # Filtering by subway and light_rail types
     with {:ok, routes_at_stop} <- fetch_routes_by_stop_fn.(stop_id, now, [0, 1]),
-         route_ids_at_stop = Enum.map(routes_at_stop, & &1.route_id),
+         route_ids_at_stop = routes_at_stop
+         |> Enum.map(& &1.route_id)
+         # We shouldn't handle Mattapan outages at this time
+         |> Enum.reject(fn id -> id === "Mattapan" end),
          {:ok, alerts} <- fetch_alerts_fn.(route_ids: route_ids_at_stop),
-         {:ok, station_sequences} <-
+         {:ok, stop_sequences} <-
            fetch_stop_sequences_by_stop_fn.(stop_id, route_ids_at_stop) do
       alerts
-      |> Enum.filter(&relevant?(&1, config, station_sequences, routes_at_stop, now))
+      |> Enum.filter(&relevant?(&1, config, stop_sequences, routes_at_stop, now))
       |> Enum.map(fn alert ->
         %ReconstructedAlert{
           screen: config,
           alert: alert,
           now: now,
-          stop_sequences: station_sequences,
+          stop_sequences: stop_sequences,
           routes_at_stop: routes_at_stop,
           informed_stations_string: get_stations(alert, fetch_stop_name_fn)
         }

--- a/lib/screens/v2/widget_instance/reconstructed_alert.ex
+++ b/lib/screens/v2/widget_instance/reconstructed_alert.ex
@@ -113,6 +113,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
     end
   end
 
+  defp to_set(nil), do: MapSet.new([])
   defp to_set(stop_id) when is_binary(stop_id), do: MapSet.new([stop_id])
   defp to_set(stop_ids), do: MapSet.new(stop_ids)
 


### PR DESCRIPTION
**Asana task**: [Add stations to the destination lookup table as needed](https://app.asana.com/0/1185117109217413/1202101724194527)

Added headsigns to config of new Pre-Fare screens (headsigns are needed for reconstructed alerts)

Also fixed Mattapan error that only appears for Ashmont. (We need to filter out "Mattapan" from the route ids associated with Ashmont to prevent Mattapan alerts from being returned)
