### PR TITLE
polish: Widget sim background

### DIFF
--- a/assets/css/v2/bus_eink/simulation.scss
+++ b/assets/css/v2/bus_eink/simulation.scss
@@ -31,10 +31,10 @@
       content: "";
       position: absolute;
       right: 100%;
-      height: 216px;
-      border-top: 50px solid transparent;
-      border-right: 70px solid #2e3f4d;
-      border-bottom: 50px solid transparent;
+      // NO HEIGHT
+      border-top: 158px solid transparent;
+      border-right: 128px solid #2e3f4d;
+      border-bottom: 158px solid transparent;
     }
   }
 

--- a/assets/css/v2/bus_eink/simulation.scss
+++ b/assets/css/v2/bus_eink/simulation.scss
@@ -23,22 +23,30 @@
     margin-top: auto;
     margin-bottom: auto;
     border-radius: 8px;
+    height: 316px;
+    border-radius: 0 8px 8px 0;
   }
 
   .simulation__flex-zone-widget {
     width: 300px;
     height: 286px;
+    margin-top: auto;
+    margin-bottom: auto;
+
+    &:last-child {
+      margin-right: 8px;
+    }
 
     &:not(:last-child) {
       margin-right: 24px;
     }
 
     .flex-one-medium {
+      transform-origin: top left;
+      transform: scale(25%);
+
       & > * {
-        width: 1200px;
-        height: 1164px;
-        transform-origin: top left;
-        transform: scale(25%);
+        position: unset;
       }
     }
   }

