### PR TITLE
fix: Active Elevator alert end date

### DIFF
--- a/assets/src/components/v2/elevator_status.tsx
+++ b/assets/src/components/v2/elevator_status.tsx
@@ -153,7 +153,7 @@ const getTimeframeEndText = (
     if (activePeriod.end === null) {
       endText = "Until further notice";
     } else {
-      const endDate = moment(activePeriod.end).tz("America/New_York");
+      const endDate = moment(activePeriod.end).subtract(3, "hours");
 
       if (endDate.date() === moment().tz("America/New_York").date()) {
         endText = "Until later today";
@@ -168,7 +168,7 @@ const getTimeframeEndText = (
     } else {
       // We use the Los Angeles TZ whenever we want "end of service" to reflect
       // the previous day's date.
-      const endDate = moment(activePeriod.end).tz("America/Los_Angeles");
+      const endDate = moment(activePeriod.end).subtract(3, "hours");
       if (startDate.month() === endDate.month()) {
         if (startDate.day() === endDate.day()) {
           endText = `${startDate.format("MMM D")}`;


### PR DESCRIPTION
**Asana task**: [[Pre-fare] Inconsistent dates in elevator alert detail view](https://app.asana.com/0/1185117109217413/1202230640868854/f)

This was fixed a while ago for upcoming alerts, but the problem still occurs on active alerts that end after the current day. Adjusting the end date on active alerts fixes the issue. I also changed how hours are adjusted for end dates. Instead of using LA timezone, I just used moment's `subtract` function. 

- [ ] Tests added?
