### PR TITLE
feat: Add per-screen `hidden_from_screenplay` config field

### DIFF
--- a/assets/src/components/admin/admin_tables.tsx
+++ b/assets/src/components/admin/admin_tables.tsx
@@ -87,6 +87,13 @@ const AllScreensTable = (): JSX.Element => {
       FormCell: FormBoolean,
     },
     {
+      Header: "Hidden from Screenplay",
+      accessor: "hidden_from_screenplay",
+      Cell: EditableCheckbox,
+      Filter: DefaultColumnFilter,
+      FormCell: FormBoolean,
+    },
+    {
       Header: "Tags",
       accessor: "tags",
       Cell: EditableList,

--- a/lib/screens/config/screen.ex
+++ b/lib/screens/config/screen.ex
@@ -28,6 +28,7 @@ defmodule Screens.Config.Screen do
           app_id: app_id(),
           refresh_if_loaded_before: DateTime.t() | nil,
           disabled: boolean(),
+          hidden_from_screenplay: boolean(),
           app_params:
             Bus.t()
             | Dup.t()
@@ -72,6 +73,7 @@ defmodule Screens.Config.Screen do
             app_id: nil,
             refresh_if_loaded_before: nil,
             disabled: false,
+            hidden_from_screenplay: false,
             app_params: nil,
             tags: []
 


### PR DESCRIPTION
**Asana task**: ad hoc / Screenplay polish

This adds a per-screen boolean field that has no corresponding logic in the Screens app, but lets us hide screens from the listing in Screenplay.

Reasons for hiding a screen include test screens, as well as ones we've configured for non-MBTA locations like stores and libraries.

- [ ] Tests added?
