### PR TITLE
feat: Screens-by-alert self-refresh job runner

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -196,6 +196,7 @@ config :screens,
 
 config :screens, :screens_by_alert,
   cache_module: Screens.ScreensByAlert.GenServer,
+  screen_data_fn: &Screens.V2.ScreenData.by_screen_id/2,
   screens_by_alert_ttl_seconds: 40,
   screens_last_updated_ttl_seconds: 3600,
   screens_ttl_seconds: 40

--- a/config/test.exs
+++ b/config/test.exs
@@ -33,6 +33,7 @@ config :logger, level: :warn
 
 config :screens, :screens_by_alert,
   cache_module: Screens.ScreensByAlert.GenServer,
+  screen_data_fn: &Screens.ScreensByAlert.SelfRefreshRunner.fake_screen_data_fn/2,
   screens_by_alert_ttl_seconds: 2,
   screens_last_updated_ttl_seconds: 2,
   screens_ttl_seconds: 1

--- a/config/test.exs
+++ b/config/test.exs
@@ -33,7 +33,7 @@ config :logger, level: :warn
 
 config :screens, :screens_by_alert,
   cache_module: Screens.ScreensByAlert.GenServer,
-  screen_data_fn: &Screens.ScreensByAlert.SelfRefreshRunner.fake_screen_data_fn/2,
+  screen_data_fn: &Screens.V2.MockScreenData.by_screen_id/2,
   screens_by_alert_ttl_seconds: 2,
   screens_last_updated_ttl_seconds: 2,
   screens_ttl_seconds: 1

--- a/lib/screens/application.ex
+++ b/lib/screens/application.ex
@@ -23,7 +23,9 @@ defmodule Screens.Application do
       :hackney_pool.child_spec(:api_v3_pool, max_connections: 100),
       {Screens.Stops.StationsWithRoutesAgent, %{}},
       {Screens.BlueBikes.State, name: Screens.BlueBikes.State},
-      Screens.ScreensByAlert
+      Screens.ScreensByAlert,
+      {Task.Supervisor, name: Screens.ScreensByAlert.SelfRefreshRunner.TaskSupervisor},
+      {Screens.ScreensByAlert.SelfRefreshRunner, name: Screens.ScreensByAlert.SelfRefreshRunner}
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html

--- a/lib/screens/config/screen.ex
+++ b/lib/screens/config/screen.ex
@@ -43,6 +43,9 @@ defmodule Screens.Config.Screen do
           tags: list(String.t())
         }
 
