### PR TITLE
feat: Shuttle Bus Widget Backend

### DIFF
--- a/lib/screens/config/v2/pre_fare.ex
+++ b/lib/screens/config/v2/pre_fare.ex
@@ -6,7 +6,8 @@ defmodule Screens.Config.V2.PreFare do
     ContentSummary,
     ElevatorStatus,
     EvergreenContentItem,
-    FullLineMap
+    FullLineMap,
+    ShuttleBusInfo
   }
 
   alias Screens.Config.V2.Header.CurrentStopId
@@ -18,7 +19,8 @@ defmodule Screens.Config.V2.PreFare do
           full_line_map: list(FullLineMap.t()),
           evergreen_content: list(EvergreenContentItem.t()),
           content_summary: ContentSummary.t(),
-          audio: Audio.t()
+          audio: Audio.t(),
+          shuttle_bus_info: ShuttleBusInfo.t()
         }
 
   @enforce_keys [
@@ -34,7 +36,8 @@ defmodule Screens.Config.V2.PreFare do
             full_line_map: [],
             evergreen_content: [],
             content_summary: nil,
-            audio: Audio.from_json(:default)
+            audio: Audio.from_json(:default),
+            shuttle_bus_info: nil
 
   use Screens.Config.Struct,
     children: [
@@ -44,6 +47,7 @@ defmodule Screens.Config.V2.PreFare do
       evergreen_content: {:list, EvergreenContentItem},
       reconstructed_alert_widget: CurrentStopId,
       content_summary: ContentSummary,
-      audio: Audio
+      audio: Audio,
+      shuttle_bus_info: ShuttleBusInfo
     ]
 end

--- a/lib/screens/config/v2/shuttle_bus_info.ex
+++ b/lib/screens/config/v2/shuttle_bus_info.ex
@@ -26,7 +26,7 @@ defmodule Screens.Config.V2.ShuttleBusInfo do
 
   use Screens.Config.Struct
 
-  for arrow <- ~w[n ne e se s sw w nw nil]a do
+  for arrow <- ~w[n ne e se s sw w nw]a do
     arrow_string = Atom.to_string(arrow)
     defp value_from_json("arrow", unquote(arrow_string)), do: unquote(arrow)
   end

--- a/lib/screens/config/v2/shuttle_bus_info.ex
+++ b/lib/screens/config/v2/shuttle_bus_info.ex
@@ -7,15 +7,26 @@ defmodule Screens.Config.V2.ShuttleBusInfo do
           minutes_range_to_destination: String.t(),
           destination: String.t(),
           arrow: arrow(),
+          english_boarding_instructions: String.t(),
+          spanish_boarding_instructions: String.t(),
           priority: WidgetInstance.priority()
         }
 
   @type arrow :: :n | :ne | :e | :se | :s | :sw | :w | :nw | nil
 
-  @enforce_keys [:minutes_range_to_destination, :destination, :arrow, :priority]
+  @enforce_keys [
+    :minutes_range_to_destination,
+    :destination,
+    :arrow,
+    :english_boarding_instructions,
+    :spanish_boarding_instructions,
+    :priority
+  ]
   defstruct minutes_range_to_destination: nil,
             destination: nil,
             arrow: nil,
+            english_boarding_instructions: nil,
+            spanish_boarding_instructions: nil,
             priority: nil
 
   use Screens.Config.Struct

--- a/lib/screens/config/v2/shuttle_bus_info.ex
+++ b/lib/screens/config/v2/shuttle_bus_info.ex
@@ -4,7 +4,7 @@ defmodule Screens.Config.V2.ShuttleBusInfo do
   alias Screens.V2.WidgetInstance
 
   @type t :: %__MODULE__{
-          eta: String.t(),
+          minutes_range_to_destination: String.t(),
           destination: String.t(),
           arrow: arrow(),
           priority: WidgetInstance.priority()
@@ -12,8 +12,8 @@ defmodule Screens.Config.V2.ShuttleBusInfo do
 
   @type arrow :: :n | :ne | :e | :se | :s | :sw | :w | :nw | nil
 
-  @enforce_keys [:eta, :destination, :arrow, :priority]
-  defstruct eta: nil,
+  @enforce_keys [:minutes_range_to_destination, :destination, :arrow, :priority]
+  defstruct minutes_range_to_destination: nil,
             destination: nil,
             arrow: nil,
             priority: nil

--- a/lib/screens/config/v2/shuttle_bus_info.ex
+++ b/lib/screens/config/v2/shuttle_bus_info.ex
@@ -22,12 +22,7 @@ defmodule Screens.Config.V2.ShuttleBusInfo do
     :spanish_boarding_instructions,
     :priority
   ]
