### PR TITLE
Include the GLX in trunk

### DIFF
--- a/lib/screens/stops/stop.ex
+++ b/lib/screens/stops/stop.ex
@@ -183,6 +183,10 @@ defmodule Screens.Stops.Stop do
   ]
 
   @green_line_trunk_stops [
+    # These 3 eventually will NOT be trunk stops, but are until Medford opens
+    {"place-unsqu", {"Union Square", "Union Sq"}},
+    {"place-lech", {"Lechmere", "Lechmere"}},
+    {"place-spmnl", {"Science Park/West End", "Science Pk"}},
     {"place-north", {"North Station", "North Sta"}},
     {"place-haecl", {"Haymarket", "Haymarket"}},
     {"place-gover", {"Government Center", "Gov't Ctr"}},
@@ -298,6 +302,8 @@ defmodule Screens.Stops.Stop do
   """
   def get_stop_sequence(informed_entities, route_id) do
     stop_sequences = Map.get(@route_stop_sequences, route_id)
+    |> IO.inspect(label: "stop sequences")
+    IO.inspect(informed_entities, label: "informed entities")
     Enum.find(stop_sequences, &sequence_match?(&1, informed_entities))
   end
 

--- a/lib/screens/stops/stop.ex
+++ b/lib/screens/stops/stop.ex
@@ -302,8 +302,6 @@ defmodule Screens.Stops.Stop do
   """
   def get_stop_sequence(informed_entities, route_id) do
     stop_sequences = Map.get(@route_stop_sequences, route_id)
-    |> IO.inspect(label: "stop sequences")
-    IO.inspect(informed_entities, label: "informed entities")
     Enum.find(stop_sequences, &sequence_match?(&1, informed_entities))
   end
 


### PR DESCRIPTION
**Asana task**: adhoc

For now, will the whole norther part of the GL is all in-line, PIOs can create alerts that are non-branch-specific, and we can show the endpoints for that alert. For example, shuttling on the D and E starting at Govt Center and northward? We can and show endpoints for that, as if Science Park, Lechmere, and Union Sq are all a part of the GL "trunk" (even though they kinda aren't). When Medford branch pops up, then we'll need to remove these stops.

- [ ] Tests added?
