### PR TITLE
Prevent V3 API requests from being added to tests; fixed tests

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,4 +2,4 @@
 
 Description
 
-- [ ] Needs version bump?
+- [ ] Tests added?

--- a/config/config.exs
+++ b/config/config.exs
@@ -18,6 +18,12 @@ config :screens, ScreensWeb.Endpoint,
 config :logger,
   backends: [:console, Sentry.LoggerBackend]
 
+# Do not send local errors to Sentry
+config :sentry,
+  dsn: "",
+  environment_name: "dev",
+  included_environments: []
+
 # Configures Elixir's Logger
 config :logger, :console,
   format: "$time $metadata[$level] $message\n",

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -30,12 +30,6 @@ config :screens,
 
 config :screens, ScreensWeb.AuthManager, secret_key: "secret key"
 
-# Do not send local errors to Sentry
-config :sentry,
-  dsn: "",
-  environment_name: "dev",
-  included_environments: []
-
 config :ueberauth, Ueberauth,
   providers: [
     cognito: {Screens.Ueberauth.Strategy.Fake, []}

--- a/config/test.exs
+++ b/config/test.exs
@@ -9,7 +9,8 @@ config :screens, ScreensWeb.Endpoint,
 config :screens,
   config_fetcher: Screens.Config.State.LocalFetch,
   local_config_file_spec: {:test, "config.json"},
-  signs_ui_config_fetcher: Screens.SignsUiConfig.State.LocalFetch
+  signs_ui_config_fetcher: Screens.SignsUiConfig.State.LocalFetch,
+  default_api_v3_url: [:no_api_requests_allowed_during_testing]
 
 config :screens, ScreensWeb.AuthManager, secret_key: "test key"
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -10,6 +10,12 @@ config :screens,
   config_fetcher: Screens.Config.State.LocalFetch,
   local_config_file_spec: {:test, "config.json"},
   signs_ui_config_fetcher: Screens.SignsUiConfig.State.LocalFetch,
+  # This will help us write testable functions.
+  # Functions that request external data cause flaky tests, so to stop us from writing tests that execute API requests,
+  # we pass a non-string as the default URL (causing tests to break.)
+  #
+  # To write testable functions: pass request-firing functions as arguments. Default value can be the "normal" fetch function,
+  # and then during tests, we can pass a stubbed version
   default_api_v3_url: [:no_api_requests_allowed_during_testing]
 
 config :screens, ScreensWeb.AuthManager, secret_key: "test key"

--- a/lib/screens/v2/candidate_generator/gl_eink.ex
+++ b/lib/screens/v2/candidate_generator/gl_eink.ex
@@ -85,18 +85,18 @@ defmodule Screens.V2.CandidateGenerator.GlEink do
   def audio_only_instances(_widgets, _config), do: []
 
   defp line_map_instances(
-        %Screen{
-          app_params: %GlEink{
-            line_map: %V2.LineMap{
-              station_id: station_id,
-              direction_id: direction_id,
-              route_id: route_id
-            }
-          }
-        } = config,
-        stops_by_route_and_direction_fn \\ &RoutePattern.stops_by_route_and_direction/2,
-        fetch_departures_fn \\ &Screens.V2.Departure.fetch/2
-      ) do
+         %Screen{
+           app_params: %GlEink{
+             line_map: %V2.LineMap{
+               station_id: station_id,
+               direction_id: direction_id,
+               route_id: route_id
+             }
+           }
+         } = config,
+         stops_by_route_and_direction_fn \\ &RoutePattern.stops_by_route_and_direction/2,
+         fetch_departures_fn \\ &Screens.V2.Departure.fetch/2
+       ) do
     {:ok, stops} = stops_by_route_and_direction_fn.(route_id, direction_id)
     {:ok, reverse_stops} = stops_by_route_and_direction_fn.(route_id, 1 - direction_id)
 

--- a/lib/screens/v2/candidate_generator/gl_eink.ex
+++ b/lib/screens/v2/candidate_generator/gl_eink.ex
@@ -84,7 +84,7 @@ defmodule Screens.V2.CandidateGenerator.GlEink do
   @impl CandidateGenerator
   def audio_only_instances(_widgets, _config), do: []
 
