### PR TITLE
tweak: Change boundary shuttle/suspensions at terminals to takeover

### DIFF
--- a/lib/screens/v2/candidate_generator/widgets/reconstructed_alert.ex
+++ b/lib/screens/v2/candidate_generator/widgets/reconstructed_alert.ex
@@ -48,7 +48,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlert do
           stop_sequences: stop_sequences,
           routes_at_stop: routes_at_stop,
           informed_stations_string: get_stations(alert, fetch_stop_name_fn),
-          is_terminal: is_terminal?(stop_id, stop_sequences)
+          is_terminal_station: is_terminal?(stop_id, stop_sequences)
         }
       end)
     else

--- a/lib/screens/v2/candidate_generator/widgets/reconstructed_alert.ex
+++ b/lib/screens/v2/candidate_generator/widgets/reconstructed_alert.ex
@@ -47,7 +47,8 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlert do
           now: now,
           stop_sequences: stop_sequences,
           routes_at_stop: routes_at_stop,
-          informed_stations_string: get_stations(alert, fetch_stop_name_fn)
+          informed_stations_string: get_stations(alert, fetch_stop_name_fn),
+          is_terminal: is_terminal?(stop_id, stop_sequences)
         }
       end)
     else
@@ -118,4 +119,10 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlert do
         |> Util.format_name_list_to_string()
     end
   end
+
+  defp is_terminal?(stop_id, [stop_sequence]) do
+    List.first(stop_sequence) == stop_id or List.last(stop_sequence) == stop_id
+  end
+
+  defp is_terminal?(_, _), do: false
 end

--- a/lib/screens/v2/candidate_generator/widgets/reconstructed_alert.ex
+++ b/lib/screens/v2/candidate_generator/widgets/reconstructed_alert.ex
@@ -120,9 +120,9 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlert do
     end
   end
 
-  defp is_terminal?(stop_id, [stop_sequence]) do
-    List.first(stop_sequence) == stop_id or List.last(stop_sequence) == stop_id
+  defp is_terminal?(stop_id, stop_sequences) do
+    Enum.any?(stop_sequences, fn stop_sequence ->
+      List.first(stop_sequence) == stop_id or List.last(stop_sequence) == stop_id
+    end)
   end
-
-  defp is_terminal?(_, _), do: false
 end

--- a/lib/screens/v2/widget_instance/alert.ex
+++ b/lib/screens/v2/widget_instance/alert.ex
@@ -8,6 +8,7 @@ defmodule Screens.V2.WidgetInstance.Alert do
   alias Screens.RouteType
   alias Screens.Util
   alias Screens.V2.WidgetInstance
+  alias Screens.V2.WidgetInstance.ReconstructedAlert
   alias Screens.V2.WidgetInstance.Common.BaseAlert
   alias Screens.V2.WidgetInstance.Serializer.RoutePill
 
@@ -155,9 +156,12 @@ defmodule Screens.V2.WidgetInstance.Alert do
       BaseAlert.location(t) == :inside
   end
 
-  def takeover_alert?(%{screen: %Screen{app_id: :pre_fare_v2}} = t) do
+  def takeover_alert?(
+        %ReconstructedAlert{screen: %Screen{app_id: :pre_fare_v2}, is_terminal: is_terminal} = t
+      ) do
     active?(t) and effect(t) in [:station_closure, :suspension, :shuttle] and
-      BaseAlert.location(t) == :inside and informs_all_active_routes_at_home_stop?(t)
+      ((BaseAlert.location(t) == :inside and informs_all_active_routes_at_home_stop?(t)) or
+         is_terminal)
   end
 
   defp takeover_slot_names(%__MODULE__{screen: %Screen{app_id: :bus_shelter_v2}}) do
@@ -262,7 +266,7 @@ defmodule Screens.V2.WidgetInstance.Alert do
     |> MapSet.new()
   end
 
