### PR TITLE
polish: Prevent caching for hidden screens

### DIFF
--- a/lib/screens/v2/screen_data.ex
+++ b/lib/screens/v2/screen_data.ex
@@ -42,7 +42,7 @@ defmodule Screens.V2.ScreenData do
     layout_and_widgets =
       config
       |> fetch_data()
-      |> tap(&cache_visible_alert_widgets(&1, screen_id))
+      |> tap(&cache_visible_alert_widgets(&1, screen_id, config.hidden_from_screenplay))
       |> resolve_paging(refresh_rate)
 
     unless opts[:skip_serialize] do
@@ -478,7 +478,9 @@ defmodule Screens.V2.ScreenData do
     end
   end
 
-  def cache_visible_alert_widgets({_layout, instance_map}, screen_id) do
+  def cache_visible_alert_widgets(_, _, true), do: nil
+
+  def cache_visible_alert_widgets({_layout, instance_map}, screen_id, _) do
     alert_ids =
       instance_map
       |> Map.values()


### PR DESCRIPTION
Notion [task](https://www.notion.so/mbta-downtown-crossing/Bus-alerts-always-show-0-places-even-when-screen-count-is-more-than-0-d860bb7e91fd4756b994ab100d07d312)

For screens refreshing on their own, we were not checking if it is hidden from screenplay before caching. With this check, counts will be more accurate on the Alerts page in screenplay.

- [ ] Tests added?
