### PR TITLE
[do not merge] debug: Log Sentry init failures to splunk

### DIFF
--- a/assets/src/util/sentry.tsx
+++ b/assets/src/util/sentry.tsx
@@ -6,15 +6,29 @@ import { isRealScreen } from "Util/util";
  * a real production screen.
  */
 const initSentry = (appString: string) => {
-  const dataset = document.getElementById("app")?.dataset ?? {};
-  const { sentry: sentryDsn, environmentName: env } = dataset;
+  try {
+    const dataset = document.getElementById("app")?.dataset ?? {};
+    const { sentry: sentryDsn, environmentName: env } = dataset;
 
-  if (sentryDsn && isRealScreen()) {
-    Sentry.init({
-      dsn: sentryDsn,
-      environment: env,
-    });
-    Sentry.captureMessage(`Sentry intialized for app: ${appString}`);
+    if (sentryDsn && isRealScreen()) {
+      Sentry.init({
+        dsn: sentryDsn,
+        environment: env,
+      });
+      Sentry.captureMessage(`Sentry intialized for app: ${appString}`);
+    }
+  } catch (e) {
+    const failureLogUrl = new URL("/debug/log_sentry_init_failure", window.location.href);
+    failureLogUrl.searchParams.set("app_id", appString);
+    if (e instanceof Error) {
+      failureLogUrl.searchParams.set("message", e.message);
+    } else if (typeof e == "string") {
+      failureLogUrl.searchParams.set("message", e);
+    } else {
+      failureLogUrl.searchParams.set("message", JSON.stringify(e));
+    }
+
+    fetch(failureLogUrl);
   }
 };
 

--- a/lib/screens_web/controllers/debug_controller.ex
+++ b/lib/screens_web/controllers/debug_controller.ex
@@ -1,0 +1,10 @@
+defmodule ScreensWeb.DebugController do
+  use ScreensWeb, :controller
+  require Logger
+
+  def log_sentry_init_failure(conn, %{"app_id" => app_id, "message" => message}) do
+    Logger.warn("[sentry_init_failure] app_id=#{app_id} message=\"#{message}\"")
+
+    text(conn, "")
+  end
+end

--- a/lib/screens_web/router.ex
+++ b/lib/screens_web/router.ex
@@ -131,4 +131,10 @@ defmodule ScreensWeb.Router do
 
     get "/:id", AlertPriorityController, :show
   end
+
+  scope "/debug", ScreensWeb do
+    pipe_through [:redirect_prod_http, :api, :browser]
+
+    get "/log_sentry_init_failure", DebugController, :log_sentry_init_failure
+  end
 end


### PR DESCRIPTION
**Asana task**: ad hoc

Intended as a temporary change to assist with determining whether an error is being thrown while initializing Sentry on the client for certain screen types. To be deployed to dev-green only and reverted after we're done gathering info.

This wraps the Sentry init code in a try/catch, and if an error is thrown, sends the message back to our server, which logs the error message to splunk.

![image](https://user-images.githubusercontent.com/63608771/178785462-ff45e25f-3b56-483a-9c65-4ad298a67f89.png)


- [ ] Tests added?