-  @spec effect(t()) :: Alert.effect()
+  @spec effect(t() | ReconstructedAlert.t()) :: Alert.effect()
   def effect(%{alert: %Alert{effect: effect}}), do: effect
 
   def all_routes_at_stop(%{routes_at_stop: routes}) do

--- a/lib/screens/v2/widget_instance/alert.ex
+++ b/lib/screens/v2/widget_instance/alert.ex
@@ -8,8 +8,8 @@ defmodule Screens.V2.WidgetInstance.Alert do
   alias Screens.RouteType
   alias Screens.Util
   alias Screens.V2.WidgetInstance
-  alias Screens.V2.WidgetInstance.ReconstructedAlert
   alias Screens.V2.WidgetInstance.Common.BaseAlert
+  alias Screens.V2.WidgetInstance.ReconstructedAlert
   alias Screens.V2.WidgetInstance.Serializer.RoutePill
 
   defstruct screen: nil,

--- a/lib/screens/v2/widget_instance/alert.ex
+++ b/lib/screens/v2/widget_instance/alert.ex
@@ -157,11 +157,11 @@ defmodule Screens.V2.WidgetInstance.Alert do
   end
 
   def takeover_alert?(
-        %ReconstructedAlert{screen: %Screen{app_id: :pre_fare_v2}, is_terminal: is_terminal} = t
+        %{screen: %Screen{app_id: :pre_fare_v2}, is_terminal_station: is_terminal_station} = t
       ) do
     active?(t) and effect(t) in [:station_closure, :suspension, :shuttle] and
-      ((BaseAlert.location(t) == :inside and informs_all_active_routes_at_home_stop?(t)) or
-         is_terminal)
+      BaseAlert.location(t, is_terminal_station) == :inside and
+      informs_all_active_routes_at_home_stop?(t)
   end
 
   defp takeover_slot_names(%__MODULE__{screen: %Screen{app_id: :bus_shelter_v2}}) do

--- a/lib/screens/v2/widget_instance/reconstructed_alert.ex
+++ b/lib/screens/v2/widget_instance/reconstructed_alert.ex
@@ -15,7 +15,8 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
             now: nil,
             stop_sequences: nil,
             routes_at_stop: nil,
-            informed_stations_string: nil
+            informed_stations_string: nil,
+            is_terminal: false
 
   @type stop_id :: String.t()
 
@@ -27,7 +28,8 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
           now: DateTime.t(),
           stop_sequences: list(list(stop_id())),
           routes_at_stop: list(%{route_id: route_id(), active?: boolean()}),
