### PR TITLE
tweak: Increase V3 API connection pool size

### DIFF
--- a/lib/screens/application.ex
+++ b/lib/screens/application.ex
@@ -19,7 +19,7 @@ defmodule Screens.Application do
       Screens.Config.State.Supervisor,
       Screens.SignsUiConfig.State.Supervisor,
       :hackney_pool.child_spec(:ex_aws_pool, []),
-      :hackney_pool.child_spec(:api_v3_pool, []),
+      :hackney_pool.child_spec(:api_v3_pool, max_connections: 100),
       {Screens.Stops.StationsWithRoutesAgent, %{}}
     ]
 


### PR DESCRIPTION
**Asana task**: ad hoc

The default size, which we were using previously, was 50. This doubles it to 100.

- [ ] Tests added?
