### PR TITLE
tweak: Add is_real_screen to v1 api requests

### DIFF
--- a/assets/src/hooks/use_api_response.tsx
+++ b/assets/src/hooks/use_api_response.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { isDup } from "Util/util";
 import useInterval from "Hooks/use_interval";
+import { useLocation } from "react-router-dom";
 
 const MINUTE_IN_MS = 60_000;
 
@@ -22,6 +23,17 @@ const doFailureBuffer = (
   }
 };
 
+const useQuery = () => {
+  return new URLSearchParams(useLocation().search);
+};
+
+const useIsRealScreenParam = () => {
+  const query = useQuery();
+  const isRealScreen = query.get("is_real_screen");
+
+  return isRealScreen === "true" || isDup() ? "&is_real_screen=true" : "";
+};
+
 interface UseApiResponseArgs {
   id: string;
   datetime?: string;
@@ -41,9 +53,16 @@ const useApiResponse = ({
 }: UseApiResponseArgs) => {
   const [apiResponse, setApiResponse] = useState<object | null>(null);
   const [lastSuccess, setLastSuccess] = useState<number>(Date.now());
-  const lastRefresh = document.getElementById("app").dataset.lastRefresh;
+  const lastRefresh = document.getElementById("app")?.dataset.lastRefresh;
+  const isRealScreenParam = useIsRealScreenParam();
 
-  const apiPath = buildApiPath({ id, datetime, rotationIndex, lastRefresh });
+  const apiPath = buildApiPath({
+    id,
+    datetime,
+    rotationIndex,
+    lastRefresh,
+    isRealScreenParam,
+  });
 
   const fetchData = async () => {
     try {
@@ -92,6 +111,7 @@ interface BuildApiPathArgs {
   datetime?: string;
   rotationIndex?: number;
   lastRefresh?: string;
+  isRealScreenParam: string;
 }
 
 const buildApiPath = ({
@@ -99,6 +119,7 @@ const buildApiPath = ({
   datetime,
   rotationIndex,
   lastRefresh,
+  isRealScreenParam,
 }: BuildApiPathArgs) => {
   let apiPath = `/api/screen/${id}`;
 
@@ -106,7 +127,7 @@ const buildApiPath = ({
     apiPath += `/${rotationIndex}`;
   }
 
-  apiPath += `?last_refresh=${lastRefresh}`;
+  apiPath += `?last_refresh=${lastRefresh}${isRealScreenParam}`;
 
   if (datetime != null) {
     apiPath += `&datetime=${datetime}`;


### PR DESCRIPTION
**Asana task**: [Part 1](https://app.asana.com/0/1185117109217413/1202341706104113/f)

DUPs will always get the param. Other v1 screens will not until URL is changed by Ana.

- [ ] Tests added?