-  def line_map_instances(
+  defp line_map_instances(
         %Screen{
           app_params: %GlEink{
             line_map: %V2.LineMap{
@@ -93,13 +93,15 @@ defmodule Screens.V2.CandidateGenerator.GlEink do
               route_id: route_id
             }
           }
-        } = config
+        } = config,
+        stops_by_route_and_direction_fn \\ &RoutePattern.stops_by_route_and_direction/2,
+        fetch_departures_fn \\ &Screens.V2.Departure.fetch/2
       ) do
-    {:ok, stops} = RoutePattern.stops_by_route_and_direction(route_id, direction_id)
-    {:ok, reverse_stops} = RoutePattern.stops_by_route_and_direction(route_id, 1 - direction_id)
+    {:ok, stops} = stops_by_route_and_direction_fn.(route_id, direction_id)
+    {:ok, reverse_stops} = stops_by_route_and_direction_fn.(route_id, 1 - direction_id)
 
     {:ok, departures} =
-      Screens.V2.Departure.fetch(%{stop_ids: [station_id]},
+      fetch_departures_fn.(%{stop_ids: [station_id]},
         include_schedules: true,
         now: DateTime.add(DateTime.utc_now(), -@scheduled_terminal_departure_lookback_seconds)
       )
@@ -139,7 +141,7 @@ defmodule Screens.V2.CandidateGenerator.GlEink do
     end
   end
 
-  defp footer_instances(config) do
+  def footer_instances(config) do
     %Screen{
       app_params: %GlEink{footer: %Footer{stop_id: stop_id}}
     } = config

--- a/lib/screens/v2/candidate_generator/pre_fare.ex
+++ b/lib/screens/v2/candidate_generator/pre_fare.ex
@@ -93,7 +93,7 @@ defmodule Screens.V2.CandidateGenerator.PreFare do
         config,
         now,
         fetch_stop_name_fn \\ &Stop.fetch_stop_name/1
-    ) do
+      ) do
     %Screen{app_params: %PreFare{header: %CurrentStopId{stop_id: stop_id}}} = config
 
     stop_name = fetch_stop_name_fn.(stop_id)

--- a/lib/screens/v2/candidate_generator/pre_fare.ex
+++ b/lib/screens/v2/candidate_generator/pre_fare.ex
@@ -89,10 +89,14 @@ defmodule Screens.V2.CandidateGenerator.PreFare do
     |> Enum.flat_map(fn {:ok, instances} -> instances end)
   end
 
-  defp header_instances(config, now) do
+  def header_instances(
+        config,
+        now,
+        fetch_stop_name_fn \\ &Stop.fetch_stop_name/1
+    ) do
     %Screen{app_params: %PreFare{header: %CurrentStopId{stop_id: stop_id}}} = config
 
-    stop_name = Stop.fetch_stop_name(stop_id)
+    stop_name = fetch_stop_name_fn.(stop_id)
 
     [%NormalHeader{screen: config, text: stop_name, time: now}]
   end

--- a/test/screens/v2/candidate_generator/bus_shelter_test.exs
+++ b/test/screens/v2/candidate_generator/bus_shelter_test.exs
@@ -79,6 +79,7 @@ defmodule Screens.V2.CandidateGenerator.BusShelterTest do
       fetch_stop_fn = fn "1216" -> "Columbus Ave @ Dimock St" end
       now = ~U[2020-04-06T10:00:00Z]
       evergreen_content_instances_fn = fn _ -> [] end
+      subway_status_instances_fn = fn _ -> [] end
 
       expected_header = %NormalHeader{
         screen: config,
@@ -96,7 +97,8 @@ defmodule Screens.V2.CandidateGenerator.BusShelterTest do
           fetch_stop_fn,
           departures_instances_fn,
           alert_instances_fn,
-          evergreen_content_instances_fn
+          evergreen_content_instances_fn,
+          subway_status_instances_fn
         )
 
       assert expected_header in actual_instances
@@ -112,6 +114,7 @@ defmodule Screens.V2.CandidateGenerator.BusShelterTest do
       fetch_stop_fn = fn "1216" -> raise "This should not be called!" end
       now = ~U[2020-04-06T10:00:00Z]
       evergreen_content_instances_fn = fn _ -> [] end
