### PR TITLE
polish: Change header for shuttle alerts.

### DIFF
--- a/lib/screens/v2/widget_instance/alert.ex
+++ b/lib/screens/v2/widget_instance/alert.ex
@@ -53,6 +53,9 @@ defmodule Screens.V2.WidgetInstance.Alert do
                       :elevator_closure ->
                         "Elevator Closed"
 
+                      :shuttle ->
+                        "Shuttle Buses"
+
                       effect ->
                         effect
                         |> Atom.to_string()


### PR DESCRIPTION
Notion [link](https://www.notion.so/mbta-downtown-crossing/Say-Shuttle-buses-instead-of-Shuttle-in-alert-header-83f8977a055a4bd89551adc87076576b)

The header for shuttle alerts now say `Shuttle Buses` instead of just `Shuttle`.

- [ ] Tests added?
