### PR TITLE
feat: Add DUP rotation index to data request logs.

### DIFF
--- a/lib/screens/log_screen_data.ex
+++ b/lib/screens/log_screen_data.ex
@@ -13,7 +13,14 @@ defmodule Screens.LogScreenData do
     end
   end
 
-  def log_data_request(screen_id, last_refresh, is_screen, source, screen_side \\ nil) do
+  def log_data_request(
+        screen_id,
+        last_refresh,
+        is_screen,
+        source,
+        screen_side \\ nil,
+        rotation_index \\ nil
+      ) do
     if is_screen or not is_nil(source) do
       data =
         %{
@@ -23,6 +30,7 @@ defmodule Screens.LogScreenData do
         }
         |> insert_screen_side(screen_side)
         |> insert_source(source)
+        |> insert_dup_rotation_index(rotation_index)
 
       log_message("[screen data request]", data)
     end
@@ -117,4 +125,9 @@ defmodule Screens.LogScreenData do
 
   defp insert_source(data, nil), do: data
   defp insert_source(data, source), do: Map.put(data, :source, source)
+
+  defp insert_dup_rotation_index(data, nil), do: data
+
+  defp insert_dup_rotation_index(data, rotation_index),
+    do: Map.put(data, :page_number, rotation_index)
 end

--- a/lib/screens_web/controllers/screen_api_controller.ex
+++ b/lib/screens_web/controllers/screen_api_controller.ex
@@ -50,7 +50,15 @@ defmodule ScreensWeb.ScreenApiController do
   def show_dup(conn, %{"id" => screen_id, "rotation_index" => rotation_index} = params) do
     is_screen = ScreensWeb.UserAgent.is_screen_conn?(conn, screen_id)
 
-    _ = Screens.LogScreenData.log_data_request(screen_id, nil, is_screen, params["source"])
+    _ =
+      Screens.LogScreenData.log_data_request(
+        screen_id,
+        nil,
+        is_screen,
+        params["source"],
+        nil,
+        rotation_index
+      )
 
     if nonexistent_screen?(screen_id) do
       not_found_response(conn)


### PR DESCRIPTION
**Asana task**: [Specify in logs which DUP screen page we're loading](https://app.asana.com/0/1164574158255689/1203081402939552/f)

Added DUP rotation index to DUP data request logs. The term `page_number` was used in the ticket so I went with that instead of `rotation_index`. Happy to stay consistent if anyone feels strongly about it.

- [ ] Tests added?
