### PR TITLE
polish: Shows GL pill if more than 2 affected branches

### DIFF
--- a/lib/screens/v2/widget_instance/alert.ex
+++ b/lib/screens/v2/widget_instance/alert.ex
@@ -355,6 +355,8 @@ defmodule Screens.V2.WidgetInstance.Alert do
     MapSet.subset?(active_routes_at_stop(t), BaseAlert.informed_routes_at_home_stop(t))
   end
 
+  # For GL, we want to list all affected branches for the alert and not just the branch serving the home stop.
+  # This allows us to show a pill for each branch in the informed_entities of the alert (or GL pill if all branches are affected).
   defp informed_routes(%__MODULE__{screen: %Screen{app_id: :gl_eink_v2}} = t) do
     Enum.filter(informed_entities(t), fn
       %{route: "Green" <> _} -> true
@@ -372,6 +374,8 @@ defmodule Screens.V2.WidgetInstance.Alert do
     end)
   end
 
+  # Takes all_routes_at_stop and removes any route that is not affected by the alert.
+  # Remaining routes show as pills on the alert component.
   defp informed_routes(t) do
     rt = route_type(t)
     home_stop = home_stop_id(t)

--- a/lib/screens/v2/widget_instance/alert.ex
+++ b/lib/screens/v2/widget_instance/alert.ex
@@ -116,7 +116,7 @@ defmodule Screens.V2.WidgetInstance.Alert do
           _ -> route_id
         end
       end)
-      |> Enum.map(&RoutePill.serialize_route_for_alert/1)
+      |> Enum.map(&RoutePill.serialize_route_for_alert(&1, MapSet.size(routes) == 1))
     else
       t
       |> route_type()

--- a/lib/screens/v2/widget_instance/alert.ex
+++ b/lib/screens/v2/widget_instance/alert.ex
@@ -358,7 +358,9 @@ defmodule Screens.V2.WidgetInstance.Alert do
   # For GL, we want to list all affected branches for the alert and not just the branch serving the home stop.
   # This allows us to show a pill for each branch in the informed_entities of the alert (or GL pill if all branches are affected).
   defp informed_routes(%__MODULE__{screen: %Screen{app_id: :gl_eink_v2}} = t) do
