### PR TITLE
fix: CR Departures Widget audio

### DIFF
--- a/lib/screens_web/views/v2/audio/cr_departures_view.ex
+++ b/lib/screens_web/views/v2/audio/cr_departures_view.ex
@@ -109,12 +109,23 @@ defmodule ScreensWeb.V2.Audio.CRDeparturesView do
   defp preposition_for_time_type(:minutes), do: "in"
   defp preposition_for_time_type(:timestamp), do: "at"
 
-  defp render_headsign(%{headsign: headsign, variation: nil}) do
+  defp render_headsign(%{
+         headsign: headsign,
+         station_service_list: [%{service: false}, %{service: false}]
+       }) do
     ~E|<%= headsign %>|
   end
 
-  defp render_headsign(%{headsign: headsign, variation: variation}) do
-    ~E|<%= headsign %> <%= variation %>|
+  defp render_headsign(%{headsign: headsign, station_service_list: [station1, station2]}) do
+    via_string =
+      cond do
+        station1.service and station2.service -> "via #{station1.name} and #{station2.name}"
+        station1.service -> "via #{station1.name}"
+        station2.service -> "via #{station2.name}"
+        true -> ""
+      end
+
+    ~E|<%= headsign %> <%= via_string %>|
   end
 
   defp pluralize_minutes(1), do: "minute"

--- a/lib/screens_web/views/v2/audio/cr_departures_view.ex
+++ b/lib/screens_web/views/v2/audio/cr_departures_view.ex
@@ -109,13 +109,6 @@ defmodule ScreensWeb.V2.Audio.CRDeparturesView do
   defp preposition_for_time_type(:minutes), do: "in"
   defp preposition_for_time_type(:timestamp), do: "at"
 
-  defp render_headsign(%{
-         headsign: headsign,
-         station_service_list: [%{service: false}, %{service: false}]
-       }) do
-    ~E|<%= headsign %>|
-  end
-
   defp render_headsign(%{headsign: headsign, station_service_list: [station1, station2]}) do
     via_string =
       cond do


### PR DESCRIPTION
**Asana task**: ad-hoc

Headsign changes broke audio for the widget. These changes fix the audio while also implementing the suggested changes found [here](https://miro.com/app/board/uXjVPfv2P_g=/?moveToWidget=3458764532967523924&cot=14).

- [ ] Tests added?