-  defstruct minutes_range_to_destination: nil,
-            destination: nil,
-            arrow: nil,
-            english_boarding_instructions: nil,
-            spanish_boarding_instructions: nil,
-            priority: nil
+  defstruct @enforce_keys
 
   use Screens.Config.Struct
 

--- a/lib/screens/config/v2/shuttle_bus_info.ex
+++ b/lib/screens/config/v2/shuttle_bus_info.ex
@@ -1,0 +1,24 @@
+defmodule Screens.Config.V2.ShuttleBusInfo do
+  @moduledoc false
+
+  alias Screens.V2.WidgetInstance
+
+  @type t :: %__MODULE__{
+          eta: String.t(),
+          destination: String.t(),
+          direction: String.t(),
+          priority: WidgetInstance.priority()
+        }
+
+  @enforce_keys [:eta, :destination, :direction, :priority]
+  defstruct eta: nil,
+            destination: nil,
+            direction: nil,
+            priority: nil
+
+  use Screens.Config.Struct
+
+  defp value_from_json(_, value), do: value
+
+  defp value_to_json(_, value), do: value
+end

--- a/lib/screens/config/v2/shuttle_bus_info.ex
+++ b/lib/screens/config/v2/shuttle_bus_info.ex
@@ -6,17 +6,24 @@ defmodule Screens.Config.V2.ShuttleBusInfo do
   @type t :: %__MODULE__{
           eta: String.t(),
           destination: String.t(),
-          direction: String.t(),
+          arrow: arrow(),
           priority: WidgetInstance.priority()
         }
 
-  @enforce_keys [:eta, :destination, :direction, :priority]
+  @type arrow :: :n | :ne | :e | :se | :s | :sw | :w | :nw | nil
+
+  @enforce_keys [:eta, :destination, :arrow, :priority]
   defstruct eta: nil,
             destination: nil,
-            direction: nil,
+            arrow: nil,
             priority: nil
 
   use Screens.Config.Struct
+
+  for arrow <- ~w[n ne e se s sw w nw nil]a do
+    arrow_string = Atom.to_string(arrow)
+    defp value_from_json("arrow", unquote(arrow_string)), do: unquote(arrow)
+  end
 
   defp value_from_json(_, value), do: value
 

--- a/lib/screens/v2/candidate_generator/pre_fare.ex
+++ b/lib/screens/v2/candidate_generator/pre_fare.ex
@@ -3,7 +3,7 @@ defmodule Screens.V2.CandidateGenerator.PreFare do
 
   alias Screens.Config.Screen
   alias Screens.Config.V2.Header.CurrentStopId
-  alias Screens.Config.V2.{PreFare, ShuttleBusInfo}
+  alias Screens.Config.V2.PreFare
   alias Screens.Routes.Route
   alias Screens.Stops.Stop
   alias Screens.V2.CandidateGenerator
@@ -103,27 +103,8 @@ defmodule Screens.V2.CandidateGenerator.PreFare do
     [%NormalHeader{screen: config, text: stop_name, time: now}]
   end
 
-  def shuttle_bus_info_instances(
-        %Screen{
-          app_params: %PreFare{
-            shuttle_bus_info: %ShuttleBusInfo{
-              eta: eta,
-              destination: destination,
-              arrow: arrow,
-              priority: priority
-            }
-          }
-        } = config
-      ) do
-    [
-      %ShuttleBusInfoWidget{
-        screen: config,
-        eta: eta,
-        destination: destination,
-        arrow: arrow,
-        priority: priority
-      }
-    ]
+  def shuttle_bus_info_instances(config) do
+    [%ShuttleBusInfoWidget{screen: config}]
   end
 
   defp content_summary_instances(widgets, config, fetch_routes_by_stop_fn) do

