### PR TITLE
feat: (Local dev) ScreensByAlert implementation

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -194,7 +194,10 @@ config :screens,
     ]
   }
 
-config :screens, :screens_by_alert, cache_module: Screens.ScreensByAlert.GenServer
+config :screens, :screens_by_alert,
+  cache_module: Screens.ScreensByAlert.GenServer,
+  screens_by_alert_ttl_seconds: 40,
+  screens_last_updated_ttl_seconds: 3600
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -24,7 +24,10 @@ config :ehmon, :report_mf, {:ehmon, :info_report}
 config :screens,
   record_sentry: true
 
-config :screens, :screens_by_alert, cache_module: Screens.ScreensByAlert.Memcache
+config :screens, :screens_by_alert,
+  cache_module: Screens.ScreensByAlert.Memcache,
+  screens_by_alert_ttl_seconds: 40,
+  screens_last_updated_ttl_seconds: 3600
 
 # ## SSL Support
 #

--- a/config/test.exs
+++ b/config/test.exs
@@ -34,4 +34,4 @@ config :logger, level: :warn
 config :screens, :screens_by_alert,
   cache_module: Screens.ScreensByAlert.GenServer,
   screens_by_alert_ttl_seconds: 1,
-  screens_last_updated_ttl_seconds: 3
+  screens_last_updated_ttl_seconds: 1

--- a/config/test.exs
+++ b/config/test.exs
@@ -31,8 +31,7 @@ config :ueberauth, Ueberauth,
 # Print only warnings and errors during test
 config :logger, level: :warn
 
-config :screens, ScreensByAlert.Memcache,
-  connection_opts: [
-    namespace: "api_test_rate_limit",
-    hostname: "localhost"
-  ]
+config :screens, :screens_by_alert,
+  cache_module: Screens.ScreensByAlert.Memcache,
+  screens_by_alert_ttl_seconds: 1,
+  screens_last_updated_ttl_seconds: 3

--- a/config/test.exs
+++ b/config/test.exs
@@ -32,6 +32,6 @@ config :ueberauth, Ueberauth,
 config :logger, level: :warn
 
 config :screens, :screens_by_alert,
-  cache_module: Screens.ScreensByAlert.Memcache,
+  cache_module: Screens.ScreensByAlert.GenServer,
   screens_by_alert_ttl_seconds: 1,
   screens_last_updated_ttl_seconds: 3

