### PR TITLE
fix: Recon alerts bug with alerts affecting all stops on a line

### DIFF
--- a/lib/screens/stops/stop.ex
+++ b/lib/screens/stops/stop.ex
@@ -302,12 +302,18 @@ defmodule Screens.Stops.Stop do
   end
 
   defp sequence_match?(stop_sequence, informed_entities) do
-    stations =
+    ie_stops =
       informed_entities
       |> Enum.map(fn %{stop: stop_id} -> stop_id end)
-      |> Enum.filter(&String.starts_with?(&1, "place-"))
+      |> Enum.reject(&is_nil/1)
 
-    Enum.all?(stations, &stop_on_route?(&1, stop_sequence))
+    if Enum.empty?(ie_stops) do
+      nil
+    else
+      ie_stops
+      |> Enum.filter(&String.starts_with?(&1, "place-"))
+      |> Enum.all?(&stop_on_route?(&1, stop_sequence))
+    end
   end
 
   def gl_trunk_stops do

--- a/test/screens/v2/widget_instance/reconstructed_alert_test.exs
+++ b/test/screens/v2/widget_instance/reconstructed_alert_test.exs
@@ -913,7 +913,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
   end
 
   describe "alert edge cases" do
-    setup [:setup_screen_config, :setup_now]
+    setup [:setup_screen_config, :setup_now, :setup_active_period]
 
     test "handles GL alert affecting all branches", %{widget: widget} do
       widget =
@@ -964,6 +964,47 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
         urgent: false,
         region: :outside,
         remedy: "Use shuttle bus"
+      }
+
+      assert expected == ReconstructedAlert.serialize(widget)
+    end
+
+    test "handles alert affecting all stops on a line", %{widget: widget} do
+      widget =
+        widget
+        |> put_home_stop(PreFare, "place-tumnl")
+        |> put_effect(:suspension)
+        |> put_informed_entities([
+          ie(stop: nil, route: "Orange")
+        ])
+        |> put_cause(:unknown)
+        |> put_stop_sequences([
+          [
+            "place-chncl",
+            "place-tumnl",
+            "place-bbsta"
+          ]
+        ])
+        |> put_routes_at_stop([
+          %{
+            route_id: "Orange",
+            active?: true,
+            direction_destinations: nil,
+            long_name: nil,
+            short_name: nil,
+            type: :subway
+          }
+        ])
+
+      expected = %{
+        issue: %{icon: nil, text: ["No", %{route: "orange"}, "trains"]},
+        location: nil,
+        cause: "",
+        routes: [%{color: :orange, text: "ORANGE LINE", type: :text}],
+        effect: :suspension,
+        urgent: true,
+        region: :inside,
+        remedy: "Seek alternate route"
       }
 
       assert expected == ReconstructedAlert.serialize(widget)


### PR DESCRIPTION
**Asana task**: ad-hoc

Alerts that affect an entire line were failing to get endpoints and causing screens to error. This changes the logic to return `nil` in those scenarios instead of looking for the endpoints.

- [ ] Tests added?
