### PR TITLE
Updated the CR "next departure" Spanish header

### DIFF
--- a/assets/src/components/v2/cr_departures/cr_departures_table.tsx
+++ b/assets/src/components/v2/cr_departures/cr_departures_table.tsx
@@ -55,9 +55,9 @@ const DeparturesTable: React.ComponentType<Props> = ({
     }
 
     if (direction === "inbound") {
-      return "a";
+      return "entrantes a";
     } else {
-      return "que salen de";
+      return "saliendo de";
     }
   };
 
@@ -74,7 +74,7 @@ const DeparturesTable: React.ComponentType<Props> = ({
               Upcoming {getHeaderDirection("english")} departures
             </div>
             <div className="table-header__spanish">
-              Próximos {getHeaderDirection("spanish")} Boston
+              Trenes {getHeaderDirection("spanish")} Boston
             </div>
           </td>
           <td className="arrival"></td>


### PR DESCRIPTION
Adhoc. [Slack message](https://mbta.slack.com/archives/C039ARUM48H/p1662753971428869?thread_ts=1662749168.276069&cid=C039ARUM48H)

The Spanish for the CR "next train" header needed a fix.
