### PR TITLE
bugfix: Elevator closure timestamp for upcoming events

### DIFF
--- a/assets/src/components/v2/elevator_status.tsx
+++ b/assets/src/components/v2/elevator_status.tsx
@@ -166,7 +166,9 @@ const getTimeframeEndText = (
     if (activePeriod.end === null) {
       endText = `Starting ${startDate.format("MMM D")}`;
     } else {
-      const endDate = moment(activePeriod.end).tz("America/New_York");
+      // We use the Los Angeles TZ whenever we want "end of service" to reflect
+      // the previous day's date.
+      const endDate = moment(activePeriod.end).tz("America/Los_Angeles");
       if (startDate.month() === endDate.month()) {
         if (startDate.day() === endDate.day()) {
           endText = `${startDate.format("MMM D")}`;


### PR DESCRIPTION
**Asana task**: [[Pre-fare] Inconsistent dates in elevator alert detail view](https://app.asana.com/0/1185117109217413/1202230640868854)

Use LA timezone to shift an "end of service" date on an elevator closure to the previous day.