### PR TITLE
feat: OL Surge PreFare Slots

### DIFF
--- a/assets/css/pre_fare_v2.scss
+++ b/assets/css/pre_fare_v2.scss
@@ -16,6 +16,7 @@
 
 @import "v2/pre_fare/body_right/normal";
 @import "v2/pre_fare/body_right/takeover";
+@import "v2/pre_fare/body_right/surge";
 
 @import "v2/pre_fare/normal_header";
 

--- a/assets/css/v2/pre_fare/body_right/normal.scss
+++ b/assets/css/v2/pre_fare/body_right/normal.scss
@@ -1,4 +1,4 @@
-// body total height: 1648px
+// body total height: 1720px
 
 .body-right-normal {
   position: relative;

--- a/assets/css/v2/pre_fare/body_right/surge.scss
+++ b/assets/css/v2/pre_fare/body_right/surge.scss
@@ -1,4 +1,4 @@
-// body total height: 1648px
+// body total height: 1720px
 
 .body-right-surge {
   position: relative;
@@ -10,16 +10,16 @@
   left: 0;
 
   width: 1080px;
-  height: 876px;
+  height: 830px;
   overflow: hidden;
 }
 
 .body-right-surge__lower {
   position: absolute;
-  top: 918px;
+  top: 830px;
   left: 0;
 
   width: 1080px;
-  height: 876px;
+  height: 890px;
   overflow: hidden;
 }

--- a/assets/css/v2/pre_fare/body_right/surge.scss
+++ b/assets/css/v2/pre_fare/body_right/surge.scss
@@ -1,0 +1,25 @@
+// body total height: 1648px
+
+.body-right-surge {
+  position: relative;
+}
+
+.body-right-surge__upper {
+  position: absolute;
+  top: 0;
+  left: 0;
+
+  width: 1080px;
+  height: 876px;
+  overflow: hidden;
+}
+
+.body-right-surge__lower {
+  position: absolute;
+  top: 918px;
+  left: 0;
+
+  width: 1080px;
+  height: 876px;
+  overflow: hidden;
+}

--- a/assets/src/apps/v2/pre_fare.tsx
+++ b/assets/src/apps/v2/pre_fare.tsx
@@ -39,6 +39,7 @@ import NoData from "Components/v2/pre_fare/no_data";
 import ReconstructedTakeover from "Components/v2/reconstructed_takeover";
 import MultiScreenPage from "Components/v2/multi_screen_page";
 import SimulationScreenPage from "Components/v2/simulation_screen_page";
+import SurgeBodyRight from "Components/v2/pre_fare/surge_body_right";
 
 const TYPE_TO_COMPONENT = {
   screen_normal: NormalScreen,
@@ -48,6 +49,7 @@ const TYPE_TO_COMPONENT = {
   body_left_normal: NormalBodyLeft,
   body_left_takeover: BodyLeftTakeover,
   body_right_normal: NormalBodyRight,
+  body_right_surge: SurgeBodyRight,
   body_right_takeover: BodyRightTakeover,
   normal_header: NormalHeader,
   one_large: OneLarge,

--- a/assets/src/components/v2/pre_fare/flex/one_large.tsx
+++ b/assets/src/components/v2/pre_fare/flex/one_large.tsx
@@ -14,7 +14,6 @@ const OneLarge: React.ComponentType<Props> = ({
   num_pages: numPages,
   page_index: pageIndex,
 }) => {
-  console.log(numPages);
   return (
     <div className="flex-one-large">
       <div className="flex-one-large__large">

--- a/assets/src/components/v2/pre_fare/surge_body_right.tsx
+++ b/assets/src/components/v2/pre_fare/surge_body_right.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+
+import Widget, { WidgetData } from "Components/v2/widget";
+
+interface Props {
+  orange_line_surge_upper: WidgetData;
+  orange_line_surge_lower: WidgetData;
+}
+
+const SurgeBodyRight: React.ComponentType<Props> = ({
+  orange_line_surge_upper: orangeLineSurgeUpper,
+  orange_line_surge_lower: orangeLineSurgeLower,
+}) => {
+  return (
+    <div className="body-right-surge">
+      <div className="body-right-surge__upper">
+        <Widget data={orangeLineSurgeUpper} />
+      </div>
+      <div className="body-right-surge__lower">
+        <Widget data={orangeLineSurgeLower} />
+      </div>
+    </div>
+  );
+};
+
+export default SurgeBodyRight;

--- a/lib/screens/v2/candidate_generator/pre_fare.ex
+++ b/lib/screens/v2/candidate_generator/pre_fare.ex
@@ -41,7 +41,11 @@ defmodule Screens.V2.CandidateGenerator.PreFare do
                      4
                    )
                  ],
-                 body_right_takeover: [:full_body_right]
+                 body_right_takeover: [:full_body_right],
+                 body_right_surge: [
+                   :orange_line_surge_upper,
+                   :orange_line_surge_lower
+                 ]
                }}
             ],
             body_takeover: [:full_body]

--- a/lib/screens/v2/widget_instance/shuttle_bus_info.ex
+++ b/lib/screens/v2/widget_instance/shuttle_bus_info.ex
@@ -44,7 +44,7 @@ defmodule Screens.V2.WidgetInstance.ShuttleBusInfo do
   def valid_candidate?(%__MODULE__{screen: %Screen{app_id: :pre_fare_v2}}), do: true
   def valid_candidate?(_), do: false
 
-  def slot_names(_instance), do: [:tbd]
+  def slot_names(_instance), do: [:orange_line_surge_lower]
 
   def audio_serialize(instance), do: serialize(instance)
 

--- a/test/screens/v2/candidate_generator/pre_fare_test.exs
+++ b/test/screens/v2/candidate_generator/pre_fare_test.exs
@@ -70,7 +70,8 @@ defmodule Screens.V2.CandidateGenerator.PreFareTest do
                               two_medium: [{3, :medium_left}, {3, :medium_right}]
                             }}
                          ],
-                         body_right_takeover: [:full_body_right]
+                         body_right_takeover: [:full_body_right],
+                         body_right_surge: [:orange_line_surge_upper, :orange_line_surge_lower]
                        }
                      ],
                      body_takeover: [:full_body]

--- a/test/screens/v2/widget_instance/shuttle_bus_info_test.exs
+++ b/test/screens/v2/widget_instance/shuttle_bus_info_test.exs
@@ -67,7 +67,7 @@ defmodule Screens.V2.WidgetInstance.ShuttleBusInfoTest do
 
   describe "slot_names/1" do
     test "returns slot names defined on the struct", %{widget: widget} do
-      assert [:tbd] == WidgetInstance.slot_names(widget)
+      assert [:orange_line_surge_lower] == WidgetInstance.slot_names(widget)
     end
   end
 


### PR DESCRIPTION
**Asana task**: [Add new slots to pre-fare template](https://app.asana.com/0/1185117109217413/1202809139605053/f)

Added a new slot for OL Surge widgets: `orange_line_surge_upper` and `orange_line_surge_lower`. Right now, each slot takes up half of the space under the header. If any widget in the `body_right_normal` group has a higher priority, it will not show these new widgets.

- [ ] Tests added?
