### PR TITLE
feat: Add cache update to framework

### DIFF
--- a/lib/screens/v2/alert_widget_instance.ex
+++ b/lib/screens/v2/alert_widget_instance.ex
@@ -1,0 +1,7 @@
+defprotocol Screens.V2.AlertWidgetInstance do
+  @type alert_id :: String.t()
+
+  @doc "Gets the ID of the alert that this widget shows."
+  @spec alert_id(t) :: alert_id()
+  def alert_id(widget)
+end

--- a/lib/screens/v2/screen_data.ex
+++ b/lib/screens/v2/screen_data.ex
@@ -472,4 +472,21 @@ defmodule Screens.V2.ScreenData do
       Enum.find_value(children, &get_containing_slot(&1, target_slot_ids))
     end
   end
+
+  def cache_visible_alert_widgets({layout, instance_map}, screen_id) do
+    alert_ids =
+      instance_map
+      |> Enum.filter(fn
+        {_slot_id, %widget{}} ->
+          widget in @alert_widgets
+
+        _ ->
+          false
+      end)
+      |> Enum.map(fn {_slot_id, %{alert: %Screens.Alerts.Alert{id: id}}} -> id end)
+
+    :ok = ScreensByAlert.put_data(screen_id, alert_ids)
+
+    {layout, instance_map}
+  end
 end

--- a/lib/screens/v2/screen_data.ex
+++ b/lib/screens/v2/screen_data.ex
@@ -481,14 +481,9 @@ defmodule Screens.V2.ScreenData do
   def cache_visible_alert_widgets({_layout, instance_map}, screen_id) do
     alert_ids =
       instance_map
-      |> Enum.filter(fn
-        {_slot_id, %widget{}} ->
-          widget in @alert_widgets
-
-        _ ->
-          false
-      end)
-      |> Enum.map(fn {_slot_id, %{alert: %Screens.Alerts.Alert{id: id}}} -> id end)
+      |> Map.values()
+      |> Enum.filter(fn %widget{} -> widget in @alert_widgets end)
+      |> Enum.map(fn %{alert: %Screens.Alerts.Alert{id: id}} -> id end)
 
     :ok = ScreensByAlert.put_data(screen_id, alert_ids)
   end

--- a/lib/screens/v2/screen_data.ex
+++ b/lib/screens/v2/screen_data.ex
@@ -44,7 +44,7 @@ defmodule Screens.V2.ScreenData do
     data =
       config
       |> fetch_data()
-      |> cache_visible_alert_widgets(screen_id)
+      |> tap(&cache_visible_alert_widgets(&1, screen_id))
       |> resolve_paging(refresh_rate)
       |> serialize()
 
@@ -478,7 +478,7 @@ defmodule Screens.V2.ScreenData do
     end
   end
 
