### PR TITLE
tweak: Show partial alerts on DUP screen 1 if configured for CR/SL

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -188,16 +188,7 @@ config :screens,
       {"70064", "70068", "Alewife"},
       {"70067", "70063", "Ashmont/Braintree"}
     ]
-  },
-  # Stop IDs at stations serviced by two subway lines, where we also have DUP screens.
-  two_line_stops: [
-    # Haymarket
-    "70024",
-    "70025",
-    "70203",
-    "70204",
-    "place-haecl"
-  ]
+  }
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/lib/screens/dup_screen_data.ex
+++ b/lib/screens/dup_screen_data.ex
@@ -67,9 +67,9 @@ defmodule Screens.DupScreenData do
     alerts_by_section = fetch_and_interpret_alerts(primary_departures)
     alerts = flatten_alerts(alerts_by_section)
 
-    line_count = Data.station_line_count(primary_departures)
+    mode_or_line_count = length(primary_departures.sections)
 
-    case Data.response_type(alerts, line_count, rotation_index) do
+    case Data.response_type(alerts, mode_or_line_count, rotation_index) do
       :departures ->
         fetch_departures_response(primary_departures, alerts_by_section, current_time)
 
@@ -77,7 +77,7 @@ defmodule Screens.DupScreenData do
         fetch_partial_alert_response(primary_departures, alerts_by_section, current_time)
 
       :fullscreen_alert ->
-        fetch_fullscreen_alert_response(primary_departures, alerts, line_count)
+        fetch_fullscreen_alert_response(primary_departures, alerts, mode_or_line_count)
     end
   end
 

--- a/lib/screens/dup_screen_data.ex
+++ b/lib/screens/dup_screen_data.ex
@@ -90,7 +90,7 @@ defmodule Screens.DupScreenData do
     alerts_by_section = fetch_and_interpret_alerts(primary_departures)
     alerts = flatten_alerts(alerts_by_section)
 
-    line_count = Data.station_line_count(primary_departures)
+    line_count = length(primary_departures.sections)
 
     case Data.response_type(alerts, line_count, rotation_index) do
       :fullscreen_alert ->

--- a/lib/screens/dup_screen_data/data.ex
+++ b/lib/screens/dup_screen_data/data.ex
@@ -1,8 +1,6 @@
 defmodule Screens.DupScreenData.Data do
   @moduledoc false
 
-  alias Screens.Config.Dup
-
   def choose_alert([]), do: nil
 
   def choose_alert(alerts) do
@@ -46,11 +44,6 @@ defmodule Screens.DupScreenData.Data do
     alert.informed_entities
     |> Enum.filter(filter_fn)
     |> Enum.flat_map(route_fn)
-  end
-
-  def station_line_count(%Dup.Departures{sections: [section | _]}) do
-    stop_id = hd(section.stop_ids)
-    if stop_id in Application.get_env(:screens, :two_line_stops), do: 2, else: 1
   end
 
   def limit_three_departures([[d1, d2], [d3, _d4]]), do: [[d1, d2], [d3]]


### PR DESCRIPTION
**Asana task**: [DUP: Preserve CR/SL predictions](https://app.asana.com/0/1185117109217413/1202809139605042/f)

The code for this was there, but we needed to change how we determine if a stop has multiple lines. It originally was hardcoded and only Haymarkey met the criteria. Now, it just looks at the number of `sections` in the `primary` of the config. If there is more than one section, show a partial alert on screen 1 and a fullscreen alert on screen 2. 

- [ ] Tests added?