--- a/lib/screens/v2/candidate_generator/pre_fare.ex
+++ b/lib/screens/v2/candidate_generator/pre_fare.ex
@@ -109,7 +109,7 @@ defmodule Screens.V2.CandidateGenerator.PreFare do
             shuttle_bus_info: %ShuttleBusInfo{
               eta: eta,
               destination: destination,
-              direction: direction,
+              arrow: arrow,
               priority: priority
             }
           }
@@ -120,7 +120,7 @@ defmodule Screens.V2.CandidateGenerator.PreFare do
         screen: config,
         eta: eta,
         destination: destination,
-        direction: direction,
+        arrow: arrow,
         priority: priority
       }
     ]

--- a/lib/screens/v2/widget_instance/shuttle_bus_info.ex
+++ b/lib/screens/v2/widget_instance/shuttle_bus_info.ex
@@ -36,6 +36,14 @@ defmodule Screens.V2.WidgetInstance.ShuttleBusInfo do
 
   def slot_names(_instance), do: [:tbd]
 
+  def audio_serialize(instance), do: serialize(instance)
+
+  def audio_sort_key(_instance), do: [2]
+
+  def audio_valid_candidate?(_instance), do: true
+
+  def audio_view(_instance), do: ScreensWeb.V2.Audio.ShuttleBusInfoView
+
   defimpl Screens.V2.WidgetInstance do
     alias Screens.V2.WidgetInstance.ShuttleBusInfo
 
@@ -44,9 +52,9 @@ defmodule Screens.V2.WidgetInstance.ShuttleBusInfo do
     def slot_names(instance), do: ShuttleBusInfo.slot_names(instance)
     def widget_type(instance), do: ShuttleBusInfo.widget_type(instance)
     def valid_candidate?(instance), do: ShuttleBusInfo.valid_candidate?(instance)
-    def audio_serialize(_instance), do: %{}
-    def audio_sort_key(_instance), do: [0]
-    def audio_valid_candidate?(_instance), do: false
-    def audio_view(_instance), do: ScreensWeb.V2.Audio.ShuttleBusInfoView
+    def audio_serialize(instance), do: ShuttleBusInfo.audio_serialize(instance)
+    def audio_sort_key(instance), do: ShuttleBusInfo.audio_sort_key(instance)
+    def audio_valid_candidate?(instance), do: ShuttleBusInfo.audio_valid_candidate?(instance)
+    def audio_view(instance), do: ShuttleBusInfo.audio_view(instance)
   end
 end

--- a/lib/screens/v2/widget_instance/shuttle_bus_info.ex
+++ b/lib/screens/v2/widget_instance/shuttle_bus_info.ex
@@ -2,7 +2,7 @@ defmodule Screens.V2.WidgetInstance.ShuttleBusInfo do
   @moduledoc false
 
   alias Screens.Config.Screen
-  alias Screens.Config.V2.ShuttleBusInfo
+  alias Screens.Config.V2.{PreFare, ShuttleBusInfo}
 
   @enforce_keys ~w[screen]a
   defstruct screen: nil
@@ -11,15 +11,21 @@ defmodule Screens.V2.WidgetInstance.ShuttleBusInfo do
           screen: Screen.t()
         }
 
