### PR TITLE
fix: Headsigns for late trains

### DIFF
--- a/lib/screens/departures/departure.ex
+++ b/lib/screens/departures/departure.ex
@@ -170,7 +170,7 @@ defmodule Screens.Departures.Departure do
     filtered_predictions = filter_predictions_or_schedules(all_predictions)
     filtered_schedules = filter_predictions_or_schedules(all_schedules)
 
-    filtered_predictions = copy_stop_headsigns(filtered_predictions, filtered_schedules)
+    filtered_predictions = copy_stop_headsigns(filtered_predictions, all_schedules)
 
     predicted_trip_ids =
       filtered_predictions

--- a/lib/screens/v2/departure.ex
+++ b/lib/screens/v2/departure.ex
@@ -35,7 +35,11 @@ defmodule Screens.V2.Departure do
       relevant_schedules = Builder.get_relevant_departures(schedules, now)
 
       departures =
-        Builder.merge_predictions_and_schedules(relevant_predictions, relevant_schedules)
+        Builder.merge_predictions_and_schedules(
+          relevant_predictions,
+          relevant_schedules,
+          schedules
+        )
 
       {:ok, departures}
     else

--- a/lib/screens/v2/departure/builder.ex
+++ b/lib/screens/v2/departure/builder.ex
@@ -71,21 +71,21 @@ defmodule Screens.V2.Departure.Builder do
     |> Enum.sort_by(&(&1.departure_time || &1.arrival_time), DateTime)
   end
 
-  def merge_predictions_and_schedules(predictions, schedules) do
+  def merge_predictions_and_schedules(filtered_predictions, filtered_schedules, all_schedules) do
     predicted_trip_ids =
-      predictions
+      filtered_predictions
       |> Enum.reject(&is_nil(&1.trip))
       |> Enum.map(& &1.trip.id)
       |> Enum.reject(&is_nil/1)
       |> Enum.into(MapSet.new())
 
     schedules_by_trip_id =
-      schedules
+      all_schedules
       |> Enum.map(fn %{trip: %{id: trip_id}} = s -> {trip_id, s} end)
       |> Enum.into(%{})
 
     predicted_departures =
-      predictions
+      filtered_predictions
       |> Enum.map(fn
         %{trip: %{id: trip_id}} = p when not is_nil(trip_id) ->
           %Departure{prediction: p, schedule: Map.get(schedules_by_trip_id, trip_id)}
@@ -95,7 +95,7 @@ defmodule Screens.V2.Departure.Builder do
       end)
 
     unpredicted_departures =
-      schedules
+      filtered_schedules
       |> Enum.filter(fn
         %{trip: %{id: trip_id}} when not is_nil(trip_id) ->
           trip_id not in predicted_trip_ids

--- a/test/screens/v2/departure/builder_test.exs
+++ b/test/screens/v2/departure/builder_test.exs
@@ -178,7 +178,8 @@ defmodule Screens.V2.Departure.BuilderTest do
         %Departure{prediction: p2, schedule: s1}
       ]
 
-      assert expected == Builder.merge_predictions_and_schedules(predictions, schedules)
+      assert expected ==
+               Builder.merge_predictions_and_schedules(predictions, schedules, schedules)
     end
 
     test "returns predictions without matching schedules" do
@@ -194,7 +195,8 @@ defmodule Screens.V2.Departure.BuilderTest do
         %Departure{prediction: p2, schedule: nil}
       ]
 
-      assert expected == Builder.merge_predictions_and_schedules(predictions, schedules)
+      assert expected ==
+               Builder.merge_predictions_and_schedules(predictions, schedules, schedules)
     end
 
     test "returns schedules without matching predictions" do
@@ -210,7 +212,8 @@ defmodule Screens.V2.Departure.BuilderTest do
         %Departure{prediction: nil, schedule: s1}
       ]
 
-      assert expected == Builder.merge_predictions_and_schedules(predictions, schedules)
+      assert expected ==
+               Builder.merge_predictions_and_schedules(predictions, schedules, schedules)
     end
 
     test "returns departures in increasing time order" do
@@ -249,7 +252,8 @@ defmodule Screens.V2.Departure.BuilderTest do
         %Departure{prediction: p3, schedule: nil}
       ]
 
-      assert expected == Builder.merge_predictions_and_schedules(predictions, schedules)
+      assert expected ==
+               Builder.merge_predictions_and_schedules(predictions, schedules, schedules)
     end
   end
 end


### PR DESCRIPTION
**Asana task**: ad-hoc

This was discovered when working on the CR widget updates. When a train is late, the schedule is booted from the list of filtered schedules. So when we merge the schedule with the prediction, the schedule is always `nil`. While we only want to show upcoming schedules in the departures list, late predictions need to be matched with a past schedule. 

Josh Fabian also noticed that Solari screens have the same issue (he captured a clip [here](https://mbta.slack.com/archives/C03K6NLKKD1/p1662042194604599?thread_ts=1662041513.854729&cid=C03K6NLKKD1)). That's the reason for the v1 change.

- [ ] Tests added?
