### PR TITLE
polish: Adjust max label length for line map stop names

### DIFF
--- a/assets/src/components/v2/gl_eink_double/line_map.tsx
+++ b/assets/src/components/v2/gl_eink_double/line_map.tsx
@@ -15,7 +15,7 @@ const TEXT_LEFT_MARGIN = 18;
 const TEXT_TOP_MARGIN = 10;
 const VEHICLE_ICON_SIZE = 44;
 const SCHEDULED_DEPARTURE_SIZE = 192;
-const MAXIMUM_STOP_LABEL_LENGTH = 18;
+const MAXIMUM_STOP_LABEL_LENGTH = 16;
 
 const abbreviateStop = (stop) => {
   if (stop === "Heath Street") {


### PR DESCRIPTION
Notion [task](https://www.notion.so/mbta-downtown-crossing/Consider-putting-Washington-Square-on-two-lines-if-possible-c9ac6d354ae940cabd4eedad3d5996b2)

Adjusted max label length because longer stop names look a little crowded.

- [ ] Tests added?
