### PR TITLE
fix: hide overflow for v1 e-ink

### DIFF
--- a/assets/css/connection_error.scss
+++ b/assets/css/connection_error.scss
@@ -3,4 +3,5 @@
   padding: 0px;
   width: 1200px;
   height: 1600px;
+  overflow: hidden;
 }

--- a/assets/css/screen_container.scss
+++ b/assets/css/screen_container.scss
@@ -4,6 +4,7 @@
   padding: 0px;
   width: 1200px;
   height: 1600px;
+  overflow: hidden;
 
   &--gl-mercury {
     // Mercury single screens have a few pixels obscured by a "surface graphic mask",


### PR DESCRIPTION
**Asana task**: ad-hoc

There was a tiny bit of overflow on the v1 eink screens that was causing a scrollbar to be visible in the Screenplay simulations. Hiding the overflow removes that scrollbar.

- [ ] Tests added?
