### PR TITLE
tweak: Medford/Tufts SubwayStatus abbreviation

### DIFF
--- a/lib/screens/stops/stop.ex
+++ b/lib/screens/stops/stop.ex
@@ -169,7 +169,7 @@ defmodule Screens.Stops.Stop do
   ]
 
   @green_line_e_stops [
-    {"place-mdftf", {"Medford / Tufts", "Medfd/Tufts"}},
+    {"place-mdftf", {"Medford / Tufts", "Medford"}},
     {"place-balsq", {"Ball Square", "Ball Sq"}},
     {"place-mgngl", {"Magoun Square", "Magoun Sq"}},
     {"place-gilmn", {"Gilman Square", "Gilman Sq"}},


### PR DESCRIPTION
**Asana task**: [Abbreviate "Medfd/Tufts" to "Medford" on Subway Status](https://app.asana.com/0/1185117109217413/1203657591974126/f)

The original abbreviation was still a little too long. Changing to Medford gives text more room.

![Screenshot 2023-01-06 at 8 25 54 AM](https://user-images.githubusercontent.com/10713153/211021465-16885f09-dd70-4bfc-ad77-cec26ae952c7.png)

- [ ] Tests added?
