### PR TITLE
bug: gl_eink_v2 overnight bug

### DIFF
--- a/lib/screens/v2/candidate_generator/gl_eink.ex
+++ b/lib/screens/v2/candidate_generator/gl_eink.ex
@@ -195,14 +195,14 @@ defmodule Screens.V2.CandidateGenerator.GlEink do
 
     Enum.map(sections, fn
       {:ok, departures} when length(departures) <= 1 ->
-        {:ok, format_headway(route_id, stop_id, direction_id, departures)}
+        format_headway(route_id, stop_id, direction_id, departures)
 
       {:ok, departures} ->
         {:ok, departures}
 
       # Show headway instead of nothing when API fetch fails
       :error ->
-        {:ok, format_headway(route_id, stop_id, direction_id)}
+        format_headway(route_id, stop_id, direction_id)
     end)
   end
 
@@ -214,19 +214,20 @@ defmodule Screens.V2.CandidateGenerator.GlEink do
         :overnight
 
       headway ->
-        departures_to_concat ++
-          [
-            %{
-              text: %FreeTextLine{
-                icon: nil,
-                text: [
-                  "Trains to #{destination} every",
-                  %{format: :bold, text: "#{headway - 2}-#{headway + 2}"},
-                  "minutes"
-                ]
-              }
-            }
-          ]
+        {:ok,
+         departures_to_concat ++
+           [
+             %{
+               text: %FreeTextLine{
+                 icon: nil,
+                 text: [
+                   "Trains to #{destination} every",
+                   %{format: :bold, text: "#{headway - 2}-#{headway + 2}"},
+                   "minutes"
+                 ]
+               }
+             }
+           ]}
     end
   end
 end


### PR DESCRIPTION
**Asana task**: ad-hoc
Sentry error: https://sentry.io/organizations/mbtace/issues/3648861164/?project=6061747&referrer=issue_alert-slack

The return value for the `departures_post_processing` function for `gl_eink_v2` was not quite right for overnight. Value should only be `{:ok, _}` if there are departures to display. Otherwise, it only returns `:overnight`.

- [ ] Tests added?