-  def priority(%__MODULE__{screen: %Screen{app_params: %ShuttleBusInfo{priority: priority}}}),
-    do: priority
+  def priority(%__MODULE__{
+        screen: %Screen{
+          app_params: %PreFare{shuttle_bus_info: %ShuttleBusInfo{priority: priority}}
+        }
+      }),
+      do: priority
 
   def serialize(%__MODULE__{
         screen: %Screen{
-          app_params: %ShuttleBusInfo{
-            minutes_range_to_destination: minutes_range_to_destination,
-            destination: destination,
-            arrow: arrow
+          app_params: %PreFare{
+            shuttle_bus_info: %ShuttleBusInfo{
+              minutes_range_to_destination: minutes_range_to_destination,
+              destination: destination,
+              arrow: arrow
+            }
           }
         }
       }),

--- a/lib/screens/v2/widget_instance/shuttle_bus_info.ex
+++ b/lib/screens/v2/widget_instance/shuttle_bus_info.ex
@@ -3,27 +3,31 @@ defmodule Screens.V2.WidgetInstance.ShuttleBusInfo do
 
   alias Screens.Config.Screen
   alias Screens.Config.V2.ShuttleBusInfo
-  alias Screens.V2.WidgetInstance
 
-  @enforce_keys ~w[screen eta destination arrow priority]a
-  defstruct screen: nil,
-            eta: nil,
-            destination: nil,
-            arrow: nil,
-            priority: nil
+  @enforce_keys ~w[screen]a
+  defstruct screen: nil
 
   @type t :: %__MODULE__{
-          screen: Screen.t(),
-          eta: String.t(),
-          destination: String.t(),
-          arrow: atom(),
-          priority: WidgetInstance.priority()
+          screen: Screen.t()
         }
 
-  def priority(instance), do: instance.priority
+  def priority(%__MODULE__{screen: %Screen{app_params: %ShuttleBusInfo{priority: priority}}}),
+    do: priority
 
-  def serialize(%__MODULE__{eta: eta, destination: destination, arrow: arrow}),
-    do: %{eta: eta, destination: destination, arrow: arrow}
+  def serialize(%__MODULE__{
+        screen: %Screen{
+          app_params: %ShuttleBusInfo{
+            minutes_range_to_destination: minutes_range_to_destination,
+            destination: destination,
+            arrow: arrow
+          }
+        }
+      }),
+      do: %{
+        minutes_range_to_destination: minutes_range_to_destination,
+        destination: destination,
+        arrow: arrow
+      }
 
   def widget_type(_instance), do: :shuttle_bus_info
 

--- a/lib/screens/v2/widget_instance/shuttle_bus_info.ex
+++ b/lib/screens/v2/widget_instance/shuttle_bus_info.ex
@@ -1,0 +1,47 @@
+defmodule Screens.V2.WidgetInstance.ShuttleBusInfo do
+  @moduledoc false
+
+  alias Screens.Config.Screen
+  alias Screens.V2.WidgetInstance
+
+  @enforce_keys ~w[screen eta destination direction priority]a
+  defstruct screen: nil,
+            eta: nil,
+            destination: nil,
+            direction: nil,
+            priority: nil
+
+  @type t :: %__MODULE__{
+          screen: Screen.t(),
+          eta: String.t(),
+          destination: String.t(),
+          direction: String.t(),
+          priority: WidgetInstance.priority()
+        }
+
+  def priority(instance), do: instance.priority
+
+  def serialize(%__MODULE__{eta: eta, destination: destination}),
+    do: %{eta: eta, destination: destination}
+
+  def widget_type(_instance), do: :shuttle_bus_info
+
+  def valid_candidate?(%__MODULE__{screen: %Screen{app_id: :pre_fare_v2}}), do: true
+  def valid_candidate?(_), do: false
+
+  def slot_names(_instance), do: [:tbd]
+
+  defimpl Screens.V2.WidgetInstance do
+    alias Screens.V2.WidgetInstance.ShuttleBusInfo
+
+    def priority(instance), do: ShuttleBusInfo.priority(instance)
+    def serialize(instance), do: ShuttleBusInfo.serialize(instance)
+    def slot_names(instance), do: ShuttleBusInfo.slot_names(instance)
+    def widget_type(instance), do: ShuttleBusInfo.widget_type(instance)
+    def valid_candidate?(instance), do: ShuttleBusInfo.valid_candidate?(instance)
+    def audio_serialize(_instance), do: %{}
+    def audio_sort_key(_instance), do: [0]
+    def audio_valid_candidate?(_instance), do: false
+    def audio_view(_instance), do: ScreensWeb.V2.Audio.ShuttleBusInfo
+  end
+end

--- a/lib/screens/v2/widget_instance/shuttle_bus_info.ex
+++ b/lib/screens/v2/widget_instance/shuttle_bus_info.ex
@@ -2,27 +2,28 @@ defmodule Screens.V2.WidgetInstance.ShuttleBusInfo do
   @moduledoc false
 
   alias Screens.Config.Screen
+  alias Screens.Config.V2.ShuttleBusInfo
   alias Screens.V2.WidgetInstance
 
-  @enforce_keys ~w[screen eta destination direction priority]a
+  @enforce_keys ~w[screen eta destination arrow priority]a
   defstruct screen: nil,
             eta: nil,
             destination: nil,
-            direction: nil,
+            arrow: nil,
             priority: nil
 
   @type t :: %__MODULE__{
           screen: Screen.t(),
           eta: String.t(),
           destination: String.t(),
-          direction: String.t(),
+          arrow: atom(),
           priority: WidgetInstance.priority()
         }
 
   def priority(instance), do: instance.priority
 
-  def serialize(%__MODULE__{eta: eta, destination: destination}),
-    do: %{eta: eta, destination: destination}
+  def serialize(%__MODULE__{eta: eta, destination: destination, arrow: arrow}),
+    do: %{eta: eta, destination: destination, arrow: arrow}
 
   def widget_type(_instance), do: :shuttle_bus_info
 

--- a/lib/screens/v2/widget_instance/shuttle_bus_info.ex
+++ b/lib/screens/v2/widget_instance/shuttle_bus_info.ex
@@ -42,6 +42,6 @@ defmodule Screens.V2.WidgetInstance.ShuttleBusInfo do
     def audio_serialize(_instance), do: %{}
     def audio_sort_key(_instance), do: [0]
     def audio_valid_candidate?(_instance), do: false
-    def audio_view(_instance), do: ScreensWeb.V2.Audio.ShuttleBusInfo
+    def audio_view(_instance), do: ScreensWeb.V2.Audio.ShuttleBusInfoView
   end
 end

--- a/lib/screens/v2/widget_instance/shuttle_bus_info.ex
+++ b/lib/screens/v2/widget_instance/shuttle_bus_info.ex
@@ -24,7 +24,9 @@ defmodule Screens.V2.WidgetInstance.ShuttleBusInfo do
             shuttle_bus_info: %ShuttleBusInfo{
               minutes_range_to_destination: minutes_range_to_destination,
               destination: destination,
-              arrow: arrow
+              arrow: arrow,
+              english_boarding_instructions: english_boarding_instructions,
+              spanish_boarding_instructions: spanish_boarding_instructions
             }
           }
         }
