### PR TITLE
feat: Always use mbta.com/alerts as Alert widget CTA url

### DIFF
--- a/assets/src/components/v2/alert.tsx
+++ b/assets/src/components/v2/alert.tsx
@@ -11,7 +11,6 @@ interface Props {
   icon: AlertIcon;
   header: string;
   body: string;
-  url: string;
 }
 
 interface BaseAlertProps {
@@ -31,7 +30,7 @@ type AlertIcon = "bus" | "x" | "warning" | "snowflake";
 
 const BaseAlert: ComponentType<BaseAlertProps> = ({
   classModifier,
-  alertProps: { route_pills: routePills, icon, header, body, url },
+  alertProps: { route_pills: routePills, icon, header, body },
   CardComponent,
   LinkArrowComponent,
   bodyTextMaxHeight,
@@ -73,7 +72,7 @@ const BaseAlert: ComponentType<BaseAlertProps> = ({
                 <LinkArrowComponent />
               </div>
             )}
-            <div className="alert-widget__content__cta__url">{url}</div>
+            <div className="alert-widget__content__cta__url">mbta.com/alerts</div>
           </div>
         </div>
       </CardComponent>

--- a/lib/screens/v2/widget_instance/alert.ex
+++ b/lib/screens/v2/widget_instance/alert.ex
@@ -97,8 +97,7 @@ defmodule Screens.V2.WidgetInstance.Alert do
       route_pills: serialize_route_pills(t),
       icon: serialize_icon(e),
       header: serialize_header(e),
-      body: t.alert.header,
-      url: clean_up_url(t.alert.url || "mbta.com/alerts")
+      body: t.alert.header
     }
   end
 
@@ -131,14 +130,6 @@ defmodule Screens.V2.WidgetInstance.Alert do
 
   for {e, icon} <- @effect_icons do
     defp serialize_icon(unquote(e)), do: unquote(icon)
-  end
-
-  # Removes leading scheme specifier ("http[s]"), www. prefix, and trailing "/" from url.
-  defp clean_up_url(url) do
-    url
-    |> String.replace(~r|^https?://|i, "")
-    |> String.replace(~r|^www\.|i, "")
-    |> String.replace(~r|/$|, "")
   end
 
   def slot_names(t) do

--- a/test/screens/v2/widget_instance/alert_test.exs
+++ b/test/screens/v2/widget_instance/alert_test.exs
@@ -181,8 +181,7 @@ defmodule Screens.V2.WidgetInstance.AlertTest do
         ],
         icon: :x,
         header: "Stop Closed",
-        body: "Stop is closed.",
-        url: "mbta.com/alerts"
+        body: "Stop is closed."
       }
 
       assert expected_json_map == AlertWidget.serialize(widget)
@@ -199,8 +198,7 @@ defmodule Screens.V2.WidgetInstance.AlertTest do
         ],
         icon: :x,
         header: "Stop Closed",
-        body: "Stop is closed.",
-        url: "mbta.com/alerts"
+        body: "Stop is closed."
       }
 
       assert expected_json_map == AlertWidget.serialize(widget)
@@ -222,8 +220,7 @@ defmodule Screens.V2.WidgetInstance.AlertTest do
         route_pills: [%{type: :icon, icon: :bus, color: :yellow}],
         icon: :x,
         header: "Stop Closed",
-        body: "Stop is closed.",
-        url: "mbta.com/alerts"
+        body: "Stop is closed."
       }
 
       assert expected_json_map == AlertWidget.serialize(widget)


### PR DESCRIPTION
**Asana task**: [Always use mbta.com/alerts as e-Ink alert widget URL](https://app.asana.com/0/1185117109217413/1202072393748976/f)

- [x] Tests added?
