### PR TITLE
feat: Add DeparturesNoData component to v2 eink

### DIFF
--- a/assets/css/bus_eink_v2.scss
+++ b/assets/css/bus_eink_v2.scss
@@ -17,6 +17,7 @@
 @import "v2/eink/page_load_no_data";
 @import "v2/eink/alert";
 @import "v2/eink/bottom_screen_filler";
+@import "v2/eink/departures_no_data";
 
 @import "v2/eink/flex/page_indicator";
 @import "v2/eink/flex/one_medium";

--- a/assets/css/gl_eink_v2.scss
+++ b/assets/css/gl_eink_v2.scss
@@ -5,6 +5,7 @@
 
 @import "v2/gl_eink/body/normal";
 @import "v2/eink/body/takeover";
+@import "v2/gl_eink/body/top_takeover";
 @import "v2/gl_eink/body/bottom_takeover";
 @import "v2/eink/flex/one_medium";
 @import "v2/eink/flex/page_indicator";

--- a/assets/css/gl_eink_v2.scss
+++ b/assets/css/gl_eink_v2.scss
@@ -18,6 +18,7 @@
 @import "v2/eink/departures/alert";
 @import "v2/eink/alert";
 @import "v2/eink/bottom_screen_filler";
+@import "v2/eink/departures_no_data";
 
 @import "v2/eink/departures/overnight";
 @import "v2/eink/no_data";

--- a/assets/css/v2/eink/departures_no_data.scss
+++ b/assets/css/v2/eink/departures_no_data.scss
@@ -1,0 +1,58 @@
+.departures-no-data-container {
+  width: 1200px;
+  height: 1312px;
+}
+
+.departures-no-data__main-content {
+  margin-bottom: 53px;
+  margin-left: 208px;
+}
+
+.departures-no-data__main-content__no-connection-icon-container {
+  width: 236px;
+  height: 236px;
+  margin-bottom: 48px;
+  margin-top: 111px;
+}
+
+.departures-no-data__main-content__heading {
+  width: 770px;
+  height: 448px;
+  color: rgb(0, 0, 0);
+  font-size: 104px;
+  font-family: Inter, sans-serif;
+  font-weight: bold;
+  letter-spacing: 0px;
+  line-height: 112px;
+}
+
+.departures-no-data__hairline {
+  content: "";
+  background: #171f26;
+  width: 784px;
+  height: 1px;
+  margin-left: 208px;
+  margin-top: 53px;
+}
+
+.departures-no-data__alternatives-container {
+  margin-top: 47px;
+  margin-left: 208px;
+}
+
+.departures-no-data__alternatives__message {
+  width: 872px;
+  height: 300px;
+  color: rgb(0, 0, 0);
+  font-size: 72px;
+  font-family: Inter, sans-serif;
+  font-weight: normal;
+  letter-spacing: 0px;
+  line-height: 92px;
+}
+
+.departures-no-data__main-content__no-connection-icon {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}

--- a/assets/css/v2/eink/departures_no_data.scss
+++ b/assets/css/v2/eink/departures_no_data.scss
@@ -4,7 +4,7 @@
 }
 
 .departures-no-data__main-content {
-  margin-bottom: 53px;
+  margin-bottom: 52px;
   margin-left: 208px;
 }
 
@@ -28,11 +28,11 @@
 
 .departures-no-data__hairline {
   content: "";
-  background: #171f26;
+  background: #000000;
   width: 784px;
   height: 1px;
   margin-left: 208px;
-  margin-top: 53px;
+  margin-top: 52px;
 }
 
 .departures-no-data__alternatives-container {

--- a/assets/css/v2/eink/no_data.scss
+++ b/assets/css/v2/eink/no_data.scss
@@ -54,7 +54,6 @@
   object-fit: contain;
 }
 
-
 .no-data__main-content {
   margin-left: 208px;
 }