+  # If a Screens client app uses widgets, its ID must end with this suffix.
+  @v2_app_id_suffix "_v2"
+
   @recognized_app_ids ~w[bus_eink dup gl_eink_single gl_eink_double solari solari_large]a
   @recognized_v2_app_ids ~w[bus_eink_v2 bus_shelter_v2 dup_v2 gl_eink_v2 solari_v2 solari_large_v2 pre_fare_v2]a
   @recognized_app_id_strings Enum.map(
@@ -106,6 +109,13 @@ defmodule Screens.Config.Screen do
   @spec schedule_refresh_at_time(t(), DateTime.t()) :: t()
   def schedule_refresh_at_time(screen_config, time) do
     %__MODULE__{screen_config | refresh_if_loaded_before: time}
+  end
+
+  @spec v2_screen?(t()) :: boolean()
+  def v2_screen?(screen_config) do
+    screen_config.app_id
+    |> Atom.to_string()
+    |> String.ends_with?(@v2_app_id_suffix)
   end
 
   for vendor <- ~w[gds mercury solari c3ms outfront]a do

--- a/lib/screens/screens_by_alert.ex
+++ b/lib/screens/screens_by_alert.ex
@@ -46,12 +46,12 @@ defmodule Screens.ScreensByAlert do
   end
 
   @impl true
-  def get_screens_by_alert(alert_id) do
-    @cache_module.get_screens_by_alert(alert_id)
+  def get_screens_by_alert(alert_ids) do
+    @cache_module.get_screens_by_alert(alert_ids)
   end
 
   @impl true
-  def get_screens_last_updated(screen_id) do
-    @cache_module.get_screens_last_updated(screen_id)
+  def get_screens_last_updated(screen_ids) do
+    @cache_module.get_screens_last_updated(screen_ids)
   end
 end

--- a/lib/screens/screens_by_alert/behaviour.ex
+++ b/lib/screens/screens_by_alert/behaviour.ex
@@ -12,7 +12,6 @@ defmodule Screens.ScreensByAlert.Behaviour do
   @type screen_id :: String.t()
   @type alert_id :: String.t()
   @type timestamp :: integer()
-  @type timestamped_screen_id :: {screen_id, timestamp}
 
   @doc """
   Starts the process that interfaces with the screens-by-alert cache.

--- a/lib/screens/screens_by_alert/behaviour.ex
+++ b/lib/screens/screens_by_alert/behaviour.ex
@@ -5,8 +5,8 @@ defmodule Screens.ScreensByAlert.Behaviour do
   - `start_link(opts)` is called to start the backend by the supervisor.
   - `put_data(screen_id, list(alert_id))` inserts the list of alert_ids visible on a given screen_id
     to the cache.
-  - `get_screens_by_alert(alert_id)` returns all screen_ids that are currently displaying the given alert_id.
-  - `get_screens_last_updated(screen_id)` returns the timestamp that represents the last time a given screen_id was updated.
+  - `get_screens_by_alert(alert_ids)` returns a map associating each requested alert_id with the screen IDs that are currently displaying it.
+  - `get_screens_last_updated(screen_ids)` returns a map associating each requested screen_id with its last-updated Unix timestamp.
 
   """
   @type screen_id :: String.t()
@@ -14,6 +14,9 @@ defmodule Screens.ScreensByAlert.Behaviour do
   @type timestamp :: integer()
   @type timestamped_screen_id :: {screen_id, timestamp}
 
+  @doc """
+  Starts the process that interfaces with the screens-by-alert cache.
+  """
   @callback start_link(Keyword.t()) :: {:ok, pid()}
 
   @doc """
@@ -23,6 +26,19 @@ defmodule Screens.ScreensByAlert.Behaviour do
   """
   @callback put_data(screen_id(), list(alert_id())) :: :ok
 
-  @callback get_screens_by_alert(alert_id()) :: list(timestamped_screen_id())
-  @callback get_screens_last_updated(screen_id()) :: timestamp() | nil
+  @doc """
+  Given a list of 0 or more alert IDs, returns a mapping from each requested alert ID
+  to the list of screens currently showing it.
+
+  If a cache item is missing for some alert, its screens-list value will default to [].
+  """
+  @callback get_screens_by_alert(list(alert_id())) :: %{alert_id() => list(screen_id())}
+
+  @doc """
+  Given a list of 0 or more screen IDs, returns a mapping from each requested screen ID
+  to its last-updated Unix timestamp.
+
+  If a cache item is missing for some screen, its timestamp value will default to 0.
+  """
+  @callback get_screens_last_updated(list(screen_id())) :: %{screen_id() => timestamp()}
 end

--- a/lib/screens/screens_by_alert/memcache.ex
+++ b/lib/screens/screens_by_alert/memcache.ex
@@ -18,12 +18,12 @@ defmodule Screens.ScreensByAlert.Memcache do
   end
 
   @impl true
-  def get_screens_by_alert(_alert_id) do
-    []
+  def get_screens_by_alert(alert_ids) do
+    Map.new(alert_ids, &{&1, []})
   end
 
   @impl true
-  def get_screens_last_updated(_screen_id) do
-    0
+  def get_screens_last_updated(screen_ids) do
+    Map.new(screen_ids, &{&1, 0})
   end
 end

--- a/lib/screens/screens_by_alert/self_refresh_runner.ex
+++ b/lib/screens/screens_by_alert/self_refresh_runner.ex
@@ -73,12 +73,11 @@ defmodule Screens.ScreensByAlert.SelfRefreshRunner do
     # Doing the work in a separate, unlinked task process protects this GenServer
     # process from going down if an exception is raised while running
     # ScreenData.by_screen_id/1 for some screen.
-    for screen_id <- screen_ids_to_refresh do
-      _ =
-        Task.Supervisor.start_child(TaskSupervisor, fn ->
-          @screen_data_fn.(screen_id, skip_serialize: true)
-        end)
-    end
+    Enum.each(screen_ids_to_refresh, fn screen_id ->
+      Task.Supervisor.start_child(TaskSupervisor, fn ->
+        @screen_data_fn.(screen_id, skip_serialize: true)
+      end)
+    end)
 
     {:noreply, state}
   end

--- a/lib/screens/screens_by_alert/self_refresh_runner.ex
+++ b/lib/screens/screens_by_alert/self_refresh_runner.ex
@@ -83,7 +83,4 @@ defmodule Screens.ScreensByAlert.SelfRefreshRunner do
   defp schedule_run do
     Process.send_after(self(), :run, @job_run_interval_ms)
   end
-
-  @doc "A fake screen-data-fetching function to be used during tests, to avoid making requests."
-  def fake_screen_data_fn(_screen_id, _opts), do: nil
 end

--- a/lib/screens/screens_by_alert/self_refresh_runner.ex
+++ b/lib/screens/screens_by_alert/self_refresh_runner.ex
@@ -58,7 +58,7 @@ defmodule Screens.ScreensByAlert.SelfRefreshRunner do
       |> Enum.split(@max_screen_updates_per_run)
 
     Logger.info(
-      ~s|[running screens_by_alert self refresh] screen_ids_being_refreshed_now="#{Enum.join(screen_ids_to_refresh, ",")}" remaining_screen_ids_to_refresh="#{Enum.join(overflow, ",")}"|
+      "[running screens_by_alert self refresh] screen_ids_being_refreshed_now=#{Enum.join(screen_ids_to_refresh, ",")} count_of_remaining_screen_ids_to_refresh=#{length(overflow)}"
     )
 
     # We don't care about the result of the work, just its side-effect

--- a/lib/screens/screens_by_alert/self_refresh_runner.ex
+++ b/lib/screens/screens_by_alert/self_refresh_runner.ex
@@ -57,10 +57,8 @@ defmodule Screens.ScreensByAlert.SelfRefreshRunner do
       |> Enum.map(fn {screen_id, _timestamp} -> screen_id end)
       |> Enum.split(@max_screen_updates_per_run)
 
-    max_refreshes_per_run_exceeded = match?([_ | _], overflow)
-
     Logger.info(
-      "[running screens_by_alert self refresh] refreshing_screen_ids=#{Enum.join(screen_ids_to_refresh, ",")} max_refreshes_per_run_exceeded=#{max_refreshes_per_run_exceeded}"
+      ~s|[running screens_by_alert self refresh] screen_ids_being_refreshed_now="#{Enum.join(screen_ids_to_refresh, ",")}" remaining_screen_ids_to_refresh="#{Enum.join(overflow, ",")}"|
     )
 
     # We don't care about the result of the work, just its side-effect

--- a/lib/screens/screens_by_alert/self_refresh_runner.ex
+++ b/lib/screens/screens_by_alert/self_refresh_runner.ex
@@ -35,14 +35,9 @@ defmodule Screens.ScreensByAlert.SelfRefreshRunner do
 
   @impl true
   def init(:ok) do
-    {:ok, nil, {:continue, :schedule_first_run}}
-  end
-
-  @impl true
-  def handle_continue(:schedule_first_run, state) do
     schedule_run()
 
-    {:noreply, state}
+    {:ok, nil}
   end
 
   @impl true

--- a/lib/screens/screens_by_alert/self_refresh_runner.ex
+++ b/lib/screens/screens_by_alert/self_refresh_runner.ex
@@ -6,7 +6,7 @@ defmodule Screens.ScreensByAlert.SelfRefreshRunner do
 
   alias Screens.ScreensByAlert
 
-  # (Not a real module--just a name assigned to the Task.Supervisor that supervises each simulated data request run)
+  # (Not a real module--just a name assigned to the Task.Supervisor process that supervises each simulated data request run)
   alias Screens.ScreensByAlert.SelfRefreshRunner.TaskSupervisor
 
   require Logger
@@ -16,6 +16,14 @@ defmodule Screens.ScreensByAlert.SelfRefreshRunner do
 
   # The server is not stateful.
   defstruct []
+
+  ### Client
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, :ok, opts)
+  end
+
+  ### Server
 
   # Maximum number of screen updates that can happen per run.
   # Assuming a worst case of .5 sec per screen update, a max
