### PR TITLE
fix: Shuttle Bus time schedules

### DIFF
--- a/lib/screens/v2/widget_instance/shuttle_bus_info.ex
+++ b/lib/screens/v2/widget_instance/shuttle_bus_info.ex
@@ -75,7 +75,9 @@ defmodule Screens.V2.WidgetInstance.ShuttleBusInfo do
   def audio_view(_instance), do: ScreensWeb.V2.Audio.ShuttleBusInfoView
 
   defp get_minute_range(schedule, now) do
+    # Shift to find current service day. i.e. 1AM Monday is actually still in the Sunday service day.
     {:ok, service_day_now} = DateTime.shift_zone(now, "America/Los_Angeles")
+    # Shift the time to local time.
     {:ok, local_time_now} = DateTime.shift_zone(now, "America/New_York")
 
     %ShuttleBusSchedule{minute_range: minutes_range_to_destination} =

--- a/lib/screens/v2/widget_instance/shuttle_bus_info.ex
+++ b/lib/screens/v2/widget_instance/shuttle_bus_info.ex
@@ -75,7 +75,8 @@ defmodule Screens.V2.WidgetInstance.ShuttleBusInfo do
   def audio_view(_instance), do: ScreensWeb.V2.Audio.ShuttleBusInfoView
 
   defp get_minute_range(schedule, now) do
-    {:ok, now} = DateTime.shift_zone(now, "America/Los_Angeles")
+    {:ok, service_day_now} = DateTime.shift_zone(now, "America/Los_Angeles")
+    {:ok, local_time_now} = DateTime.shift_zone(now, "America/New_York")
 
     %ShuttleBusSchedule{minute_range: minutes_range_to_destination} =
       Enum.find(schedule, fn %ShuttleBusSchedule{
@@ -90,8 +91,8 @@ defmodule Screens.V2.WidgetInstance.ShuttleBusInfo do
             :sunday -> [7]
           end
 
-        Date.day_of_week(now) in day_range and
-          Util.time_in_range?(DateTime.to_time(now), start_time, end_time)
+        Date.day_of_week(service_day_now) in day_range and
+          Util.time_in_range?(DateTime.to_time(local_time_now), start_time, end_time)
       end)
 
     minutes_range_to_destination

--- a/lib/screens/v2/widget_instance/shuttle_bus_info.ex
+++ b/lib/screens/v2/widget_instance/shuttle_bus_info.ex
@@ -75,10 +75,11 @@ defmodule Screens.V2.WidgetInstance.ShuttleBusInfo do
   def audio_view(_instance), do: ScreensWeb.V2.Audio.ShuttleBusInfoView
 
   defp get_minute_range(schedule, now) do
-    # Shift to find current service day. i.e. 1AM Monday is actually still in the Sunday service day.
-    {:ok, service_day_now} = DateTime.shift_zone(now, "America/Los_Angeles")
     # Shift the time to local time.
     {:ok, local_time_now} = DateTime.shift_zone(now, "America/New_York")
+
+    # Shift to find current service day. i.e. 1AM Monday is actually still in the Sunday service day.
+    service_day_now = DateTime.add(local_time_now, -3 * 60 * 60, :second)
 
     %ShuttleBusSchedule{minute_range: minutes_range_to_destination} =
       Enum.find(schedule, fn %ShuttleBusSchedule{

--- a/test/screens/v2/widget_instance/shuttle_bus_info_test.exs
+++ b/test/screens/v2/widget_instance/shuttle_bus_info_test.exs
@@ -29,6 +29,12 @@ defmodule Screens.V2.WidgetInstance.ShuttleBusInfoTest do
                       minute_range: "15-25"
                     },
                     %ShuttleBusSchedule{
+                      start_time: ~T[00:00:00],
+                      end_time: ~T[10:59:59],
+                      days: :sunday,
+                      minute_range: "18-28"
+                    },
+                    %ShuttleBusSchedule{
                       start_time: ~T[11:00:00],
                       end_time: ~T[23:59:59],
                       days: :sunday,
@@ -147,6 +153,21 @@ defmodule Screens.V2.WidgetInstance.ShuttleBusInfoTest do
 
       assert %{
                minutes_range_to_destination: "17-27",
+               destination: "Test Station",
+               arrow: :n,
+               english_boarding_instructions: "Hello",
+               spanish_boarding_instructions: "Hola"
+             } == WidgetInstance.serialize(widget)
+    end
+
+    test "returns map with minutes_range_to_destination for correct day just before DST",
+         %{
+           widget: widget
+         } do
+      widget = put_now(widget, ~U[2022-03-13T08:00:00Z])
+
+      assert %{
+               minutes_range_to_destination: "18-28",
                destination: "Test Station",
                arrow: :n,
                english_boarding_instructions: "Hello",

--- a/test/screens/v2/widget_instance/shuttle_bus_info_test.exs
+++ b/test/screens/v2/widget_instance/shuttle_bus_info_test.exs
@@ -138,6 +138,21 @@ defmodule Screens.V2.WidgetInstance.ShuttleBusInfoTest do
                spanish_boarding_instructions: "Hola"
              } == WidgetInstance.serialize(widget)
     end
+
+    test "returns map with minutes_range_to_destination for correct day outside of DST",
+         %{
+           widget: widget
+         } do
+      widget = put_now(widget, ~U[2023-01-02T01:00:00Z])
+
+      assert %{
+               minutes_range_to_destination: "17-27",
+               destination: "Test Station",
+               arrow: :n,
+               english_boarding_instructions: "Hello",
+               spanish_boarding_instructions: "Hola"
+             } == WidgetInstance.serialize(widget)
+    end
   end
 
   describe "slot_names/1" do

--- a/test/screens/v2/widget_instance/shuttle_bus_info_test.exs
+++ b/test/screens/v2/widget_instance/shuttle_bus_info_test.exs
@@ -27,6 +27,12 @@ defmodule Screens.V2.WidgetInstance.ShuttleBusInfoTest do
                       end_time: ~T[23:00:00],
                       days: :weekday,
                       minute_range: "15-25"
+                    },
+                    %ShuttleBusSchedule{
+                      start_time: ~T[11:00:00],
+                      end_time: ~T[23:59:59],
+                      days: :sunday,
+                      minute_range: "17-27"
                     }
                   ],
                   destination: "Test Station",
@@ -111,6 +117,21 @@ defmodule Screens.V2.WidgetInstance.ShuttleBusInfoTest do
 
       assert %{
                minutes_range_to_destination: "15-25",
+               destination: "Test Station",
+               arrow: :n,
+               english_boarding_instructions: "Hello",
+               spanish_boarding_instructions: "Hola"
+             } == WidgetInstance.serialize(widget)
+    end
+
+    test "returns map with minutes_range_to_destination for correct service day",
+         %{
+           widget: widget
+         } do
+      widget = put_now(widget, ~U[2022-09-05T01:00:00Z])
+
+      assert %{
+               minutes_range_to_destination: "17-27",
                destination: "Test Station",
                arrow: :n,
                english_boarding_instructions: "Hello",


### PR DESCRIPTION
**Asana task**: [Shuttle Bus Widget: Our travel time estimates for peak / non-peak are not showing up at the scheduled time](https://app.asana.com/0/1185117109217413/1202901200468413/f)

Slight timezone shifting issue. We need to find the time for the service day, so the day we look at is correct. The time we look at should be local time though. Just need to have two separate shifts for date and time.

- [ ] Tests added?
