### PR TITLE
Temporarily disable screens-by-alert self-refresh job until other code is ready

### DIFF
--- a/lib/screens/application.ex
+++ b/lib/screens/application.ex
@@ -23,9 +23,9 @@ defmodule Screens.Application do
       :hackney_pool.child_spec(:api_v3_pool, max_connections: 100),
       {Screens.Stops.StationsWithRoutesAgent, %{}},
       {Screens.BlueBikes.State, name: Screens.BlueBikes.State},
-      Screens.ScreensByAlert,
-      {Task.Supervisor, name: Screens.ScreensByAlert.SelfRefreshRunner.TaskSupervisor},
-      {Screens.ScreensByAlert.SelfRefreshRunner, name: Screens.ScreensByAlert.SelfRefreshRunner}
+      Screens.ScreensByAlert
+      # {Task.Supervisor, name: Screens.ScreensByAlert.SelfRefreshRunner.TaskSupervisor},
+      # {Screens.ScreensByAlert.SelfRefreshRunner, name: Screens.ScreensByAlert.SelfRefreshRunner}
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html


### PR DESCRIPTION
**Asana task**: ad hoc

Disabling the job so it doesn't put unnecessary load on dev or otherwise before other necessary logic is ready.

- [ ] Tests added?