--- a/assets/css/v2/bus_eink/simulation.scss
+++ b/assets/css/v2/bus_eink/simulation.scss
@@ -8,8 +8,9 @@
   .simulation__full-page {
     height: 480px;
     width: 180px;
-    margin-right: 24px;
+    margin-right: 72px;
     background-color: white;
+    z-index: 999;
 
     & > * {
       transform-origin: top left;
@@ -22,9 +23,19 @@
     display: flex;
     margin-top: auto;
     margin-bottom: auto;
-    border-radius: 8px;
     height: 316px;
     border-radius: 0 8px 8px 0;
+    position: relative;
+
+    &:before {
+      content: "";
+      position: absolute;
+      right: 100%;
+      height: 216px;
+      border-top: 50px solid transparent;
+      border-right: 70px solid #2e3f4d;
+      border-bottom: 50px solid transparent;
+    }
   }
 
   .simulation__flex-zone-widget {

--- a/assets/css/v2/bus_shelter/simulation.scss
+++ b/assets/css/v2/bus_shelter/simulation.scss
@@ -9,6 +9,7 @@
     height: 344px;
     width: 193.5px;
     margin-right: 24px;
+    z-index: 999;
 
     & > * {
       transform-origin: top left;
@@ -21,13 +22,26 @@
     display: flex;
     margin-top: auto;
     margin-bottom: auto;
-    border: 8px solid #2e3f4d;
-    border-radius: 8px;
+    height: 160px;
+    border-radius: 0 8px 8px 0;
+    position: relative;
+
+    &:before {
+      content: "";
+      position: absolute;
+      right: 100%;
+      height: 134px;
+      border-top: 13px solid transparent;
+      border-right: 26px solid #2e3f4d;
+      border-bottom: 13px solid transparent;
+    }
   }
 
   .simulation__flex-zone-widget {
     width: 256px;
     height: 145px;
+    margin-top: auto;
+    margin-bottom: auto;
 
     &:not(:last-child) {
       margin-right: 24px;

--- a/assets/css/v2/bus_shelter/simulation.scss
+++ b/assets/css/v2/bus_shelter/simulation.scss
@@ -39,9 +39,13 @@
 
   .simulation__flex-zone-widget {
     width: 256px;
-    height: 145px;
+    height: 144px;
     margin-top: auto;
     margin-bottom: auto;
+
+    &:last-child {
+      margin-right: 8px;
+    }
 
     &:not(:last-child) {
       margin-right: 24px;

--- a/assets/css/v2/bus_shelter/simulation.scss
+++ b/assets/css/v2/bus_shelter/simulation.scss
@@ -30,10 +30,10 @@
       content: "";
       position: absolute;
       right: 100%;
-      height: 134px;
-      border-top: 13px solid transparent;
-      border-right: 26px solid #2e3f4d;
-      border-bottom: 13px solid transparent;
+      // NO HEIGHT
+      border-top: 80px solid transparent;
+      border-right: 100px solid #2e3f4d;
+      border-bottom: 80px solid transparent;
     }
   }
 

--- a/assets/css/v2/gl_eink/simulation.scss
+++ b/assets/css/v2/gl_eink/simulation.scss
@@ -31,10 +31,10 @@
       content: "";
       position: absolute;
       right: 100%;
-      height: 216px;
-      border-top: 50px solid transparent;
-      border-right: 70px solid #2e3f4d;
-      border-bottom: 50px solid transparent;
+      // NO HEIGHT
+      border-top: 158px solid transparent;
+      border-right: 128px solid #2e3f4d;
+      border-bottom: 158px solid transparent;
     }
   }
 

--- a/assets/css/v2/gl_eink/simulation.scss
+++ b/assets/css/v2/gl_eink/simulation.scss
@@ -22,23 +22,31 @@
     display: flex;
     margin-top: auto;
     margin-bottom: auto;
-    border-radius: 8px;
+    height: 316px;
+    border-radius: 0 8px 8px 0;
+    position: relative;
   }
 
   .simulation__flex-zone-widget {
     width: 300px;
     height: 286px;
+    margin-top: auto;
+    margin-bottom: auto;
+
+    &:last-child {
+      margin-right: 8px;
+    }
 
     &:not(:last-child) {
       margin-right: 24px;
     }
 
     .flex-one-medium {
+      transform-origin: top left;
+      transform: scale(25%);
+
       & > * {
-        width: 1200px;
-        height: 1164px;
-        transform-origin: top left;
-        transform: scale(25%);
+        position: unset;
       }
     }
   }

--- a/assets/css/v2/gl_eink/simulation.scss
+++ b/assets/css/v2/gl_eink/simulation.scss
@@ -10,6 +10,7 @@
     width: 180px;
     margin-right: 24px;
     background-color: white;
+    z-index: 999;
 
     & > * {
       transform-origin: top left;
@@ -25,6 +26,16 @@
     height: 316px;
     border-radius: 0 8px 8px 0;
     position: relative;
+
+    &:before {
+      content: "";
+      position: absolute;
+      right: 100%;
+      height: 216px;
+      border-top: 50px solid transparent;
+      border-right: 70px solid #2e3f4d;
+      border-bottom: 50px solid transparent;
+    }
   }
 
   .simulation__flex-zone-widget {

--- a/assets/css/v2/gl_eink/simulation.scss
+++ b/assets/css/v2/gl_eink/simulation.scss
@@ -8,7 +8,7 @@
   .simulation__full-page {
     height: 480px;
     width: 180px;
-    margin-right: 24px;
+    margin-right: 72px;
     background-color: white;
     z-index: 999;
 

--- a/assets/css/v2/pre_fare/simulation.scss
+++ b/assets/css/v2/pre_fare/simulation.scss
@@ -38,10 +38,14 @@
   }
 
   .simulation__flex-zone-widget {
-    width: 270px;
-    height: 145px;
+    width: 256px;
+    height: 144px;
     margin-top: auto;
     margin-bottom: auto;
+
+    &:last-child {
+      margin-right: 8px;
+    }
 
     &:not(:last-child) {
       margin-right: 24px;
@@ -49,14 +53,17 @@
 
     .flex-one-large,
     .flex-two-medium {
-      & > * {
-        width: 1080px;
-        height: 628px;
-        transform-origin: top left;
-        transform: scale(25%);
+      transform-origin: top left;
+      transform: scale(25%);
 
+      & > * {
+        position: unset;
+
+        // Pre-Fare flex-zones are a little weird.
+        // For some reason, the subway status has margins that throw off the positioning in the sim.
+        // Removing margins in the widget fixes it.
         & > * {
-          margin: auto;
+          margin: 0;
         }
       }
     }

--- a/assets/css/v2/pre_fare/simulation.scss
+++ b/assets/css/v2/pre_fare/simulation.scss
@@ -9,6 +9,7 @@
     height: 344px;
     width: 387px;
     margin-right: 24px;
+    z-index: 999;
 
     & > * {
       transform-origin: top left;
@@ -21,13 +22,26 @@
     display: flex;
     margin-top: auto;
     margin-bottom: auto;
-    border: 8px solid #2e3f4d;
-    border-radius: 8px;
+    height: 160px;
+    border-radius: 0 8px 8px 0;
+    position: relative;
+
+    &:before {
+      content: "";
+      position: absolute;
+      right: 100%;
+      height: 134px;
+      border-top: 13px solid transparent;
+      border-right: 26px solid #2e3f4d;
+      border-bottom: 13px solid transparent;
+    }
   }
 
   .simulation__flex-zone-widget {
     width: 270px;
     height: 145px;
+    margin-top: auto;
+    margin-bottom: auto;
 
     &:not(:last-child) {
       margin-right: 24px;

--- a/assets/css/v2/pre_fare/simulation.scss
+++ b/assets/css/v2/pre_fare/simulation.scss
@@ -27,7 +27,7 @@
 
   .simulation__flex-zone-widget {
     width: 270px;
-    height: 157px;
+    height: 145px;
 
     &:not(:last-child) {
       margin-right: 24px;

--- a/assets/css/v2/pre_fare/simulation.scss
+++ b/assets/css/v2/pre_fare/simulation.scss
@@ -60,10 +60,11 @@
         position: unset;
 
         // Pre-Fare flex-zones are a little weird.
-        // For some reason, the subway status has margins that throw off the positioning in the sim.
-        // Removing margins in the widget fixes it.
+        // For some reason, some widgets have padding or margin that throw off the positioning in the sim.
+        // Removing margin and padding in the widget fixes it.
         & > * {
           margin: 0;
+          padding: 0;
         }
       }
     }

--- a/assets/css/v2/pre_fare/simulation.scss
+++ b/assets/css/v2/pre_fare/simulation.scss
@@ -30,10 +30,10 @@
       content: "";
       position: absolute;
       right: 100%;
-      height: 134px;
-      border-top: 13px solid transparent;
-      border-right: 26px solid #2e3f4d;
-      border-bottom: 13px solid transparent;
+      // NO HEIGHT
+      border-top: 80px solid transparent;
+      border-right: 100px solid #2e3f4d;
+      border-bottom: 80px solid transparent;
     }
   }
 


### PR DESCRIPTION
**Asana task**: [📺▶️ : 🇵🇱 | Make "speech bubble" around widgets match Figma](https://app.asana.com/0/1185117109217413/1202728175921081/f)

This one was a doozy but I think I got it. Some of the CSS in the existing background was not right/not at all written well so I corrected what I saw. The angled background is done in the `:before` part of the CSS files.

- [ ] Tests added?
