### PR TITLE
tweak: Validate screens_by_alert query param

### DIFF
--- a/lib/screens_web/controllers/screens_by_alert_controller.ex
+++ b/lib/screens_web/controllers/screens_by_alert_controller.ex
@@ -18,7 +18,7 @@ defmodule ScreensWeb.ScreensByAlertController do
     if valid_alert_ids_param?(alert_ids) do
       json(conn, ScreensByAlert.get_screens_by_alert(alert_ids))
     else
-      Plug.Conn.send_resp(conn, 400, "Invalid alert ID found")
+      send_resp(conn, 400, "Invalid alert ID found")
     end
   end
 

--- a/lib/screens_web/controllers/screens_by_alert_controller.ex
+++ b/lib/screens_web/controllers/screens_by_alert_controller.ex
@@ -7,6 +7,8 @@ defmodule ScreensWeb.ScreensByAlertController do
     json(conn, %{})
   end
 
+  # `ids` must be a comma-separated list of integers.
+  # If any item in the list is an invalid integer, 400 is returned.
   def index(conn, %{"ids" => alert_ids_string}) do
     alert_ids =
       alert_ids_string

--- a/lib/screens_web/controllers/screens_by_alert_controller.ex
+++ b/lib/screens_web/controllers/screens_by_alert_controller.ex
@@ -12,8 +12,8 @@ defmodule ScreensWeb.ScreensByAlertController do
   def index(conn, %{"ids" => alert_ids_string}) do
     alert_ids =
       alert_ids_string
-      |> String.trim()
-      |> String.split(",")
+      |> String.split(",", trim: true)
+      |> Enum.map(&String.trim/1)
 
     if valid_alert_ids_param?(alert_ids) do
       json(conn, ScreensByAlert.get_screens_by_alert(alert_ids))

--- a/lib/screens_web/controllers/screens_by_alert_controller.ex
+++ b/lib/screens_web/controllers/screens_by_alert_controller.ex
@@ -27,6 +27,6 @@ defmodule ScreensWeb.ScreensByAlertController do
   end
 
   defp valid_alert_ids_param?(alert_ids) do
-    Enum.all?(alert_ids, &(Integer.parse(&1) != :error))
+    Enum.all?(alert_ids, &match?({_n, ""}, Integer.parse(&1)))
   end
 end

--- a/lib/screens_web/controllers/screens_by_alert_controller.ex
+++ b/lib/screens_web/controllers/screens_by_alert_controller.ex
@@ -3,20 +3,28 @@ defmodule ScreensWeb.ScreensByAlertController do
 
   alias Screens.ScreensByAlert
 
-  def index(conn, %{"ids" => alert_ids_string}) do
-    if alert_ids_string == "" do
-      json(conn, %{})
-    else
-      screens_by_alerts =
-        alert_ids_string
-        |> String.split(",")
-        |> ScreensByAlert.get_screens_by_alert()
+  def index(conn, %{"ids" => ""}) do
+    json(conn, %{})
+  end
 
-      json(conn, screens_by_alerts)
+  def index(conn, %{"ids" => alert_ids_string}) do
+    alert_ids =
+      alert_ids_string
+      |> String.trim()
+      |> String.split(",")
+
+    if valid_alert_ids_param?(alert_ids) do
+      json(conn, ScreensByAlert.get_screens_by_alert(alert_ids))
+    else
+      Plug.Conn.send_resp(conn, 400, "Invalid alert ID found")
     end
   end
 
   def index(conn, _) do
     json(conn, %{})
+  end
+
+  defp valid_alert_ids_param?(alert_ids) do
+    Enum.all?(alert_ids, &(Integer.parse(&1) != :error))
   end
 end

--- a/test/screens_web/controllers/screens_by_alert_controller_test.exs
+++ b/test/screens_web/controllers/screens_by_alert_controller_test.exs
@@ -26,6 +26,13 @@ defmodule ScreensWeb.ScreensByAlertControllerTest do
     assert %{status: 200} = conn
   end
 
+  test "returns 200 in status when query param is provided with excess whitespace", %{
+    conn: conn
+  } do
+    conn = get(conn, "/api/screens_by_alert?ids=1,  2,3  ,, 5")
+    assert %{status: 200} = conn
+  end
+
   test "returns 400 in status when query param contains a nonnumeric string", %{
     conn: conn
   } do

--- a/test/screens_web/controllers/screens_by_alert_controller_test.exs
+++ b/test/screens_web/controllers/screens_by_alert_controller_test.exs
@@ -25,4 +25,11 @@ defmodule ScreensWeb.ScreensByAlertControllerTest do
     conn = get(conn, "/api/screens_by_alert?ids=1,2,3")
     assert %{status: 200} = conn
   end
+
+  test "returns 400 in status when query param contains a nonnumeric string", %{
+    conn: conn
+  } do
+    conn = get(conn, "/api/screens_by_alert?ids=test,2,3")
+    assert %{status: 400} = conn
+  end
 end


### PR DESCRIPTION
**Asana task**: ad-hoc

We don't want any list of strings to be passed to `ScreensByAlert`, only a list of strings that are valid integers. If any string in the list is not an integer, a status code of 400 is returned.

- [ ] Tests added?