@@ -32,7 +34,9 @@ defmodule Screens.V2.WidgetInstance.ShuttleBusInfo do
       do: %{
         minutes_range_to_destination: minutes_range_to_destination,
         destination: destination,
-        arrow: arrow
+        arrow: arrow,
+        english_boarding_instructions: english_boarding_instructions,
+        spanish_boarding_instructions: spanish_boarding_instructions
       }
 
   def widget_type(_instance), do: :shuttle_bus_info

--- a/lib/screens_web/views/v2/audio/shuttle_bus_info_view.ex
+++ b/lib/screens_web/views/v2/audio/shuttle_bus_info_view.ex
@@ -1,0 +1,7 @@
+defmodule ScreensWeb.V2.Audio.ShuttleBusInfoView do
+  use ScreensWeb, :view
+
+  def render("_widget.ssml", _) do
+    ~E""
+  end
+end

--- a/lib/screens_web/views/v2/audio/shuttle_bus_info_view.ex
+++ b/lib/screens_web/views/v2/audio/shuttle_bus_info_view.ex
@@ -5,6 +5,6 @@ defmodule ScreensWeb.V2.Audio.ShuttleBusInfoView do
         minutes_range_to_destination: minutes_range_to_destination,
         destination: destination
       }) do
-    ~E""
+    ~E|<p>Estimated <%= minutes_range_to_destination %> minute to <%= destination %></p>|
   end
 end

--- a/lib/screens_web/views/v2/audio/shuttle_bus_info_view.ex
+++ b/lib/screens_web/views/v2/audio/shuttle_bus_info_view.ex
@@ -1,7 +1,10 @@
 defmodule ScreensWeb.V2.Audio.ShuttleBusInfoView do
   use ScreensWeb, :view
 
-  def render("_widget.ssml", _) do
+  def render("_widget.ssml", %{
+        minutes_range_to_destination: minutes_range_to_destination,
+        destination: destination
+      }) do
     ~E""
   end
 end

--- a/test/screens/v2/widget_instance/shuttle_bus_info_test.exs
+++ b/test/screens/v2/widget_instance/shuttle_bus_info_test.exs
@@ -4,7 +4,6 @@ defmodule Screens.V2.WidgetInstance.ShuttleBusInfoTest do
   alias Screens.V2.WidgetInstance
   alias Screens.Config.Screen
   alias Screens.V2.WidgetInstance.ShuttleBusInfo
