### PR TITLE
Temporary override for Heath St Sign

### DIFF
--- a/assets/src/components/v2/normal_header.tsx
+++ b/assets/src/components/v2/normal_header.tsx
@@ -43,7 +43,8 @@ const NormalHeaderTitle = forwardRef(
       modifiers.push("with-icon");
     }
 
-    const abbreviatedText = fullName ? text : abbreviateText(text);
+    let abbreviatedText = fullName ? text : abbreviateText(text);
+    abbreviatedText = abbreviatedText === "Medford/Tufts" ? "Lechmere" : abbreviatedText;
 
     return (
       <div className="normal-header-title">


### PR DESCRIPTION
Ad-hoc: When the GLX is deployed in the new GTFS later today, there is one screen that will start using the new destination name (Medford/Tufts) before we want that to be visible. So here's a hardcoded fix that we'll revert Sunday evening (along with deploying other changes)
