### PR TITLE
Bugfix: Sentry MatchError appeared in dev-green

### DIFF
--- a/lib/screens/route_patterns/parser.ex
+++ b/lib/screens/route_patterns/parser.ex
@@ -55,8 +55,16 @@ defmodule Screens.RoutePatterns.Parser do
          },
          included_data
        ) do
-    included_data
+    # The only way this function output an empty array is if the trip data has an empty stop list
+    # This happens occasionally in dev-green
+    parsed = included_data
     |> Map.get({"trip", trip_id})
     |> Enum.map(fn stop_id -> Map.get(included_data, {"stop", stop_id}) end)
+
+    case parsed do
+      # If `trip` is present, but the stop array is empty, there's a problem with the trip in the API
+      [] -> :error
+      _ -> parsed
+    end
   end
 end

--- a/lib/screens/route_patterns/parser.ex
+++ b/lib/screens/route_patterns/parser.ex
@@ -1,9 +1,16 @@
 defmodule Screens.RoutePatterns.Parser do
   @moduledoc false
 
+  require Logger
+
   def parse_result(%{"data" => data, "included" => included}, route_id) do
     included_data = parse_included_data(included)
     parse_data(data, included_data, route_id)
+  end
+
+  def parse_result(_, _) do
+    Logger.warn("Unrecognized format of route_pattern data.")
+    :error
   end
 
   defp parse_included_data(data) do

--- a/lib/screens/route_patterns/parser.ex
+++ b/lib/screens/route_patterns/parser.ex
@@ -64,16 +64,19 @@ defmodule Screens.RoutePatterns.Parser do
        ) do
     # The only way this function output an empty array is if the trip data has an empty stop list
     # This happens occasionally in dev-green
-    parsed = included_data
-    |> Map.get({"trip", trip_id})
-    |> Enum.map(fn stop_id -> Map.get(included_data, {"stop", stop_id}) end)
+    parsed =
+      included_data
+      |> Map.get({"trip", trip_id})
+      |> Enum.map(fn stop_id -> Map.get(included_data, {"stop", stop_id}) end)
 
     case parsed do
       # If `trip` is present, but the stop array is empty, there's a problem with the trip in the API
-      [] -> 
+      [] ->
         Logger.warn("Trip data doesn't contain stop ids. trip_id: #{trip_id}")
         :error
-      _ -> parsed
+
+      _ ->
+        parsed
     end
   end
 end

--- a/lib/screens/route_patterns/parser.ex
+++ b/lib/screens/route_patterns/parser.ex
@@ -63,7 +63,9 @@ defmodule Screens.RoutePatterns.Parser do
 
     case parsed do
       # If `trip` is present, but the stop array is empty, there's a problem with the trip in the API
-      [] -> :error
+      [] -> 
+        Logger.warn("Trip data doesn't contain stop ids. trip_id: #{trip_id}")
+        :error
       _ -> parsed
     end
   end

--- a/lib/screens/route_patterns/route_pattern.ex
+++ b/lib/screens/route_patterns/route_pattern.ex
@@ -24,14 +24,16 @@ defmodule Screens.RoutePatterns.RoutePattern do
         }
 
   def stops_by_route_and_direction(route_id, direction_id) do
-    with {:ok, route_patterns} <- V3Api.get_json("route_patterns", %{
-        "filter[route]" => route_id,
-        "filter[direction_id]" => direction_id,
-        "sort" => "typicality",
-        "include" => "representative_trip.stops"
-      }),
-      parsed_result when parsed_result != :error <- RoutePatterns.Parser.parse_result(route_patterns, route_id) do
-        {:ok, parsed_result}
+    with {:ok, route_patterns} <-
+           V3Api.get_json("route_patterns", %{
+             "filter[route]" => route_id,
+             "filter[direction_id]" => direction_id,
+             "sort" => "typicality",
+             "include" => "representative_trip.stops"
+           }),
+         parsed_result when parsed_result != :error <-
+           RoutePatterns.Parser.parse_result(route_patterns, route_id) do
+      {:ok, parsed_result}
     else
       :error -> :error
     end

--- a/lib/screens/route_patterns/route_pattern.ex
+++ b/lib/screens/route_patterns/route_pattern.ex
@@ -24,14 +24,16 @@ defmodule Screens.RoutePatterns.RoutePattern do
         }
 
   def stops_by_route_and_direction(route_id, direction_id) do
-    case V3Api.get_json("route_patterns", %{
-           "filter[route]" => route_id,
-           "filter[direction_id]" => direction_id,
-           "sort" => "typicality",
-           "include" => "representative_trip.stops"
-         }) do
-      {:ok, result} -> {:ok, RoutePatterns.Parser.parse_result(result, route_id)}
-      _ -> :error
+    with {:ok, route_patterns} <- V3Api.get_json("route_patterns", %{
+        "filter[route]" => route_id,
+        "filter[direction_id]" => direction_id,
+        "sort" => "typicality",
+        "include" => "representative_trip.stops"
+      }),
+      parsed_result when parsed_result != :error <- RoutePatterns.Parser.parse_result(route_patterns, route_id) do
+        {:ok, parsed_result}
+    else
+      :error -> :error
     end
   end
 


### PR DESCRIPTION
**Asana task**: adhoc

[This error](https://sentry.io/organizations/mbtace/issues/3281205710/?environment=screens-dev-green&project=6061747&query=is%3Aunresolved) appeared in Sentry while testing screen 216 on dev-green. I believe this is due to spotty data in dev-green, but added a handler for it anyway. 

[This error](https://sentry.io/organizations/mbtace/issues/3281204701/?environment=screens-dev-green&project=6061747&query=is%3Aunresolved) also occurs in the same section of code (which re-affirms the idea that this issue is a problem with the dev-green data.) Handled that as well.

- [ ] Tests added?
