### PR TITLE
tweak: SubwayStatus minutes abbreviations

### DIFF
--- a/assets/src/components/v2/subway_status.tsx
+++ b/assets/src/components/v2/subway_status.tsx
@@ -137,10 +137,6 @@ const SubwayStatusNormalRow: ComponentType<SubwayStatusNormalRowProps> = ({
     }
   });
 
-  if (abbreviate) {
-    status = status.replace(" minutes", "m");
-  }
-
   if (dropTimes && status.startsWith("Delays")) {
     status = "Delays";
   }
@@ -178,74 +174,75 @@ interface GlMultipleProps {
   statuses: [IconRouteId[] | null, string][];
 }
 
-const SubwayStatusGreenLineMultipleAlertsRow: ComponentType<GlMultipleProps> =
-  ({ statuses }) => {
-    const [dropTimes, setDropTimes] = useState(false);
-    const [doneSizing, setDoneSizing] = useState(false);
-    const ref = useRef<HTMLElement>(null);
+const SubwayStatusGreenLineMultipleAlertsRow: ComponentType<
+  GlMultipleProps
+> = ({ statuses }) => {
+  const [dropTimes, setDropTimes] = useState(false);
+  const [doneSizing, setDoneSizing] = useState(false);
+  const ref = useRef<HTMLElement>(null);
 
-    const includesStopClosure = statuses.some(([_, status]) =>
-      status.toLowerCase().startsWith("bypassing")
-    );
-    const modifier = includesStopClosure ? "small" : "normal";
+  const includesStopClosure = statuses.some(([_, status]) =>
+    status.toLowerCase().startsWith("bypassing")
+  );
+  const modifier = includesStopClosure ? "small" : "normal";
 
-    useLayoutEffect(() => {
-      if (ref.current) {
-        if (ref.current.clientHeight > 122) {
-          if (!dropTimes) {
-            setDropTimes(true);
-            setDoneSizing(true);
-          }
-        } else {
+  useLayoutEffect(() => {
+    if (ref.current) {
+      if (ref.current.clientHeight > 122) {
+        if (!dropTimes) {
+          setDropTimes(true);
           setDoneSizing(true);
         }
+      } else {
+        setDoneSizing(true);
       }
-    });
-
-    if (dropTimes) {
-      statuses = statuses.map(([routes, status]) => [
-        routes,
-        status.startsWith("Delays") ? "Delays" : status,
-      ]);
     }
+  });
 
-    const rowClassName = doneSizing
-      ? classWithModifier("subway-status-row", "done")
-      : "subway-status-row";
+  if (dropTimes) {
+    statuses = statuses.map(([routes, status]) => [
+      routes,
+      status.startsWith("Delays") ? "Delays" : status,
+    ]);
+  }
 
-    return (
-      <div className={rowClassName} ref={ref}>
-        <div className="subway-status-branch-row__route">
-          <RoutePill type="text" color="green" text="GL" />
-        </div>
-        <div className="subway-status-branch-row__groups">
-          {statuses.map(([routes, status]) => (
-            <div className="subway-status-branch-row__group" key={status}>
-              {routes && (
-                <div className="subway-status-branch-row__group-routes">
-                  {routes.map((route) => (
-                    <IconForRoute
-                      className="subway-status-branch-row__route-icon"
-                      routeId={route}
-                      key={route}
-                    />
-                  ))}
-                </div>
-              )}
-              <div
-                className={classWithModifier(
-                  "subway-status-branch-row__group-status",
-                  modifier
-                )}
-              >
-                {status}
-              </div>
-            </div>
-          ))}
-        </div>
+  const rowClassName = doneSizing
+    ? classWithModifier("subway-status-row", "done")
+    : "subway-status-row";
+
+  return (
+    <div className={rowClassName} ref={ref}>
+      <div className="subway-status-branch-row__route">
+        <RoutePill type="text" color="green" text="GL" />
       </div>
-    );
-  };
+      <div className="subway-status-branch-row__groups">
+        {statuses.map(([routes, status]) => (
+          <div className="subway-status-branch-row__group" key={status}>
+            {routes && (
+              <div className="subway-status-branch-row__group-routes">
+                {routes.map((route) => (
+                  <IconForRoute
+                    className="subway-status-branch-row__route-icon"
+                    routeId={route}
+                    key={route}
+                  />
+                ))}
+              </div>
+            )}
+            <div
+              className={classWithModifier(
+                "subway-status-branch-row__group-status",
+                modifier
+              )}
+            >
+              {status}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
 
 type GlRowProps =
   | (SubwayStatusNormalRowProps & { type: "single" })

--- a/lib/screens/v2/widget_instance/subway_status.ex
+++ b/lib/screens/v2/widget_instance/subway_status.ex
@@ -263,8 +263,8 @@ defmodule Screens.V2.WidgetInstance.SubwayStatus do
 
     duration_text =
       case delay_description do
-        :up_to -> "up to #{delay_minutes} minutes"
-        :more_than -> "over #{delay_minutes} minutes"
+        :up_to -> "up to #{delay_minutes}m"
+        :more_than -> "over #{delay_minutes}m"
       end
 
     %{status: "Delays #{duration_text}", location: get_location(informed_entities, route_id)}

--- a/test/screens/v2/widget_instance/subway_status_test.exs
+++ b/test/screens/v2/widget_instance/subway_status_test.exs
@@ -110,7 +110,7 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
 
       grouped_alerts = %{"Blue" => blue_line_alerts}
 
-      assert %{status: "Delays up to 10 minutes", location: nil} =
+      assert %{status: "Delays up to 10m", location: nil} =
                SubwayStatus.serialize_route(grouped_alerts, "Blue")
     end
 
@@ -126,7 +126,7 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
       grouped_alerts = %{"Blue" => blue_line_alerts}
 
       assert %{
-               status: "Delays over 60 minutes",
+               status: "Delays over 60m",
                location: %{full: "Eastbound", abbrev: "Eastbound"}
              } = SubwayStatus.serialize_route(grouped_alerts, "Blue")
     end
@@ -342,7 +342,7 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
 
       assert %{
                location: nil,
-               status: "Delays up to 10 minutes",
+               status: "Delays up to 10m",
                type: :single
              } = SubwayStatus.serialize_green_line(grouped_alerts)
     end
@@ -369,7 +369,7 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
       }
 
       assert %{
-               status: "Delays over 60 minutes",
+               status: "Delays over 60m",
                location: %{full: "Eastbound", abbrev: "Eastbound"}
              } = SubwayStatus.serialize_green_line(grouped_alerts)
     end


### PR DESCRIPTION
**Asana task**: [[Bug] Subway status: abbreviate delays consistently](https://app.asana.com/0/1185117109217413/1202306188159487/f)

`minutes` is now always abbreviated to `m`.

- [ ] Tests added?
