### PR TITLE
polish: bus route pill font-size

### DIFF
--- a/assets/css/v2/eink/route_pill.scss
+++ b/assets/css/v2/eink/route_pill.scss
@@ -15,6 +15,10 @@
   font-family: "neue-haas-grotesk-text";
   font-weight: 700;
   color: white;
+
+  &--small {
+    font-size: 112px;
+  }
 }
 
 .route-pill__slashed-text {

--- a/assets/src/components/v2/departures/departure_row.tsx
+++ b/assets/src/components/v2/departures/departure_row.tsx
@@ -11,10 +11,14 @@ const DepartureRow = ({
   times_with_crowding: timesWithCrowding,
   inline_alerts: inlineAlerts,
 }) => {
+  const routeText = Number(route.text);
   return (
     <div className="departure-row">
       <div className="departure-row__route">
-        <RoutePill {...route} />
+        <RoutePill
+          {...route}
+          size={isNaN(routeText) || routeText > 200 ? "small" : "large"}
+        />
       </div>
       <div className="departure-row__destination">
         <Destination {...headsign} />

--- a/assets/src/components/v2/departures/route_pill.tsx
+++ b/assets/src/components/v2/departures/route_pill.tsx
@@ -14,6 +14,7 @@ interface BasePill {
 
 interface TextPill extends BasePill {
   text: string;
+  size?: string;
 }
 
 interface IconPill extends BasePill {
@@ -29,10 +30,19 @@ type Color = "red" | "orange" | "green" | "blue" | "purple" | "yellow" | "teal";
 
 type PillIcon = "bus" | "light_rail" | "rail" | "boat";
 
-const TextRoutePill: ComponentType<TextPill> = ({ color, text, outline }) => {
+const TextRoutePill: ComponentType<TextPill> = ({
+  color,
+  text,
+  outline,
+  size,
+}) => {
   const modifiers: string[] = [color];
   if (outline) {
     modifiers.push("outline");
+  }
+
+  if (size) {
+    modifiers.push(size);
   }
 
   return (
@@ -86,24 +96,29 @@ const RoutePill: ComponentType<Pill> = (pill) => {
   let branches = null;
   if (pill.branches) {
     branches = pill.branches.map((branch: string) => (
-      <div key={branch} className={classWithModifiers("route-pill", modifiers.concat(["branch"]))}>
+      <div
+        key={branch}
+        className={classWithModifiers(
+          "route-pill",
+          modifiers.concat(["branch"])
+        )}
+      >
         <TextRoutePill {...pill} text={branch} />
       </div>
-    ))
+    ));
   }
 
   return (
     <>
       <div className={classWithModifiers("route-pill", modifiers)}>
         {innerContent}
-        
       </div>
-      {branches && 
+      {branches && (
         <div className="route-pills__branches">
           <span className="route-pills__branches__dot"></span>
           {branches}
         </div>
-      }
+      )}
     </>
   );
 };


### PR DESCRIPTION
Notion [task](https://www.notion.so/mbta-downtown-crossing/Reduce-route-pill-text-size-for-higher-number-routes-and-routes-with-letters-cb3119572b7f4a7f81f20fe006a824dc)

If a bus route is > 200 or contains letters, reduce the size to 112px.

- [ ] Tests added?