@@ -29,14 +37,6 @@ defmodule Screens.ScreensByAlert.SelfRefreshRunner do
   @job_run_interval_ms @screens_ttl_seconds * 1_000
 
   @screen_data_fn Application.compile_env(:screens, :screens_by_alert)[:screen_data_fn]
-
-  ### Client
-
-  def start_link(opts) do
-    GenServer.start_link(__MODULE__, :ok, opts)
-  end
-
-  ### Server
 
   @impl true
   def init(:ok) do
@@ -97,6 +97,6 @@ defmodule Screens.ScreensByAlert.SelfRefreshRunner do
     Process.send_after(self(), :run, @job_run_interval_ms)
   end
 
-  # A fake screen-data-fetching function to be used during tests, to avoid making requests.
+  @doc "A fake screen-data-fetching function to be used during tests, to avoid making requests."
   def fake_screen_data_fn(_screen_id, _opts), do: nil
 end

--- a/lib/screens/screens_by_alert/self_refresh_runner.ex
+++ b/lib/screens/screens_by_alert/self_refresh_runner.ex
@@ -1,0 +1,102 @@
+defmodule Screens.ScreensByAlert.SelfRefreshRunner do
+  @moduledoc """
+  A "job-runner" GenServer that routinely checks for out-of-date
+  screen data, and simulates data requests for any that it finds.
+  """
+
+  alias Screens.ScreensByAlert
+
+  # (Not a real module--just a name assigned to the Task.Supervisor that supervises each simulated data request run)
+  alias Screens.ScreensByAlert.SelfRefreshRunner.TaskSupervisor
+
+  require Logger
+  use GenServer
+
+  @type state :: %__MODULE__{}
+
+  # The server is not stateful.
+  defstruct []
+
+  # Maximum number of screen updates that can happen per run.
+  # Assuming a worst case of .5 sec per screen update, a max
+  # of 20 has the job take 10 seconds max per run, giving
+  # plenty of space to avoid overlapping runs.
+  @max_screen_updates_per_run 20
+
+  @screens_ttl_seconds Application.compile_env(:screens, :screens_by_alert)[:screens_ttl_seconds]
+
+  # The job runs at the same rate as screen data expiration from the cache (though these "windows" will be offset from one another)
+  @job_run_interval_ms @screens_ttl_seconds * 1_000
+
+  @screen_data_fn Application.compile_env(:screens, :screens_by_alert)[:screen_data_fn]
+
+  ### Client
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, :ok, opts)
+  end
+
+  ### Server
+
+  @impl true
+  def init(:ok) do
+    {:ok, %__MODULE__{}, {:continue, :schedule_first_run}}
+  end
+
+  @impl true
+  def handle_continue(:schedule_first_run, state) do
+    schedule_run()
+
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_info(:run, state) do
+    schedule_run()
+
+    now = System.system_time(:second)
+
+    {screen_ids_to_refresh, overflow} =
+      Screens.Config.State.v2_screens_visible_to_screenplay()
+      # get a mapping from each ID to its last updated time
+      |> ScreensByAlert.get_screens_last_updated()
+      # filter to outdated IDs
+      |> Enum.filter(fn {_screen_id, timestamp} -> now - timestamp > @screens_ttl_seconds end)
+      # sort by age, oldest first
+      |> Enum.sort_by(fn {_screen_id, timestamp} -> timestamp end)
+      |> Enum.map(fn {screen_id, _timestamp} -> screen_id end)
+      |> Enum.split(@max_screen_updates_per_run)
+
+    max_refreshes_per_run_exceeded = match?([_ | _], overflow)
+
+    Logger.info(
+      "[running screens_by_alert self refresh] refreshing_screen_ids=#{Enum.join(screen_ids_to_refresh, ",")} max_refreshes_per_run_exceeded=#{max_refreshes_per_run_exceeded}"
+    )
+
+    # We don't care about the result of the work, just its side-effect
+    # of updating the relevant cached data.
+    # In fact, we don't even care if the function call succeeds.
+    #
+    # Task.Supervisor.start_child/3 lets us run each update concurrently without
+    # using the return value, while also providing graceful handling of shutdowns.
+    #
+    # Doing the work in a separate, unlinked task process protects this GenServer
+    # process from going down if an exception is raised while running
+    # ScreenData.by_screen_id/1 for some screen.
+    for screen_id <- screen_ids_to_refresh do
+      _ =
+        Task.Supervisor.start_child(TaskSupervisor, fn ->
+          @screen_data_fn.(screen_id, skip_serialize: true)
+        end)
+    end
+
+    {:noreply, state}
+  end
+
+  defp schedule_run do
+    Process.send_after(self(), :run, @job_run_interval_ms)
+  end
+
+  # A fake screen-data-fetching function to be used during tests, to avoid making requests.
+  def fake_screen_data_fn(_screen_id, _opts), do: nil
+end

