### PR TITLE
feat: Audio for evergreen content

### DIFF
--- a/lib/screens/config/v2/evergreen_content_item.ex
+++ b/lib/screens/config/v2/evergreen_content_item.ex
@@ -8,14 +8,16 @@ defmodule Screens.Config.V2.EvergreenContentItem do
           slot_names: list(WidgetInstance.slot_id()),
           asset_path: String.t(),
           priority: WidgetInstance.priority(),
-          schedule: list(Schedule.t())
+          schedule: list(Schedule.t()),
+          text_for_audio: String.t()
         }
 
   @enforce_keys ~w[slot_names asset_path priority]a
   defstruct slot_names: nil,
             asset_path: nil,
             priority: nil,
-            schedule: [%Schedule{}]
+            schedule: [%Schedule{}],
+            text_for_audio: nil
 
   use Screens.Config.Struct, children: [schedule: {:list, Schedule}]
 

--- a/lib/screens/v2/candidate_generator/widgets/evergreen.ex
+++ b/lib/screens/v2/candidate_generator/widgets/evergreen.ex
@@ -20,7 +20,8 @@ defmodule Screens.V2.CandidateGenerator.Widgets.Evergreen do
            slot_names: slot_names,
            asset_path: asset_path,
            priority: priority,
-           schedule: schedule
+           schedule: schedule,
+           text_for_audio: text_for_audio
          },
          config,
          now
@@ -31,7 +32,8 @@ defmodule Screens.V2.CandidateGenerator.Widgets.Evergreen do
       asset_url: Assets.s3_asset_url(asset_path),
       priority: priority,
       schedule: schedule,
-      now: now
+      now: now,
+      text_for_audio: text_for_audio
     }
   end
 end

--- a/lib/screens/v2/widget_instance/evergreen_content.ex
+++ b/lib/screens/v2/widget_instance/evergreen_content.ex
@@ -11,7 +11,8 @@ defmodule Screens.V2.WidgetInstance.EvergreenContent do
             asset_url: nil,
             priority: nil,
             schedule: [%Schedule{}],
-            now: nil
+            now: nil,
+            text_for_audio: nil
 
   @type t :: %__MODULE__{
           screen: Screen.t(),
@@ -19,7 +20,8 @@ defmodule Screens.V2.WidgetInstance.EvergreenContent do
           asset_url: String.t(),
           priority: WidgetInstance.priority(),
           schedule: list(Schedule.t()),
-          now: DateTime.t()
+          now: DateTime.t(),
+          text_for_audio: String.t()
         }
 
   def priority(%__MODULE__{} = instance), do: instance.priority
@@ -47,6 +49,17 @@ defmodule Screens.V2.WidgetInstance.EvergreenContent do
     end)
   end
 
+  def audio_serialize(%__MODULE__{text_for_audio: text_for_audio}),
+    do: %{text_for_audio: text_for_audio}
+
+  def audio_sort_key(_instance), do: [99]
+
+  def audio_valid_candidate?(%__MODULE__{text_for_audio: text_for_audio})
+      when not is_nil(text_for_audio),
+      do: true
+
+  def audio_valid_candidate?(_), do: false
+
   defimpl Screens.V2.WidgetInstance do
     alias Screens.V2.WidgetInstance.EvergreenContent
 
@@ -55,9 +68,12 @@ defmodule Screens.V2.WidgetInstance.EvergreenContent do
     def slot_names(instance), do: EvergreenContent.slot_names(instance)
     def widget_type(instance), do: EvergreenContent.widget_type(instance)
     def valid_candidate?(instance), do: EvergreenContent.valid_candidate?(instance)
-    def audio_serialize(_instance), do: %{}
-    def audio_sort_key(_instance), do: [0]
-    def audio_valid_candidate?(_instance), do: false
+    def audio_serialize(instance), do: EvergreenContent.audio_serialize(instance)
+    def audio_sort_key(instance), do: EvergreenContent.audio_sort_key(instance)
+
+    def audio_valid_candidate?(instance),
+      do: EvergreenContent.audio_valid_candidate?(instance)
+
     def audio_view(_instance), do: ScreensWeb.V2.Audio.EvergreenContentView
   end
 end

