### PR TITLE
Add direction filter config for DUPs

### DIFF
--- a/lib/screens/config/dup/section.ex
+++ b/lib/screens/config/dup/section.ex
@@ -9,7 +9,8 @@ defmodule Screens.Config.Dup.Section do
           route_ids: list(route_id()),
           route_type: RouteType.t() | nil,
           pill: :bus | :red | :orange | :green | :blue | :cr | :mattapan | :silver | :ferry,
-          headway: Headway.t()
+          headway: Headway.t(),
+          direction_id: 0 | 1 | nil
         }
 
   @type stop_id :: String.t()
@@ -20,7 +21,8 @@ defmodule Screens.Config.Dup.Section do
             route_ids: [],
             route_type: nil,
             pill: nil,
-            headway: Headway.from_json(:default)
+            headway: Headway.from_json(:default),
+            direction_id: nil
 
   use Screens.Config.Struct, children: [headway: Headway]
 

--- a/lib/screens/dup_screen_data/request.ex
+++ b/lib/screens/dup_screen_data/request.ex
@@ -168,7 +168,13 @@ defmodule Screens.DupScreenData.Request do
   end
 
   defp fetch_section_departures(stop_ids, route_ids, route_type, direction_id, pill, num_rows) do
-    query_params = %{stop_ids: stop_ids, route_ids: route_ids, route_type: route_type, direction_id: direction_id}
+    query_params = %{
+      stop_ids: stop_ids,
+      route_ids: route_ids,
+      route_type: route_type,
+      direction_id: direction_id
+    }
+
     include_schedules? = Enum.member?([:cr, :ferry], pill)
 
     case Departure.fetch(query_params, include_schedules?) do

--- a/lib/screens/dup_screen_data/request.ex
+++ b/lib/screens/dup_screen_data/request.ex
@@ -86,7 +86,8 @@ defmodule Screens.DupScreenData.Request do
             route_ids: route_ids,
             route_type: route_type,
             pill: pill,
-            headway: headway
+            headway: headway,
+            direction_id: direction_id
           } = section, section_alert},
          num_rows,
          current_time
@@ -96,7 +97,7 @@ defmodule Screens.DupScreenData.Request do
         {:ok, %{pill: pill, headway: Response.render_headway_lines(pill, {lo, hi}, num_rows)}}
 
       :inactive ->
-        fetch_section_departures(stop_ids, route_ids, route_type, pill, num_rows)
+        fetch_section_departures(stop_ids, route_ids, route_type, direction_id, pill, num_rows)
     end
   end
 
@@ -166,8 +167,8 @@ defmodule Screens.DupScreenData.Request do
     Logger.info("[dup empty section] stop_ids=#{stop_id_string} route_ids=#{route_id_string}")
   end
 
-  defp fetch_section_departures(stop_ids, route_ids, route_type, pill, num_rows) do
-    query_params = %{stop_ids: stop_ids, route_ids: route_ids, route_type: route_type}
+  defp fetch_section_departures(stop_ids, route_ids, route_type, direction_id, pill, num_rows) do
+    query_params = %{stop_ids: stop_ids, route_ids: route_ids, route_type: route_type, direction_id: direction_id}
     include_schedules? = Enum.member?([:cr, :ferry], pill)
 
     case Departure.fetch(query_params, include_schedules?) do


### PR DESCRIPTION
**Asana task**: [DUP: Config option to filter by direction_id](https://app.asana.com/0/1185117109217413/1202841301882262)

If direction config provided, filter departures by that direction.

I started writing a test, but then didn't see how a test would be useful here, where the direction_id is simply passed as a param to the API query... thoughts on that?

- [ ] Tests added?
