### PR TITLE
fix: Adjust CSS for PreFare large evergreen videos.

### DIFF
--- a/assets/css/v2/pre_fare/evergreen/video.scss
+++ b/assets/css/v2/pre_fare/evergreen/video.scss
@@ -25,8 +25,8 @@
 
   .evergreen-content-video,
   .looping-video {
-    width: 1024px;
-    height: 576px;
+    width: 1080px;
+    height: 628px;
   }
 }
 

--- a/assets/src/components/v2/screen_container.tsx
+++ b/assets/src/components/v2/screen_container.tsx
@@ -17,7 +17,6 @@ type ResponseMapper = (
 ) => WidgetData | SimulationApiResponse;
 
 const defaultResponseMapper: ResponseMapper = (apiResponse) => {
-  console.log(apiResponse);
   switch (apiResponse.state) {
     case "success":
       return apiResponse.data;


### PR DESCRIPTION
**Asana task**: ad-hoc

Pre-fare evergreen videos in the large slot were not being given the correct dimensions. Changed it so it fills the whole slot.

- [ ] Tests added?