--- a/lib/screens/screens_by_alert/self_refresh_runner.ex
+++ b/lib/screens/screens_by_alert/self_refresh_runner.ex
@@ -1,6 +1,6 @@
 defmodule Screens.ScreensByAlert.SelfRefreshRunner do
   @moduledoc """
-  A "job-runner" GenServer that routinely checks for out-of-date
+  A stateless "job-runner" GenServer that routinely checks for out-of-date
   screen data, and simulates data requests for any that it finds.
   """
 
@@ -11,11 +11,6 @@ defmodule Screens.ScreensByAlert.SelfRefreshRunner do
 
   require Logger
   use GenServer
-
-  @type state :: %__MODULE__{}
-
-  # The server is not stateful.
-  defstruct []
 
   ### Client
 
@@ -40,7 +35,7 @@ defmodule Screens.ScreensByAlert.SelfRefreshRunner do
 
   @impl true
   def init(:ok) do
-    {:ok, %__MODULE__{}, {:continue, :schedule_first_run}}
+    {:ok, nil, {:continue, :schedule_first_run}}
   end
 
   @impl true

--- a/lib/screens/v2/screen_data.ex
+++ b/lib/screens/v2/screen_data.ex
@@ -32,18 +32,20 @@ defmodule Screens.V2.ScreenData do
   @spec disabled_response() :: response_map()
   def disabled_response, do: response(disabled: true)
 
