### PR TITLE
tweak: DUP headsign replacement

### DIFF
--- a/lib/screens/dup_screen_data/request.ex
+++ b/lib/screens/dup_screen_data/request.ex
@@ -213,7 +213,7 @@ defmodule Screens.DupScreenData.Request do
       # Find any headsign with a slash that does NOT have a space on each side and add spaces
       # i.e. String.replace("Middleborough/ Lakeville", ~r/([^[:space:]])([\/])(.)/, "\\1 / \\3") => "Middleborough / Lakeville"
       # i.e. String.replace("Middleborough/Lakeville", ~r/([^[:space:]])([\/])(.)/, "\\1 / \\3") => "Middleborough /  Lakeville"
-      |> String.replace(~r/([^[:space:]])([\/])(.)/, "\\1 / \\3")
+      |> String.replace(~r/(.)([\/])(.)/, "\\1 / \\3")
 
     %{departure_map | destination: replaced_destination}
   end

--- a/lib/screens/dup_screen_data/request.ex
+++ b/lib/screens/dup_screen_data/request.ex
@@ -213,7 +213,7 @@ defmodule Screens.DupScreenData.Request do
       # Find any headsign with a slash that does NOT have a space on each side and add spaces
       # i.e. String.replace("Middleborough/ Lakeville", ~r/([^[:space:]])([\/])(.)/, "\\1 / \\3") => "Middleborough / Lakeville"
       # i.e. String.replace("Middleborough/Lakeville", ~r/([^[:space:]])([\/])(.)/, "\\1 / \\3") => "Middleborough /  Lakeville"
-      |> String.replace(~r/(.)([\/])(.)/, "\\1 / \\3")
+      |> String.replace(~r/[[:space:]]?\/[[:space:]]?/, "\\1 / \\2")
 
     %{departure_map | destination: replaced_destination}
   end

--- a/lib/screens/dup_screen_data/request.ex
+++ b/lib/screens/dup_screen_data/request.ex
@@ -210,9 +210,10 @@ defmodule Screens.DupScreenData.Request do
     replaced_destination =
       @headsign_replacements
       |> Map.get(destination, destination)
-      # Find any headsign with a slash that does NOT have spaces around it and add spaces
-      # i.e. String.replace("Middleborough/Lakeville", ~r/([^[:space:]])([\/])([^[:space:]])/, "\\1 / \\3") => "Middleborough / Lakeville"
-      |> String.replace(~r/([^[:space:]])([\/])([^[:space:]])/, "\\1 / \\3")
+      # Find any headsign with a slash that does NOT have a space on each side and add spaces
+      # i.e. String.replace("Middleborough/ Lakeville", ~r/([^[:space:]])([\/])(.)/, "\\1 / \\3") => "Middleborough / Lakeville"
+      # i.e. String.replace("Middleborough/Lakeville", ~r/([^[:space:]])([\/])(.)/, "\\1 / \\3") => "Middleborough /  Lakeville"
+      |> String.replace(~r/([^[:space:]])([\/])(.)/, "\\1 / \\3")
 
     %{departure_map | destination: replaced_destination}
   end

--- a/lib/screens/dup_screen_data/request.ex
+++ b/lib/screens/dup_screen_data/request.ex
@@ -26,7 +26,6 @@ defmodule Screens.DupScreenData.Request do
   ]
 
   @headsign_replacements %{
-    "Holbrook/Randolph" => "Holbrook / Randolph",
     "Charlestown Navy Yard" => "Charlestown",
     "Saugus Center via Kennedy Dr & Square One Mall" => "Saugus Center via Kndy Dr & Square One",
     "Malden via Square One Mall & Kennedy Dr" => "Malden via Square One Mall & Kndy Dr",
@@ -208,7 +207,13 @@ defmodule Screens.DupScreenData.Request do
   end
 
   defp replace_long_headsigns(%{destination: destination} = departure_map) do
-    replaced_destination = Map.get(@headsign_replacements, destination, destination)
+    replaced_destination =
+      @headsign_replacements
+      |> Map.get(destination, destination)
+      # Find any headsign with a slash that does NOT have spaces around it and add spaces
+      # i.e. String.replace("Middleborough/Lakeville", ~r/([^[:space:]])([\/])([^[:space:]])/, "\\1 / \\3") => "Middleborough / Lakeville"
+      |> String.replace(~r/([^[:space:]])([\/])([^[:space:]])/, "\\1 / \\3")
+
     %{departure_map | destination: replaced_destination}
   end
 


### PR DESCRIPTION
**Asana task**: [Add new DUP headsign abbreviation for "Middleborough/Lakeville"](https://app.asana.com/0/1185117109217413/1203658337706587/f)

Instead of adding a new case for every headsign with a `/`, I added a `String.replace` call that looks for a `/` without spaces around it. Needed to use regex to make it happen, but this should keep us from needing a task for each new headsign.

- [ ] Tests added?
