### PR TITLE
feat: Log sim/real_screen requests

### DIFF
--- a/assets/src/hooks/use_api_response.tsx
+++ b/assets/src/hooks/use_api_response.tsx
@@ -41,6 +41,17 @@ const useIsRealScreenParam = () => {
   return isRealScreen() ? "&is_real_screen=true" : "";
 };
 
+const useSourceParam = () => {
+  if (isDup()) return `&source=real_screen`;
+
+  let source = getDatasetValue("source");
+  if (!source && isRealScreen()) {
+    source = "real_screen";
+  }
+
+  return source ? `&source=${source}` : "";
+};
+
 interface UseApiResponseArgs {
   id: string;
   datetime?: string;
@@ -64,6 +75,7 @@ const useApiResponse = ({
   const [lastSuccess, setLastSuccess] = useState<number | null>(null);
   const lastRefresh = getDatasetValue("lastRefresh");
   const isRealScreenParam = useIsRealScreenParam();
+  const sourceParam = useSourceParam();
 
   const apiPath = buildApiPath({
     id,
@@ -71,6 +83,7 @@ const useApiResponse = ({
     rotationIndex,
     lastRefresh,
     isRealScreenParam,
+    sourceParam,
   });
 
   const fetchData = async () => {
@@ -127,6 +140,7 @@ interface BuildApiPathArgs {
   rotationIndex?: number;
   lastRefresh?: string;
   isRealScreenParam: string;
+  sourceParam: string;
 }
 
 const buildApiPath = ({
@@ -135,6 +149,7 @@ const buildApiPath = ({
   rotationIndex,
   lastRefresh,
   isRealScreenParam,
+  sourceParam,
 }: BuildApiPathArgs) => {
   let apiPath = `/api/screen/${id}`;
 
@@ -142,7 +157,7 @@ const buildApiPath = ({
     apiPath += `/${rotationIndex}`;
   }
 
-  apiPath += `?last_refresh=${lastRefresh}${isRealScreenParam}`;
+  apiPath += `?last_refresh=${lastRefresh}${isRealScreenParam}${sourceParam}`;
 
   if (datetime != null) {
     apiPath += `&datetime=${datetime}`;

--- a/lib/screens/log_screen_data.ex
+++ b/lib/screens/log_screen_data.ex
@@ -13,8 +13,8 @@ defmodule Screens.LogScreenData do
     end
   end
 
-  def log_data_request(screen_id, last_refresh, is_screen, screen_side \\ nil) do
-    if is_screen do
+  def log_data_request(screen_id, last_refresh, is_screen, source, screen_side \\ nil) do
+    if is_screen or not is_nil(source) do
       data =
         %{
           screen_id: screen_id,
@@ -22,6 +22,7 @@ defmodule Screens.LogScreenData do
           last_refresh: last_refresh
         }
         |> insert_screen_side(screen_side)
+        |> insert_source(source)
 
       log_message("[screen data request]", data)
     end
@@ -113,4 +114,7 @@ defmodule Screens.LogScreenData do
 
   defp insert_screen_side(data, nil), do: data
   defp insert_screen_side(data, screen_side), do: Map.put(data, :screen_side, screen_side)
+
+  defp insert_source(data, nil), do: data
+  defp insert_source(data, source), do: Map.put(data, :source, source)
 end

--- a/lib/screens_web/controllers/screen_api_controller.ex
+++ b/lib/screens_web/controllers/screen_api_controller.ex
@@ -26,10 +26,11 @@ defmodule ScreensWeb.ScreenApiController do
     end
   end
 
-  def show(conn, %{"id" => screen_id, "last_refresh" => last_refresh}) do
+  def show(conn, %{"id" => screen_id, "last_refresh" => last_refresh} = params) do
     is_screen = ScreensWeb.UserAgent.is_screen_conn?(conn, screen_id)
 
-    _ = Screens.LogScreenData.log_data_request(screen_id, last_refresh, is_screen)
+    _ =
+      Screens.LogScreenData.log_data_request(screen_id, last_refresh, is_screen, params["source"])
 
     if nonexistent_screen?(screen_id) do
       Screens.LogScreenData.log_api_response(:nonexistent, screen_id, last_refresh, is_screen)
@@ -46,10 +47,10 @@ defmodule ScreensWeb.ScreenApiController do
     end
   end
 
-  def show_dup(conn, %{"id" => screen_id, "rotation_index" => rotation_index}) do
+  def show_dup(conn, %{"id" => screen_id, "rotation_index" => rotation_index} = params) do
     is_screen = ScreensWeb.UserAgent.is_screen_conn?(conn, screen_id)
 
-    _ = Screens.LogScreenData.log_data_request(screen_id, nil, is_screen)
+    _ = Screens.LogScreenData.log_data_request(screen_id, nil, is_screen, params["source"])
 
     if nonexistent_screen?(screen_id) do
       not_found_response(conn)

--- a/lib/screens_web/controllers/screen_controller.ex
+++ b/lib/screens_web/controllers/screen_controller.ex
@@ -83,6 +83,7 @@ defmodule ScreensWeb.ScreenController do
         |> assign(:app_id, app_id)
         |> assign(:sentry_frontend_dsn, Application.get_env(:screens, :sentry_frontend_dsn))
         |> assign(:is_real_screen, match?(%{"is_real_screen" => "true"}, params))
+        |> assign(:source, params["source"])
         |> render("index.html")
 
       nil ->

--- a/lib/screens_web/controllers/v2/screen_api_controller.ex
+++ b/lib/screens_web/controllers/v2/screen_api_controller.ex
@@ -24,6 +24,7 @@ defmodule ScreensWeb.V2.ScreenApiController do
       screen_id,
       last_refresh,
       is_screen,
+      params["source"],
       screen_side
     )
 
@@ -74,7 +75,15 @@ defmodule ScreensWeb.V2.ScreenApiController do
     end
   end
 
-  def simulation(conn, %{"id" => screen_id, "last_refresh" => last_refresh}) do
+  def simulation(conn, %{"id" => screen_id, "last_refresh" => last_refresh} = params) do
+    Screens.LogScreenData.log_data_request(
+      screen_id,
+      last_refresh,
+      false,
+      params["source"],
+      params["screen_side"]
+    )
+
     cond do
       nonexistent_screen?(screen_id) ->
         not_found_response(conn)

--- a/lib/screens_web/controllers/v2/screen_controller.ex
+++ b/lib/screens_web/controllers/v2/screen_controller.ex
@@ -83,6 +83,7 @@ defmodule ScreensWeb.V2.ScreenController do
         )
         |> assign(:is_real_screen, match?(%{"is_real_screen" => "true"}, params))
         |> assign(:screen_side, screen_side(params))
+        |> assign(:source, params["source"])
         |> put_view(ScreensWeb.V2.ScreenView)
         |> render("index.html")
 

--- a/lib/screens_web/templates/screen/index.html.eex
+++ b/lib/screens_web/templates/screen/index.html.eex
@@ -3,6 +3,7 @@
   data-last-refresh="<%= @last_refresh %>"
   data-environment-name="<%= @environment_name %>"
   data-is-real-screen="<%= @is_real_screen %>"
+  data-source="<%= @source %>"
   <%= if record_sentry?() do %>
     data-sentry="<%= @sentry_frontend_dsn %>"
   <% end %>

--- a/lib/screens_web/templates/v2/screen/index.html.eex
+++ b/lib/screens_web/templates/v2/screen/index.html.eex
@@ -13,4 +13,5 @@
   <%= if record_sentry?() do %>
     data-sentry="<%= @sentry_frontend_dsn %>"
   <% end %>
+  data-source="<%= @source %>"
 ></div>


### PR DESCRIPTION
**Asana task**: [Log screens simulation requests](https://app.asana.com/0/1185117109217413/1202766648515759/f)

Added a `source` to screen data request logs. This will mean that all screens with either `is_real_screen=true` or `source=screenplay` will log a data request. The new source will only be used in Screenplay sims for now. URLs do not need to change for this change to work. Existing URLs with `is_real_screen=true` will continue to produce logs, but will have an added `source=real_screen` for data request log lines. 

- [ ] Tests added?
