### PR TITLE
fix[dup]: add new OL surge commuter rail headsign abbreviations

### DIFF
--- a/lib/screens/dup_screen_data/request.ex
+++ b/lib/screens/dup_screen_data/request.ex
@@ -37,7 +37,15 @@ defmodule Screens.DupScreenData.Request do
     "Wickford Junction" => "Wickford Jct",
     "Needham Heights" => "Needham Hts",
     "Houghs Neck via McGrath & Germantown" => "Houghs Neck via McGth & Gtwn",
-    "Houghs Neck via Germantown" => "Houghs Neck via Germntwn"
+    "Houghs Neck via Germantown" => "Houghs Neck via Germntwn",
+
+    # The following are special headsigns for the 2022 Orange Line surge
+    "Needham Heights via Ruggles" => "Needham Hts via Ruggles",
+    "Needham Heights via Forest Hills" => "Needham Hts via Forest Hills",
+    "Wickford Junction via Ruggles" => "Wickford Jct via Ruggles",
+    "Wickford Junction via Forest Hills" => "Wickford Jct via Forest Hills",
+    "Providence & Needham via Forest Hills" => "Providence via Forest Hills",
+    "Norwood Central via Ruggles" => "Norwood Cntrl via Ruggles"
   }
 
   def fetch_alerts(stop_ids, route_ids) do


### PR DESCRIPTION
**Asana task**: [DUP: Abbreviate new long headsigns with "via"](https://app.asana.com/0/1202777352373945/1202809139605048)

I ran through and tested this list (courtesy of Christian).

> Back Bay:
> "Needham Heights via Forest Hills"
> "South Station via Forest Hills"
> "South Station via Ruggles"
> "South Station via Back Bay"
> "Wickford Junction via Ruggles"
> "Providence via Ruggles"
> "Stoughton via Ruggles"
> "Providence & Needham via Forest Hills"
> "Norwood Central via Ruggles"
> "Framingham via Back Bay"
> "Foxboro via Back Bay"
> "Foxboro via Ruggles"
> "Walpole via Ruggles"
> "Forge Park/495 via Fairmount"
> "Forge Park/495 via Ruggles"
> "Worcester via Back Bay"
> "Stoughton via Forest Hills"
> "Wickford Junction via Forest Hills"
> "Providence via Forest Hills"
> 
> Malden Center:
> "North Station via Oak Grove"
> "North Station via Malden Center"
> "Reading via Oak Grove"
> "Haverhill via Oak Grove"