-  @spec by_screen_id(screen_id()) :: response_map()
-  def by_screen_id(screen_id) do
+  @spec by_screen_id(screen_id(), Keyword.t()) :: response_map() | nil
+  def by_screen_id(screen_id, opts \\ []) do
     config = get_config(screen_id)
     refresh_rate = Parameters.get_refresh_rate(config)
 
-    data =
+    layout_and_widgets =
       config
       |> fetch_data()
       |> resolve_paging(refresh_rate)
-      |> serialize()
 
-    response(data: data)
+    unless opts[:skip_serialize] do
+      data = serialize(layout_and_widgets)
+      response(data: data)
+    end
   end
 
   @spec simulation_data_by_screen_id(screen_id()) :: response_map()

--- a/lib/screens_web/controllers/screens_by_alert_controller.ex
+++ b/lib/screens_web/controllers/screens_by_alert_controller.ex
@@ -5,20 +5,18 @@ defmodule ScreensWeb.ScreensByAlertController do
 
   def index(conn, %{"ids" => alert_ids_string}) do
     if alert_ids_string == "" do
-      json(conn, [])
+      json(conn, %{})
     else
       screens_by_alerts =
         alert_ids_string
         |> String.split(",")
-        |> Enum.map(fn alert_id ->
-          ScreensByAlert.get_screens_by_alert(alert_id)
-        end)
+        |> ScreensByAlert.get_screens_by_alert()
 
       json(conn, screens_by_alerts)
     end
   end
 
   def index(conn, _) do
-    json(conn, [])
+    json(conn, %{})
   end
 end

--- a/test/screens/screens_by_alert_test.exs
+++ b/test/screens/screens_by_alert_test.exs
@@ -39,21 +39,23 @@ defmodule Screens.ScreensByAlertTest do
       }
     end
 
-    test "returns list with data when called before expiration" do
-      assert [{1, _}] = ScreensByAlert.get_screens_by_alert(1)
+    test "returns map with data when called before expiration" do
+      assert %{1 => [1]} == ScreensByAlert.get_screens_by_alert([1])
     end
 
-    test "returns empty list when called after expiration", %{screens_by_alert_ttl: ttl} do
-      assert [{1, _}] = ScreensByAlert.get_screens_by_alert(1)
+    test "returns map with default empty list when called after expiration", %{
+      screens_by_alert_ttl: ttl
+    } do
+      assert %{1 => [1]} == ScreensByAlert.get_screens_by_alert([1])
       Process.sleep((ttl + 1) * 1000)
-      assert [] = ScreensByAlert.get_screens_by_alert(1)
+      assert %{1 => []} == ScreensByAlert.get_screens_by_alert([1])
     end
 
