### PR TITLE
chore: Add custom credo check to prevent untestable `now` values in functions

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -2,11 +2,13 @@
   configs: [
     %{
       name: "default",
+      requires: ["lib/screens/checks/**/*.ex"],
       files: %{
         included: ["lib/"],
         excluded: []
       },
       checks: [
+        {Screens.Checks.UntestableDateTime},
         {Credo.Check.Design.AliasUsage, false},
         {Credo.Check.Readability.MaxLineLength, false},
         {Credo.Check.Consistency.ExceptionNames},

--- a/lib/screens/bus_screen_data.ex
+++ b/lib/screens/bus_screen_data.ex
@@ -9,18 +9,18 @@ defmodule Screens.BusScreenData do
   alias Screens.Config.{Bus, State}
   alias Screens.Util
 
-  def by_screen_id(screen_id, is_screen) do
+  def by_screen_id(screen_id, is_screen, now \\ DateTime.utc_now()) do
     if State.mode_disabled?(:bus) do
       %{
         force_reload: false,
         success: false
       }
     else
-      by_enabled_screen_id(screen_id, is_screen)
+      by_enabled_screen_id(screen_id, is_screen, now)
     end
   end
 
-  defp by_enabled_screen_id(screen_id, is_screen) do
+  defp by_enabled_screen_id(screen_id, is_screen, now) do
     %Bus{stop_id: stop_id} = State.app_params(screen_id)
 
     # If we are unable to fetch alerts:
@@ -64,7 +64,6 @@ defmodule Screens.BusScreenData do
 
     {psa_type, psa_url} = Screens.Psa.current_psa_for(screen_id)
 
-    now = DateTime.utc_now()
     in_service_day? = in_service_day_at_stop?(stop_id, now)
 
     case departures do

--- a/lib/screens/checks/untestable_datetime.ex
+++ b/lib/screens/checks/untestable_datetime.ex
@@ -1,0 +1,109 @@
+# `use Credo.Check` generates a @moduledoc tag for the module, but Credo isn't smart enough to know that
+# credo:disable-for-next-line Credo.Check.Readability.ModuleDoc
+defmodule Screens.Checks.UntestableDateTime do
+  use Credo.Check,
+    base_priority: :high,
+    category: :warning,
+    explanations: [
+      check: """
+      Creating representations of "now" within a function's body
+      via `DateTime.utc_now/1` and similar functions causes the
+      function to be untestable. It's not possible to control the
+      "now" value from unit tests, so their outcomes can vary depending
+      on when they are run--that is, they become "flaky".
+
+      Instead, the "now" value should be taken as an argument with
+      a default value. (Or no default value if it's a private function)
+      In normal circumstances, the default value
+      will be used, but unit tests can pass their own fixed "now" value
+      so that they have full control over the test's outcome.
+
+      Untestable:
+
+          def after_noon_utc?, do: DateTime.utc_now().hour >= 12
+
+      Testable:
+
+          def after_noon_utc?(now \\\\ DateTime.utc_now()), do: now.hour >= 12
+
+      Using the testable function in production code:
+
+          if after_noon_utc?(), do: "Good afternoon", else: "Good morning"
+
+      Testing the testable function:
+
+          morning = ~U[2022-01-01T09:00:00Z]
+          afternoon = ~U[2022-01-01T15:00:00Z]
+
+          refute after_noon_utc?(morning)
+          assert after_noon_utc?(afternoon)
+      """
+    ]
+
+  @def_ops [:def, :defp]
+
+  @impl true
+  def run(source_file, params \\ []) do
+    issue_meta = IssueMeta.for(source_file, params)
+
+    Credo.Code.prewalk(source_file, &traverse(&1, &2, issue_meta))
+  end
+
+  for def_op <- @def_ops do
+    # Matches function definition with or without guards. Passes all blocks of the function body to secondary traverse function.
+    # NOTE: In addition to the usual `do` block, a function def can have additional `rescue`, `catch`, `after`, and `else` blocks.
+    # We consider all of these to be parts of the function body, so we enforce this check across all blocks.
+    defp traverse(
+           {unquote(def_op), _, [_func_head_or_guards, body_blocks]} = ast,
+           issues,
+           issue_meta
+         ) do
+      new_issues = Credo.Code.prewalk(body_blocks, &traverse_function_body(&1, &2, issue_meta))
+
+      {ast, issues ++ new_issues}
+    end
+  end
+
+  defp traverse(ast, issues, _issue_meta) do
+    {ast, issues}
+  end
+
+  @function_denylist [
+    {:DateTime, :utc_now, 0},
+    {:DateTime, :now, 1},
+    {:DateTime, :now!, 1},
+    {:Date, :utc_tody, 0},
+    {:NaiveDateTime, :local_now, 0},
+    {:NaiveDateTime, :utc_now, 0},
+    {:Time, :utc_now, 0}
+  ]
+
+  for {module, function, arity} = mfa <- @function_denylist do
+    quoted_mfa = Macro.escape(mfa)
+
+    # This function is only called once we're already looking inside a function's body.
+    # Any usages of one of the "now" functions that we find here are not allowed.
+    defp traverse_function_body(
+           {{:., _, [{:__aliases__, _, [unquote(module)]}, unquote(function)]}, meta, args} = ast,
+           issues,
+           issue_meta
+         )
+         when length(args) == unquote(arity) do
+      {ast, issues ++ [issue_for(unquote(quoted_mfa), meta[:line], issue_meta)]}
+    end
+  end
+
+  defp traverse_function_body(ast, issues, _issue_meta) do
+    {ast, issues}
+  end
+
+  defp issue_for({module, function, arity}, line_no, issue_meta) do
+    format_issue(
+      issue_meta,
+      message:
+        "To prevent flaky unit tests, a `now` value must be passed as an argument (with a default value if the function is public), not created in the function body.",
+      trigger: "#{module}.#{function}/#{arity}",
+      line_no: line_no
+    )
+  end
+end

--- a/lib/screens/checks/untestable_datetime.ex
+++ b/lib/screens/checks/untestable_datetime.ex
@@ -69,27 +69,25 @@ defmodule Screens.Checks.UntestableDateTime do
   end
 
   @function_denylist [
-    {:DateTime, :utc_now, 0},
-    {:DateTime, :now, 1},
-    {:DateTime, :now!, 1},
-    {:Date, :utc_tody, 0},
-    {:NaiveDateTime, :local_now, 0},
-    {:NaiveDateTime, :utc_now, 0},
-    {:Time, :utc_now, 0}
+    {:DateTime, :utc_now},
+    {:DateTime, :now},
+    {:DateTime, :now!},
+    {:Date, :utc_today},
+    {:NaiveDateTime, :local_now},
+    {:NaiveDateTime, :utc_now},
+    {:Time, :utc_now}
   ]
 
-  for {module, function, arity} = mfa <- @function_denylist do
-    quoted_mfa = Macro.escape(mfa)
-
+  for {module, function} = mf <- @function_denylist do
     # This function is only called once we're already looking inside a function's body.
     # Any usages of one of the "now" functions that we find here are not allowed.
     defp traverse_function_body(
            {{:., _, [{:__aliases__, _, [unquote(module)]}, unquote(function)]}, meta, args} = ast,
            issues,
            issue_meta
-         )
-         when length(args) == unquote(arity) do
-      {ast, issues ++ [issue_for(unquote(quoted_mfa), meta[:line], issue_meta)]}
+         ) do
+      mfa = Tuple.append(unquote(mf), length(args))
+      {ast, issues ++ [issue_for(mfa, meta[:line], issue_meta)]}
     end
   end
 

--- a/lib/screens/checks/untestable_datetime.ex
+++ b/lib/screens/checks/untestable_datetime.ex
@@ -5,7 +5,7 @@ defmodule Screens.Checks.UntestableDateTime do
     base_priority: :high,
     category: :warning,
     explanations: [
-      check: """
+      check: ~S"""
       Creating representations of "now" within a function's body
       via `DateTime.utc_now/1` and similar functions causes the
       function to be untestable. It's not possible to control the
@@ -24,7 +24,7 @@ defmodule Screens.Checks.UntestableDateTime do
 
       Testable:
 
-          def after_noon_utc?(now \\\\ DateTime.utc_now()), do: now.hour >= 12
+          def after_noon_utc?(now \\ DateTime.utc_now()), do: now.hour >= 12
 
       Using the testable function in production code:
 

--- a/lib/screens/checks/untestable_datetime.ex
+++ b/lib/screens/checks/untestable_datetime.ex
@@ -7,7 +7,7 @@ defmodule Screens.Checks.UntestableDateTime do
     explanations: [
       check: ~S"""
       Creating representations of "now" within a function's body
-      via `DateTime.utc_now/1` and similar functions causes the
+      via `DateTime.utc_now/0` and similar functions causes the
       function to be untestable. It's not possible to control the
       "now" value from unit tests, so their outcomes can vary depending
       on when they are run--that is, they become "flaky".

--- a/lib/screens/config.ex
+++ b/lib/screens/config.ex
@@ -18,11 +18,9 @@ defmodule Screens.Config do
 
   use Screens.Config.Struct, children: [screens: {:map, Screen}, devops: Devops]
 
-  @spec schedule_refresh_for_screen_ids(t(), list(String.t())) :: t()
-  def schedule_refresh_for_screen_ids(config, screen_ids) do
+  @spec schedule_refresh_for_screen_ids(t(), list(String.t()), DateTime.t()) :: t()
+  def schedule_refresh_for_screen_ids(config, screen_ids, now \\ DateTime.utc_now()) do
     %__MODULE__{screens: current_screens, devops: devops} = config
-
-    now = DateTime.utc_now()
 
     new_screens =
       current_screens

--- a/lib/screens/departures/departure.ex
+++ b/lib/screens/departures/departure.ex
@@ -451,8 +451,8 @@ defmodule Screens.Departures.Departure do
     end)
   end
 
-  def departure_in_past(%{departure_time: departure_time}) do
-    DateTime.compare(departure_time, DateTime.utc_now()) == :lt
+  def departure_in_past(%{departure_time: departure_time}, now \\ DateTime.utc_now()) do
+    DateTime.compare(departure_time, now) == :lt
   end
 
   def associate_alerts_with_departures(departures, alerts) do

--- a/lib/screens/dup_screen_data.ex
+++ b/lib/screens/dup_screen_data.ex
@@ -54,7 +54,7 @@ defmodule Screens.DupScreenData do
   end
 
   defp primary_screen_response(primary_departures, rotation_index, current_time) do
-    case SpecialCases.handle_special_cases(primary_departures, rotation_index) do
+    case SpecialCases.handle_special_cases(primary_departures, rotation_index, current_time) do
       {:ok, response} ->
         response
 

--- a/lib/screens/dup_screen_data.ex
+++ b/lib/screens/dup_screen_data.ex
@@ -11,28 +11,28 @@ defmodule Screens.DupScreenData do
 
   alias Screens.DupScreenData.{Data, Request, Response, SpecialCases}
 
-  def by_screen_id(screen_id, rotation_index)
+  def by_screen_id(screen_id, rotation_index, now \\ DateTime.utc_now())
 
-  def by_screen_id(screen_id, rotation_index) when rotation_index in ~w[0 1] do
+  def by_screen_id(screen_id, rotation_index, now) when rotation_index in ~w[0 1] do
     %Dup{primary: primary_departures, override: override} = State.app_params(screen_id)
     disabled = State.disabled?(screen_id)
 
     case {override, rotation_index, disabled} do
       {_, _, true} ->
-        disabled_response()
+        disabled_response(now)
 
       {nil, _, _} ->
-        primary_screen_response(primary_departures, rotation_index)
+        primary_screen_response(primary_departures, rotation_index, now)
 
       {{screen0, _}, "0", _} ->
-        primary_screen_response_with_override(primary_departures, rotation_index, screen0)
+        primary_screen_response_with_override(primary_departures, rotation_index, screen0, now)
 
       {{_, screen1}, "1", _} ->
-        primary_screen_response_with_override(primary_departures, rotation_index, screen1)
+        primary_screen_response_with_override(primary_departures, rotation_index, screen1, now)
     end
   end
 
-  def by_screen_id(screen_id, "2") do
+  def by_screen_id(screen_id, "2", now) do
     %Dup{secondary: secondary_departures} = State.app_params(screen_id)
 
     case secondary_departures do
@@ -40,14 +40,11 @@ defmodule Screens.DupScreenData do
         by_screen_id(screen_id, "0")
 
       _ ->
-        current_time = DateTime.utc_now()
-        fetch_departures_response(secondary_departures, %{}, current_time)
+        fetch_departures_response(secondary_departures, %{}, now)
     end
   end
 
-  defp disabled_response do
-    current_time = DateTime.utc_now()
-
+  defp disabled_response(current_time) do
     %{
       force_reload: false,
       success: true,
@@ -56,23 +53,21 @@ defmodule Screens.DupScreenData do
     }
   end
 
-  defp primary_screen_response(primary_departures, rotation_index) do
+  defp primary_screen_response(primary_departures, rotation_index, current_time) do
     case SpecialCases.handle_special_cases(primary_departures, rotation_index) do
       {:ok, response} ->
         response
 
       nil ->
-        default_primary_screen_response(primary_departures, rotation_index)
+        default_primary_screen_response(primary_departures, rotation_index, current_time)
     end
   end
 
-  defp default_primary_screen_response(primary_departures, rotation_index) do
+  defp default_primary_screen_response(primary_departures, rotation_index, current_time) do
     alerts_by_section = fetch_and_interpret_alerts(primary_departures)
     alerts = flatten_alerts(alerts_by_section)
 
     line_count = Data.station_line_count(primary_departures)
-
-    current_time = DateTime.utc_now()
 
     case Data.response_type(alerts, line_count, rotation_index) do
       :departures ->
@@ -89,14 +84,13 @@ defmodule Screens.DupScreenData do
   defp primary_screen_response_with_override(
          primary_departures,
          rotation_index,
-         %PartialAlertList{} = override
+         %PartialAlertList{} = override,
+         current_time
        ) do
     alerts_by_section = fetch_and_interpret_alerts(primary_departures)
     alerts = flatten_alerts(alerts_by_section)
 
     line_count = Data.station_line_count(primary_departures)
-
-    current_time = DateTime.utc_now()
 
     case Data.response_type(alerts, line_count, rotation_index) do
       :fullscreen_alert ->
@@ -107,7 +101,12 @@ defmodule Screens.DupScreenData do
     end
   end
 
-  defp primary_screen_response_with_override(primary_departures, _, %FullscreenAlert{} = override) do
+  defp primary_screen_response_with_override(
+         primary_departures,
+         _,
+         %FullscreenAlert{} = override,
+         _current_time
+       ) do
     alert_response = FullscreenAlert.to_json(override)
 
     Map.merge(
@@ -124,10 +123,9 @@ defmodule Screens.DupScreenData do
   defp primary_screen_response_with_override(
          _primary_departures,
          _,
-         %FullscreenImage{image_url: image_url}
+         %FullscreenImage{image_url: image_url},
+         current_time
        ) do
-    current_time = DateTime.utc_now()
-
     %{
       force_reload: false,
       success: true,

--- a/lib/screens/gl_screen_data.ex
+++ b/lib/screens/gl_screen_data.ex
@@ -32,6 +32,7 @@ defmodule Screens.GLScreenData do
       %{
         force_reload: false,
         success: true,
+        # credo:disable-for-next-line Screens.Checks.UntestableDateTime
         current_time: Screens.Util.format_time(DateTime.utc_now()),
         stop_name: destination,
         stop_id: stop_id,

--- a/lib/screens/line_map.ex
+++ b/lib/screens/line_map.ex
@@ -56,6 +56,7 @@ defmodule Screens.LineMap do
   end
 
   defp next_scheduled_departure(origin_stop_id, route_id, predictions) do
+    # credo:disable-for-next-line Screens.Checks.UntestableDateTime
     time = DateTime.add(DateTime.utc_now(), -180)
 
     case Screens.Schedules.Schedule.fetch(%{

--- a/lib/screens/psa.ex
+++ b/lib/screens/psa.ex
@@ -37,6 +37,7 @@ defmodule Screens.Psa do
   end
 
   defp get_active_psa_list(scheduled_overrides, default_list) do
+    # credo:disable-for-next-line Screens.Checks.UntestableDateTime
     now = DateTime.utc_now()
 
     Enum.find_value(scheduled_overrides, default_list, fn override ->
@@ -84,6 +85,7 @@ defmodule Screens.Psa do
   defp choose_from_rotating_list([psa], _), do: psa
 
   defp choose_from_rotating_list(list, seconds_to_show) do
+    # credo:disable-for-next-line Screens.Checks.UntestableDateTime
     t = DateTime.utc_now()
     seconds_since_midnight = t.hour * 60 * 60 + t.minute * 60 + t.second
     periods_since_midnight = div(seconds_since_midnight, seconds_to_show)

--- a/lib/screens/solari_screen_data.ex
+++ b/lib/screens/solari_screen_data.ex
@@ -27,6 +27,7 @@ defmodule Screens.SolariScreenData do
 
     current_time =
       case at_historical_datetime do
+        # credo:disable-for-next-line Screens.Checks.UntestableDateTime
         nil -> DateTime.utc_now()
         dt -> dt
       end
@@ -229,6 +230,7 @@ defmodule Screens.SolariScreenData do
   defp filter_by_minutes(query_data, %{max_minutes: :infinity}), do: query_data
 
   defp filter_by_minutes(query_data, %{max_minutes: max_minutes}) do
+    # credo:disable-for-next-line Screens.Checks.UntestableDateTime
     max_departure_time = DateTime.add(DateTime.utc_now(), 60 * max_minutes)
 
     Enum.reject(query_data, fn %{time: time_str} ->

--- a/lib/screens/v2/candidate_generator/gl_eink.ex
+++ b/lib/screens/v2/candidate_generator/gl_eink.ex
@@ -73,7 +73,7 @@ defmodule Screens.V2.CandidateGenerator.GlEink do
       end,
       fn -> alert_instances_fn.(config) end,
       fn -> footer_instances(config) end,
-      fn -> line_map_instances(config) end,
+      fn -> line_map_instances(config, now) end,
       fn -> evergreen_content_instances_fn.(config) end,
       fn -> bottom_screen_filler_instances(config) end
     ]
@@ -94,6 +94,7 @@ defmodule Screens.V2.CandidateGenerator.GlEink do
              }
            }
          } = config,
+         now,
          stops_by_route_and_direction_fn \\ &RoutePattern.stops_by_route_and_direction/2,
          fetch_departures_fn \\ &Screens.V2.Departure.fetch/2
        ) do
@@ -103,7 +104,7 @@ defmodule Screens.V2.CandidateGenerator.GlEink do
     {:ok, departures} =
       fetch_departures_fn.(%{stop_ids: [station_id]},
         include_schedules: true,
-        now: DateTime.add(DateTime.utc_now(), -@scheduled_terminal_departure_lookback_seconds)
+        now: DateTime.add(now, -@scheduled_terminal_departure_lookback_seconds)
       )
 
     [%LineMap{screen: config, stops: stops, reverse_stops: reverse_stops, departures: departures}]

--- a/lib/screens/v2/candidate_generator/widgets/evergreen.ex
+++ b/lib/screens/v2/candidate_generator/widgets/evergreen.ex
@@ -8,10 +8,11 @@ defmodule Screens.V2.CandidateGenerator.Widgets.Evergreen do
   alias Screens.Util.Assets
 
   def evergreen_content_instances(
-        %Screen{app_params: %app{evergreen_content: evergreen_content}} = config
+        %Screen{app_params: %app{evergreen_content: evergreen_content}} = config,
+        now \\ DateTime.utc_now()
       )
       when app in [BusEink, BusShelter, GlEink, PreFare] do
-    Enum.map(evergreen_content, &evergreen_content_instance(&1, config))
+    Enum.map(evergreen_content, &evergreen_content_instance(&1, config, now))
   end
 
   defp evergreen_content_instance(
@@ -21,7 +22,8 @@ defmodule Screens.V2.CandidateGenerator.Widgets.Evergreen do
            priority: priority,
            schedule: schedule
          },
-         config
+         config,
+         now
        ) do
     %EvergreenContent{
       screen: config,
@@ -29,7 +31,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.Evergreen do
       asset_url: Assets.s3_asset_url(asset_path),
       priority: priority,
       schedule: schedule,
-      now: DateTime.utc_now()
+      now: now
     }
   end
 end

--- a/lib/screens/v2/departure.ex
+++ b/lib/screens/v2/departure.ex
@@ -17,6 +17,8 @@ defmodule Screens.V2.Departure do
             schedule: nil
 
   def fetch(params, opts \\ []) do
+    # This is equivalent to an argument with a default value, so it's fine
+    # credo:disable-for-next-line Screens.Checks.UntestableDateTime
     now = Keyword.get(opts, :now, DateTime.utc_now())
 
     if opts[:include_schedules] do

--- a/lib/screens_web/controllers/screen_controller.ex
+++ b/lib/screens_web/controllers/screen_controller.ex
@@ -23,9 +23,9 @@ defmodule ScreensWeb.ScreenController do
     end
   end
 
-  defp last_refresh(conn, _) do
-    now = DateTime.utc_now() |> DateTime.to_iso8601()
-    assign(conn, :last_refresh, now)
+  defp last_refresh(conn, _, now \\ DateTime.utc_now()) do
+    timestamp = DateTime.to_iso8601(now)
+    assign(conn, :last_refresh, timestamp)
   end
 
   defp environment_name(conn, _) do

--- a/lib/screens_web/controllers/v2/screen_controller.ex
+++ b/lib/screens_web/controllers/v2/screen_controller.ex
@@ -23,9 +23,9 @@ defmodule ScreensWeb.V2.ScreenController do
     end
   end
 
-  defp last_refresh(conn, _) do
-    now = DateTime.utc_now() |> DateTime.to_iso8601()
-    assign(conn, :last_refresh, now)
+  defp last_refresh(conn, _, now \\ DateTime.utc_now()) do
+    timestamp = DateTime.to_iso8601(now)
+    assign(conn, :last_refresh, timestamp)
   end
 
   defp environment_name(conn, _) do

--- a/mix.exs
+++ b/mix.exs
@@ -28,10 +28,10 @@ defmodule Screens.MixProject do
     apps = [:logger, :runtime_tools]
 
     apps =
-      if Mix.env() == :prod do
-        [:ehmon | apps]
-      else
-        apps
+      case Mix.env() do
+        :prod -> [:ehmon | apps]
+        :test -> [:credo | apps]
+        _ -> apps
       end
 
     [

--- a/test/screens/checks/untestable_datetime_test.exs
+++ b/test/screens/checks/untestable_datetime_test.exs
@@ -1,0 +1,103 @@
+defmodule Screens.Checks.UntestableDateTimeTest do
+  use Credo.Test.Case
+
+  alias Screens.Checks.UntestableDateTime
+
+  test "it should not report 'now' function calls used as default values in a function's parameters" do
+    """
+    defmodule MyTestableCode do
+      @type t :: %__MODULE__{
+        value: integer()
+      }
+
+      @enforce_keys [:value]
+      defstruct @enforce_keys
+
+      def get_current_value(t, utc_now \\\\ Time.utc_now())
+
+      def get_current_value(%__MODULE__{value: value} = t, utc_now)
+        when is_integer(value)
+        when is_struct(utc_now)  do
+        if utc_now.hour < 12, do: morning(value, utc_now), else: evening(t.value, utc_now)
+      end
+
+      def get_current_value(_t, _utc_now), do: nil
+
+      defp morning(value, utc_now) do
+        if utc_now.minute == 0, do: value + 1, else: value - 1
+      end
+
+      defp evening(value, utc_now) do
+        if utc_now.minute == 0, do: value, else: -value
+      end
+    end
+    """
+    |> to_source_file()
+    |> run_check(UntestableDateTime)
+    |> refute_issues()
+  end
+
+  test "it should report 'now' function calls within function body" do
+    """
+    defmodule MyUntestableCode do
+      @type t :: %__MODULE__{
+        value: integer()
+      }
+
+      @enforce_keys [:value]
+      defstruct @enforce_keys
+
+      def get_current_value(%__MODULE__{value: value} = t) when is_integer(value) do
+        utc_now = Time.utc_now()
+        if utc_now.hour < 12, do: morning(value), else: evening(t.value)
+      end
+
+      def get_current_value(_t), do: nil
+
+      def extremely_untestable_function do
+        now1 = DateTime.utc_now()
+        {:ok, now2} = DateTime.now("Etc/UTC")
+        now3 = DateTime.now!("Etc/UTC")
+        now4 = Date.utc_today()
+        now5 = NaiveDateTime.local_now()
+        now6 = NaiveDateTime.utc_now()
+        now7 = Time.utc_now()
+
+        [now1, now2, now3, now4, now5, now6, now7]
+      end
+
+      defp morning(value) do
+        utc_now = DateTime.utc_now()
+        if utc_now.minute == 0, do: value + 1, else: value - 1
+      end
+
+      defp evening(value) do
+        utc_now = DateTime.utc_now()
+        if utc_now.minute == 0, do: value, else: -value
+      end
+    end
+    """
+    |> to_source_file()
+    |> run_check(UntestableDateTime)
+    |> assert_issues(fn issues ->
+      assert Enum.count(issues) == 10
+
+      expected_trigger_counts = %{
+        "Time.utc_now/0" => 2,
+        "Date.utc_today/0" => 1,
+        "DateTime.now!/1" => 1,
+        "DateTime.now/1" => 1,
+        "DateTime.utc_now/0" => 3,
+        "NaiveDateTime.local_now/0" => 1,
+        "NaiveDateTime.utc_now/0" => 1
+      }
+
+      trigger_counts =
+        issues
+        |> Enum.map(& &1.trigger)
+        |> Enum.frequencies()
+
+      assert expected_trigger_counts == trigger_counts
+    end)
+  end
+end


### PR DESCRIPTION
**Asana task**: [[tech debt] Prevent creation of "now" and similar values in function bodies](https://app.asana.com/0/1185117109217413/1202112353590272/f)

This adds a custom Credo check that flags usages of `DateTime.utc_now/0` and similar within function bodies, and suggests how to change the code to be testable.

- [x] Tests added?