-  alias Screens.Config.V2.Schedule
 
   setup do
     %{
@@ -16,10 +15,9 @@ defmodule Screens.V2.WidgetInstance.ShuttleBusInfoTest do
           name: nil,
           app_id: :pre_fare_v2
         },
-        slot_names: [:large],
         eta: "35-45",
         destination: "Test Station",
-        direction: "north",
+        arrow: :n,
         priority: [2, 3, 1]
       },
       widget_not_pre_fare: %ShuttleBusInfo{
@@ -29,7 +27,11 @@ defmodule Screens.V2.WidgetInstance.ShuttleBusInfoTest do
           device_id: nil,
           name: nil,
           app_id: :bus_shelter_v2
-        }
+        },
+        eta: "35-45",
+        destination: "Test Station",
+        arrow: :n,
+        priority: [2, 3, 1]
       }
     }
   end
@@ -45,14 +47,14 @@ defmodule Screens.V2.WidgetInstance.ShuttleBusInfoTest do
       assert %{
                eta: "35-45",
                destination: "Test Station",
-               direction: "north"
+               arrow: :n
              } == WidgetInstance.serialize(widget)
     end
   end
 
   describe "slot_names/1" do
     test "returns slot names defined on the struct", %{widget: widget} do
-      assert [:large] == WidgetInstance.slot_names(widget)
+      assert [:tbd] == WidgetInstance.slot_names(widget)
     end
   end
 

--- a/test/screens/v2/widget_instance/shuttle_bus_info_test.exs
+++ b/test/screens/v2/widget_instance/shuttle_bus_info_test.exs
@@ -18,6 +18,8 @@ defmodule Screens.V2.WidgetInstance.ShuttleBusInfoTest do
                   minutes_range_to_destination: "35-45",
                   destination: "Test Station",
                   arrow: :n,
+                  english_boarding_instructions: "",
+                  spanish_boarding_instructions: "",
                   priority: [2, 3, 1]
                 }
               })
@@ -32,6 +34,8 @@ defmodule Screens.V2.WidgetInstance.ShuttleBusInfoTest do
                 shuttle_bus_info: %ShuttleBusInfo{
                   minutes_range_to_destination: "35-45",
                   destination: "Test Station",
+                  english_boarding_instructions: "",
+                  spanish_boarding_instructions: "",
                   arrow: :n,
                   priority: [2, 3, 1]
                 }
@@ -54,7 +58,9 @@ defmodule Screens.V2.WidgetInstance.ShuttleBusInfoTest do
       assert %{
                minutes_range_to_destination: "35-45",
                destination: "Test Station",
-               arrow: :n
+               arrow: :n,
+               english_boarding_instructions: "",
+               spanish_boarding_instructions: ""
              } == WidgetInstance.serialize(widget)
     end
   end

--- a/test/screens/v2/widget_instance/shuttle_bus_info_test.exs
+++ b/test/screens/v2/widget_instance/shuttle_bus_info_test.exs
@@ -80,20 +80,20 @@ defmodule Screens.V2.WidgetInstance.ShuttleBusInfoTest do
   end
 
   describe "audio_serialize/1" do
-    test "returns empty string", %{widget: widget} do
-      assert %{} == WidgetInstance.audio_serialize(widget)
+    test "returns same result as serialize/1", %{widget: widget} do
+      assert WidgetInstance.serialize(widget) == WidgetInstance.audio_serialize(widget)
     end
   end
 
   describe "audio_sort_key/1" do
-    test "returns [0]", %{widget: widget} do
-      assert [0] == WidgetInstance.audio_sort_key(widget)
+    test "returns [2]", %{widget: widget} do
+      assert [2] == WidgetInstance.audio_sort_key(widget)
     end
   end
 
   describe "audio_valid_candidate?/1" do
-    test "returns false", %{widget: widget} do
-      refute WidgetInstance.audio_valid_candidate?(widget)
+    test "returns true", %{widget: widget} do
+      assert WidgetInstance.audio_valid_candidate?(widget)
     end
   end
 

