### PR TITLE
fix: Remove requirement for shuttle bus config

### DIFF
--- a/lib/screens/config/v2/pre_fare.ex
+++ b/lib/screens/config/v2/pre_fare.ex
@@ -37,7 +37,7 @@ defmodule Screens.Config.V2.PreFare do
             evergreen_content: [],
             content_summary: nil,
             audio: Audio.from_json(:default),
-            shuttle_bus_info: nil
+            shuttle_bus_info: ShuttleBusInfo.from_json(:default)
 
   use Screens.Config.Struct,
     children: [

--- a/lib/screens/config/v2/shuttle_bus_info.ex
+++ b/lib/screens/config/v2/shuttle_bus_info.ex
@@ -14,17 +14,14 @@ defmodule Screens.Config.V2.ShuttleBusInfo do
 
   @type arrow :: :n | :ne | :e | :se | :s | :sw | :w | :nw | nil
 
-  @enforce_keys [
-    :minutes_range_to_destination,
-    :destination,
-    :arrow,
-    :english_boarding_instructions,
-    :spanish_boarding_instructions,
-    :priority
-  ]
-  defstruct @enforce_keys
+  defstruct minutes_range_to_destination: nil,
+            destination: nil,
+            arrow: nil,
+            english_boarding_instructions: nil,
+            spanish_boarding_instructions: nil,
+            priority: [99]
 
-  use Screens.Config.Struct
+  use Screens.Config.Struct, with_default: true
 
   for arrow <- ~w[n ne e se s sw w nw]a do
     arrow_string = Atom.to_string(arrow)


### PR DESCRIPTION
**Asana task**: ad-hoc

This change allows PreFares screens to work even if they do not have the shuttle bus widget config.

- [ ] Tests added?
