### PR TITLE
ci: Add "deploy to ECS" GitHub Action config

### DIFF
--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -1,0 +1,23 @@
+name: Deploy to ECS
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        type: environment
+        required: true
+        default: dev
+  push:
+    branches: ["master"]
+
+jobs:
+  call-workflow:
+    uses: mbta/workflows/.github/workflows/deploy.yml@main
+    with:
+      app-name: __app_name__
+      environment: ${{ github.event.inputs.environment || 'dev' }}
+    secrets:
+      aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      docker-repo: ${{ secrets.DOCKER_REPO }}
+      slack-webhook: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
**Asana task**: [Migrate Screens to ECS](https://app.asana.com/0/1185117109217413/1199929177825008/f)

Created from the `deploy-ecs.yml` [GitHub Action template](https://github.com/mbta/screens/new/master?filename=.github%2Fworkflows%2Fdeploy-ecs.yml&workflow_template=deploy-ecs), with no additional changes.