### PR TITLE
fix: GL Location Text Bug

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -36,5 +36,13 @@ config :screens,
       # RL
       {"70076", "70080", "Alewife"},
       {"70079", "70075", "Ashmont/Braintree"}
+    ],
+    "place-gover" => [
+      # GL
+      {"70203", "70200", "North Station & North"},
+      {~w[70199 70198 70197 70196], "70204", "Copley & West"},
+      # BL
+      {"70042", "70038", "Wonderland"},
+      {"70038", "70041", "Bowdoin"}
     ]
   }

--- a/lib/screens/v2/widget_instance/reconstructed_alert.ex
+++ b/lib/screens/v2/widget_instance/reconstructed_alert.ex
@@ -659,6 +659,12 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
     end
   end
 
+  def get_endpoints(ie, "Green") do
+    Enum.find_value(@green_line_branches, fn branch ->
+      get_endpoints(ie, branch)
+    end)
+  end
+
   def get_endpoints(informed_entities, route_id) do
     case Stop.get_stop_sequence(informed_entities, route_id) do
       nil ->

--- a/test/screens/v2/widget_instance/reconstructed_alert_test.exs
+++ b/test/screens/v2/widget_instance/reconstructed_alert_test.exs
@@ -912,6 +912,64 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
     end
   end
 
+  describe "alert edge cases" do
+    setup [:setup_screen_config, :setup_now]
+
+    test "handles GL alert affecting all branches", %{widget: widget} do
+      widget =
+        widget
+        |> put_home_stop(PreFare, "place-gover")
+        |> put_effect(:shuttle)
+        |> put_informed_entities([
+          ie(stop: "place-north", route: "Green-B"),
+          ie(stop: "place-north", route: "Green-C"),
+          ie(stop: "place-north", route: "Green-D"),
+          ie(stop: "place-north", route: "Green-E"),
+          ie(stop: "place-spmnl", route: "Green-E")
+        ])
+        |> put_cause(:unknown)
+        |> put_stop_sequences([
+          [
+            "place-smpmnl",
+            "place-north",
+            "place-haecl",
+            "place-gover"
+          ]
+        ])
+        |> put_routes_at_stop([
+          %{
+            route_id: "Green-D",
+            active?: true,
+            direction_destinations: nil,
+            long_name: nil,
+            short_name: nil,
+            type: :subway
+          },
+          %{
+            route_id: "Green-E",
+            active?: true,
+            direction_destinations: nil,
+            long_name: nil,
+            short_name: nil,
+            type: :subway
+          }
+        ])
+
+      expected = %{
+        issue: "No trains",
+        location: "between Science Park/West End and North Station",
+        cause: "",
+        routes: [%{color: :green, text: "GREEN LINE", type: :text}],
+        effect: :shuttle,
+        urgent: false,
+        region: :outside,
+        remedy: "Use shuttle bus"
+      }
+
+      assert expected == ReconstructedAlert.serialize(widget)
+    end
+  end
+
   describe "audio_serialize/1" do
     setup @alert_widget_context_setup_group ++ [:setup_active_period]
 


### PR DESCRIPTION
**Asana task**: ad-hoc

When GL alert is created that doesn't specify a branch, the location text returns nil unless a single trunk stop is affected. Added some logic that looks for endpoints in each branch `stop_sequences` before returning `nil`.

- [x] Tests added?