--- a/lib/screens/screens_by_alert.ex
+++ b/lib/screens/screens_by_alert.ex
@@ -15,7 +15,8 @@ defmodule Screens.ScreensByAlert do
   """
 
   @behaviour Screens.ScreensByAlert.Behaviour
-  @cache_module Application.compile_env(:screens, :screens_by_alert)[:cache_module]
+  @config Application.compile_env(:screens, :screens_by_alert)
+  @cache_module @config[:cache_module]
 
   # Need to define a child_spec since this module does not itself use GenServer or Supervisor,
   # but is a simple wrapper for @cache_module
@@ -29,12 +30,18 @@ defmodule Screens.ScreensByAlert do
 
   @impl true
   def start_link(_opts \\ []) do
-    @cache_module.start_link(name: @cache_module)
+    @cache_module.start_link(
+      screens_by_alert_ttl_seconds: @config[:screens_by_alert_ttl_seconds],
+      screens_last_updated_ttl_seconds: @config[:screens_last_updated_ttl_seconds]
+    )
   end
 
   @impl true
   def put_data(screen_id, alert_ids) do
-    @cache_module.put_data(screen_id, alert_ids)
+    @cache_module.put_data(
+      screen_id,
+      alert_ids
+    )
   end
 
   @impl true

--- a/lib/screens/screens_by_alert/gen_server.ex
+++ b/lib/screens/screens_by_alert/gen_server.ex
@@ -50,12 +50,33 @@ defmodule Screens.ScreensByAlert.GenServer do
   end
 
   @impl GenServer
-  def handle_call({:get_screens_by_alert, _alert_id}, _from, state) do
-    {:reply, [], state}
+  def handle_call(
+        {:get_screens_by_alert, alert_id},
+        _from,
+        %__MODULE__{
+          screens_by_alert: screens_by_alert,
+          screens_last_updated: screens_last_updated
+        } = state
+      ) do
+    result =
+      screens_by_alert
+      |> Map.get(alert_id, [])
+      |> Enum.map(fn screen_id ->
+        last_updated = Map.get(screens_last_updated, screen_id)
+        {screen_id, last_updated}
+      end)
+
+    {:reply, result, state}
   end
 
   @impl GenServer
-  def handle_call({:get_screens_last_updated, _screen_id}, _from, state) do
-    {:reply, 0, state}
+  def handle_call(
+        {:get_screens_last_updated, screen_id},
+        _from,
+        %__MODULE__{
+          screens_last_updated: screens_last_updated
+        } = state
+      ) do
+    {:reply, Map.get(screens_last_updated, screen_id), state}
   end
 end

--- a/test/screens/screens_by_alert_test.exs
+++ b/test/screens/screens_by_alert_test.exs
@@ -31,15 +31,19 @@ defmodule Screens.ScreensByAlertTest do
       {:ok, pid} = ScreensByAlert.start_link()
       ScreensByAlert.put_data(1, [1])
       on_exit(fn -> Process.exit(pid, :done) end)
+
+      %{
+        ttl: Application.get_env(:screens, :screens_by_alert)[:screens_by_alert_ttl_seconds]
+      }
     end
 
     test "returns list with data when called before expiration" do
       assert [{1, _}] = ScreensByAlert.get_screens_by_alert(1)
     end
 
-    test "returns empty list when called after expiration" do
+    test "returns empty list when called after expiration", %{ttl: ttl} do
       assert [{1, _}] = ScreensByAlert.get_screens_by_alert(1)
-      Process.sleep(1001)
+      Process.sleep((ttl + 1) * 1000)
       assert [] = ScreensByAlert.get_screens_by_alert(1)
     end
   end
@@ -50,16 +54,19 @@ defmodule Screens.ScreensByAlertTest do
       ScreensByAlert.put_data(1, [1])
       on_exit(fn -> Process.exit(pid, :done) end)
 
-      %{last_updated: System.system_time(:second)}
+      %{
+        last_updated: System.system_time(:second),
+        ttl: Application.get_env(:screens, :screens_by_alert)[:screens_last_updated_ttl_seconds]
+      }
     end
 
     test "returns when screen was last updated", %{last_updated: last_updated} do
       assert last_updated == ScreensByAlert.get_screens_last_updated(1)
     end
 
-    test "returns nil after expiration", %{last_updated: last_updated} do
+    test "returns nil after expiration", %{last_updated: last_updated, ttl: ttl} do
       assert last_updated == ScreensByAlert.get_screens_last_updated(1)
-      Process.sleep(1001)
+      Process.sleep((ttl + 1) * 1000)
       assert is_nil(ScreensByAlert.get_screens_last_updated(1))
     end
   end

--- a/test/screens/screens_by_alert_test.exs
+++ b/test/screens/screens_by_alert_test.exs
@@ -1,35 +1,66 @@
 defmodule Screens.ScreensByAlertTest do
   @moduledoc false
-  use ExUnit.Case, async: true
+  use ExUnit.Case
   alias Screens.ScreensByAlert
+
+  setup do
+    Application.stop(:screens)
+
+    on_exit(fn ->
+      Application.start(:screens)
+    end)
+  end
 
   describe "start_link/1" do
     test "returns {:ok, pid} when start_link is called" do
-      Application.stop(:screens)
-
-      on_exit(fn ->
-        Application.start(:screens)
-      end)
-
-      assert {:ok, _pid} = ScreensByAlert.start_link()
+      assert {:ok, pid} = ScreensByAlert.start_link()
+      on_exit(fn -> Process.exit(pid, :done) end)
     end
   end
 
   describe "put_data/2" do
     test "returns :ok" do
-      assert :ok = ScreensByAlert.put_data(0, [])
+      {:ok, pid} = ScreensByAlert.start_link()
+      assert :ok = ScreensByAlert.put_data(1, [1])
+      on_exit(fn -> Process.exit(pid, :done) end)
     end
   end
 
   describe "get_screens_by_alert/1" do
-    test "returns []" do
-      assert [] = ScreensByAlert.get_screens_by_alert(0)
+    setup do
+      {:ok, pid} = ScreensByAlert.start_link()
+      ScreensByAlert.put_data(1, [1])
+      on_exit(fn -> Process.exit(pid, :done) end)
+    end
+
+    test "returns list with data when called before expiration" do
+      assert [{1, _}] = ScreensByAlert.get_screens_by_alert(1)
+    end
+
+    test "returns empty list when called after expiration" do
+      assert [{1, _}] = ScreensByAlert.get_screens_by_alert(1)
+      Process.sleep(1001)
+      assert [] = ScreensByAlert.get_screens_by_alert(1)
     end
   end
 
   describe "get_screens_last_updated/1" do
-    test "returns 0" do
-      assert 0 = ScreensByAlert.get_screens_last_updated(0)
+    setup do
+      {:ok, pid} = ScreensByAlert.start_link()
+      ScreensByAlert.put_data(1, [1])
+      on_exit(fn -> Process.exit(pid, :done) end)
+
+      %{last_updated: System.system_time(:second)}
+    end
+
+    test "returns when screen was last updated", %{last_updated: last_updated} do
+      assert last_updated == ScreensByAlert.get_screens_last_updated(1)
+    end
+
+    test "returns nil after expiration", %{last_updated: last_updated} do
+      assert last_updated == ScreensByAlert.get_screens_last_updated(1)
+      Process.sleep(1001)
+      assert is_nil(ScreensByAlert.get_screens_last_updated(1))
     end
   end
 end


### PR DESCRIPTION
**Asana task**: [(local dev) Write logic to interface with screens-by-alert caching layer](https://app.asana.com/0/1185117109217413/1203086969471686/f)

This adds all of the logic needed for the caching module to work in local development. This includes object expiration based on TTL values present in the app config. This is not yet being used in any part of the codebase. To test, calls to the `Screens.ScreensByAlert` module will need to be made in IEx. 

- [ ] Tests added?
