### PR TITLE
fix: Alerts CandidateGenerator function for nil stop_sequences 

### DIFF
--- a/lib/screens/v2/candidate_generator/widgets/alerts.ex
+++ b/lib/screens/v2/candidate_generator/widgets/alerts.ex
@@ -82,6 +82,10 @@ defmodule Screens.V2.CandidateGenerator.Widgets.Alerts do
     |> Enum.to_list()
   end
 
+  defp local_and_downstream_stop_ids(nil, home_stop) do
+    [home_stop]
+  end
+
   defp local_and_downstream_stop_ids(stop_sequences, home_stop) do
     downstream_stop_ids =
       stop_sequences


### PR DESCRIPTION
**Asana task**: ad-hoc

At the moment, the API is having issues with the E branch so our alerts code is failing when getting the stop_sequences for E branch stations. Adding this function clause will allow us to get local alerts even when we cannot get downstream stops from the stop_sequences.

- [ ] Tests added?
