### PR TITLE
feat: log NoData state

### DIFF
--- a/assets/src/hooks/use_api_response.tsx
+++ b/assets/src/hooks/use_api_response.tsx
@@ -25,11 +25,14 @@ const doFailureBuffer = (
       setApiResponse((state) => state);
     }
     if (elapsedMs >= failureModeElapsedMs) {
-      setApiResponse(apiResponse);
+      // This will trigger until a success API response is received.
+      setApiResponse((prevApiResponse) => {
+        if (prevApiResponse != null && prevApiResponse.success) {
+          Sentry.captureMessage("Entering no-data state.");
+        }
+        return apiResponse;
+      });
     }
-
-    // This will trigger until a success API response is received.
-    Sentry.captureMessage("API response failure encountered.");
   }
 };
 
@@ -88,7 +91,7 @@ const useApiResponse = ({
         // If the last response was a failure, log that we are no longer failing.
         setApiResponse((prevApiResponse) => {
           if (prevApiResponse != null && !prevApiResponse.success) {
-            Sentry.captureMessage("Recovered from API response failure.");
+            Sentry.captureMessage("Exiting no-data state.");
           }
           return json;
         });

--- a/assets/src/hooks/use_api_response.tsx
+++ b/assets/src/hooks/use_api_response.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { isDup, isRealScreen } from "Util/util";
+import { isDup } from "Util/util";
 import useInterval from "Hooks/use_interval";
 import { useLocation } from "react-router-dom";
 import * as Sentry from "@sentry/react";
@@ -34,9 +34,7 @@ const doFailureBuffer = (
     }
 
     // This will trigger until a success API response is received.
-    if (isRealScreen()) {
-      Sentry.captureMessage("API response failure encountered.");
-    }
+    Sentry.captureMessage("API response failure encountered.");
   }
 };
 

--- a/assets/src/hooks/use_api_response.tsx
+++ b/assets/src/hooks/use_api_response.tsx
@@ -6,7 +6,7 @@ import * as Sentry from "@sentry/react";
 
 const MINUTE_IN_MS = 60_000;
 
-const FAILURE_RESPONSE = { success: false, lastSuccess: null };
+const FAILURE_RESPONSE = { success: false };
 
 const doFailureBuffer = (
   lastSuccess: number | null,

--- a/assets/src/hooks/v2/use_api_response.tsx
+++ b/assets/src/hooks/v2/use_api_response.tsx
@@ -2,7 +2,6 @@ import { WidgetData } from "Components/v2/widget";
 import useDriftlessInterval from "Hooks/use_driftless_interval";
 import React, { useEffect, useState } from "react";
 import { useLocation } from "react-router-dom";
-import { isRealScreen } from "Util/util";
 import * as Sentry from "@sentry/react";
 
 const MINUTE_IN_MS = 60_000;
@@ -64,9 +63,7 @@ const doFailureBuffer = (
     }
 
     // This will trigger until a success API response is received.
-    if (isRealScreen()) {
-      Sentry.captureMessage("API response failure encountered.");
-    }
+    Sentry.captureMessage("API response failure encountered.");
   }
 };
 

--- a/assets/src/hooks/v2/use_api_response.tsx
+++ b/assets/src/hooks/v2/use_api_response.tsx
@@ -54,11 +54,14 @@ const doFailureBuffer = (
       setApiResponse((state) => state);
     }
     if (elapsedMs >= failureModeElapsedMs) {
-      setApiResponse(apiResponse);
+      // This will trigger until a success API response is received.
+      setApiResponse((prevApiResponse) => {
+        if (prevApiResponse != null && prevApiResponse.state === "success") {
+          Sentry.captureMessage("Entering no-data state.");
+        }
+        return apiResponse;
+      });
     }
-
-    // This will trigger until a success API response is received.
-    Sentry.captureMessage("API response failure encountered.");
   }
 };
 
@@ -139,7 +142,7 @@ const useApiResponse = ({
       } else {
         setApiResponse((prevApiResponse) => {
           if (prevApiResponse != null && prevApiResponse.state !== "success") {
-            Sentry.captureMessage("Recovered from API response failure.");
+            Sentry.captureMessage("Exiting no-data state.");
           }
           return apiResponse;
         });

--- a/assets/src/util/sentry.tsx
+++ b/assets/src/util/sentry.tsx
@@ -9,13 +9,14 @@ const initSentry = (appString: string) => {
   const dataset = document.getElementById("app")?.dataset ?? {};
   const { sentry: sentryDsn, environmentName: env } = dataset;
 
-  if (sentryDsn && isRealScreen()) {
-    Sentry.init({
-      dsn: sentryDsn,
-      environment: env,
-    });
-    Sentry.captureMessage(`Sentry intialized for app: ${appString}`);
-  }
+  // Note: passing an empty string as the DSN sets up a "no-op SDK" that captures errors and lets you call its methods,
+  // but does not actually log anything to the Sentry service.
+  Sentry.init({
+    dsn: sentryDsn && isRealScreen() ? sentryDsn : "",
+    environment: env,
+  });
+
+  Sentry.captureMessage(`Sentry intialized for app: ${appString}`);
 };
 
 export default initSentry;


### PR DESCRIPTION
**Asana task**: [Manually send a Sentry log from client when switching to/from no-data state](https://app.asana.com/0/1185117109217413/1202527610604013/f)

Added a manual Sentry log when a screen enters and leaves a NoData state. This will not trigger when the NoData state appears on page log. 

- [ ] Tests added?
