### PR TITLE
fix: Add credo to prod dependencies so that custom credo check can compile (even though it is not used by the application)

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -59,7 +59,7 @@ defmodule Screens.MixProject do
       {:plug_cowboy, "~> 2.5"},
       {:httpoison, "~> 1.8.0"},
       {:tzdata, "~> 1.1"},
-      {:credo, "~> 1.6.0", only: [:dev, :test]},
+      {:credo, "~> 1.6.0"},
       {:dialyxir, "~> 1.1.0", only: [:dev, :test], runtime: false},
       {:mix_test_watch, "~> 1.0", only: :dev, runtime: false},
       {:ex_aws, "~> 2.1"},


### PR DESCRIPTION
**Asana task**: [[tech debt] Prevent creation of "now" and similar values in function bodies](https://app.asana.com/0/1185117109217413/1202112353590272/f)

While we don't actually use credo in the prod application, the `Credo.Check` module is now required in order to compile our custom check definition in lib/checks/

- [ ] Tests added?
