### PR TITLE
tweak: Add clock to eInk no data state.

### DIFF
--- a/assets/css/connection_error.scss
+++ b/assets/css/connection_error.scss
@@ -5,3 +5,13 @@
   height: 1600px;
   overflow: hidden;
 }
+
+.connection-error__time {
+  position: absolute;
+  margin-left: 1000px;
+  margin-top: 40px;
+  font-family: Inter;
+  color: #ffffff;
+  font-size: 72px;
+  line-height: 72px;
+}

--- a/assets/css/v2/eink/no_data.scss
+++ b/assets/css/v2/eink/no_data.scss
@@ -54,7 +54,6 @@
   object-fit: contain;
 }
 
-
 .no-data__main-content {
   margin-left: 208px;
 }
@@ -91,4 +90,14 @@
   font-weight: normal;
   letter-spacing: 0px;
   line-height: 92px;
+}
+
+.no-data__time {
+  position: absolute;
+  right: 40px;
+  top: 40px;
+  font-family: Inter;
+  color: #ffffff;
+  font-size: 72px;
+  line-height: 72px;
 }

--- a/assets/src/components/eink/no_connection_single.tsx
+++ b/assets/src/components/eink/no_connection_single.tsx
@@ -1,9 +1,13 @@
+import moment from "moment";
 import React from "react";
 import { imagePath } from "Util/util";
 
 const NoConnectionSingle = (): JSX.Element => {
+  const currentTime = moment().tz("America/New_York").format("h:mm");
+
   return (
     <div className="connection-error">
+      <div className="connection-error__time">{currentTime}</div>
       <img src={imagePath("no-data-static-single.png")} />
     </div>
   );

--- a/assets/src/components/eink/no_connection_top.tsx
+++ b/assets/src/components/eink/no_connection_top.tsx
@@ -1,9 +1,13 @@
+import moment from "moment";
 import React from "react";
 import { imagePath } from "Util/util";
 
 const NoConnectionTop = (): JSX.Element => {
+  const currentTime = moment().tz("America/New_York").format("h:mm");
+
   return (
     <div className="connection-error">
+      <div className="connection-error__time">{currentTime}</div>
       <img src={imagePath("no-data-static-top.png")} />
     </div>
   );

--- a/assets/src/components/v2/eink/no_data.tsx
+++ b/assets/src/components/v2/eink/no_data.tsx
@@ -2,8 +2,11 @@ import React, { ComponentType } from "react";
 import { imagePath } from "Util/util";
 import NoConnection from "Components/v2/bundled_svg/no_connection";
 import BottomScreenFiller from "Components/v2/eink/bottom_screen_filler";
+import moment from "moment";
 
 const NoData: ComponentType = () => {
+  const currentTime = moment().tz("America/New_York").format("h:mm");
+
   return (
     <div className="no-data-container">
       <div className="no-data__top-screen">
@@ -19,6 +22,7 @@ const NoData: ComponentType = () => {
               Thank you for your patience
             </div>
           </div>
+          <div className="no-data__time">{currentTime}</div>
         </div>
         <div className="no-data__main-content">
           <div className="no-data__main-content__no-connection-icon-container">


### PR DESCRIPTION
**Asana task**: [[E-Ink] Add a clock to full screen fallback image](https://app.asana.com/0/1185117109217413/1202593548281747/f)

This should be all places that were missing a clock. `OvernightDepartures` components in v1 and v2 and the v1 `FullScreenTakeover` component already had it. 

- [ ] Tests added?
