### PR TITLE
tweak: Add overrides for DUP secondary departures

### DIFF
--- a/lib/screens/config/dup.ex
+++ b/lib/screens/config/dup.ex
@@ -6,7 +6,7 @@ defmodule Screens.Config.Dup do
   @type t :: %__MODULE__{
           primary: Departures.t(),
           secondary: Departures.t(),
-          override: {Override.screen0(), Override.screen1(), Override.scrren2()} | nil
+          override: {Override.screen0(), Override.screen1(), Override.screen2()} | nil
         }
 
   defstruct primary: Departures.from_json(:default),

--- a/lib/screens/config/dup.ex
+++ b/lib/screens/config/dup.ex
@@ -6,7 +6,7 @@ defmodule Screens.Config.Dup do
   @type t :: %__MODULE__{
           primary: Departures.t(),
           secondary: Departures.t(),
-          override: {Override.screen0(), Override.screen1()} | nil
+          override: {Override.screen0(), Override.screen1(), Override.scrren2()} | nil
         }
 
   defstruct primary: Departures.from_json(:default),
@@ -15,14 +15,19 @@ defmodule Screens.Config.Dup do
 
   use Screens.Config.Struct, children: [primary: Departures, secondary: Departures]
 
-  defp value_from_json("override", [screen0, screen1]) do
-    {Override.screen0_from_json(screen0), Override.screen1_from_json(screen1)}
+  defp value_from_json("override", [screen0, screen1, screen2]) do
+    {Override.screen0_from_json(screen0), Override.screen1_from_json(screen1),
+     Override.screen2_from_json(screen2)}
   end
 
   defp value_from_json(_, value), do: value
 
-  defp value_to_json(:override, {screen0, screen1}) do
-    [Override.screen0_to_json(screen0), Override.screen1_to_json(screen1)]
+  defp value_to_json(:override, {screen0, screen1, screen2}) do
+    [
+      Override.screen0_to_json(screen0),
+      Override.screen1_to_json(screen1),
+      Override.screen2_to_json(screen2)
+    ]
   end
 
   defp value_to_json(_, value), do: value

--- a/lib/screens/config/dup/override.ex
+++ b/lib/screens/config/dup/override.ex
@@ -3,8 +3,9 @@ defmodule Screens.Config.Dup.Override do
 
   alias Screens.Config.Dup.Override.{FullscreenAlert, FullscreenImage, PartialAlertList}
 
-  @type screen0 :: PartialAlertList.t() | FullscreenAlert.t() | FullscreenImage.t()
-  @type screen1 :: FullscreenAlert.t() | FullscreenImage.t()
+  @type screen0 :: PartialAlertList.t() | FullscreenAlert.t() | FullscreenImage.t() | nil
+  @type screen1 :: FullscreenAlert.t() | FullscreenImage.t() | nil
+  @type screen2 :: PartialAlertList.t() | nil
 
   def screen0_from_json(%{"type" => "partial"} = json) do
     PartialAlertList.from_json(json)
@@ -18,12 +19,28 @@ defmodule Screens.Config.Dup.Override do
     FullscreenImage.from_json(json)
   end
 
+  def screen0_from_json(_) do
+    nil
+  end
+
   def screen1_from_json(%{"type" => "fullscreen"} = json) do
     FullscreenAlert.from_json(json)
   end
 
   def screen1_from_json(%{"type" => "image"} = json) do
     FullscreenImage.from_json(json)
+  end
+
+  def screen1_from_json(_) do
+    nil
+  end
+
+  def screen2_from_json(%{"type" => "partial"} = json) do
+    PartialAlertList.from_json(json)
+  end
+
+  def screen2_from_json(_) do
+    nil
   end
 
   def screen0_to_json(%PartialAlertList{} = screen0) do
@@ -44,5 +61,9 @@ defmodule Screens.Config.Dup.Override do
 
   def screen1_to_json(%FullscreenImage{} = screen1) do
     FullscreenImage.to_json(screen1)
+  end
+
+  def screen2_to_json(%PartialAlertList{} = screen2) do
+    PartialAlertList.to_json(screen2)
   end
 end

--- a/lib/screens/dup_screen_data.ex
+++ b/lib/screens/dup_screen_data.ex
@@ -21,25 +21,28 @@ defmodule Screens.DupScreenData do
       {_, _, true} ->
         disabled_response(now)
 
-      {nil, _, _} ->
-        primary_screen_response(primary_departures, rotation_index, now)
-
-      {{screen0, _}, "0", _} ->
+      {{screen0, _, _}, "0", _} when not is_nil(screen0) ->
         primary_screen_response_with_override(primary_departures, rotation_index, screen0, now)
 
-      {{_, screen1}, "1", _} ->
+      {{_, screen1, _}, "1", _} when not is_nil(screen1) ->
         primary_screen_response_with_override(primary_departures, rotation_index, screen1, now)
+
+      {_, _, _} ->
+        primary_screen_response(primary_departures, rotation_index, now)
     end
   end
 
   def by_screen_id(screen_id, "2", now) do
-    %Dup{secondary: secondary_departures} = State.app_params(screen_id)
+    %Dup{secondary: secondary_departures, override: override} = State.app_params(screen_id)
 
-    case secondary_departures do
-      %Dup.Departures{sections: []} ->
+    case {secondary_departures, override} do
+      {%Dup.Departures{sections: []}, _} ->
         by_screen_id(screen_id, "0")
 
-      _ ->
+      {_, {_, _, screen2}} ->
+        fetch_partial_alert_response(secondary_departures, screen2, now, override: true)
+
+      {_, _} ->
         fetch_departures_response(secondary_departures, %{}, now)
     end
   end


### PR DESCRIPTION
**Asana task**: [DUP: Add config option to show a partial alert on the secondary departures (bus) page](https://app.asana.com/0/1185117109217413/1202809139605045/f)

This adds the ability to override the secondary departures screen on DUPs. Right now, only partial alerts can be added. This also changes the config so that we no longer need to override all screens at the same time. A value of `null` can be added for a screen override if we do not need an override for that rotation. 

- [ ] Tests added?