--- a/lib/screens_web/views/v2/audio/evergreen_content_view.ex
+++ b/lib/screens_web/views/v2/audio/evergreen_content_view.ex
@@ -1,7 +1,7 @@
 defmodule ScreensWeb.V2.Audio.EvergreenContentView do
   use ScreensWeb, :view
 
-  def render("_widget.ssml", _) do
-    ~E""
+  def render("_widget.ssml", %{text_for_audio: text_for_audio}) do
+    ~E"<p><%= text_for_audio %></p>"
   end
 end

--- a/test/screens/v2/widget_instance/evergreen_content_test.exs
+++ b/test/screens/v2/widget_instance/evergreen_content_test.exs
@@ -14,7 +14,8 @@ defmodule Screens.V2.WidgetInstance.EvergreenContentTest do
         asset_url: "https://mbta-screens.s3.amazonaws.com/screens-dev/videos/some-video.mp4",
         priority: [2, 3, 1],
         schedule: [%Schedule{}],
-        now: ~U[2021-02-01T00:00:00Z]
+        now: ~U[2021-02-01T00:00:00Z],
+        text_for_audio: "This is text."
       },
       widget_old_schedule: %EvergreenContent{
         screen: %Screen{app_params: nil, vendor: nil, device_id: nil, name: nil, app_id: nil},
@@ -24,6 +25,14 @@ defmodule Screens.V2.WidgetInstance.EvergreenContentTest do
         schedule: [
           %Schedule{start_dt: ~U[2021-01-01T00:00:00Z], end_dt: ~U[2021-01-02T00:00:00Z]}
         ],
+        now: ~U[2021-02-01T00:00:00Z]
+      },
+      widget_no_audio: %EvergreenContent{
+        screen: %Screen{app_params: nil, vendor: nil, device_id: nil, name: nil, app_id: nil},
+        slot_names: [:medium_left, :medium_right],
+        asset_url: "https://mbta-screens.s3.amazonaws.com/screens-dev/videos/some-video.mp4",
+        priority: [2, 3, 1],
+        schedule: [%Schedule{}],
         now: ~U[2021-02-01T00:00:00Z]
       }
     }
@@ -67,20 +76,24 @@ defmodule Screens.V2.WidgetInstance.EvergreenContentTest do
   end
 
   describe "audio_serialize/1" do
-    test "returns empty string", %{widget: widget} do
-      assert %{} == WidgetInstance.audio_serialize(widget)
+    test "returns map with text to read out", %{widget: widget} do
+      assert %{text_for_audio: "This is text."} == WidgetInstance.audio_serialize(widget)
     end
   end
 
   describe "audio_sort_key/1" do
-    test "returns [0]", %{widget: widget} do
-      assert [0] == WidgetInstance.audio_sort_key(widget)
+    test "returns [99]", %{widget: widget} do
+      assert [99] == WidgetInstance.audio_sort_key(widget)
     end
   end
 
   describe "audio_valid_candidate?/1" do
-    test "returns false", %{widget: widget} do
-      refute WidgetInstance.audio_valid_candidate?(widget)
+    test "returns true for widgets with configured text", %{widget: widget} do
+      assert WidgetInstance.audio_valid_candidate?(widget)
+    end
+
+    test "returns false for widgets without configured audio", %{widget_no_audio: widget_no_audio} do
+      refute WidgetInstance.audio_valid_candidate?(widget_no_audio)
     end
   end
 


### PR DESCRIPTION
**Asana task**: [Audio equivalence for evergreen content widgets](https://app.asana.com/0/1185117109217413/1202815198320926/f)

This adds audio equivalence to evergreen content. `audio_valid_candidate?/1` will only return true if the widget config actually has a string value. For now, evergreen audio will always have the lowest priority. 

- [ ] Tests added?