--- a/test/screens/v2/widget_instance/shuttle_bus_info_test.exs
+++ b/test/screens/v2/widget_instance/shuttle_bus_info_test.exs
@@ -1,37 +1,40 @@
 defmodule Screens.V2.WidgetInstance.ShuttleBusInfoTest do
   use ExUnit.Case, async: true
 
-  alias Screens.V2.WidgetInstance
   alias Screens.Config.Screen
-  alias Screens.V2.WidgetInstance.ShuttleBusInfo
+  alias Screens.Config.V2.ShuttleBusInfo
+  alias Screens.V2.WidgetInstance
+  alias Screens.V2.WidgetInstance.ShuttleBusInfo, as: ShuttleBusInfoWidget
 
   setup do
     %{
-      widget: %ShuttleBusInfo{
+      widget: %ShuttleBusInfoWidget{
         screen: %Screen{
-          app_params: nil,
+          app_params: %ShuttleBusInfo{
+            minutes_range_to_destination: "35-45",
+            destination: "Test Station",
+            arrow: :n,
+            priority: [2, 3, 1]
+          },
           vendor: nil,
           device_id: nil,
           name: nil,
           app_id: :pre_fare_v2
-        },
-        eta: "35-45",
-        destination: "Test Station",
-        arrow: :n,
-        priority: [2, 3, 1]
+        }
       },
-      widget_not_pre_fare: %ShuttleBusInfo{
+      widget_not_pre_fare: %ShuttleBusInfoWidget{
         screen: %Screen{
-          app_params: nil,
+          app_params: %ShuttleBusInfo{
+            minutes_range_to_destination: "35-45",
+            destination: "Test Station",
+            arrow: :n,
+            priority: [2, 3, 1]
+          },
           vendor: nil,
           device_id: nil,
           name: nil,
           app_id: :bus_shelter_v2
-        },
-        eta: "35-45",
-        destination: "Test Station",
-        arrow: :n,
-        priority: [2, 3, 1]
+        }
       }
     }
   end
@@ -43,9 +46,11 @@ defmodule Screens.V2.WidgetInstance.ShuttleBusInfoTest do
   end
 
   describe "serialize/1" do
-    test "returns map with eta, destination, and direction", %{widget: widget} do
+    test "returns map with minutes_range_to_destination, destination, and direction", %{
+      widget: widget
+    } do
       assert %{
-               eta: "35-45",
+               minutes_range_to_destination: "35-45",
                destination: "Test Station",
                arrow: :n
              } == WidgetInstance.serialize(widget)

--- a/test/screens/v2/widget_instance/shuttle_bus_info_test.exs
+++ b/test/screens/v2/widget_instance/shuttle_bus_info_test.exs
@@ -2,39 +2,41 @@ defmodule Screens.V2.WidgetInstance.ShuttleBusInfoTest do
   use ExUnit.Case, async: true
 
   alias Screens.Config.Screen
-  alias Screens.Config.V2.ShuttleBusInfo
+  alias Screens.Config.V2.{PreFare, ShuttleBusInfo}
   alias Screens.V2.WidgetInstance
   alias Screens.V2.WidgetInstance.ShuttleBusInfo, as: ShuttleBusInfoWidget
 
   setup do
     %{
       widget: %ShuttleBusInfoWidget{
-        screen: %Screen{
-          app_params: %ShuttleBusInfo{
-            minutes_range_to_destination: "35-45",
-            destination: "Test Station",
-            arrow: :n,
-            priority: [2, 3, 1]
-          },
-          vendor: nil,
-          device_id: nil,
-          name: nil,
-          app_id: :pre_fare_v2
-        }
+        screen:
+          struct(Screen, %{
+            app_id: :pre_fare_v2,
+            app_params:
+              struct(PreFare, %{
+                shuttle_bus_info: %ShuttleBusInfo{
+                  minutes_range_to_destination: "35-45",
+                  destination: "Test Station",
+                  arrow: :n,
+                  priority: [2, 3, 1]
+                }
+              })
+          })
       },
       widget_not_pre_fare: %ShuttleBusInfoWidget{
-        screen: %Screen{
-          app_params: %ShuttleBusInfo{
-            minutes_range_to_destination: "35-45",
-            destination: "Test Station",
-            arrow: :n,
-            priority: [2, 3, 1]
-          },
-          vendor: nil,
-          device_id: nil,
-          name: nil,
-          app_id: :bus_shelter_v2
-        }
+        screen:
+          struct(Screen, %{
+            app_id: :bus_shelter_v2,
+            app_params:
+              struct(PreFare, %{
+                shuttle_bus_info: %ShuttleBusInfo{
+                  minutes_range_to_destination: "35-45",
+                  destination: "Test Station",
+                  arrow: :n,
+                  priority: [2, 3, 1]
+                }
+              })
+          })
       }
     }
   end

