### PR TITLE
fix: Prevent crash when line map API fails

### DIFF
--- a/lib/screens/v2/candidate_generator/gl_eink.ex
+++ b/lib/screens/v2/candidate_generator/gl_eink.ex
@@ -119,7 +119,7 @@ defmodule Screens.V2.CandidateGenerator.GlEink do
         }
       ]
     else
-      :error -> []
+      _ -> []
     end
   end
 

--- a/lib/screens/v2/candidate_generator/gl_eink.ex
+++ b/lib/screens/v2/candidate_generator/gl_eink.ex
@@ -103,16 +103,24 @@ defmodule Screens.V2.CandidateGenerator.GlEink do
          stops_by_route_and_direction_fn \\ &RoutePattern.stops_by_route_and_direction/2,
          fetch_departures_fn \\ &Screens.V2.Departure.fetch/2
        ) do
-    {:ok, stops} = stops_by_route_and_direction_fn.(route_id, direction_id)
-    {:ok, reverse_stops} = stops_by_route_and_direction_fn.(route_id, 1 - direction_id)
-
-    {:ok, departures} =
-      fetch_departures_fn.(%{stop_ids: [station_id]},
-        include_schedules: true,
-        now: DateTime.add(now, -@scheduled_terminal_departure_lookback_seconds)
-      )
-
-    [%LineMap{screen: config, stops: stops, reverse_stops: reverse_stops, departures: departures}]
+    with {:ok, stops} <- stops_by_route_and_direction_fn.(route_id, direction_id),
+         {:ok, reverse_stops} <- stops_by_route_and_direction_fn.(route_id, 1 - direction_id),
+         {:ok, departures} <-
+           fetch_departures_fn.(%{stop_ids: [station_id]},
+             include_schedules: true,
+             now: DateTime.add(now, -@scheduled_terminal_departure_lookback_seconds)
+           ) do
+      [
+        %LineMap{
+          screen: config,
+          stops: stops,
+          reverse_stops: reverse_stops,
+          departures: departures
+        }
+      ]
+    else
+      :error -> []
+    end
   end
 
   def header_instances(config, now, fetch_destination_fn) do


### PR DESCRIPTION
**Asana task**: [🐞MatchError: no match of right hand side value](https://app.asana.com/0/1185117109217413/1202561076967107/f)

Bug in the Sentry link pointed to an API error when getting data for the line map. Changed that function to use a `with/else` so we can allow line map to fail without making the screen go into a no-data state.

- [ ] Tests added?
