### PR TITLE
experiment: Switch sides for pre-fare content

### DIFF
--- a/lib/screens/v2/candidate_generator/pre_fare.ex
+++ b/lib/screens/v2/candidate_generator/pre_fare.ex
@@ -25,11 +25,6 @@ defmodule Screens.V2.CandidateGenerator.PreFare do
             body_normal: [
               {:body_left,
                %{
-                 body_left_normal: [:main_content_left],
-                 body_left_takeover: [:full_body_left]
-               }},
-              {:body_right,
-               %{
                  body_right_normal: [
                    Builder.with_paging(
                      {:upper_right,
@@ -42,6 +37,11 @@ defmodule Screens.V2.CandidateGenerator.PreFare do
                    :lower_right
                  ],
                  body_right_takeover: [:full_body_right]
+               }},
+              {:body_right,
+               %{
+                 body_left_normal: [:main_content_left],
+                 body_left_takeover: [:full_body_left]
                }}
             ],
             body_takeover: [:full_body]

--- a/test/screens/v2/candidate_generator/pre_fare_test.exs
+++ b/test/screens/v2/candidate_generator/pre_fare_test.exs
@@ -43,10 +43,6 @@ defmodule Screens.V2.CandidateGenerator.PreFareTest do
                    %{
                      body_normal: [
                        body_left: %{
-                         body_left_normal: [:main_content_left],
-                         body_left_takeover: [:full_body_left]
-                       },
-                       body_right: %{
                          body_right_normal: [
                            {{0, :upper_right},
                             %{
@@ -71,6 +67,10 @@ defmodule Screens.V2.CandidateGenerator.PreFareTest do
                            :lower_right
                          ],
                          body_right_takeover: [:full_body_right]
+                       },
+                       body_right: %{
+                         body_left_normal: [:main_content_left],
+                         body_left_takeover: [:full_body_left]
                        }
                      ],
                      body_takeover: [:full_body]


### PR DESCRIPTION
**Asana task**: [Implement alert experiment: switch left and right pre-fare screens](https://app.asana.com/0/1185117109217413/1202709465836408/f)

See design mock-up in task.

***This should not be deployed until go-ahead is given by design**

- [ ] Tests added?
