### PR TITLE
Added Medford branch stations to stop.ex

### DIFF
--- a/lib/screens/stops/stop.ex
+++ b/lib/screens/stops/stop.ex
@@ -141,6 +141,9 @@ defmodule Screens.Stops.Stop do
   ]
 
   @green_line_d_stops [
+    {"place-unsqu", {"Union Square", "Union Sq"}},
+    {"place-lech", {"Lechmere", "Lechmere"}},
+    {"place-spmnl", {"Science Park/West End", "Science Pk"}},
     {"place-north", {"North Station", "North Sta"}},
     {"place-haecl", {"Haymarket", "Haymarket"}},
     {"place-gover", {"Government Center", "Gov't Ctr"}},
@@ -166,7 +169,11 @@ defmodule Screens.Stops.Stop do
   ]
 
   @green_line_e_stops [
-    {"place-unsqu", {"Union Square", "Union Sq"}},
+    {"place-mdftf", {"Medford / Tufts", "Medfd/Tufts"}},
+    {"place-balsq", {"Ball Square", "Ball Sq"}},
+    {"place-mgngl", {"Magoun Square", "Magoun Sq"}},
+    {"place-gilmn", {"Gilman Square", "Gilman Sq"}},
+    {"place-esomr", {"East Somerville", "E Somerville"}},
     {"place-lech", {"Lechmere", "Lechmere"}},
     {"place-spmnl", {"Science Park/West End", "Science Pk"}},
     {"place-north", {"North Station", "North Sta"}},


### PR DESCRIPTION
We don't seem to need to add anything for these stops to the config.exs file, because none of these new stops have DUPs or Pre-Fare screens.

~Stops were added to stop.ex. Untested, but needs the stops to be assigned to trips in dev-green.~ Has been tested at this point.

To be deployed later, before the opening.

- [ ] Tests added?
