### PR TITLE
fix: CR prediction departure time when time is a string.

### DIFF
--- a/assets/src/components/v2/cr_departures/cr_departure_time.tsx
+++ b/assets/src/components/v2/cr_departures/cr_departure_time.tsx
@@ -40,11 +40,18 @@ const CRDepartureTime = ({
     );
   }
 
-  return (
-    <div className="cr-departure-time">
+  const predictionTime =
+    typeof time === "string" ? (
+      <span style={{ display: "inline-block" }}>{formattedTime}</span>
+    ) : (
       <span style={{ display: "inline-block" }}>
         <BaseDepartureTime time={time as TimeRepresentation} hideAmPm />
       </span>
+    );
+
+  return (
+    <div className="cr-departure-time">
+      {predictionTime}
       <span style={{ display: "inline-block", marginLeft: "19px" }}>
         <LiveData
           className="cr-departure-time__live-data-icon"


### PR DESCRIPTION
**Asana task**: ad-hoc

When a prediction is valuable (exists and has an assigned vehicle) and it is more than 60 minutes out, we show the clock time instead of a timestamp. Existing logic assumed all predictions are timestamps. Adding a conditional type check helps us determine what to show.

- [ ] Tests added?
