### PR TITLE
fix: Increase departure time font size for bus_eink_v2

### DIFF
--- a/assets/css/v2/bus_eink/departures/time.scss
+++ b/assets/css/v2/bus_eink/departures/time.scss
@@ -32,7 +32,7 @@
   display: inline-block;
   margin-left: 3px;
 
-  font-size: 96px;
+  font-size: 120px;
   line-height: 120px;
   font-weight: 800;
 }


### PR DESCRIPTION
**Asana task**: [[Bus E-Ink] Prediction sizes are consistent with V1](https://app.asana.com/0/1185117109217413/1201542162358586/f)

During migration, the departure time for bus_eink_v2 was decrease by mistake. Bumped it up to match designs.

- [ ] Tests added?
