### PR TITLE
tweak: Rename source to requestor in logs.

### DIFF
--- a/assets/src/hooks/use_api_response.tsx
+++ b/assets/src/hooks/use_api_response.tsx
@@ -41,15 +41,15 @@ const useIsRealScreenParam = () => {
   return isRealScreen() ? "&is_real_screen=true" : "";
 };
 
-const useSourceParam = () => {
-  if (isDup()) return `&source=real_screen`;
+const useRequestorParam = () => {
+  if (isDup()) return `&requestor=real_screen`;
 
-  let source = getDatasetValue("source");
-  if (!source && isRealScreen()) {
-    source = "real_screen";
+  let requestor = getDatasetValue("requestor");
+  if (!requestor && isRealScreen()) {
+    requestor = "real_screen";
   }
 
-  return source ? `&source=${source}` : "";
+  return requestor ? `&requestor=${requestor}` : "";
 };
 
 interface UseApiResponseArgs {
@@ -75,7 +75,7 @@ const useApiResponse = ({
   const [lastSuccess, setLastSuccess] = useState<number | null>(null);
   const lastRefresh = getDatasetValue("lastRefresh");
   const isRealScreenParam = useIsRealScreenParam();
-  const sourceParam = useSourceParam();
+  const requestorParam = useRequestorParam();
 
   const apiPath = buildApiPath({
     id,
@@ -83,7 +83,7 @@ const useApiResponse = ({
     rotationIndex,
     lastRefresh,
     isRealScreenParam,
-    sourceParam,
+    requestorParam,
   });
 
   const fetchData = async () => {
@@ -140,7 +140,7 @@ interface BuildApiPathArgs {
   rotationIndex?: number;
   lastRefresh?: string;
   isRealScreenParam: string;
-  sourceParam: string;
+  requestorParam: string;
 }
 
 const buildApiPath = ({
@@ -149,7 +149,7 @@ const buildApiPath = ({
   rotationIndex,
   lastRefresh,
   isRealScreenParam,
-  sourceParam,
+  requestorParam,
 }: BuildApiPathArgs) => {
   let apiPath = `/api/screen/${id}`;
 
@@ -157,7 +157,7 @@ const buildApiPath = ({
     apiPath += `/${rotationIndex}`;
   }
 
-  apiPath += `?last_refresh=${lastRefresh}${isRealScreenParam}${sourceParam}`;
+  apiPath += `?last_refresh=${lastRefresh}${isRealScreenParam}${requestorParam}`;
 
   if (datetime != null) {
     apiPath += `&datetime=${datetime}`;

--- a/assets/src/hooks/v2/use_api_response.tsx
+++ b/assets/src/hooks/v2/use_api_response.tsx
@@ -116,16 +116,16 @@ const getScreenSideParam = () => {
   return screenSide ? `&screen_side=${screenSide}` : "";
 };
 
-const getSourceParam = () => {
+const getRequestorParam = () => {
   // Adding this to v2 because we will eventually widgetize DUPs.
-  if (isDup()) return `&source=real_screen`;
+  if (isDup()) return `&requestor=real_screen`;
 
-  let source = getDatasetValue("source");
-  if (!source && isRealScreen()) {
-    source = "real_screen";
+  let requestor = getDatasetValue("requestor");
+  if (!requestor && isRealScreen()) {
+    requestor = "real_screen";
   }
 
-  return source ? `&source=${source}` : "";
+  return requestor ? `&requestor=${requestor}` : "";
 };
 
 interface UseApiResponseArgs {
@@ -148,7 +148,7 @@ const useBaseApiResponse = ({
 }: UseApiResponseArgs): UseApiResponseReturn => {
   const isRealScreenParam = getIsRealScreenParam();
   const screenSideParam = getScreenSideParam();
-  const sourceParam = getSourceParam();
+  const requestorParam = getRequestorParam();
   const [apiResponse, setApiResponse] = useState<ApiResponse>(LOADING_RESPONSE);
   const [requestCount, setRequestCount] = useState<number>(0);
   const [lastSuccess, setLastSuccess] = useState<number | null>(null);
@@ -160,7 +160,7 @@ const useBaseApiResponse = ({
   } = getDataset();
   const refreshMs = parseInt(refreshRate, 10) * 1000;
   let refreshRateOffsetMs = parseInt(refreshRateOffset, 10) * 1000;
-  const apiPath = `/v2/api/screen/${id}${routePart}?last_refresh=${lastRefresh}${isRealScreenParam}${screenSideParam}${sourceParam}`;
+  const apiPath = `/v2/api/screen/${id}${routePart}?last_refresh=${lastRefresh}${isRealScreenParam}${screenSideParam}${requestorParam}`;
 
   if (screenIdsWithOffsetMap) {
     const screens = JSON.parse(screenIdsWithOffsetMap);

--- a/lib/screens/log_screen_data.ex
+++ b/lib/screens/log_screen_data.ex
@@ -13,8 +13,8 @@ defmodule Screens.LogScreenData do
     end
   end
 
-  def log_data_request(screen_id, last_refresh, is_screen, source, screen_side \\ nil) do
-    if is_screen or not is_nil(source) do
+  def log_data_request(screen_id, last_refresh, is_screen, requestor, screen_side \\ nil) do
+    if is_screen or not is_nil(requestor) do
       data =
         %{
           screen_id: screen_id,
@@ -22,7 +22,7 @@ defmodule Screens.LogScreenData do
           last_refresh: last_refresh
         }
         |> insert_screen_side(screen_side)
-        |> insert_source(source)
+        |> insert_requestor(requestor)
 
       log_message("[screen data request]", data)
     end
@@ -115,6 +115,6 @@ defmodule Screens.LogScreenData do
   defp insert_screen_side(data, nil), do: data
   defp insert_screen_side(data, screen_side), do: Map.put(data, :screen_side, screen_side)
 
-  defp insert_source(data, nil), do: data
-  defp insert_source(data, source), do: Map.put(data, :source, source)
+  defp insert_requestor(data, nil), do: data
+  defp insert_requestor(data, requestor), do: Map.put(data, :requestor, requestor)
 end

--- a/lib/screens_web/controllers/screen_api_controller.ex
+++ b/lib/screens_web/controllers/screen_api_controller.ex
@@ -30,7 +30,12 @@ defmodule ScreensWeb.ScreenApiController do
     is_screen = ScreensWeb.UserAgent.is_screen_conn?(conn, screen_id)
 
     _ =
-      Screens.LogScreenData.log_data_request(screen_id, last_refresh, is_screen, params["source"])
+      Screens.LogScreenData.log_data_request(
+        screen_id,
+        last_refresh,
+        is_screen,
+        params["requestor"]
+      )
 
     if nonexistent_screen?(screen_id) do
       Screens.LogScreenData.log_api_response(:nonexistent, screen_id, last_refresh, is_screen)
@@ -50,7 +55,7 @@ defmodule ScreensWeb.ScreenApiController do
   def show_dup(conn, %{"id" => screen_id, "rotation_index" => rotation_index} = params) do
     is_screen = ScreensWeb.UserAgent.is_screen_conn?(conn, screen_id)
 
-    _ = Screens.LogScreenData.log_data_request(screen_id, nil, is_screen, params["source"])
+    _ = Screens.LogScreenData.log_data_request(screen_id, nil, is_screen, params["requestor"])
 
     if nonexistent_screen?(screen_id) do
       not_found_response(conn)

--- a/lib/screens_web/controllers/screen_controller.ex
+++ b/lib/screens_web/controllers/screen_controller.ex
@@ -83,7 +83,7 @@ defmodule ScreensWeb.ScreenController do
         |> assign(:app_id, app_id)
         |> assign(:sentry_frontend_dsn, Application.get_env(:screens, :sentry_frontend_dsn))
         |> assign(:is_real_screen, match?(%{"is_real_screen" => "true"}, params))
-        |> assign(:source, params["source"])
+        |> assign(:requestor, params["requestor"])
         |> render("index.html")
 
       nil ->

--- a/lib/screens_web/controllers/v2/screen_api_controller.ex
+++ b/lib/screens_web/controllers/v2/screen_api_controller.ex
@@ -24,7 +24,7 @@ defmodule ScreensWeb.V2.ScreenApiController do
       screen_id,
       last_refresh,
       is_screen,
-      params["source"],
+      params["requestor"],
       screen_side
     )
 
@@ -80,7 +80,7 @@ defmodule ScreensWeb.V2.ScreenApiController do
       screen_id,
       last_refresh,
       false,
-      params["source"],
+      params["requestor"],
       params["screen_side"]
     )
 

--- a/lib/screens_web/controllers/v2/screen_controller.ex
+++ b/lib/screens_web/controllers/v2/screen_controller.ex
@@ -83,7 +83,7 @@ defmodule ScreensWeb.V2.ScreenController do
         )
         |> assign(:is_real_screen, match?(%{"is_real_screen" => "true"}, params))
         |> assign(:screen_side, screen_side(params))
-        |> assign(:source, params["source"])
+        |> assign(:requestor, params["requestor"])
         |> put_view(ScreensWeb.V2.ScreenView)
         |> render("index.html")
 

--- a/lib/screens_web/templates/screen/index.html.eex
+++ b/lib/screens_web/templates/screen/index.html.eex
@@ -3,7 +3,7 @@
   data-last-refresh="<%= @last_refresh %>"
   data-environment-name="<%= @environment_name %>"
   data-is-real-screen="<%= @is_real_screen %>"
-  data-source="<%= @source %>"
+  data-requestor="<%= @requestor %>"
   <%= if record_sentry?() do %>
     data-sentry="<%= @sentry_frontend_dsn %>"
   <% end %>

--- a/lib/screens_web/templates/v2/screen/index.html.eex
+++ b/lib/screens_web/templates/v2/screen/index.html.eex
@@ -13,5 +13,5 @@
   <%= if record_sentry?() do %>
     data-sentry="<%= @sentry_frontend_dsn %>"
   <% end %>
-  data-source="<%= @source %>"
+  data-requestor="<%= @requestor %>"
 ></div>


### PR DESCRIPTION
**Asana task**: [Update Splunk E-Ink logging so there are not 2 'source' fields](https://app.asana.com/0/1164574158255689/1203166122404934/f)

There is already a `source` field in E-Ink Splunk logs, so we need to rename the key we use. `requestor` use a suggestion in the original task so I went with that. Open to other ideas though. 

- [ ] Tests added?
