### PR TITLE
fix: Use full station names where we expect them for Clev Circ, Wash Sq

### DIFF
--- a/lib/screens/stops/stop.ex
+++ b/lib/screens/stops/stop.ex
@@ -126,11 +126,11 @@ defmodule Screens.Stops.Stop do
     {"place-sumav", {"Summit Avenue", "Summit Ave"}},
     {"place-bndhl", {"Brandon Hall", "Brandon Hll"}},
     {"place-fbkst", {"Fairbanks Street", "Fairbanks"}},
-    {"place-bcnwa", {"Wash Sq", "Washington"}},
+    {"place-bcnwa", {"Washington Square", "Washington"}},
     {"place-tapst", {"Tappan Street", "Tappan St"}},
     {"place-denrd", {"Dean Road", "Dean Rd"}},
     {"place-engav", {"Englewood Avenue", "Englew'd Av"}},
-    {"place-clmnl", {"Clvlnd Circ", "Clvlnd Cir"}}
+    {"place-clmnl", {"Cleveland Circle", "Clvlnd Cir"}}
   ]
 
   @green_line_d_stops [


### PR DESCRIPTION
**Asana task**: [Add full-length "Cleveland Circle" name for reconstructed alerts](https://app.asana.com/0/1185117109217422/1202661980135928/f)

I didn't work directly on this code, so I might be missing some context around why these two stops are abbreviated in two different ways rather than the first string in the tuple being unabbreviated like the rest of the entries. Please let me know if there was a reason for this!

(:thinking: Also, should the abbreviation for Washington Square be Wash Sq? Or keep it as-is (Washington))

- [ ] Tests added?
