### PR TITLE
fix: Add clause to departures_post_processing mapper fn to handle failed section fetches

### DIFF
--- a/lib/screens/v2/candidate_generator/gl_eink.ex
+++ b/lib/screens/v2/candidate_generator/gl_eink.ex
@@ -207,6 +207,9 @@ defmodule Screens.V2.CandidateGenerator.GlEink do
 
       {:ok, departures} ->
         {:ok, departures}
+
+      :error ->
+        :error
     end)
   end
 end


### PR DESCRIPTION
**Asana task**: [🐞 FunctionClauseError: no function clause matching in anonymous fn/1 in Screens.V2.CandidateGenerator.GlEink.departures_...](https://app.asana.com/0/1185117109217413/1202253124588511/f)

The surrounding code that calls this function already handles when a section fetch comes back as `:error`—we just needed to pass through that value when encountered.

- [ ] Tests added?
