### PR TITLE
feat: Standardize on using data attributes on `#app` div for "frontend env vars"

### DIFF
--- a/assets/src/apps/v2/bus_shelter.tsx
+++ b/assets/src/apps/v2/bus_shelter.tsx
@@ -43,6 +43,7 @@ import DeparturesNoData from "Components/v2/bus_shelter/departures_no_data";
 
 import { FlexZoneAlert, FullBodyAlert } from "Components/v2/bus_shelter/alert";
 import MultiScreenPage from "Components/v2/multi_screen_page";
+import { fetchDatasetValue } from "Util/dataset";
 
 const TYPE_TO_COMPONENT = {
   screen_normal: NormalScreen,
@@ -92,12 +93,8 @@ const blinkConfig: BlinkConfig = {
 };
 
 const audioConfig: AudioConfig = {
-  intervalOffsetSeconds: parseInt(
-    document.getElementById("app").dataset.audioIntervalOffsetSeconds
-  ),
-  readoutIntervalMinutes: parseInt(
-    document.getElementById("app").dataset.audioReadoutInterval
-  ),
+  intervalOffsetSeconds: parseInt(fetchDatasetValue("audioIntervalOffsetSeconds")),
+  readoutIntervalMinutes: parseInt(fetchDatasetValue("audioReadoutInterval")),
 };
 
 const App = (): JSX.Element => {

--- a/assets/src/components/dup/dup_screen_page.tsx
+++ b/assets/src/components/dup/dup_screen_page.tsx
@@ -5,6 +5,7 @@ import useOutfrontStation from "Hooks/use_outfront_station";
 import { ROTATION_INDEX } from "./rotation_index";
 import { NoDataLayout } from "Components/dup/screen_container";
 import { isDup } from "Util/util";
+import { fetchDatasetValue } from "Util/dataset";
 
 const DupScreenPage = ({
   screenContainer: ScreenContainer,
@@ -61,9 +62,7 @@ const MultiRotationPage = ({
 }: {
   screenContainer: React.ComponentType;
 }): JSX.Element => {
-  const screenIds = JSON.parse(
-    document.getElementById("app").dataset.screenIds
-  );
+  const screenIds = JSON.parse(fetchDatasetValue("screenIds")) as string[];
 
   return (
     <div className="rotation-page">

--- a/assets/src/components/dup/header.tsx
+++ b/assets/src/components/dup/header.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { getDatasetValue } from "Util/dataset";
 
 import { classWithModifier, formatTimeString, imagePath } from "Util/util";
 import { DUP_VERSION } from "./version";
@@ -34,8 +35,7 @@ const Header = ({
   color,
   code,
 }): JSX.Element => {
-  const environmentName =
-    document.getElementById("app").dataset.environmentName;
+  const environmentName = getDatasetValue("environmentName");
 
   const className = color
     ? classWithModifier("header", `color-${color}`)

--- a/assets/src/components/eink/bus/header.tsx
+++ b/assets/src/components/eink/bus/header.tsx
@@ -1,4 +1,5 @@
 import React, { useLayoutEffect, useRef, useState } from "react";
+import { getDatasetValue } from "Util/dataset";
 
 import { classWithModifier, formatTimeString, imagePath } from "Util/util";
 
@@ -17,8 +18,7 @@ const Header = ({ stopName, currentTimeString }): JSX.Element => {
     }
   });
 
-  const environmentName =
-    document.getElementById("app").dataset.environmentName;
+  const environmentName = getDatasetValue("environmentName");
 
   return (
     <div className="header">

--- a/assets/src/components/eink/green_line/header.tsx
+++ b/assets/src/components/eink/green_line/header.tsx
@@ -2,6 +2,8 @@ import React, { useLayoutEffect, useRef, useState } from "react";
 
 import { classWithModifier, formatTimeString, imagePath } from "Util/util";
 
+import { getDatasetValue } from "Util/dataset";
+
 const abbreviateStop = (stop) => {
   if (stop === "Government Center") {
     return "Government Ctr";
@@ -65,8 +67,7 @@ const Header = ({ stopName, routeId, currentTimeString }): JSX.Element => {
     }
   });
 
-  const environmentName =
-    document.getElementById("app").dataset.environmentName;
+  const environmentName = getDatasetValue("environmentName");
 
   const abbreviatedStop = abbreviateStop(stopName);
 

--- a/assets/src/components/eink/screen_page.tsx
+++ b/assets/src/components/eink/screen_page.tsx
@@ -1,15 +1,14 @@
 import DebugErrorBoundary from "Components/helpers/debug_error_boundary";
 import React, { useState } from "react";
 import { useParams } from "react-router-dom";
+import { fetchDatasetValue } from "Util/dataset";
 
 const MultiScreenPage = ({
   screenContainer: ScreenContainer,
 }: {
   screenContainer: React.ComponentType;
 }): JSX.Element => {
-  const screenIds = JSON.parse(
-    document.getElementById("app").dataset.screenIds
-  );
+  const screenIds = JSON.parse(fetchDatasetValue("screenIds"));
 
   return (
     <div className="multi-screen-page">

--- a/assets/src/components/solari/header.tsx
+++ b/assets/src/components/solari/header.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { getDatasetValue } from "Util/dataset";
 
 import { formatTimeString } from "Util/util";
 
@@ -8,8 +9,7 @@ const Header = ({
   sections,
   overhead,
 }): JSX.Element => {
-  const environmentName =
-    document.getElementById("app").dataset.environmentName;
+  const environmentName = getDatasetValue("environmentName");
 
   const currentTime = formatTimeString(currentTimeString);
   const subtitle = overhead ? `${sections[0].name} Trips` : "Upcoming Trips";

--- a/assets/src/components/v2/multi_screen_page.tsx
+++ b/assets/src/components/v2/multi_screen_page.tsx
@@ -5,6 +5,7 @@ import ScreenContainer, {
   ResponseMapperContext,
 } from "Components/v2/screen_container";
 import { MappingContext } from "Components/v2/widget";
+import { fetchDatasetValue } from "Util/dataset";
 
 const MultiScreenPage = ({
   components,
@@ -13,9 +14,7 @@ const MultiScreenPage = ({
   components: any;
   responseMapper?: ResponseMapper;
 }) => {
-  const screenIds = JSON.parse(
-    document.getElementById("app").dataset.screenIdsWithOffsetMap
-  );
+  const screenIds = JSON.parse(fetchDatasetValue("screenIdsWithOffsetMap"));
 
   return (
     <div className="multi-screen-page">

--- a/assets/src/components/v2/pre_fare/viewport.tsx
+++ b/assets/src/components/v2/pre_fare/viewport.tsx
@@ -1,22 +1,17 @@
 import React from "react";
 
-import { useLocation } from "react-router-dom";
-
-type ScreenSide = "left" | "right";
+import { getScreenSide } from "Util/util";
 
 /**
  * Shifts either the left or right side of the screen content into
- * view, based on a `screen_side` query param.
+ * view, based on a `data-screen-side` data attribute on the #app div.
  * If the param is missing, this will show the full
  * screen content (2160px x 1920px).
  */
 const Viewport: React.ComponentType<{}> = ({ children }) => {
-  const query = new URLSearchParams(useLocation().search);
-  const screenSide: ScreenSide | null = query.get("screen_side") as ScreenSide;
-
   let viewportClassName = "pre-fare-screen-viewport";
   let shifterClassName = "pre-fare-shifter";
-  switch (screenSide) {
+  switch (getScreenSide()) {
     case "left":
       shifterClassName += " pre-fare-shifter--left";
       break;

--- a/assets/src/hooks/use_api_response.tsx
+++ b/assets/src/hooks/use_api_response.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
-import { isDup } from "Util/util";
+import { isDup, isRealScreen } from "Util/util";
 import useInterval from "Hooks/use_interval";
-import { useLocation } from "react-router-dom";
+import { getDatasetValue } from "Util/dataset";
 
 const MINUTE_IN_MS = 60_000;
 
@@ -23,12 +23,8 @@ const doFailureBuffer = (
   }
 };
 
-const useQuery = () => {
-  return new URLSearchParams(useLocation().search);
-};
-
 const useIsRealScreenParam = () => {
-  return isDup() || useQuery().get("is_real_screen") === "true"
+  return isRealScreen()
     ? "&is_real_screen=true"
     : "";
 };
@@ -52,7 +48,7 @@ const useApiResponse = ({
 }: UseApiResponseArgs) => {
   const [apiResponse, setApiResponse] = useState<object | null>(null);
   const [lastSuccess, setLastSuccess] = useState<number>(Date.now());
-  const lastRefresh = document.getElementById("app")?.dataset.lastRefresh;
+  const lastRefresh = getDatasetValue("lastRefresh");
   const isRealScreenParam = useIsRealScreenParam();
 
   const apiPath = buildApiPath({

--- a/assets/src/hooks/v2/use_api_response.tsx
+++ b/assets/src/hooks/v2/use_api_response.tsx
@@ -1,7 +1,8 @@
 import { WidgetData } from "Components/v2/widget";
 import useDriftlessInterval from "Hooks/use_driftless_interval";
 import React, { useEffect, useState } from "react";
-import { useLocation } from "react-router-dom";
+import { getDataset } from "Util/dataset";
+import { getScreenSide, isRealScreen } from "Util/util";
 
 const MINUTE_IN_MS = 60_000;
 
@@ -58,21 +59,12 @@ const doFailureBuffer = (
   }
 };
 
-const useQuery = () => {
-  return new URLSearchParams(useLocation().search);
+const getIsRealScreenParam = () => {
+  return isRealScreen() ? "&is_real_screen=true" : "";
 };
 
-const useIsRealScreenParam = () => {
-  const query = useQuery();
-  const isRealScreen = query.get("is_real_screen");
-
-  return isRealScreen === "true" ? "&is_real_screen=true" : "";
-};
-
-const useScreenSideParam = () => {
-  const query = useQuery();
-  const screenSide = query.get("screen_side");
-
+const getScreenSideParam = () => {
+  const screenSide = getScreenSide();
   return screenSide ? `&screen_side=${screenSide}` : "";
 };
 
@@ -91,8 +83,8 @@ const useApiResponse = ({
   id,
   failureModeElapsedMs = MINUTE_IN_MS,
 }: UseApiResponseArgs): UseApiResponseReturn => {
-  const isRealScreenParam = useIsRealScreenParam();
-  const screenSideParam = useScreenSideParam();
+  const isRealScreenParam = getIsRealScreenParam();
+  const screenSideParam = getScreenSideParam();
   const [apiResponse, setApiResponse] = useState<ApiResponse>(FAILURE_RESPONSE);
   const [requestCount, setRequestCount] = useState<number>(0);
   const [lastSuccess, setLastSuccess] = useState<number | null>(null);
@@ -101,7 +93,7 @@ const useApiResponse = ({
     refreshRate,
     refreshRateOffset,
     screenIdsWithOffsetMap,
-  } = document.getElementById("app").dataset;
+  } = getDataset();
   const refreshMs = parseInt(refreshRate, 10) * 1000;
   let refreshRateOffsetMs = parseInt(refreshRateOffset, 10) * 1000;
   const apiPath = `/v2/api/screen/${id}?last_refresh=${lastRefresh}${isRealScreenParam}${screenSideParam}`;

--- a/assets/src/hooks/v2/use_audio_readout.tsx
+++ b/assets/src/hooks/v2/use_audio_readout.tsx
@@ -1,5 +1,6 @@
 import { AudioConfig } from "Components/v2/screen_container";
 import useDriftlessInterval from "Hooks/use_driftless_interval";
+import { fetchDatasetValue, getDataset } from "Util/dataset";
 
 const readoutPath = (id: string) => `/v2/audio/${id}/readout.mp3`;
 const volumePath = (id: string) => `/v2/audio/${id}/volume`;
@@ -40,8 +41,7 @@ const useAudioReadout = ({
 
   const intervalPeriodMs = config.readoutIntervalMinutes * 60000;
 
-  const { refreshRateOffset } = document.getElementById("app").dataset;
-  const refreshRateOffsetMs = parseInt(refreshRateOffset, 10) * 1000;
+  const refreshRateOffsetMs = parseInt(fetchDatasetValue("refreshRateOffset"), 10) * 1000;
   const intervalOffsetSeconds = config.intervalOffsetSeconds;
   const intervalOffsetMs = refreshRateOffsetMs + (intervalOffsetSeconds * 1000);
 

--- a/assets/src/hooks/v2/use_audio_readout.tsx
+++ b/assets/src/hooks/v2/use_audio_readout.tsx
@@ -1,6 +1,6 @@
 import { AudioConfig } from "Components/v2/screen_container";
 import useDriftlessInterval from "Hooks/use_driftless_interval";
-import { fetchDatasetValue, getDataset } from "Util/dataset";
+import { fetchDatasetValue } from "Util/dataset";
 
 const readoutPath = (id: string) => `/v2/audio/${id}/readout.mp3`;
 const volumePath = (id: string) => `/v2/audio/${id}/volume`;

--- a/assets/src/util/dataset.tsx
+++ b/assets/src/util/dataset.tsx
@@ -1,0 +1,23 @@
+// Functions to get values from the #app div's data attributes.
+
+/**
+ * Gets the entire dataset.
+ */
+export const getDataset = () => document.getElementById("app")?.dataset ?? {};
+
+/**
+ * Gets one value from the dataset, or undefined if the key is not present.
+ */
+export const getDatasetValue = (key: string) => getDataset()[key];
+
+/**
+ * Gets one value from the dataset, or throws an error if the key is not present.
+ */
+export const fetchDatasetValue = (key: string) => {
+  const dataset = getDataset();
+  if (key in dataset) {
+    return dataset[key] as string;
+  } else {
+    throw new Error(`key "${key}" missing from #app div data attributes`);
+  }
+};

--- a/assets/src/util/sentry.tsx
+++ b/assets/src/util/sentry.tsx
@@ -1,13 +1,13 @@
 import * as Sentry from "@sentry/react";
 import { isRealScreen } from "Util/util";
+import { getDataset } from "Util/dataset";
 
 /**
  * Initializes Sentry if the DSN is defined and this client is running on
  * a real production screen.
  */
 const initSentry = (appString: string) => {
-  const dataset = document.getElementById("app")?.dataset ?? {};
-  const { sentry: sentryDsn, environmentName: env } = dataset;
+  const { sentry: sentryDsn, environmentName: env } = getDataset();
 
   if (sentryDsn && isRealScreen()) {
     Sentry.init({

--- a/assets/src/util/util.tsx
+++ b/assets/src/util/util.tsx
@@ -1,5 +1,6 @@
 import moment from "moment";
 import "moment-timezone";
+import { getDatasetValue } from "Util/dataset";
 
 export const classWithModifier = (baseClass, modifier) => {
   return `${baseClass} ${baseClass}--${modifier}`;
@@ -23,9 +24,21 @@ export const isDup = () => location.href.startsWith("file:");
 export const imagePath = (fileName: string): string =>
   isDup() ? `images/${fileName}` : `/images/${fileName}`;
 
-const hasTrueIsRealScreenParam = () => {
-  const params = new URLSearchParams(window.location.search);
-  return params.get("is_real_screen") === "true";
+export const isRealScreen = () =>
+  (isDup() || getDatasetValue("isRealScreen") === "true");
+
+type ScreenSide = "left" | "right";
+const isScreenSide = (value: any): value is ScreenSide => {
+  return value === "left" || value === "right";
 };
 
-export const isRealScreen = () => (isDup() || hasTrueIsRealScreenParam());
+/**
+ * For screen types that are split across two separate displays (pre-fare),
+ * this gets the value of the data attribute dictating which side to show.
+ * 
+ * Returns null if the data attribute is missing or not a valid screen side value.
+ */
+export const getScreenSide = (): ScreenSide | null => {
+  const screenSide = getDatasetValue("screenSide");
+  return isScreenSide(screenSide) ? screenSide : null;
+};

--- a/lib/screens_web/controllers/screen_controller.ex
+++ b/lib/screens_web/controllers/screen_controller.ex
@@ -72,7 +72,7 @@ defmodule ScreensWeb.ScreenController do
     |> render("index_multi.html")
   end
 
-  def index(conn, %{"id" => screen_id}) do
+  def index(conn, %{"id" => screen_id} = params) do
     is_screen = ScreensWeb.UserAgent.is_screen_conn?(conn, screen_id)
 
     _ = Screens.LogScreenData.log_page_load(screen_id, is_screen)
@@ -82,6 +82,7 @@ defmodule ScreensWeb.ScreenController do
         conn
         |> assign(:app_id, app_id)
         |> assign(:sentry_frontend_dsn, Application.get_env(:screens, :sentry_frontend_dsn))
+        |> assign(:is_real_screen, match?(%{"is_real_screen" => "true"}, params))
         |> render("index.html")
 
       nil ->

--- a/lib/screens_web/controllers/v2/screen_controller.ex
+++ b/lib/screens_web/controllers/v2/screen_controller.ex
@@ -37,6 +37,14 @@ defmodule ScreensWeb.V2.ScreenController do
     put_layout(conn, {ScreensWeb.V2.LayoutView, "app.html"})
   end
 
+  defp screen_side(params) do
+    case params["screen_side"] do
+      "left" -> "left"
+      "right" -> "right"
+      _ -> nil
+    end
+  end
+
   def index(conn, %{"id" => app_id})
       when app_id in @app_id_strings do
     app_id = String.to_existing_atom(app_id)
@@ -52,7 +60,7 @@ defmodule ScreensWeb.V2.ScreenController do
   def index(conn, %{"id" => screen_id} = params) do
     is_screen = ScreensWeb.UserAgent.is_screen_conn?(conn, screen_id)
 
-    _ = Screens.LogScreenData.log_page_load(screen_id, is_screen, params["screen_side"])
+    _ = Screens.LogScreenData.log_page_load(screen_id, is_screen, screen_side(params))
 
     config = State.screen(screen_id)
 
@@ -73,6 +81,8 @@ defmodule ScreensWeb.V2.ScreenController do
           :refresh_rate_offset,
           calculate_refresh_rate_offset(screen_id, refresh_rate)
         )
+        |> assign(:is_real_screen, match?(%{"is_real_screen" => "true"}, params))
+        |> assign(:screen_side, screen_side(params))
         |> put_view(ScreensWeb.V2.ScreenView)
         |> render("index.html")
 

--- a/lib/screens_web/templates/screen/index.html.eex
+++ b/lib/screens_web/templates/screen/index.html.eex
@@ -2,6 +2,7 @@
   id="app"
   data-last-refresh="<%= @last_refresh %>"
   data-environment-name="<%= @environment_name %>"
+  data-is-real-screen="<%= @is_real_screen %>"
   <%= if record_sentry?() do %>
     data-sentry="<%= @sentry_frontend_dsn %>"
   <% end %>

--- a/lib/screens_web/templates/v2/screen/index.html.eex
+++ b/lib/screens_web/templates/v2/screen/index.html.eex
@@ -6,6 +6,10 @@
   data-audio-readout-interval="<%= @audio_readout_interval %>"
   data-audio-interval-offset-seconds="<%= @audio_interval_offset_seconds %>"
   data-refresh-rate-offset="<%= @refresh_rate_offset %>"
+  data-is-real-screen="<%= @is_real_screen %>"
+  <%= if not is_nil(@screen_side) do %>
+    data-screen-side="<%= @screen_side %>"
+  <% end %>
   <%= if record_sentry?() do %>
     data-sentry="<%= @sentry_frontend_dsn %>"
   <% end %>


### PR DESCRIPTION
**Asana task**: ad hoc

This PR does the following:
- adds JS utility functions to easily get values from data attributes on the `#app` div, in much the same way that we use `Application.get_env` on the server
  - this includes a function, `fetchDatasetValue`, that throws an error if a given key is not present, so that we can avoid ending up with `NaN` (from `parseInt(undefined)`) and other bad values that silently cause problems
- uses the new functions throughout the client code, replacing any JS logic that looks at URL query params in the process
- has the server set new data attributes for `is_real_screen` and `screen_side`.

The overall goal is to standardize our approach to passing values from the server to the client, when the values are constant for the lifetime of the client.

Since there are a number of other large PRs that add the new screen simulation logic, I'm happy to wait on merging this until after those higher-priority changes are merged, to avoid slowdowns caused by conflicts.

- [ ] Tests added?