-  def cache_visible_alert_widgets({layout, instance_map}, screen_id) do
+  def cache_visible_alert_widgets({_layout, instance_map}, screen_id) do
     alert_ids =
       instance_map
       |> Enum.filter(fn
@@ -491,7 +491,5 @@ defmodule Screens.V2.ScreenData do
       |> Enum.map(fn {_slot_id, %{alert: %Screens.Alerts.Alert{id: id}}} -> id end)
 
     :ok = ScreensByAlert.put_data(screen_id, alert_ids)
-
-    {layout, instance_map}
   end
 end

--- a/lib/screens/v2/screen_data.ex
+++ b/lib/screens/v2/screen_data.ex
@@ -5,14 +5,12 @@ defmodule Screens.V2.ScreenData do
 
   alias Screens.ScreensByAlert
   alias Screens.Util
+  alias Screens.V2.AlertWidgetInstance
   alias Screens.V2.ScreenData.Parameters
   alias Screens.V2.Template
   alias Screens.V2.WidgetInstance
-  alias Screens.V2.WidgetInstance.{Alert, ReconstructedAlert}
 
   import Screens.V2.Template.Guards
-
-  @alert_widgets [Alert, ReconstructedAlert]
 
   @type screen_id :: String.t()
   @type config :: Screens.Config.Screen.t()
@@ -482,8 +480,10 @@ defmodule Screens.V2.ScreenData do
     alert_ids =
       instance_map
       |> Map.values()
-      |> Enum.filter(fn %widget{} -> widget in @alert_widgets end)
-      |> Enum.map(fn %{alert: %Screens.Alerts.Alert{id: id}} -> id end)
+      |> Enum.filter(fn widget_struct ->
+        not is_nil(AlertWidgetInstance.impl_for(widget_struct))
+      end)
+      |> Enum.map(fn alert_widget_struct -> AlertWidgetInstance.alert_id(alert_widget_struct) end)
 
     :ok = ScreensByAlert.put_data(screen_id, alert_ids)
   end

--- a/lib/screens/v2/screen_data.ex
+++ b/lib/screens/v2/screen_data.ex
@@ -3,12 +3,16 @@ defmodule Screens.V2.ScreenData do
 
   require Logger
 
+  alias Screens.ScreensByAlert
   alias Screens.Util
   alias Screens.V2.ScreenData.Parameters
   alias Screens.V2.Template
   alias Screens.V2.WidgetInstance
+  alias Screens.V2.WidgetInstance.{Alert, ReconstructedAlert}
 
   import Screens.V2.Template.Guards
+
+  @alert_widgets [Alert, ReconstructedAlert]
 
   @type screen_id :: String.t()
   @type config :: Screens.Config.Screen.t()
@@ -40,6 +44,7 @@ defmodule Screens.V2.ScreenData do
     data =
       config
       |> fetch_data()
+      |> cache_visible_alert_widgets(screen_id)
       |> resolve_paging(refresh_rate)
       |> serialize()
 

--- a/lib/screens/v2/widget_instance/alert.ex
+++ b/lib/screens/v2/widget_instance/alert.ex
@@ -420,6 +420,8 @@ defmodule Screens.V2.WidgetInstance.Alert do
 
   def audio_view(_instance), do: ScreensWeb.V2.Audio.AlertView
 
+  def alert_id(%__MODULE__{} = instance), do: instance.alert.id
+
   defimpl Screens.V2.WidgetInstance do
     alias Screens.V2.WidgetInstance.Alert
 
@@ -432,5 +434,11 @@ defmodule Screens.V2.WidgetInstance.Alert do
     def audio_sort_key(instance), do: Alert.audio_sort_key(instance)
     def audio_valid_candidate?(instance), do: Alert.audio_valid_candidate?(instance)
     def audio_view(instance), do: Alert.audio_view(instance)
+  end
+
+  defimpl Screens.V2.AlertWidgetInstance do
+    alias Screens.V2.WidgetInstance.Alert
+
+    def alert_id(instance), do: Alert.alert_id(instance)
   end
 end

--- a/lib/screens/v2/widget_instance/reconstructed_alert.ex
+++ b/lib/screens/v2/widget_instance/reconstructed_alert.ex
@@ -734,6 +734,8 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
       else: :reconstructed_large_alert
   end
 
+  def alert_id(%__MODULE__{} = t), do: t.alert.id
+
   defimpl Screens.V2.WidgetInstance do
     def priority(t), do: ReconstructedAlert.priority(t)
     def serialize(t), do: ReconstructedAlert.serialize(t)
@@ -744,5 +746,9 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
     def audio_sort_key(t), do: ReconstructedAlert.audio_sort_key(t)
     def audio_valid_candidate?(_instance), do: true
     def audio_view(_instance), do: ScreensWeb.V2.Audio.ReconstructedAlertView
+  end
+
+  defimpl Screens.V2.AlertWidgetInstance do
+    def alert_id(t), do: ReconstructedAlert.alert_id(t)
   end
 end

--- a/test/screens/v2/widget_instance/alert_test.exs
+++ b/test/screens/v2/widget_instance/alert_test.exs
@@ -4,6 +4,7 @@ defmodule Screens.V2.WidgetInstance.AlertTest do
   alias Screens.Alerts.Alert
   alias Screens.Config.Screen
   alias Screens.Config.V2.{BusEink, BusShelter, GlEink, Solari}
+  alias Screens.V2.AlertWidgetInstance
   alias Screens.V2.WidgetInstance.Alert, as: AlertWidget
 
   setup :setup_base
@@ -679,6 +680,12 @@ defmodule Screens.V2.WidgetInstance.AlertTest do
   describe "audio_view/1" do
     test "returns AlertView", %{widget: widget} do
       assert ScreensWeb.V2.Audio.AlertView == AlertWidget.audio_view(widget)
+    end
+  end
+
+  describe "alert_id/1" do
+    test "returns alert_id", %{widget: widget} do
+      assert widget.alert.id == AlertWidgetInstance.alert_id(widget)
     end
   end
 end

--- a/test/screens/v2/widget_instance/reconstructed_alert_test.exs
+++ b/test/screens/v2/widget_instance/reconstructed_alert_test.exs
@@ -6,6 +6,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
   alias Screens.Config.V2.{PreFare}
   alias Screens.Config.V2.Header.CurrentStopId
   alias Screens.Stops.Stop
+  alias Screens.V2.AlertWidgetInstance
   alias Screens.V2.CandidateGenerator
   alias Screens.V2.WidgetInstance
   alias Screens.V2.WidgetInstance.ReconstructedAlert
@@ -1131,6 +1132,12 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
     test "returns ReconstructedAlertView" do
       instance = %ReconstructedAlert{}
       assert ScreensWeb.V2.Audio.ReconstructedAlertView == WidgetInstance.audio_view(instance)
+    end
+  end
+
+  describe "alert_id/1" do
+    test "returns alert_id", %{widget: widget} do
+      assert widget.alert.id == AlertWidgetInstance.alert_id(widget)
     end
   end
 


### PR DESCRIPTION
**Asana task**: [Update cached alert => screens data on every v2 screen data request](https://app.asana.com/0/1185117109217413/1203111452890186/f)

Cache will now be updated automatically while a screen is open. Right now, I just have the list of widgets we should cache in a module attribute. I picked this mostly because there are not many right now, and adding to the list is super easy. Feel free to suggest another way to hold this info.

- [ ] Tests added?
