### PR TITLE
fix: Pair takeover alerts with bottom screen filler on GL e-ink

### DIFF
--- a/lib/screens/v2/candidate_generator/gl_eink.ex
+++ b/lib/screens/v2/candidate_generator/gl_eink.ex
@@ -37,11 +37,17 @@ defmodule Screens.V2.CandidateGenerator.GlEink do
               Builder.with_paging({:flex_zone, %{one_medium: [:medium]}}, 2),
               :footer
             ],
+            # This layout variant is necessary for the DeparturesNoData widget
+            # to take up both the usual main_content slot, and the left_sidebar
+            # slot to its left, while still allowing the normal flex zone
+            # to appear on the bottom screen.
             top_takeover: [
-              :full_body_top_screen,
+              :full_main_content,
               Builder.with_paging({:flex_zone, %{one_medium: [:medium]}}, 2),
               :footer
             ],
+            # This layout allows takeover alerts (or other non-fullscreen takeover content)
+            # to be paired with filler content on the bottom screen.
             body_takeover: [
               :full_body_top_screen,
               :full_body_bottom_screen

--- a/lib/screens/v2/widget_instance/departures_no_data.ex
+++ b/lib/screens/v2/widget_instance/departures_no_data.ex
@@ -17,7 +17,7 @@ defmodule Screens.V2.WidgetInstance.DeparturesNoData do
     %{show_alternatives: instance.show_alternatives?, stop_id: stop_id(instance)}
   end
 
-  def slot_names(%__MODULE__{screen: %Screen{app_id: :gl_eink_v2}}), do: [:full_body_top_screen]
+  def slot_names(%__MODULE__{screen: %Screen{app_id: :gl_eink_v2}}), do: [:full_main_content]
   def slot_names(_instance), do: [:main_content]
   def widget_type(_instance), do: :departures_no_data
   def valid_candidate?(_instance), do: true

--- a/test/screens/v2/candidate_generator/gl_eink_test.exs
+++ b/test/screens/v2/candidate_generator/gl_eink_test.exs
@@ -44,7 +44,7 @@ defmodule Screens.V2.CandidateGenerator.GlEinkTest do
                        :footer
                      ],
                      top_takeover: [
-                       :full_body_top_screen,
+                       :full_main_content,
                        {{0, :flex_zone}, %{one_medium: [{0, :medium}]}},
                        {{1, :flex_zone}, %{one_medium: [{1, :medium}]}},
                        :footer

--- a/test/screens/v2/widget_instance/departures_no_data_test.exs
+++ b/test/screens/v2/widget_instance/departures_no_data_test.exs
@@ -36,7 +36,7 @@ defmodule Screens.V2.WidgetInstance.DeparturesNoDataTest do
 
   describe "slot_names/1" do
     test "returns full_body_top_screen for gl_eink_v2", %{gl_eink_widget: gl_eink_widget} do
-      assert [:full_body_top_screen] == WidgetInstance.slot_names(gl_eink_widget)
+      assert [:full_main_content] == WidgetInstance.slot_names(gl_eink_widget)
     end
 
     test "returns main_content", %{widget: widget} do

--- a/test/screens/v2/widget_instance/departures_no_service_test.exs
+++ b/test/screens/v2/widget_instance/departures_no_service_test.exs
@@ -2,7 +2,7 @@ defmodule Screens.V2.WidgetInstance.DeparturesNoSerivceTest do
   use ExUnit.Case, async: true
   alias Screens.V2.WidgetInstance
   alias Screens.Config.Screen
-  alias Screens.Config.V2.{Alerts, BusEink, GlEink}
+  alias Screens.Config.V2.BusEink
 
   setup do
     %{


### PR DESCRIPTION
Notion [task](https://www.notion.so/mbta-downtown-crossing/E-Ink-V2-Polish-Punchlist-12bc6f522850471ca01770802a009d97?p=99cf9f899b064ff096d385f2ffad6973&pm=s)

GL e-ink takeover alerts (which replace main content: the departures list and the line map) were not causing the bottom screen to show the "filler" content instead of the usual flex zone.

This was because the GL e-ink template has an extra layout variant intended for the DeparturesNoData widget to be displayed alongside the flex zone. The framework was choosing this variant over the one with the bottom screen takeover/filler content, because the filler widget has a lower priority than any flex zone widget.

As a "surgical" fix, I separated the two cases by having DeparturesNoData use a different slot name. We may want to revisit this in the future to find a more elegant approach.

## Before
(At Heath Street)
![image](https://user-images.githubusercontent.com/63608771/208702618-b4de803f-9db9-474f-afff-6405756e8259.png)

## After
![image](https://user-images.githubusercontent.com/63608771/208701996-e0610e78-a27c-4e6c-a893-6d593df9bd74.png)


- [x] Tests added?
