### PR TITLE
[do not merge] add deploy-ecs workflow to currently prod-deployed commit

### DIFF
--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -14,7 +14,7 @@ jobs:
   call-workflow:
     uses: mbta/workflows/.github/workflows/deploy-ecs.yml@main
     with:
-      app-name: __app_name__
+      app-name: screens
       environment: ${{ github.event.inputs.environment || 'dev' }}
     secrets:
       aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   call-workflow:
-    uses: mbta/workflows/.github/workflows/deploy.yml@main
+    uses: mbta/workflows/.github/workflows/deploy-ecs.yml@main
     with:
       app-name: __app_name__
       environment: ${{ github.event.inputs.environment || 'dev' }}

--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -1,0 +1,23 @@
+name: Deploy to ECS
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        type: environment
+        required: true
+        default: dev
+  push:
+    branches: ["master"]
+
+jobs:
+  call-workflow:
+    uses: mbta/workflows/.github/workflows/deploy.yml@main
+    with:
+      app-name: __app_name__
+      environment: ${{ github.event.inputs.environment || 'dev' }}
+    secrets:
+      aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      docker-repo: ${{ secrets.DOCKER_REPO }}
+      slack-webhook: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
In order to deploy to prod ECS, the same (old) code that's currently deployed to prod EB, I need to add the GitHub workflow to make deploying to ECS possible. For future prod deploys, we won't need to do this as the workflow is already merged into master.