### PR TITLE
Cr departures: Enum.sort_by to look at DateTime

### DIFF
--- a/lib/screens/v2/departure/builder.ex
+++ b/lib/screens/v2/departure/builder.ex
@@ -107,6 +107,6 @@ defmodule Screens.V2.Departure.Builder do
 
     predicted_departures
     |> Kernel.++(unpredicted_departures)
-    |> Enum.sort_by(&Departure.time/1)
+    |> Enum.sort_by(&Departure.time/1, DateTime)
   end
 end


### PR DESCRIPTION
Why didn't we update this sort_by earlier? Was that a tech debt task? I don't see how this would adversely impact the departures on other screens, but also I don't know why we didn't see this bug earlier!