--- a/test/screens/v2/widget_instance/shuttle_bus_info_text.exs
+++ b/test/screens/v2/widget_instance/shuttle_bus_info_text.exs
@@ -1,0 +1,98 @@
+defmodule Screens.V2.WidgetInstance.ShuttleBusInfoTest do
+  use ExUnit.Case, async: true
+
+  alias Screens.V2.WidgetInstance
+  alias Screens.Config.Screen
+  alias Screens.V2.WidgetInstance.ShuttleBusInfo
+  alias Screens.Config.V2.Schedule
+
+  setup do
+    %{
+      widget: %ShuttleBusInfo{
+        screen: %Screen{
+          app_params: nil,
+          vendor: nil,
+          device_id: nil,
+          name: nil,
+          app_id: :pre_fare_v2
+        },
+        slot_names: [:large],
+        eta: "35-45",
+        destination: "Test Station",
+        direction: "north",
+        priority: [2, 3, 1]
+      },
+      widget_not_pre_fare: %ShuttleBusInfo{
+        screen: %Screen{
+          app_params: nil,
+          vendor: nil,
+          device_id: nil,
+          name: nil,
+          app_id: :bus_shelter_v2
+        }
+      }
+    }
+  end
+
+  describe "priority/1" do
+    test "returns priority defined on the struct", %{widget: widget} do
+      assert [2, 3, 1] == WidgetInstance.priority(widget)
+    end
+  end
+
+  describe "serialize/1" do
+    test "returns map with eta, destination, and direction", %{widget: widget} do
+      assert %{
+               eta: "35-45",
+               destination: "Test Station",
+               direction: "north"
+             } == WidgetInstance.serialize(widget)
+    end
+  end
+
+  describe "slot_names/1" do
+    test "returns slot names defined on the struct", %{widget: widget} do
+      assert [:large] == WidgetInstance.slot_names(widget)
+    end
+  end
+
+  describe "widget_type/1" do
+    test "returns :shuttle_bus_info", %{widget: widget} do
+      assert :shuttle_bus_info == WidgetInstance.widget_type(widget)
+    end
+  end
+
+  describe "valid_candidate?/1" do
+    test "returns true for pre-fare", %{widget: widget} do
+      assert WidgetInstance.valid_candidate?(widget)
+    end
+
+    test "returns false with old schedule", %{widget_not_pre_fare: widget_not_pre_fare} do
+      refute WidgetInstance.valid_candidate?(widget_not_pre_fare)
+    end
+  end
+
+  describe "audio_serialize/1" do
+    test "returns empty string", %{widget: widget} do
+      assert %{} == WidgetInstance.audio_serialize(widget)
+    end
+  end
+
+  describe "audio_sort_key/1" do
+    test "returns [0]", %{widget: widget} do
+      assert [0] == WidgetInstance.audio_sort_key(widget)
+    end
+  end
+
+  describe "audio_valid_candidate?/1" do
+    test "returns false", %{widget: widget} do
+      refute WidgetInstance.audio_valid_candidate?(widget)
+    end
+  end
+
+  describe "audio_view/1" do
+    test "returns ShuttleBusInfoView", %{widget: widget} do
+      assert ScreensWeb.V2.Audio.ShuttleBusInfoView == WidgetInstance.audio_view(widget)
+    end
+  end
+end


### PR DESCRIPTION
**Asana task**: [Create new Shuttle Bus pre-fare widget](https://app.asana.com/0/1185117109217413/1202791356936896/f)

This adds the backend for a new Shuttle Bus widget. Most of the widget will be static text that will live in the frontend. Boarding instructions will be stored in the config along with the arrow icon to use, the minute range, and the destination of the shuttle.

- [x] Tests added?