@@ -74,7 +73,7 @@
 
 .no-data__hairline {
   content: "";
-  background: #b9b8b6;
+  background: #000000;
   width: 811px;
   height: 2px;
   border-radius: 1px;

--- a/assets/css/v2/gl_eink/body/top_takeover.scss
+++ b/assets/css/v2/gl_eink/body/top_takeover.scss
@@ -1,0 +1,29 @@
+.body-top-takeover {
+  position: relative;
+  width: 1200px;
+  height: 2912px;
+}
+
+.body-top-takeover__top-screen {
+  position: absolute;
+  top: 0px;
+  left: 0px;
+  width: 1200px;
+  height: 1312px;
+}
+
+.body-top-takeover__flex-zone {
+  position: absolute;
+  top: 1312px;
+  left: 0px;
+  width: 1200px;
+  height: 1164px;
+}
+
+.body-top-takeover__footer {
+  position: absolute;
+  top: 2476px;
+  left: 0px;
+  width: 1200px;
+  height: 436px;
+}

--- a/assets/src/apps/v2/bus_eink.tsx
+++ b/assets/src/apps/v2/bus_eink.tsx
@@ -29,6 +29,7 @@ import {
   ResponseMapperContext,
 } from "Components/v2/screen_container";
 import NoData from "Components/v2/eink/no_data";
+import DeparturesNoData from "Components/v2/eink/departures_no_data";
 import PageLoadNoData from "Components/v2/eink/page_load_no_data";
 import {
   MediumFlexAlert,
@@ -55,6 +56,7 @@ const TYPE_TO_COMPONENT = {
   no_data: NoData,
   page_load_no_data: PageLoadNoData,
   bottom_screen_filler: BottomScreenFiller,
+  departures_no_data: DeparturesNoData,
 };
 
 const DISABLED_LAYOUT = {

--- a/assets/src/apps/v2/gl_eink.tsx
+++ b/assets/src/apps/v2/gl_eink.tsx
@@ -25,6 +25,7 @@ import NormalDepartures from "Components/v2/departures/normal_departures";
 import LineMap from "Components/v2/gl_eink_double/line_map";
 import EvergreenContent from "Components/v2/evergreen_content";
 import NoData from "Components/v2/eink/no_data";
+import DeparturesNoData from "Components/v2/eink/departures_no_data";
 import PageLoadNoData from "Components/v2/eink/page_load_no_data";
 import {
   LOADING_LAYOUT,
@@ -60,6 +61,7 @@ const TYPE_TO_COMPONENT = {
   page_load_no_data: PageLoadNoData,
   bottom_screen_filler: BottomScreenFiller,
   overnight_departures: OvernightDepartures,
+  departures_no_data: DeparturesNoData,
 };
 
 const DISABLED_LAYOUT = {

--- a/assets/src/apps/v2/gl_eink.tsx
+++ b/assets/src/apps/v2/gl_eink.tsx
@@ -15,6 +15,7 @@ import NormalScreen from "Components/v2/gl_eink_double/normal_screen";
 import TakeoverScreen from "Components/v2/takeover_screen";
 import NormalBody from "Components/v2/gl_eink_double/normal_body";
 import TakeoverBody from "Components/v2/eink/takeover_body";
+import TopTakeoverBody from "Components/v2/gl_eink_double/top_takeover_body";
 import BottomTakeoverBody from "Components/v2/gl_eink_double/bottom_takeover_body";
 import OneMedium from "Components/v2/eink/flex/one_medium";
 import Placeholder from "Components/v2/placeholder";
@@ -44,6 +45,7 @@ const TYPE_TO_COMPONENT = {
   screen_takeover: TakeoverScreen,
   body_normal: NormalBody,
   body_takeover: TakeoverBody,
+  top_takeover: TopTakeoverBody,
   bottom_takeover: BottomTakeoverBody,
   one_medium: OneMedium,
   placeholder: Placeholder,

--- a/assets/src/components/v2/eink/departures_no_data.tsx
+++ b/assets/src/components/v2/eink/departures_no_data.tsx
@@ -6,7 +6,7 @@ interface Props {
   stop_id: string;
 }
 
-const coolBlack = "#171F26";
+const black = "#000000";
 
 const DeparturesNoData: ComponentType<Props> = ({
   show_alternatives: showAlternatives,
@@ -18,7 +18,7 @@ const DeparturesNoData: ComponentType<Props> = ({
         <div className="departures-no-data__main-content__no-connection-icon-container">
           <NoConnection
             className="departures-no-data__main-content__no-connection-icon"
-            colorHex={coolBlack}
+            colorHex={black}
           />
         </div>
         <div className="departures-no-data__main-content__heading">

--- a/assets/src/components/v2/eink/departures_no_data.tsx
+++ b/assets/src/components/v2/eink/departures_no_data.tsx
@@ -1,0 +1,45 @@
+import React, { ComponentType } from "react";
+import NoConnection from "Components/v2/bundled_svg/no_connection";
+
+interface Props {
+  show_alternatives: boolean;
+  stop_id: string;
+}
+
+const coolBlack = "#171F26";
+
+const DeparturesNoData: ComponentType<Props> = ({
+  show_alternatives: showAlternatives,
+  stop_id: stopId,
+}) => {
+  return (
+    <div className="departures-no-data-container">
+      <div className="departures-no-data__main-content">
+        <div className="departures-no-data__main-content__no-connection-icon-container">
+          <NoConnection
+            className="departures-no-data__main-content__no-connection-icon"
+            colorHex={coolBlack}
+          />
+        </div>
+        <div className="departures-no-data__main-content__heading">
+          Live departure updates are temporarily unavailable.
+        </div>
+      </div>
+      {showAlternatives && (
+        <>
+          <div className="departures-no-data__hairline" />
+          <div className="departures-no-data__alternatives-container">
+            <div className="departures-no-data__alternatives__message">
+              For schedules, go to{" "}
+              <span className="departures-no-data__alternatives__message__em">
+                mbta.com/stops/{stopId}
+              </span>{" "}
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default DeparturesNoData;

--- a/assets/src/components/v2/eink/departures_no_data.tsx
+++ b/assets/src/components/v2/eink/departures_no_data.tsx
@@ -6,8 +6,6 @@ interface Props {
   stop_id: string;
 }
 
-const black = "#000000";
-
 const DeparturesNoData: ComponentType<Props> = ({
   show_alternatives: showAlternatives,
   stop_id: stopId,
@@ -18,7 +16,7 @@ const DeparturesNoData: ComponentType<Props> = ({
         <div className="departures-no-data__main-content__no-connection-icon-container">
           <NoConnection
             className="departures-no-data__main-content__no-connection-icon"
-            colorHex={black}
+            colorHex="#000000"
           />
         </div>
         <div className="departures-no-data__main-content__heading">

--- a/assets/src/components/v2/gl_eink_double/top_takeover_body.tsx
+++ b/assets/src/components/v2/gl_eink_double/top_takeover_body.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+
+import Widget, { WidgetData } from "Components/v2/widget";
+
+interface Props {
+  full_body_top_screen: WidgetData;
+  main_content: WidgetData;
+  flex_zone: WidgetData;
+  footer: WidgetData;
+}
+
+const TopTakeoverBody: React.ComponentType<Props> = ({
+  full_body_top_screen: fullBodyTopScreen,
+  flex_zone: flexZone,
+  footer,
+}) => {
+  return (
+    <div className="body-top-takeover">
+      <div className="body-top-takeover__top-screen">
+        <Widget data={fullBodyTopScreen} />
+      </div>
+      <div className="body-top-takeover__flex-zone">
+        <Widget data={flexZone} />
+      </div>
+      <div className="body-top-takeover__footer">
+        <Widget data={footer} />
+      </div>
+    </div>
+  );
+};
+
+export default TopTakeoverBody;

--- a/lib/screens/v2/candidate_generator/gl_eink.ex
+++ b/lib/screens/v2/candidate_generator/gl_eink.ex
@@ -37,6 +37,11 @@ defmodule Screens.V2.CandidateGenerator.GlEink do
               Builder.with_paging({:flex_zone, %{one_medium: [:medium]}}, 2),
               :footer
             ],
+            top_takeover: [
+              :full_body_top_screen,
+              Builder.with_paging({:flex_zone, %{one_medium: [:medium]}}, 2),
+              :footer
+            ],
             body_takeover: [
               :full_body_top_screen,
               :full_body_bottom_screen

--- a/lib/screens/v2/widget_instance/departures_no_data.ex
+++ b/lib/screens/v2/widget_instance/departures_no_data.ex
@@ -17,6 +17,7 @@ defmodule Screens.V2.WidgetInstance.DeparturesNoData do
     %{show_alternatives: instance.show_alternatives?, stop_id: stop_id(instance)}
   end
 
+  def slot_names(%__MODULE__{screen: %Screen{app_id: :gl_eink_v2}}), do: [:full_body_top_screen]
   def slot_names(_instance), do: [:main_content]
   def widget_type(_instance), do: :departures_no_data
   def valid_candidate?(_instance), do: true

--- a/test/screens/v2/candidate_generator/gl_eink_test.exs
+++ b/test/screens/v2/candidate_generator/gl_eink_test.exs
@@ -43,6 +43,12 @@ defmodule Screens.V2.CandidateGenerator.GlEinkTest do
                        {{1, :flex_zone}, %{one_medium: [{1, :medium}]}},
                        :footer
                      ],
+                     top_takeover: [
+                       :full_body_top_screen,
+                       {{0, :flex_zone}, %{one_medium: [{0, :medium}]}},
+                       {{1, :flex_zone}, %{one_medium: [{1, :medium}]}},
+                       :footer
+                     ],
                      body_takeover: [
                        :full_body_top_screen,
                        :full_body_bottom_screen

--- a/test/screens/v2/widget_instance/departures_no_data_test.exs
+++ b/test/screens/v2/widget_instance/departures_no_data_test.exs
@@ -2,59 +2,76 @@ defmodule Screens.V2.WidgetInstance.DeparturesNoDataTest do
   use ExUnit.Case, async: true
   alias Screens.V2.WidgetInstance
   alias Screens.Config.Screen
-  alias Screens.Config.V2.{Alerts, BusShelter}
+  alias Screens.Config.V2.{Alerts, BusShelter, GlEink}
 
-  @instance %WidgetInstance.DeparturesNoData{
-    screen: struct(Screen, %{app_params: struct(BusShelter, %{alerts: %Alerts{stop_id: "1"}})}),
-    show_alternatives?: true
-  }
+  setup do
+    %{
+      widget: %WidgetInstance.DeparturesNoData{
+        screen:
+          struct(Screen, %{app_params: struct(BusShelter, %{alerts: %Alerts{stop_id: "1"}})}),
+        show_alternatives?: true
+      },
+      gl_eink_widget: %WidgetInstance.DeparturesNoData{
+        screen:
+          struct(Screen, %{
+            app_id: :gl_eink_v2,
+            app_params: struct(GlEink, %{alerts: %Alerts{stop_id: "1"}})
+          }),
+        show_alternatives?: true
+      }
+    }
+  end
 
   describe "priority/1" do
-    test "returns 2" do
-      assert [2] == WidgetInstance.priority(@instance)
+    test "returns 2", %{widget: widget} do
+      assert [2] == WidgetInstance.priority(widget)
     end
   end
 
   describe "serialize/1" do
-    test "returns stop ID and `show_alternatives?`" do
-      assert %{stop_id: "1", show_alternatives: true} == WidgetInstance.serialize(@instance)
+    test "returns stop ID and `show_alternatives?`", %{widget: widget} do
+      assert %{stop_id: "1", show_alternatives: true} == WidgetInstance.serialize(widget)
     end
   end
 
   describe "slot_names/1" do
-    test "returns main_content" do
-      assert [:main_content] == WidgetInstance.slot_names(@instance)
+    test "returns full_body_top_screen for gl_eink_v2", %{gl_eink_widget: gl_eink_widget} do
+      assert [:full_body_top_screen] == WidgetInstance.slot_names(gl_eink_widget)
+    end
+
+    test "returns main_content", %{widget: widget} do
+      assert [:main_content] == WidgetInstance.slot_names(widget)
     end
   end
 
   describe "widget_type/1" do
-    test "returns departures no data" do
-      assert :departures_no_data == WidgetInstance.widget_type(@instance)
+    test "returns departures no data", %{widget: widget} do
+      assert :departures_no_data == WidgetInstance.widget_type(widget)
     end
   end
 
   describe "audio_serialize/1" do
-    test "returns empty string" do
-      assert %{} == WidgetInstance.audio_serialize(@instance)
+    test "returns empty string", %{widget: widget} do
+      assert %{} == WidgetInstance.audio_serialize(widget)
     end
   end
 
   describe "audio_sort_key/1" do
-    test "returns [0]" do
-      assert [0] == WidgetInstance.audio_sort_key(@instance)
+    test "returns [0]", %{widget: widget} do
+      assert [0] == WidgetInstance.audio_sort_key(widget)
     end
   end
 
   describe "audio_valid_candidate?/1" do
-    test "returns false" do
-      refute WidgetInstance.audio_valid_candidate?(@instance)
+    test "returns false", %{widget: widget} do
+      refute WidgetInstance.audio_valid_candidate?(widget)
     end
   end
 
   describe "audio_view/1" do
-    test "returns DeparturesNoDataView" do
+    test "returns DeparturesNoDataView", %{widget: widget} do
       assert ScreensWeb.V2.Audio.DeparturesNoDataView ==
-               WidgetInstance.audio_view(@instance)
+               WidgetInstance.audio_view(widget)
     end
   end
 end


### PR DESCRIPTION
**Asana task**: [[E-ink] Add DeparturesNoData component to eInk front-end apps](https://app.asana.com/0/1185117109217413/1202131702864644/f)

Based on the [these designs](https://share.goabstract.com/5961689f-1714-4a37-bcfc-bee55d876aa7?collectionLayerId=42bf6e24-c328-4146-95ec-e1d579e765d1&mode=design). I needed to add to the GlEink template to accommodate a top body takeover.

- [ ] Tests added?
