### PR TITLE
fix: screen_side logging

### DIFF
--- a/lib/screens/log_screen_data.ex
+++ b/lib/screens/log_screen_data.ex
@@ -5,12 +5,9 @@ defmodule Screens.LogScreenData do
 
   def log_page_load(screen_id, is_screen, screen_side \\ nil) do
     if is_screen do
-      data = %{screen_id: screen_id, screen_name: screen_name_for_id(screen_id)}
-
-      _ =
-        if not is_nil(screen_side) do
-          Map.put(data, :screen_side, screen_side)
-        end
+      data =
+        %{screen_id: screen_id, screen_name: screen_name_for_id(screen_id)}
+        |> insert_screen_side(screen_side)
 
       log_message("[screen page load]", data)
     end
@@ -18,16 +15,13 @@ defmodule Screens.LogScreenData do
 
   def log_data_request(screen_id, last_refresh, is_screen, screen_side \\ nil) do
     if is_screen do
-      data = %{
-        screen_id: screen_id,
-        screen_name: screen_name_for_id(screen_id),
-        last_refresh: last_refresh
-      }
-
-      _ =
-        if not is_nil(screen_side) do
-          Map.put(data, :screen_side, screen_side)
-        end
+      data =
+        %{
+          screen_id: screen_id,
+          screen_name: screen_name_for_id(screen_id),
+          last_refresh: last_refresh
+        }
+        |> insert_screen_side(screen_side)
 
       log_message("[screen data request]", data)
     end
@@ -72,16 +66,13 @@ defmodule Screens.LogScreenData do
 
   defp log_api_response_success(screen_id, last_refresh, is_screen, status, screen_side) do
     if is_screen do
-      data = %{
-        screen_id: screen_id,
-        screen_name: screen_name_for_id(screen_id),
-        last_refresh: last_refresh
-      }
-
-      _ =
-        if not is_nil(screen_side) do
-          Map.put(data, :screen_side, screen_side)
-        end
+      data =
+        %{
+          screen_id: screen_id,
+          screen_name: screen_name_for_id(screen_id),
+          last_refresh: last_refresh
+        }
+        |> insert_screen_side(screen_side)
 
       log_message("[screen api response #{status}]", data)
     end
@@ -129,4 +120,7 @@ defmodule Screens.LogScreenData do
     %Screen{name: name} = State.screen(screen_id)
     name
   end
+
+  defp insert_screen_side(data, nil), do: data
+  defp insert_screen_side(data, screen_side), do: Map.put(data, :screen_side, screen_side)
 end

--- a/lib/screens_web/controllers/v2/screen_api_controller.ex
+++ b/lib/screens_web/controllers/v2/screen_api_controller.ex
@@ -18,29 +18,58 @@ defmodule ScreensWeb.V2.ScreenApiController do
 
   def show(conn, %{"id" => screen_id, "last_refresh" => last_refresh} = params) do
     is_screen = ScreensWeb.UserAgent.is_screen_conn?(conn, screen_id)
+    screen_side = params["screen_side"]
 
     Screens.LogScreenData.log_data_request(
       screen_id,
       last_refresh,
       is_screen,
-      params["screen_side"]
+      screen_side
     )
 
     cond do
       nonexistent_screen?(screen_id) ->
-        Screens.LogScreenData.log_api_response(:nonexistent, screen_id, last_refresh, is_screen)
+        Screens.LogScreenData.log_api_response(
+          :nonexistent,
+          screen_id,
+          last_refresh,
+          is_screen,
+          screen_side
+        )
+
         not_found_response(conn)
 
       outdated?(screen_id, last_refresh) ->
-        Screens.LogScreenData.log_api_response(:outdated, screen_id, last_refresh, is_screen)
+        Screens.LogScreenData.log_api_response(
+          :outdated,
+          screen_id,
+          last_refresh,
+          is_screen,
+          screen_side
+        )
+
         json(conn, ScreenData.outdated_response())
 
       disabled?(screen_id) ->
-        Screens.LogScreenData.log_api_response(:disabled, screen_id, last_refresh, is_screen)
+        Screens.LogScreenData.log_api_response(
+          :disabled,
+          screen_id,
+          last_refresh,
+          is_screen,
+          screen_side
+        )
+
         json(conn, ScreenData.disabled_response())
 
       true ->
-        Screens.LogScreenData.log_api_response(:success, screen_id, last_refresh, is_screen)
+        Screens.LogScreenData.log_api_response(
+          :success,
+          screen_id,
+          last_refresh,
+          is_screen,
+          screen_side
+        )
+
         json(conn, ScreenData.by_screen_id(screen_id))
     end
   end


### PR DESCRIPTION
**Asana task**: ad-hoc

Didn't think about how `Map.put` returns the updated map and doesn't update map in place, so it wasn't actually doing anything. Also added `screen_side` to response logging.

- [ ] Needs version bump?