-          informed_stations_string: String.t()
+          informed_stations_string: String.t(),
+          is_terminal: boolean()
         }
 
   @route_directions %{

--- a/test/screens/v2/candidate_generator/widgets/reconstructed_alert_test.exs
+++ b/test/screens/v2/candidate_generator/widgets/reconstructed_alert_test.exs
@@ -152,7 +152,8 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlertTest do
         routes_at_stop: routes_at_stop,
         stop_sequences: station_sequences,
         now: now,
-        informed_stations_string: informed_stations_string
+        informed_stations_string: informed_stations_string,
+        is_terminal: true
       }
 
       expected_widgets = [
@@ -289,7 +290,8 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlertTest do
         routes_at_stop: routes_at_stop,
         stop_sequences: station_sequences,
         now: now,
-        informed_stations_string: ""
+        informed_stations_string: "",
+        is_terminal: true
       }
 
       expected_widgets = [

--- a/test/screens/v2/candidate_generator/widgets/reconstructed_alert_test.exs
+++ b/test/screens/v2/candidate_generator/widgets/reconstructed_alert_test.exs
@@ -153,7 +153,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlertTest do
         stop_sequences: station_sequences,
         now: now,
         informed_stations_string: informed_stations_string,
-        is_terminal: true
+        is_terminal_station: true
       }
 
       expected_widgets = [
@@ -291,7 +291,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlertTest do
         stop_sequences: station_sequences,
         now: now,
         informed_stations_string: "",
-        is_terminal: true
+        is_terminal_station: true
       }
 
       expected_widgets = [

--- a/test/screens/v2/widget_instance/reconstructed_alert_test.exs
+++ b/test/screens/v2/widget_instance/reconstructed_alert_test.exs
@@ -77,8 +77,8 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
     %{widget | alert: %{widget.alert | severity: severity}}
   end
 
-  defp put_is_terminal(widget, is_terminal) do
-    %{widget | is_terminal: is_terminal}
+  defp put_is_terminal_station(widget, is_terminal_station) do
+    %{widget | is_terminal_station: is_terminal_station}
   end
 
   defp ie(opts) do
@@ -229,7 +229,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
       widget =
         widget
         |> put_home_stop(PreFare, "place-forhl")
-        |> put_informed_entities([ie(stop: "place-dwnxg"), ie(stop: "place-pktrm")])
+        |> put_informed_entities([ie(stop: "place-chncl"), ie(stop: "place-forhl")])
         |> put_effect(:suspension)
         |> put_stop_sequences([
           [
@@ -239,7 +239,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
             "place-forhl"
           ]
         ])
-        |> put_is_terminal(true)
+        |> put_is_terminal_station(true)
 
       assert [1] == WidgetInstance.priority(widget)
       assert [:full_body] == WidgetInstance.slot_names(widget)
@@ -383,7 +383,17 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
             "place-forhl"
           ]
         ])
-        |> put_is_terminal(true)
+        |> put_is_terminal_station(true)
+        |> put_routes_at_stop([
+          %{
+            route_id: "Orange",
+            active?: true,
+            direction_destinations: nil,
+            long_name: nil,
+            short_name: nil,
+            type: :subway
+          }
+        ])
 
       expected = %{
         issue: %{icon: nil, text: ["No", %{route: "orange"}, "trains"]},
@@ -419,7 +429,17 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
             "place-forhl"
           ]
         ])