-    Enum.filter(informed_entities(t), fn
+    t
+    |> informed_entities()
+    |> Enum.filter(fn
       %{route: "Green" <> _} -> true
       _ -> false
     end)

--- a/lib/screens/v2/widget_instance/alert.ex
+++ b/lib/screens/v2/widget_instance/alert.ex
@@ -355,6 +355,23 @@ defmodule Screens.V2.WidgetInstance.Alert do
     MapSet.subset?(active_routes_at_stop(t), BaseAlert.informed_routes_at_home_stop(t))
   end
 
+  defp informed_routes(%__MODULE__{screen: %Screen{app_id: :gl_eink_v2}} = t) do
+    Enum.filter(informed_entities(t), fn
+      %{route: "Green" <> _} -> true
+      _ -> false
+    end)
+    |> Enum.map(fn %{route: route} -> route end)
+    |> Enum.into(MapSet.new())
+    |> Enum.reduce_while(MapSet.new(), fn
+      route, acc ->
+        if MapSet.size(acc) == 2 do
+          {:halt, MapSet.new(["Green"])}
+        else
+          {:cont, MapSet.put(acc, route)}
+        end
+    end)
+  end
+
   defp informed_routes(t) do
     rt = route_type(t)
     home_stop = home_stop_id(t)

--- a/lib/screens/v2/widget_instance/serializer/route_pill.ex
+++ b/lib/screens/v2/widget_instance/serializer/route_pill.ex
@@ -128,7 +128,7 @@ defmodule Screens.V2.WidgetInstance.Serializer.RoutePill do
 
   @spec serialize_route_for_alert(Route.id()) :: t()
   def serialize_route_for_alert(route_id) do
-    route = do_serialize(route_id, %{gl_long: true, gl_branch: true, cr_abbrev: true})
+    route = do_serialize(route_id, %{gl_long: false, gl_branch: true, cr_abbrev: true})
 
     Map.merge(route, %{color: get_color_for_route(route_id)})
   end
@@ -167,19 +167,20 @@ defmodule Screens.V2.WidgetInstance.Serializer.RoutePill do
   defp do_serialize("Red", _), do: %{type: :text, text: "RL"}
   defp do_serialize("Mattapan", _), do: %{type: :text, text: "M"}
   defp do_serialize("Orange", _), do: %{type: :text, text: "OL"}
-  defp do_serialize("Green", _), do: %{type: :text, text: "GL"}
 
   defp do_serialize("Green-" <> branch, %{gl_branch: true} = opts) do
     %{type: :text, text: if(opts[:gl_long], do: "Green Line ", else: "GL·") <> branch}
   end
 
-  defp do_serialize("Green-" <> _branch, %{gl_long: true}) do
+  defp do_serialize("Green" <> _branch, %{gl_long: true}) do
     %{type: :text, text: "Green Line"}
   end
 
   defp do_serialize("Green-" <> _branch, _) do
     %{type: :text, text: "GL"}
   end
+
+  defp do_serialize("Green", _), do: %{type: :text, text: "GL"}
 
   defp do_serialize("Blue", _), do: %{type: :text, text: "BL"}
 

--- a/lib/screens/v2/widget_instance/serializer/route_pill.ex
+++ b/lib/screens/v2/widget_instance/serializer/route_pill.ex
@@ -127,7 +127,7 @@ defmodule Screens.V2.WidgetInstance.Serializer.RoutePill do
   end
 
   @spec serialize_route_for_alert(Route.id(), boolean()) :: t()
-  def serialize_route_for_alert(route_id, gl_long) do
+  def serialize_route_for_alert(route_id, gl_long \\ true) do
     route = do_serialize(route_id, %{gl_long: gl_long, gl_branch: true, cr_abbrev: true})
 
     Map.merge(route, %{color: get_color_for_route(route_id)})

--- a/lib/screens/v2/widget_instance/serializer/route_pill.ex
+++ b/lib/screens/v2/widget_instance/serializer/route_pill.ex
@@ -126,9 +126,9 @@ defmodule Screens.V2.WidgetInstance.Serializer.RoutePill do
     %{type: :icon, icon: :boat, color: :teal}
   end
 
-  @spec serialize_route_for_alert(Route.id()) :: t()
-  def serialize_route_for_alert(route_id) do
-    route = do_serialize(route_id, %{gl_long: false, gl_branch: true, cr_abbrev: true})
+  @spec serialize_route_for_alert(Route.id(), boolean()) :: t()
+  def serialize_route_for_alert(route_id, gl_long) do
+    route = do_serialize(route_id, %{gl_long: gl_long, gl_branch: true, cr_abbrev: true})
 
     Map.merge(route, %{color: get_color_for_route(route_id)})
   end

--- a/test/screens/v2/widget_instance/alert_test.exs
+++ b/test/screens/v2/widget_instance/alert_test.exs
@@ -189,6 +189,74 @@ defmodule Screens.V2.WidgetInstance.AlertTest do
       assert expected_json_map == AlertWidget.serialize(widget)
     end
 
+    test "serializes a GL alert widget for alert affecting all branches", %{widget: widget} do
+      widget =
+        widget
+        |> put_informed_entities([
+          ie(route: "Green-B"),
+          ie(route: "Green-C"),
+          ie(route: "Green-D"),
+          ie(route: "Green-E")
+        ])
+        |> put_app_id(:gl_eink_v2)
+
+      expected_json_map = %{
+        route_pills: [
+          %{type: :text, text: "Green Line", color: :green}
+        ],
+        icon: :x,
+        header: "Stop Closed",
+        body: "Stop is closed.",
+        url: "mbta.com/alerts"
+      }
+
+      assert expected_json_map == AlertWidget.serialize(widget)
+    end
+
+    test "serializes a GL alert widget for alert affecting 2 branches", %{widget: widget} do
+      widget =
+        widget
+        |> put_informed_entities([
+          ie(route: "Green-B"),
+          ie(route: "Green-C")
+        ])
+        |> put_app_id(:gl_eink_v2)
+
+      expected_json_map = %{
+        route_pills: [
+          %{type: :text, text: "GL·B", color: :green},
+          %{type: :text, text: "GL·C", color: :green}
+        ],
+        icon: :x,
+        header: "Stop Closed",
+        body: "Stop is closed.",
+        url: "mbta.com/alerts"
+      }
+
+      assert expected_json_map == AlertWidget.serialize(widget)
+    end
+
+    test "serializes a GL alert widget for alert affecting 1 branches", %{widget: widget} do
+      widget =
+        widget
+        |> put_informed_entities([
+          ie(route: "Green-B")
+        ])
+        |> put_app_id(:gl_eink_v2)
+
+      expected_json_map = %{
+        route_pills: [
+          %{type: :text, text: "Green Line B", color: :green}
+        ],
+        icon: :x,
+        header: "Stop Closed",
+        body: "Stop is closed.",
+        url: "mbta.com/alerts"
+      }
+
+      assert expected_json_map == AlertWidget.serialize(widget)
+    end
+
     test "converts non-route informed entities to route pills as expected", %{widget: widget} do
       # widget has informed_entities: [%{stop: "5", route: nil, route_type: nil}]
 

--- a/test/screens/v2/widget_instance/serializer/route_pill_test.exs
+++ b/test/screens/v2/widget_instance/serializer/route_pill_test.exs
@@ -86,6 +86,13 @@ defmodule Screens.V2.WidgetInstance.Serializer.RoutePillTest do
     end
   end
 
+  describe "serialize_route_for_alert/2" do
+    test "Includes branch name and short text for Green Line" do
+      assert %{type: :text, text: "GL·B", color: :green} ==
+               serialize_route_for_alert("Green-B", false)
+    end
+  end
+
   describe "serialize_route_for_reconstructed_alert/1" do
     test "Returns RL for Red Line" do
       assert %{type: :text, text: "RL", color: :red} ==


### PR DESCRIPTION
Notion [task](https://www.notion.so/mbta-downtown-crossing/Alerts-alway-show-this-branch-as-the-one-impacted-even-if-it-s-an-issue-that-affects-more-than-just--c6ae955d3fc640fabbf0df3da84a7b0c)

For gl_eink_v2 screens, we now show a large GL pill if 3 or 4 branches are affected. If 1 or 2 branches are affected, show small branch pills.

- [ ] Tests added?