+      subway_status_instances_fn = fn _ -> [] end
 
       expected_header = %NormalHeader{
         screen: config,
@@ -127,7 +130,8 @@ defmodule Screens.V2.CandidateGenerator.BusShelterTest do
           fetch_stop_fn,
           departures_instances_fn,
           alert_instances_fn,
-          evergreen_content_instances_fn
+          evergreen_content_instances_fn,
+          subway_status_instances_fn
         )
 
       assert expected_header in actual_instances

--- a/test/screens/v2/candidate_generator/gl_eink_test.exs
+++ b/test/screens/v2/candidate_generator/gl_eink_test.exs
@@ -59,22 +59,16 @@ defmodule Screens.V2.CandidateGenerator.GlEinkTest do
     end
   end
 
-  describe "candidate_instances/3" do
+  describe "header_instances/3" do
     test "returns expected header", %{config: config} do
-      departures_instances_fn = fn _, _, _ -> [] end
-      alerts_instances_fn = fn _ -> [] end
       fetch_destination_fn = fn "Green-C", 0 -> "Cleveland Circle" end
       now = ~U[2020-04-06T10:00:00Z]
-      evergreen_content_instances_fn = fn _ -> [] end
 
       actual_instances =
-        GlEink.candidate_instances(
+        GlEink.header_instances(
           config,
           now,
-          fetch_destination_fn,
-          departures_instances_fn,
-          alerts_instances_fn,
-          evergreen_content_instances_fn
+          fetch_destination_fn
         )
 
       expected_header = %NormalHeader{
@@ -84,6 +78,15 @@ defmodule Screens.V2.CandidateGenerator.GlEinkTest do
         time: ~U[2020-04-06T10:00:00Z]
       }
 
+      assert expected_header in actual_instances
+    end
+  end
+
+  describe "footer_instances/1" do
+    test "returns expected footer", %{config: config} do
+
+      actual_instances = GlEink.footer_instances(config)
+
       expected_footer = %FareInfoFooter{
         screen: config,
         mode: :subway,
@@ -91,7 +94,6 @@ defmodule Screens.V2.CandidateGenerator.GlEinkTest do
         url: "mbta.com/stops/1722"
       }
 
-      assert expected_header in actual_instances
       assert expected_footer in actual_instances
     end
   end

--- a/test/screens/v2/candidate_generator/gl_eink_test.exs
+++ b/test/screens/v2/candidate_generator/gl_eink_test.exs
@@ -84,7 +84,6 @@ defmodule Screens.V2.CandidateGenerator.GlEinkTest do
 
   describe "footer_instances/1" do
     test "returns expected footer", %{config: config} do
-
       actual_instances = GlEink.footer_instances(config)
 
       expected_footer = %FareInfoFooter{

--- a/test/screens/v2/candidate_generator/pre_fare_test.exs
+++ b/test/screens/v2/candidate_generator/pre_fare_test.exs
@@ -81,29 +81,25 @@ defmodule Screens.V2.CandidateGenerator.PreFareTest do
     end
   end
 
-  describe "candidate_instances/3" do
+  describe "header_instances/3" do
     test "returns expected header", %{config: config} do
       now = ~U[2020-04-06T10:00:00Z]
-      subway_status_instance_fn = fn _ -> [] end
-      reconstructed_alert_instances_fn = fn _ -> [] end
-      elevator_status_instances_fn = fn _, _ -> [] end
+      fetch_stop_name_fn = fn _ -> "Test Stop" end
 
       expected_header = [
         %NormalHeader{
           screen: config,
           icon: nil,
-          text: "Government Center",
+          text: "Test Stop",
           time: ~U[2020-04-06T10:00:00Z]
         }
       ]
 
       actual_instances =
-        PreFare.candidate_instances(
+        PreFare.header_instances(
           config,
           now,
-          subway_status_instance_fn,
-          reconstructed_alert_instances_fn,
-          elevator_status_instances_fn
+          fetch_stop_name_fn
         )
 
       assert Enum.all?(expected_header, fn x -> x in actual_instances end)


### PR DESCRIPTION
**Asana task**: [[tech debt] Prevent V3 API (and other external) requests during unit testing](https://app.asana.com/0/1185117109217413/1202094695278057)

Added atom `default_api_v3_url` to force an error whenever an API request is made in a test.
Investigated preventing all HTTPoison requests from occurring during tests, but seems like adding ExVCR is the better solution, which would be a different task from this one.
Fixed tests that were relying on the API.
ALSO test failures were logging to Sentry, so fixed that.
