### PR TITLE
feat: disable_sentry query param

### DIFF
--- a/assets/src/util/sentry.tsx
+++ b/assets/src/util/sentry.tsx
@@ -24,13 +24,6 @@ const initSentry = (appString: string) => {
     environmentName: env,
     disableSentry,
   } = getDataset();
-
-  console.log(disableSentry);
-
-  if (!disableSentry && isRealScreen()) {
-    console.log("HERE");
-  }
-
   // Note: passing an empty string as the DSN sets up a "no-op SDK" that captures errors and lets you call its methods,
   // but does not actually log anything to the Sentry service.
 

--- a/assets/src/util/sentry.tsx
+++ b/assets/src/util/sentry.tsx
@@ -15,8 +15,8 @@ const warn = (message: string) => log(message, "warning");
 const error = (message: string) => log(message, "error");
 
 /**
- * Initializes Sentry if the DSN is defined and this client is running on
- * a real production screen.
+ * Initializes Sentry if the DSN is defined AND this client is running on
+ * a real production screen AND the URL does not contain the disable_sentry param.
  */
 const initSentry = (appString: string) => {
   const {

--- a/assets/src/util/sentry.tsx
+++ b/assets/src/util/sentry.tsx
@@ -1,6 +1,6 @@
 import { isDup, isRealScreen } from "Util/util";
 import { getDataset } from "Util/dataset";
-// Previously tried @sentry/react and @sentry/browser as the SDK, but the QtWeb browser on e-inks could not 
+// Previously tried @sentry/react and @sentry/browser as the SDK, but the QtWeb browser on e-inks could not
 // use them. Raven is an older stable SDK that better works with older browsers.
 import Raven from "raven-js";
 
@@ -8,7 +8,7 @@ import Raven from "raven-js";
 type LogLevel = "info" | "warning" | "error";
 
 const log = (message: string, level: LogLevel) => {
-  Raven.captureMessage(message, {level});
+  Raven.captureMessage(message, { level });
 };
 const info = (message: string) => log(message, "info");
 const warn = (message: string) => log(message, "warning");
@@ -19,23 +19,34 @@ const error = (message: string) => log(message, "error");
  * a real production screen.
  */
 const initSentry = (appString: string) => {
-  const { sentry: sentryDsn, environmentName: env } = getDataset();
+  const {
+    sentry: sentryDsn,
+    environmentName: env,
+    disableSentry,
+  } = getDataset();
+
+  console.log(disableSentry);
+
+  if (!disableSentry && isRealScreen()) {
+    console.log("HERE");
+  }
 
   // Note: passing an empty string as the DSN sets up a "no-op SDK" that captures errors and lets you call its methods,
   // but does not actually log anything to the Sentry service.
 
-  if (sentryDsn && isRealScreen()) {
-    Raven.config(sentryDsn, {environment: env}).install();
+  if (sentryDsn && isRealScreen() && !disableSentry) {
+    Raven.config(sentryDsn, { environment: env }).install();
     if (isDup()) {
-      const today = new Date()
-      const hour = today.getHours()
+      const today = new Date();
+      const hour = today.getHours();
       const min = today.getMinutes();
-      if (hour === 8 && min >= 0 && min < 10) info(`Sentry intialized for app: ${appString}`)
+      if (hour === 8 && min >= 0 && min < 10)
+        info(`Sentry intialized for app: ${appString}`);
     } else {
-      info(`Sentry intialized for app: ${appString}`)
+      info(`Sentry intialized for app: ${appString}`);
     }
   }
 };
 
 export default initSentry;
-export {info, warn, error}
+export { info, warn, error };

--- a/lib/screens_web/controllers/screen_controller.ex
+++ b/lib/screens_web/controllers/screen_controller.ex
@@ -84,6 +84,7 @@ defmodule ScreensWeb.ScreenController do
         |> assign(:sentry_frontend_dsn, Application.get_env(:screens, :sentry_frontend_dsn))
         |> assign(:is_real_screen, match?(%{"is_real_screen" => "true"}, params))
         |> assign(:requestor, params["requestor"])
+        |> assign(:disable_sentry, params["disable_sentry"])
         |> render("index.html")
 
       nil ->

--- a/lib/screens_web/controllers/v2/screen_controller.ex
+++ b/lib/screens_web/controllers/v2/screen_controller.ex
@@ -84,6 +84,7 @@ defmodule ScreensWeb.V2.ScreenController do
         |> assign(:is_real_screen, match?(%{"is_real_screen" => "true"}, params))
         |> assign(:screen_side, screen_side(params))
         |> assign(:requestor, params["requestor"])
+        |> assign(:disable_sentry, params["disable_sentry"])
         |> put_view(ScreensWeb.V2.ScreenView)
         |> render("index.html")
 

--- a/lib/screens_web/templates/screen/index.html.eex
+++ b/lib/screens_web/templates/screen/index.html.eex
@@ -4,6 +4,7 @@
   data-environment-name="<%= @environment_name %>"
   data-is-real-screen="<%= @is_real_screen %>"
   data-requestor="<%= @requestor %>"
+  data-disable-sentry="<%= @disable_sentry %>"
   <%= if record_sentry?() do %>
     data-sentry="<%= @sentry_frontend_dsn %>"
   <% end %>

--- a/lib/screens_web/templates/v2/screen/index.html.eex
+++ b/lib/screens_web/templates/v2/screen/index.html.eex
@@ -14,4 +14,5 @@
     data-sentry="<%= @sentry_frontend_dsn %>"
   <% end %>
   data-requestor="<%= @requestor %>"
+  data-disable-sentry="<%= @disable_sentry %>"
 ></div>


### PR DESCRIPTION
**Asana task**: [[Screens] New parameter `disable_sentry` for the 4 first-gen EIGs](https://app.asana.com/0/1164574158255689/1202958313810860/f)

Added option for `disable_sentry` param to be added to URL in order to prevent Sentry from starting in React. If a DSN is present AND it's a real screen AND the param is absent or false, Sentry will run like normal. If `disable_sentry` is true, Sentry will not initialize.

- [ ] Tests added?
