### PR TITLE
feat: ScreensByAlert endpoint

### DIFF
--- a/lib/screens_web/controllers/screens_by_alert_controller.ex
+++ b/lib/screens_web/controllers/screens_by_alert_controller.ex
@@ -1,0 +1,24 @@
+defmodule ScreensWeb.ScreensByAlertController do
+  use ScreensWeb, :controller
+
+  alias Screens.ScreensByAlert
+
+  def index(conn, %{"ids" => alert_ids_string}) do
+    if alert_ids_string == "" do
+      json(conn, [])
+    else
+      screens_by_alerts =
+        alert_ids_string
+        |> String.split(",")
+        |> Enum.map(fn alert_id ->
+          ScreensByAlert.get_screens_by_alert(alert_id)
+        end)
+
+      json(conn, screens_by_alerts)
+    end
+  end
+
+  def index(conn, _) do
+    json(conn, [])
+  end
+end

--- a/lib/screens_web/router.ex
+++ b/lib/screens_web/router.ex
@@ -133,4 +133,10 @@ defmodule ScreensWeb.Router do
 
     get "/:id", AlertPriorityController, :show
   end
+
+  scope "/api", ScreensWeb do
+    pipe_through [:redirect_prod_http, :api]
+
+    get "/screens_by_alert", ScreensByAlertController, :index
+  end
 end

--- a/test/screens_web/controllers/screens_by_alert_controller_test.exs
+++ b/test/screens_web/controllers/screens_by_alert_controller_test.exs
@@ -1,0 +1,27 @@
+defmodule ScreensWeb.ScreensByAlertControllerTest do
+  use ScreensWeb.ConnCase
+
+  describe "index/2" do
+    test "returns status code 200 and empty list in resp_body when no query param is provided", %{
+      conn: conn
+    } do
+      conn = get(conn, "/api/screens_by_alert")
+      assert %{status: 200, resp_body: "[]"} = conn
+    end
+  end
+
+  test "returns status code 200 and empty list in resp_body when empty query param is provided",
+       %{
+         conn: conn
+       } do
+    conn = get(conn, "/api/screens_by_alert?ids=")
+    assert %{status: 200, resp_body: "[]"} = conn
+  end
+
+  test "returns 200 in status when query param is provided", %{
+    conn: conn
+  } do
+    conn = get(conn, "/api/screens_by_alert?ids=1,2,3")
+    assert %{status: 200} = conn
+  end
+end


### PR DESCRIPTION
**Asana task**: [Add new screens_by_alert endpoint to Screens server](https://app.asana.com/0/1185117109217413/1203086969471681/f)

This adds the endpoint Screenplay will need to retrieve `ScreensByAlert` data. Endpoint path is `api/screens_by_alert`. Takes a query param `ids` that contains a comma separated list of `alert_ids`. If no param is given or the param is empty, it returns an empty list. Otherwise, it will return a list of `AlertID: ScreenID[]` objects.

- [ ] Tests added?