-    test "returns list with no expired screens", %{screens_ttl: ttl} do
-      assert [{1, _}] = ScreensByAlert.get_screens_by_alert(1)
+    test "returns map with no expired", %{screens_ttl: ttl} do
+      assert %{1 => [1]} == ScreensByAlert.get_screens_by_alert([1])
       Process.sleep(ttl * 1000)
       assert :ok = ScreensByAlert.put_data(2, [1])
-      assert [{2, _}] = ScreensByAlert.get_screens_by_alert(1)
+      assert %{1 => [2]} == ScreensByAlert.get_screens_by_alert([1])
     end
   end
 
@@ -70,13 +72,16 @@ defmodule Screens.ScreensByAlertTest do
     end
 
     test "returns when screen was last updated", %{last_updated: last_updated} do
-      assert last_updated == ScreensByAlert.get_screens_last_updated(1)
+      assert %{1 => last_updated} == ScreensByAlert.get_screens_last_updated([1])
     end
 
-    test "returns nil after expiration", %{last_updated: last_updated, ttl: ttl} do
-      assert last_updated == ScreensByAlert.get_screens_last_updated(1)
+    test "returns map with default timestamp of 0 after expiration", %{
+      last_updated: last_updated,
+      ttl: ttl
+    } do
+      assert %{1 => last_updated} == ScreensByAlert.get_screens_last_updated([1])
       Process.sleep((ttl + 1) * 1000)
-      assert is_nil(ScreensByAlert.get_screens_last_updated(1))
+      assert %{1 => 0} == ScreensByAlert.get_screens_last_updated([1])
     end
   end
 end

--- a/test/screens_web/controllers/screens_by_alert_controller_test.exs
+++ b/test/screens_web/controllers/screens_by_alert_controller_test.exs
@@ -2,20 +2,21 @@ defmodule ScreensWeb.ScreensByAlertControllerTest do
   use ScreensWeb.ConnCase
 
   describe "index/2" do
-    test "returns status code 200 and empty list in resp_body when no query param is provided", %{
-      conn: conn
-    } do
+    test "returns status code 200 and empty object in resp_body when no query param is provided",
+         %{
+           conn: conn
+         } do
       conn = get(conn, "/api/screens_by_alert")
-      assert %{status: 200, resp_body: "[]"} = conn
+      assert %{status: 200, resp_body: "{}"} = conn
     end
   end
 
-  test "returns status code 200 and empty list in resp_body when empty query param is provided",
+  test "returns status code 200 and empty object in resp_body when empty query param is provided",
        %{
          conn: conn
        } do
     conn = get(conn, "/api/screens_by_alert?ids=")
-    assert %{status: 200, resp_body: "[]"} = conn
+    assert %{status: 200, resp_body: "{}"} = conn
   end
 
   test "returns 200 in status when query param is provided", %{

--- a/test/support/mock_v2_screen_data.ex
+++ b/test/support/mock_v2_screen_data.ex
@@ -1,0 +1,14 @@
+defmodule Screens.V2.MockScreenData do
+  @doc "A fake screen-data-fetching function to be used during tests, to avoid making requests."
+  def by_screen_id(screen_id) do
+    %{
+      data: %{content: "mock screen data for screen #{screen_id}"},
+      force_reload: false,
+      disabled: false
+    }
+  end
+
+  def by_screen_id(screen_id, _opts) do
+    by_screen_id(screen_id)
+  end
+end


### PR DESCRIPTION
**Asana task**: [Implement screens-by-alert "self-refresh" mechanism](https://app.asana.com/0/1185117109217413/1203086969471679/f)

The job uses `screens_ttl_seconds` as its run interval.

On each run, it does the following:
1. Get a list of all v2 screen IDs in config that are not hidden from Screenplay,
2. Find which of those have not been updated in the last `screens_ttl_seconds` seconds,
3. Take up to the 20 oldest of those,
4. And run the widget logic on each, concurrently, to update the cache with new data.

I needed to make some changes to the existing screens-by-alert code to allow requesting info on multiple alert IDs, screen IDs, so that we don't overload the cache-interfacing process with messages on each job run, or make separate cache GETs for each ID.

I also added a new optional `opts` param to `V2.ScreenData.by_screen_id`, allowing us to skip the serialization step and save some computation when we don't care about the end result.

- [x] Tests added?
  - Ok actually I just updated existing tests, not entirely sure how to unit test this GenServer since it doesn't really take any inputs after being started
