### PR TITLE
Custom scrollbar on screen sims

### DIFF
--- a/assets/css/dup/dup_screen_page.scss
+++ b/assets/css/dup/dup_screen_page.scss
@@ -10,6 +10,8 @@
 }
 
 .simulation-screen-scrolling-container {
+  scrollbar-color: #607180 #2E3F4D;
+
   &::-webkit-scrollbar {
     width: 12px;
   }

--- a/assets/css/dup/dup_screen_page.scss
+++ b/assets/css/dup/dup_screen_page.scss
@@ -3,9 +3,32 @@
   grid-template-columns: 1fr 1fr 1fr;
 }
 
-.simulation-page {
+.simulation-screen-centering-container {
+  display: flex;
+  justify-content: center;
   background: #3d5366;
+}
+
+.simulation-screen-scrolling-container {
+  &::-webkit-scrollbar {
+    width: 12px;
+  }
+  &::-webkit-scrollbar-thumb {
+    background-color: #607180;
+    border-radius: 12px;
+    border: 2px solid #2E3F4D;
+  }
+  &::-webkit-scrollbar-track {
+    -webkit-box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.3);
+    border-radius: 12px;
+    background-color: #2E3F4D;
+  }
+}
+
+.simulation-screen-scrolling-container {
   height: 100%;
+  overflow-x: auto;
+  padding-bottom: 8px;
   .projection {
     display: grid;
     grid-template-columns: 280px 280px 280px;

--- a/assets/css/v2/bus_eink/simulation.scss
+++ b/assets/css/v2/bus_eink/simulation.scss
@@ -5,6 +5,8 @@
 }
 
 .simulation-screen-scrolling-container {
+  scrollbar-color: #607180 #2E3F4D;
+
   &::-webkit-scrollbar {
     width: 12px;
   }

--- a/assets/css/v2/bus_eink/simulation.scss
+++ b/assets/css/v2/bus_eink/simulation.scss
@@ -1,9 +1,30 @@
-.simulation-screen-container {
+.simulation-screen-centering-container {
   display: flex;
+  justify-content: center;
   background: #3d5366;
+}
+
+.simulation-screen-scrolling-container {
+  &::-webkit-scrollbar {
+    width: 12px;
+  }
+  &::-webkit-scrollbar-thumb {
+    background-color: #607180;
+    border-radius: 12px;
+    border: 2px solid #2E3F4D;
+  }
+  &::-webkit-scrollbar-track {
+    -webkit-box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.3);
+    border-radius: 12px;
+    background-color: #2E3F4D;
+  }
+}
+
+.simulation-screen-scrolling-container {
+  display: flex;
   overflow-y: hidden;
   overflow-x: auto;
-  justify-content: center;
+  padding-bottom: 8px;
 
   .simulation__full-page {
     height: 480px;

--- a/assets/css/v2/bus_shelter/simulation.scss
+++ b/assets/css/v2/bus_shelter/simulation.scss
@@ -5,6 +5,8 @@
 }
 
 .simulation-screen-scrolling-container {
+  scrollbar-color: #607180 #2E3F4D;
+
   &::-webkit-scrollbar {
     width: 12px;
   }

--- a/assets/css/v2/bus_shelter/simulation.scss
+++ b/assets/css/v2/bus_shelter/simulation.scss
@@ -1,9 +1,30 @@
-.simulation-screen-container {
+.simulation-screen-centering-container {
   display: flex;
+  justify-content: center;
   background: #3d5366;
+}
+
+.simulation-screen-scrolling-container {
+  &::-webkit-scrollbar {
+    width: 12px;
+  }
+  &::-webkit-scrollbar-thumb {
+    background-color: #607180;
+    border-radius: 12px;
+    border: 2px solid #2E3F4D;
+  }
+  &::-webkit-scrollbar-track {
+    -webkit-box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.3);
+    border-radius: 12px;
+    background-color: #2E3F4D;
+  }
+}
+
+.simulation-screen-scrolling-container {
+  display: flex;
   overflow-y: hidden;
   overflow-x: auto;
-  justify-content: center;
+  padding-bottom: 8px;
 
   .simulation__full-page {
     height: 344px;

--- a/assets/css/v2/gl_eink/simulation.scss
+++ b/assets/css/v2/gl_eink/simulation.scss
@@ -5,6 +5,8 @@
 }
 
 .simulation-screen-scrolling-container {
+  scrollbar-color: #607180 #2E3F4D;
+
   &::-webkit-scrollbar {
     width: 12px;
   }

--- a/assets/css/v2/gl_eink/simulation.scss
+++ b/assets/css/v2/gl_eink/simulation.scss
@@ -1,9 +1,30 @@
-.simulation-screen-container {
+.simulation-screen-centering-container {
   display: flex;
+  justify-content: center;
   background: #3d5366;
+}
+
+.simulation-screen-scrolling-container {
+  &::-webkit-scrollbar {
+    width: 12px;
+  }
+  &::-webkit-scrollbar-thumb {
+    background-color: #607180;
+    border-radius: 12px;
+    border: 2px solid #2E3F4D;
+  }
+  &::-webkit-scrollbar-track {
+    -webkit-box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.3);
+    border-radius: 12px;
+    background-color: #2E3F4D;
+  }
+}
+
+.simulation-screen-scrolling-container {
+  display: flex;
   overflow-y: hidden;
   overflow-x: auto;
-  justify-content: center;
+  padding-bottom: 8px;
 
   .simulation__full-page {
     height: 480px;

--- a/assets/css/v2/pre_fare/simulation.scss
+++ b/assets/css/v2/pre_fare/simulation.scss
@@ -1,14 +1,36 @@
+$SIMULATION_FULL_PAGE_WIDTH: 387px;
+$SIMULATION_FLEX_PAGE_WIDTH: 256px;
+
+$SIMULATION_PRIMARY_MARGIN: 24px;
+$SIMULATION_SECONDARY_MARGIN: 8px;
+
 .simulation-screen-container {
+
+  // Would love to read number of flex pages from the element JSX
+  // $flex_pages: var(--page-number);
+
+  // Could calculate the width of the simulation-screen-container, hypothetically
+  // $SIMULATION_SCREEN_CONTAINER_WIDTH:
+  //     $SIMULATION_FULL_PAGE_WIDTH + $SIMULATION_PRIMARY_MARGIN
+  //     + ($FLEX_PAGES * $SIMULATION_FLEX_PAGE_WIDTH)
+  //     + ($FLEX_PAGES - 1) * $SIMULATION_PRIMARY_MARGIN
+  //     + $SIMULATION_SECONDARY_MARGIN;
+
   display: flex;
   background: #3d5366;
   overflow-y: hidden;
   overflow-x: auto;
-  justify-content: center;
+  // justify-content: center;
+  // left: calc((100vw - $SIMULATION_SCREEN_CONTAINER_WIDTH)/2);
+
+  ::-webkit-scrollbar-track {
+    background: #2E3F4D;
+  }
 
   .simulation__full-page {
     height: 344px;
-    width: 387px;
-    margin-right: 24px;
+    width: $SIMULATION_FULL_PAGE_WIDTH;
+    margin-right: $SIMULATION_PRIMARY_MARGIN;
     z-index: 999;
 
     & > * {
@@ -38,17 +60,17 @@
   }
 
   .simulation__flex-zone-widget {
-    width: 256px;
+    width: $SIMULATION_FLEX_PAGE_WIDTH;
     height: 144px;
     margin-top: auto;
     margin-bottom: auto;
 
     &:last-child {
-      margin-right: 8px;
+      margin-right: $SIMULATION_SECONDARY_MARGIN;
     }
 
     &:not(:last-child) {
-      margin-right: 24px;
+      margin-right: $SIMULATION_PRIMARY_MARGIN;
     }
 
     .flex-one-large,

--- a/assets/css/v2/pre_fare/simulation.scss
+++ b/assets/css/v2/pre_fare/simulation.scss
@@ -1,36 +1,35 @@
-$SIMULATION_FULL_PAGE_WIDTH: 387px;
-$SIMULATION_FLEX_PAGE_WIDTH: 256px;
-
-$SIMULATION_PRIMARY_MARGIN: 24px;
-$SIMULATION_SECONDARY_MARGIN: 8px;
-
-.simulation-screen-container {
-
-  // Would love to read number of flex pages from the element JSX
-  // $flex_pages: var(--page-number);
-
-  // Could calculate the width of the simulation-screen-container, hypothetically
-  // $SIMULATION_SCREEN_CONTAINER_WIDTH:
-  //     $SIMULATION_FULL_PAGE_WIDTH + $SIMULATION_PRIMARY_MARGIN
-  //     + ($FLEX_PAGES * $SIMULATION_FLEX_PAGE_WIDTH)
-  //     + ($FLEX_PAGES - 1) * $SIMULATION_PRIMARY_MARGIN
-  //     + $SIMULATION_SECONDARY_MARGIN;
-
+.simulation-screen-centering-container {
   display: flex;
+  justify-content: center;
   background: #3d5366;
+}
+
+.simulation-screen-scrolling-container {
+  &::-webkit-scrollbar {
+    width: 12px;
+  }
+  &::-webkit-scrollbar-thumb {
+    background-color: #607180;
+    border-radius: 12px;
+    border: 2px solid #2E3F4D;
+  }
+  &::-webkit-scrollbar-track {
+    -webkit-box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.3);
+    border-radius: 12px;
+    background-color: #2E3F4D;
+  }
+}
+
+.simulation-screen-scrolling-container {
+  display: flex;
   overflow-y: hidden;
   overflow-x: auto;
-  // justify-content: center;
-  // left: calc((100vw - $SIMULATION_SCREEN_CONTAINER_WIDTH)/2);
-
-  ::-webkit-scrollbar-track {
-    background: #2E3F4D;
-  }
+  padding-bottom: 8px;
 
   .simulation__full-page {
     height: 344px;
-    width: $SIMULATION_FULL_PAGE_WIDTH;
-    margin-right: $SIMULATION_PRIMARY_MARGIN;
+    width: 387px;
+    margin-right: 24px;
     z-index: 999;
 
     & > * {
@@ -60,17 +59,17 @@ $SIMULATION_SECONDARY_MARGIN: 8px;
   }
 
   .simulation__flex-zone-widget {
-    width: $SIMULATION_FLEX_PAGE_WIDTH;
+    width: 256px;
     height: 144px;
     margin-top: auto;
     margin-bottom: auto;
 
     &:last-child {
-      margin-right: $SIMULATION_SECONDARY_MARGIN;
+      margin-right: 8px;
     }
 
     &:not(:last-child) {
-      margin-right: $SIMULATION_PRIMARY_MARGIN;
+      margin-right: 24px;
     }
 
     .flex-one-large,

--- a/assets/css/v2/pre_fare/simulation.scss
+++ b/assets/css/v2/pre_fare/simulation.scss
@@ -5,6 +5,8 @@
 }
 
 .simulation-screen-scrolling-container {
+  scrollbar-color: #607180 #2E3F4D;
+
   &::-webkit-scrollbar {
     width: 12px;
   }

--- a/assets/src/components/dup/dup_screen_page.tsx
+++ b/assets/src/components/dup/dup_screen_page.tsx
@@ -65,23 +65,25 @@ const SimulationPage = ({
 }): JSX.Element => {
   const { id } = useParams();
   return (
-    <div className="simulation-page">
-      <div className="projection">
-        <ScreenContainer
-          id={id}
-          rotationIndex={0}
-          refreshMs={DUP_SIMULATION_REFRESH_MS}
-        />
-        <ScreenContainer
-          id={id}
-          rotationIndex={1}
-          refreshMs={DUP_SIMULATION_REFRESH_MS}
-        />
-        <ScreenContainer
-          id={id}
-          rotationIndex={2}
-          refreshMs={DUP_SIMULATION_REFRESH_MS}
-        />
+    <div className="simulation-screen-centering-container">
+      <div className="simulation-screen-scrolling-container">
+        <div className="projection">
+          <ScreenContainer
+            id={id}
+            rotationIndex={0}
+            refreshMs={DUP_SIMULATION_REFRESH_MS}
+          />
+          <ScreenContainer
+            id={id}
+            rotationIndex={1}
+            refreshMs={DUP_SIMULATION_REFRESH_MS}
+          />
+          <ScreenContainer
+            id={id}
+            rotationIndex={2}
+            refreshMs={DUP_SIMULATION_REFRESH_MS}
+          />
+        </div>
       </div>
     </div>
   );

--- a/assets/src/components/v2/simulation_screen_container.tsx
+++ b/assets/src/components/v2/simulation_screen_container.tsx
@@ -21,26 +21,28 @@ const SimulationScreenLayout: ComponentType<SimulationScreenLayoutProps> = ({
   const { fullPage, flexZone } = data;
 
   return (
-    <div className="simulation-screen-container" style={{"--page-number": flexZone?.length} as React.CSSProperties}>
-      {apiResponse && (
-        <div className="simulation__full-page">
-          {fullPage ? <Widget data={fullPage} /> : <div>Loading</div>}
-        </div>
-      )}
-      {flexZone?.length > 0 && (
-        <div className="simulation__flex-zone">
-          {flexZone.map((flexZonePage: WidgetData, index: number) => {
-            return (
-              <div
-                key={`page${index}`}
-                className="simulation__flex-zone-widget"
-              >
-                <Widget data={flexZonePage} />
-              </div>
-            );
-          })}
-        </div>
-      )}
+    <div className="simulation-screen-centering-container">
+      <div className="simulation-screen-scrolling-container">
+        {apiResponse && (
+          <div className="simulation__full-page">
+            {fullPage ? <Widget data={fullPage} /> : <div>Loading</div>}
+          </div>
+        )}
+        {flexZone?.length > 0 && (
+          <div className="simulation__flex-zone">
+            {flexZone.map((flexZonePage: WidgetData, index: number) => {
+              return (
+                <div
+                  key={`page${index}`}
+                  className="simulation__flex-zone-widget"
+                >
+                  <Widget data={flexZonePage} />
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
     </div>
   );
 };

--- a/assets/src/components/v2/simulation_screen_container.tsx
+++ b/assets/src/components/v2/simulation_screen_container.tsx
@@ -21,7 +21,7 @@ const SimulationScreenLayout: ComponentType<SimulationScreenLayoutProps> = ({
   const { fullPage, flexZone } = data;
 
   return (
-    <div className="simulation-screen-container">
+    <div className="simulation-screen-container" style={{"--page-number": flexZone?.length} as React.CSSProperties}>
       {apiResponse && (
         <div className="simulation__full-page">
           {fullPage ? <Widget data={fullPage} /> : <div>Loading</div>}


### PR DESCRIPTION
**Asana task**: [📺▶️ : 🇵🇱 | Scrollbar in simulations](https://app.asana.com/0/1185117109217413/1202736912335100)

At first, using `margin-left: auto` on the simulation__full-page and `margin-right: auto` on simulation__flex-zone looked to work beautifully, but that margin-right didn't translate to Screenplay through the iframe. This was the result:

![Screen Shot 2022-08-24 at 2 24 38 PM](https://user-images.githubusercontent.com/69368883/186694165-d763629f-3136-4c2a-a40d-820fa3426cf1.png)

So had to get a little fancier with nested containers:  the outer container handles centering; the inner container handles the scroll.  This was applied to all "wide" screen types:  Prefare, Bus Shelter, V2 E-inks, DUPs. The design only shows scrollbars for screens with flex zones, but even the e-inks and DUPs could render weird if the user zooms in even slightly.

![Screen Shot 2022-08-25 at 10 45 55 AM](https://user-images.githubusercontent.com/69368883/186696601-132d36e1-03bd-4820-9a08-e1a3a49ed781.png)
![Screen Shot 2022-08-25 at 10 45 11 AM](https://user-images.githubusercontent.com/69368883/186696616-558ab703-2a1c-4759-938b-52e904597550.png)
