### PR TITLE
Add env to the job name

### DIFF
--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   call-workflow:
+    name: ${{ github.event.inputs.environment }} deploy
     uses: mbta/workflows/.github/workflows/deploy-ecs.yml@main
     with:
       app-name: screens


### PR DESCRIPTION
**Asana task**: adhoc

Would be helpful to see the env name as the job title without needing to click on the job.