### PR TITLE
tweak: gl_eink_v2 show headway on departures API error

### DIFF
--- a/lib/screens/v2/candidate_generator/gl_eink.ex
+++ b/lib/screens/v2/candidate_generator/gl_eink.ex
@@ -187,34 +187,38 @@ defmodule Screens.V2.CandidateGenerator.GlEink do
 
     Enum.map(sections, fn
       {:ok, departures} when length(departures) <= 1 ->
-        destination = fetch_destination(route_id, direction_id)
-
-        case Screens.Headways.by_route_id(route_id, stop_id, direction_id, nil) do
-          nil ->
-            :overnight
-
-          headway ->
-            {:ok,
-             departures ++
-               [
-                 %{
-                   text: %FreeTextLine{
-                     icon: nil,
-                     text: [
-                       "Trains to #{destination} every",
-                       %{format: :bold, text: "#{headway - 2}-#{headway + 2}"},
-                       "minutes"
-                     ]
-                   }
-                 }
-               ]}
-        end
+        {:ok, format_headway(route_id, stop_id, direction_id, departures)}
 
       {:ok, departures} ->
         {:ok, departures}
 
+      # Show headway instead of nothing when API fetch fails
       :error ->
-        :error
+        {:ok, format_headway(route_id, stop_id, direction_id)}
     end)
+  end
+
+  defp format_headway(route_id, stop_id, direction_id, departures_to_concat \\ []) do
+    destination = fetch_destination(route_id, direction_id)
+
+    case Screens.Headways.by_route_id(route_id, stop_id, direction_id, nil) do
+      nil ->
+        :overnight
+
+      headway ->
+        departures_to_concat ++
+          [
+            %{
+              text: %FreeTextLine{
+                icon: nil,
+                text: [
+                  "Trains to #{destination} every",
+                  %{format: :bold, text: "#{headway - 2}-#{headway + 2}"},
+                  "minutes"
+                ]
+              }
+            }
+          ]
+    end
   end
 end


### PR DESCRIPTION
**Asana task**: [v2 GL e-ink: Switch to headway mode if we fail to fetch departures](https://app.asana.com/0/1185117109217413/1202527610604015/f)

When we fail to get departures from the API, we will now show the headway instead of not showing anything. 

![Screen Shot 2022-09-26 at 8 42 17 AM](https://user-images.githubusercontent.com/10713153/192278800-3934e403-f51d-4652-a7b2-69773fa8de70.png)

- [ ] Tests added?
