### PR TITLE
feat: DUP simulation endpoint

### DIFF
--- a/assets/css/dup/dup_screen_page.scss
+++ b/assets/css/dup/dup_screen_page.scss
@@ -2,3 +2,23 @@
   display: grid;
   grid-template-columns: 1fr 1fr 1fr;
 }
+
+.simulation-page {
+  background: #3d5366;
+  height: 100%;
+  .projection {
+    display: grid;
+    grid-template-columns: 280px 280px 280px;
+    background: #2e3f4d;
+    border: 8px solid #2e3f4d;
+    border-radius: 8px;
+    width: 816px;
+    height: 144px;
+
+    & > * {
+      transform-origin: top left;
+      transform: scale(13.33%);
+      margin-right: 24px;
+    }
+  }
+}

--- a/assets/src/apps/dup.tsx
+++ b/assets/src/apps/dup.tsx
@@ -15,6 +15,7 @@ import {
   ScreenPage,
   RotationPage,
   MultiRotationPage,
+  SimulationPage,
 } from "Components/dup/dup_screen_page";
 import { isDup } from "Util/util";
 
@@ -27,6 +28,9 @@ const App = (): JSX.Element => {
         <Switch>
           <Route exact path="/screen/dup">
             <MultiRotationPage screenContainer={ScreenContainer} />
+          </Route>
+          <Route exact path="/screen/:id/simulation">
+            <SimulationPage screenContainer={ScreenContainer} />
           </Route>
           <Route path="/screen/:id/:rotationIndex">
             <ScreenPage screenContainer={ScreenContainer} />

--- a/assets/src/components/dup/dup_screen_page.tsx
+++ b/assets/src/components/dup/dup_screen_page.tsx
@@ -56,6 +56,23 @@ const RotationPage = ({
   );
 };
 
+const SimulationPage = ({
+  screenContainer: ScreenContainer,
+}: {
+  screenContainer: React.ComponentType;
+}): JSX.Element => {
+  const { id } = useParams();
+  return (
+    <div className="simulation-page">
+      <div className="projection">
+        <ScreenContainer id={id} rotationIndex={0} />
+        <ScreenContainer id={id} rotationIndex={1} />
+        <ScreenContainer id={id} rotationIndex={2} />
+      </div>
+    </div>
+  );
+};
+
 const MultiRotationPage = ({
   screenContainer: ScreenContainer,
 }: {
@@ -78,4 +95,4 @@ const MultiRotationPage = ({
   );
 };
 
-export { ScreenPage, RotationPage, MultiRotationPage };
+export { ScreenPage, RotationPage, MultiRotationPage, SimulationPage };

--- a/assets/src/hooks/use_current_dup_page.tsx
+++ b/assets/src/hooks/use_current_dup_page.tsx
@@ -4,7 +4,11 @@ const useCurrentPage = () => {
   const [page, setPage] = useState(0);
   const [paging, setPaging] = useState(false);
 
-  const mraid = parent?.parent?.mraid;
+  let mraid;
+
+  try {
+    mraid = parent?.parent?.mraid;
+  } catch (_) {}
 
   useEffect(() => {
     if (mraid) {

--- a/assets/src/hooks/use_outfront_station.tsx
+++ b/assets/src/hooks/use_outfront_station.tsx
@@ -3,16 +3,24 @@ import { useEffect, useState } from "react";
 const useOutfrontTags = () => {
   const [tags, setTags] = useState(null);
 
-  useEffect(() => {
-    if (parent?.parent?.mraid ?? false) {
-      try {
-        const rawTags = parent.parent.mraid.getTags();
-        setTags(JSON.parse(rawTags).tags);
-      } catch (err) {
-        setTags(null);
+  let mraid;
+
+  try {
+    mraid = parent?.parent?.mraid;
+  } catch (_) {}
+
+  if (mraid) {
+    useEffect(() => {
+      if (parent?.parent?.mraid ?? false) {
+        try {
+          const rawTags = parent.parent.mraid.getTags();
+          setTags(JSON.parse(rawTags).tags);
+        } catch (err) {
+          setTags(null);
+        }
       }
-    }
-  }, [parent?.parent?.mraid]);
+    }, [parent?.parent?.mraid]);
+  }
 
   return tags;
 };


### PR DESCRIPTION
**Asana task**: [Set up simulation endpoint in Screens](https://app.asana.com/0/0/1202629970306547/f)

This endpoint will be used by Screenplay to show simulations for DUPs. One change to existing code was needed. Grabbing ad data in DUP and Outfront hooks is not allowed in an iframe. To solve this, I wrapped the variable assignment in a try/catch. This should only impact browser code, but even that has little impact because `mraid` would be undefined there anyway.

- [ ] Tests added?