-        |> put_is_terminal(true)
+        |> put_is_terminal_station(true)
+        |> put_routes_at_stop([
+          %{
+            route_id: "Orange",
+            active?: true,
+            direction_destinations: nil,
+            long_name: nil,
+            short_name: nil,
+            type: :subway
+          }
+        ])
 
       expected = %{
         issue: %{icon: nil, text: ["No", %{route: "orange"}, "trains"]},

--- a/test/screens/v2/widget_instance/reconstructed_alert_test.exs
+++ b/test/screens/v2/widget_instance/reconstructed_alert_test.exs
@@ -663,6 +663,54 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
   describe "serialize_boundary_alert/1" do
     setup @alert_widget_context_setup_group ++ [:setup_active_period]
 
+    test "handles suspension", %{widget: widget} do
+      widget =
+        widget
+        |> put_effect(:suspension)
+        |> put_informed_entities([
+          ie(stop: "place-dwnxg", route: "Red", direction_id: 1),
+          ie(stop: "place-pktrm", route: "Red", direction_id: 1)
+        ])
+        |> put_cause(:unknown)
+
+      expected = %{
+        issue: "No Alewife trains",
+        location: "",
+        cause: "",
+        routes: [%{color: :red, text: "RED LINE", type: :text}],
+        effect: :suspension,
+        urgent: true,
+        region: :boundary,
+        remedy: "Seek alternate route"
+      }
+
+      assert expected == ReconstructedAlert.serialize(widget)
+    end
+
+    test "handles shuttle", %{widget: widget} do
+      widget =
+        widget
+        |> put_effect(:shuttle)
+        |> put_informed_entities([
+          ie(stop: "place-dwnxg", route: "Red", direction_id: 1),
+          ie(stop: "place-pktrm", route: "Red", direction_id: 1)
+        ])
+        |> put_cause(:unknown)
+
+      expected = %{
+        issue: "No Alewife trains",
+        location: "",
+        cause: "",
+        routes: [%{color: :red, text: "RED LINE", type: :text}],
+        effect: :shuttle,
+        urgent: true,
+        region: :boundary,
+        remedy: "Use shuttle bus"
+      }
+
+      assert expected == ReconstructedAlert.serialize(widget)
+    end
+
     test "handles moderate delay", %{widget: widget} do
       widget =
         widget

--- a/test/screens/v2/widget_instance/reconstructed_alert_test.exs
+++ b/test/screens/v2/widget_instance/reconstructed_alert_test.exs
@@ -246,8 +246,66 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
       assert :reconstructed_takeover == WidgetInstance.widget_type(widget)
     end
 
+    test "returns takeover for a terminal boundary shuttle", %{widget: widget} do
+      widget =
+        widget
+        |> put_home_stop(PreFare, "place-forhl")
+        |> put_informed_entities([ie(stop: "place-chncl"), ie(stop: "place-forhl")])
+        |> put_effect(:shuttle)
+        |> put_stop_sequences([
+          [
+            "place-ogmnl",
+            "place-dwnxg",
+            "place-chncl",
+            "place-forhl"
+          ]
+        ])
+        |> put_is_terminal_station(true)
+
+      assert [1] == WidgetInstance.priority(widget)
+      assert [:full_body] == WidgetInstance.slot_names(widget)
+      assert :reconstructed_takeover == WidgetInstance.widget_type(widget)
+    end
+
     test "returns flex zone alert for a severe delay", %{widget: widget} do
       widget = put_effect(widget, :severe_delay)
+      assert [3] == WidgetInstance.priority(widget)
+      assert [:large] == WidgetInstance.slot_names(widget)
+      assert :reconstructed_large_alert == WidgetInstance.widget_type(widget)
+    end
+
+    test "returns flex zone alert for a boundary suspension", %{widget: widget} do
+      widget = put_informed_entities(widget, [ie(stop: "place-dwnxg"), ie(stop: "place-pktrm")])
+      widget = put_effect(widget, :suspension)
+      assert [3] == WidgetInstance.priority(widget)
+      assert [:large] == WidgetInstance.slot_names(widget)
+      assert :reconstructed_large_alert == WidgetInstance.widget_type(widget)
+    end
+
+    test "returns flex zone alert for a boundary shuttle", %{widget: widget} do
+      widget = put_informed_entities(widget, [ie(stop: "place-dwnxg"), ie(stop: "place-pktrm")])
+      widget = put_effect(widget, :shuttle)
+      assert [3] == WidgetInstance.priority(widget)
+      assert [:large] == WidgetInstance.slot_names(widget)
+      assert :reconstructed_large_alert == WidgetInstance.widget_type(widget)
+    end
+
+    test "returns flex zone alert for a terminal boundary delay", %{widget: widget} do
+      widget =
+        widget
+        |> put_home_stop(PreFare, "place-forhl")
+        |> put_informed_entities([ie(stop: "place-chncl"), ie(stop: "place-forhl")])
+        |> put_effect(:severe_delay)
+        |> put_stop_sequences([
+          [
+            "place-ogmnl",
+            "place-dwnxg",
+            "place-chncl",
+            "place-forhl"
+          ]
+        ])
+        |> put_is_terminal_station(true)
+
       assert [3] == WidgetInstance.priority(widget)
       assert [:large] == WidgetInstance.slot_names(widget)
       assert :reconstructed_large_alert == WidgetInstance.widget_type(widget)


### PR DESCRIPTION
**Asana task**: [[Pre-fare] Terminal suspension/shuttle alerts should be full screen](https://app.asana.com/0/1185117109217413/1202176930559885/f)

The way I did this feels messy, so I'm open to suggestions if you agree. I tested this pretty heavily and everything is working as it should, so there may not be any need for changes. 

- [ ] Needs version bump?
