### PR TITLE
fix: Elevator route icon map bug

### DIFF
--- a/lib/screens/stops/stop.ex
+++ b/lib/screens/stops/stop.ex
@@ -263,11 +263,13 @@ defmodule Screens.Stops.Stop do
         case fetch_routes_serving_stop(station_id, [{"if-modified-since", date}]) do
           {:ok, new_routes} -> new_routes
           :not_modified -> routes
+          :error -> []
         end
 
       nil ->
         case fetch_routes_serving_stop(station_id) do
           {:ok, new_routes} -> new_routes
+          :error -> []
         end
     end
   end


### PR DESCRIPTION
**Asana task**: [🐞 CaseClauseError: no case clause matching: :error](https://app.asana.com/0/1185117109217413/1202253122085480/f)

When the V3 call fails when fetching routes at a station, the icon list will now just be empty instead of breaking the screen.

- [ ] Tests added?
