### PR TITLE
tweak: Filter upcoming alerts for Alerts widget

### DIFF
--- a/lib/screens/alerts/alert.ex
+++ b/lib/screens/alerts/alert.ex
@@ -223,11 +223,12 @@ defmodule Screens.Alerts.Alert do
   you're looking for.
   https://app.asana.com/0/0/1200476247539238/f
   """
-  @spec fetch_by_stop_and_route(list(Stop.id()), list(Route.id())) :: {:ok, list(t())} | :error
-  def fetch_by_stop_and_route(stop_ids, route_ids, get_json_fn \\ &V3Api.get_json/2) do
+  @spec fetch_by_stop_and_route(list(Stop.id()), list(Route.id()), keyword()) ::
+          {:ok, list(t())} | :error
+  def fetch_by_stop_and_route(stop_ids, route_ids, opts \\ [], get_json_fn \\ &V3Api.get_json/2) do
     with {:ok, stop_based_alerts} <-
-           fetch([stop_ids: stop_ids, route_ids: route_ids], get_json_fn),
-         {:ok, route_based_alerts} <- fetch([route_ids: route_ids], get_json_fn) do
+           fetch(opts ++ [stop_ids: stop_ids, route_ids: route_ids], get_json_fn),
+         {:ok, route_based_alerts} <- fetch(opts ++ [route_ids: route_ids], get_json_fn) do
       merged_alerts =
         [stop_based_alerts, route_based_alerts]
         |> Enum.concat()
@@ -275,6 +276,10 @@ defmodule Screens.Alerts.Alert do
     [
       {"filter[route_type]", route_type_ids}
     ]
+  end
+
+  defp format_query_param({:datetime, datetime}) do
+    [{"filter[datetime]", datetime}]
   end
 
   defp format_query_param(_), do: []

--- a/lib/screens/v2/candidate_generator/widgets/alerts.ex
+++ b/lib/screens/v2/candidate_generator/widgets/alerts.ex
@@ -21,7 +21,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.Alerts do
         now \\ DateTime.utc_now(),
         fetch_simplified_routes_at_stop_fn \\ &Route.fetch_simplified_routes_at_stop/2,
         fetch_stop_sequences_through_stop_fn \\ &RoutePattern.fetch_stop_sequences_through_stop/1,
-        fetch_alerts_by_stop_and_route_fn \\ &Alert.fetch_by_stop_and_route/2
+        fetch_alerts_by_stop_and_route_fn \\ &Alert.fetch_by_stop_and_route/3
       )
       when app in @alert_supporting_screen_types do
     with {:ok, routes_at_stop} <- fetch_simplified_routes_at_stop_fn.(stop_id, now),
@@ -29,7 +29,9 @@ defmodule Screens.V2.CandidateGenerator.Widgets.Alerts do
          reachable_stop_ids = local_and_downstream_stop_ids(stop_sequences, stop_id),
          route_ids_at_stop = Enum.map(routes_at_stop, & &1.route_id),
          {:ok, alerts} <-
-           fetch_alerts_by_stop_and_route_fn.(reachable_stop_ids, route_ids_at_stop) do
+           fetch_alerts_by_stop_and_route_fn.(reachable_stop_ids, route_ids_at_stop,
+             datetime: "NOW"
+           ) do
       alerts
       |> filter_alerts(reachable_stop_ids, route_ids_at_stop)
       |> Enum.map(fn alert ->

--- a/test/screens/alerts/alert_test.exs
+++ b/test/screens/alerts/alert_test.exs
@@ -23,7 +23,7 @@ defmodule Screens.Alerts.AlertTest do
     }
   end
 
-  describe "fetch_by_stop_and_route/3" do
+  describe "fetch_by_stop_and_route/4" do
     setup do
       stop_based_alerts = [alert_json("1"), alert_json("2"), alert_json("3")]
       route_based_alerts = [alert_json("4"), alert_json("3"), alert_json("5")]
@@ -72,7 +72,7 @@ defmodule Screens.Alerts.AlertTest do
                 %Alert{id: "3"},
                 %Alert{id: "4"},
                 %Alert{id: "5"}
-              ]} = Alert.fetch_by_stop_and_route(stop_ids, route_ids, get_json_fn)
+              ]} = Alert.fetch_by_stop_and_route(stop_ids, route_ids, [], get_json_fn)
     end
 
     test "returns :error if fetch function returns :error", context do
@@ -83,8 +83,8 @@ defmodule Screens.Alerts.AlertTest do
         x_get_json_fn2: x_get_json_fn2
       } = context
 
-      assert :error == Alert.fetch_by_stop_and_route(stop_ids, route_ids, x_get_json_fn1)
-      assert :error == Alert.fetch_by_stop_and_route(stop_ids, route_ids, x_get_json_fn2)
+      assert :error == Alert.fetch_by_stop_and_route(stop_ids, route_ids, [], x_get_json_fn1)
+      assert :error == Alert.fetch_by_stop_and_route(stop_ids, route_ids, [], x_get_json_fn2)
     end
   end
 end

--- a/test/screens/v2/candidate_generator/widgets/alerts_test.exs
+++ b/test/screens/v2/candidate_generator/widgets/alerts_test.exs
@@ -47,10 +47,10 @@ defmodule Screens.V2.CandidateGenerator.Widgets.AlertsTest do
         now: ~U[2021-01-01T00:00:00Z],
         fetch_simplified_routes_at_stop_fn: fn _, _ -> {:ok, routes_at_stop} end,
         fetch_stop_sequences_fn: fn _ -> {:ok, stop_sequences} end,
-        fetch_alerts_fn: fn _, _ -> {:ok, alerts} end,
+        fetch_alerts_fn: fn _, _, _ -> {:ok, alerts} end,
         x_fetch_simplified_routes_at_stop_fn: fn _, _ -> :error end,
         x_fetch_stop_sequences_fn: fn _ -> :error end,
-        x_fetch_alerts_fn: fn _, _ -> :error end
+        x_fetch_alerts_fn: fn _, _, _ -> :error end
       }
     end
 

--- a/test/screens/v2/widget_instance/alert_test.exs
+++ b/test/screens/v2/widget_instance/alert_test.exs
@@ -302,49 +302,35 @@ defmodule Screens.V2.WidgetInstance.AlertTest do
   describe "slot_names/1 for bus apps (Bus Shelter and Bus E-Ink)" do
     setup @alert_widget_context_setup_group
 
-    # active | high-impact | informs all routes || full-screen?
-    # n      | n           | n                  || n
-    # y      | n           | n                  || n
-    # n      | y           | n                  || n
-    # y      | y           | n                  || n
-    # n      | n           | y                  || n
-    # y      | n           | y                  || n
-    # n      | y           | y                  || n
-    # y      | y           | y                  || y
+    # high-impact | informs all routes || full-screen?
+    # n           | n                  || n
+    # y           | n                  || n
+    # n           | y                  || n
+    # y           | y                  || y
 
     @bus_slot_names_cases %{
-      {false, false, false} => [:medium_left, :medium_right],
-      {true, false, false} => [:medium_left, :medium_right],
-      {false, true, false} => [:medium_left, :medium_right],
-      {true, true, false} => [:medium_left, :medium_right],
-      {false, false, true} => [:medium_left, :medium_right],
-      {true, false, true} => [:medium_left, :medium_right],
-      {false, true, true} => [:medium_left, :medium_right],
-      {true, true, true} => [:full_body]
+      {false, false} => [:medium_left, :medium_right],
+      {true, false} => [:medium_left, :medium_right],
+      {false, true} => [:medium_left, :medium_right],
+      {true, true} => [:full_body]
     }
 
-    for {{set_active?, set_high_impact_effect?, set_informs_all_active_routes?},
-         expected_slot_names} <- @bus_slot_names_cases do
+    for {{set_high_impact_effect?, set_informs_all_active_routes?}, expected_slot_names} <-
+          @bus_slot_names_cases do
       false_to_not = fn
         true -> ""
         false -> "not "
       end
 
       test_description =
-        "returns #{inspect(expected_slot_names)} if alert is " <>
-          false_to_not.(set_active?) <>
-          "active and does " <>
+        "returns #{inspect(expected_slot_names)} if alert does " <>
           false_to_not.(set_high_impact_effect?) <>
           "have a high-impact effect and does " <>
           false_to_not.(set_informs_all_active_routes?) <>
           "inform all active routes at home stop"
 
       test test_description, %{widget: widget} do
-        active_period =
-          if(unquote(set_active?),
-            do: [{~U[2021-01-01T00:00:00Z], ~U[2021-01-01T22:00:00Z]}],
-            else: [{~U[2021-01-02T00:00:00Z], ~U[2021-01-02T22:00:00Z]}]
-          )
+        active_period = [{~U[2021-01-01T00:00:00Z], ~U[2021-01-01T22:00:00Z]}]
 
         effect = if(unquote(set_high_impact_effect?), do: :stop_closure, else: :snow_route)
 
@@ -389,29 +375,20 @@ defmodule Screens.V2.WidgetInstance.AlertTest do
       %{widget: widget}
     end
 
-    # active | high-impact | location [:inside, :boundary_downstream, :boundary_upstream]  || full-screen?
-    # n      | n           | n                                                             || n
-    # y      | n           | n                                                             || n
-    # n      | y           | n                                                             || n
-    # y      | y           | n                                                             || n
-    # n      | n           | y                                                             || n
-    # y      | n           | y                                                             || n
-    # n      | y           | y                                                             || n
-    # y      | y           | y                                                             || y
+    # high-impact | location [:inside, :boundary_downstream, :boundary_upstream]  || full-screen?
+    # n           | n                                                             || n
+    # y           | n                                                             || n
+    # n           | y                                                             || n
+    # y           | y                                                             || y
 
     @gl_slot_names_cases %{
-      {false, false, false} => [:medium],
-      {true, false, false} => [:medium],
-      {false, true, false} => [:medium],
-      {true, true, false} => [:medium],
-      {false, false, true} => [:medium],
-      {true, false, true} => [:medium],
-      {false, true, true} => [:medium],
-      {true, true, true} => [:full_body_top_screen]
+      {false, false} => [:medium],
+      {true, false} => [:medium],
+      {false, true} => [:medium],
+      {true, true} => [:full_body_top_screen]
     }
 
-    for {{set_active?, set_high_impact_effect?, set_location_inside_or_boundary?},
-         expected_slot_names} <-
+    for {{set_high_impact_effect?, set_location_inside_or_boundary?}, expected_slot_names} <-
           @gl_slot_names_cases do
       false_to_not = fn
         true -> " "
@@ -419,20 +396,14 @@ defmodule Screens.V2.WidgetInstance.AlertTest do
       end
 
       test_description =
-        "returns #{inspect(expected_slot_names)} if alert is " <>
-          false_to_not.(set_active?) <>
-          "active and does" <>
+        "returns #{inspect(expected_slot_names)} if alert does " <>
           false_to_not.(set_high_impact_effect?) <>
           "have a high-impact effect and does" <>
           false_to_not.(set_location_inside_or_boundary?) <>
           "contain home stop in informed region"
 
       test test_description, %{widget: widget} do
-        active_period =
-          if(unquote(set_active?),
-            do: [{~U[2021-01-01T00:00:00Z], ~U[2021-01-01T22:00:00Z]}],
-            else: [{~U[2021-01-02T00:00:00Z], ~U[2021-01-02T22:00:00Z]}]
-          )
+        active_period = [{~U[2021-01-01T00:00:00Z], ~U[2021-01-01T22:00:00Z]}]
 
         effect = if(unquote(set_high_impact_effect?), do: :suspension, else: :elevator_closure)
 
@@ -450,16 +421,6 @@ defmodule Screens.V2.WidgetInstance.AlertTest do
 
         assert unquote(expected_slot_names) == AlertWidget.slot_names(widget)
       end
-    end
-  end
-
-  describe "active?/2" do
-    test "simply calls Alert.happening_now?/1 on the widget's alert", %{widget: widget} do
-      yes_happening_now = fn %Alert{id: "123"}, _ -> true end
-      not_happening_now = fn %Alert{id: "123"}, _ -> false end
-
-      assert AlertWidget.active?(widget, yes_happening_now)
-      assert not AlertWidget.active?(widget, not_happening_now)
     end
   end
 
@@ -599,23 +560,6 @@ defmodule Screens.V2.WidgetInstance.AlertTest do
       assert 2 == AlertWidget.tiebreaker_primary_timeframe(widget)
     end
 
-    test "returns 2 for alerts that are inactive and next active period starts in less than 36 hours",
-         %{widget: widget} do
-      widget =
-        put_active_period(widget, [
-          {~U[2021-01-02T00:00:00Z], nil}
-        ])
-
-      assert 2 == AlertWidget.tiebreaker_primary_timeframe(widget)
-    end
-
-    test "returns 3 for alerts that are inactive and next active period starts in 36 hours or more",
-         %{widget: widget} do
-      widget = put_active_period(widget, [{~U[2021-01-10T00:00:00Z], nil}])
-
-      assert 3 == AlertWidget.tiebreaker_primary_timeframe(widget)
-    end
-
     test "returns 4 for alerts that are active and started 12-24 weeks ago", %{widget: widget} do
       widget =
         put_active_period(widget, [
@@ -678,34 +622,24 @@ defmodule Screens.V2.WidgetInstance.AlertTest do
   describe "tiebreaker_secondary_timeframe/1" do
     setup @valid_alert_setup_group
 
-    test "returns 1 for alerts that are inactive and next active period starts in less than 36 hours",
-         %{widget: widget} do
-      widget =
-        put_active_period(widget, [
-          {~U[2021-01-02T00:00:00Z], nil}
-        ])
-
-      assert 1 == AlertWidget.tiebreaker_secondary_timeframe(widget)
-    end
-
-    test "returns 2 for alerts that are active and started 4-12 weeks ago", %{widget: widget} do
+    test "returns 1 for alerts that are active and started 4-12 weeks ago", %{widget: widget} do
       widget =
         put_active_period(widget, [
           {~U[2020-11-01T00:00:00Z], ~U[2020-11-01T20:00:00Z]},
           {~U[2021-01-01T00:00:00Z], nil}
         ])
 
-      assert 2 == AlertWidget.tiebreaker_secondary_timeframe(widget)
+      assert 1 == AlertWidget.tiebreaker_secondary_timeframe(widget)
     end
 
-    test "returns 3 in all other cases", %{widget: widget} do
+    test "returns 2 in all other cases", %{widget: widget} do
       active_now_widget = put_active_period(widget, [{~U[2021-01-01T00:00:00Z], nil}])
 
-      assert 3 == AlertWidget.tiebreaker_secondary_timeframe(active_now_widget)
+      assert 2 == AlertWidget.tiebreaker_secondary_timeframe(active_now_widget)
 
       inactive_for_a_while_widget = put_active_period(widget, [{~U[2021-01-10T00:00:00Z], nil}])
 
-      assert 3 == AlertWidget.tiebreaker_secondary_timeframe(inactive_for_a_while_widget)
+      assert 2 == AlertWidget.tiebreaker_secondary_timeframe(inactive_for_a_while_widget)
     end
   end
 

--- a/test/screens/v2/widget_instance/alert_test.exs
+++ b/test/screens/v2/widget_instance/alert_test.exs
@@ -636,10 +636,6 @@ defmodule Screens.V2.WidgetInstance.AlertTest do
       active_now_widget = put_active_period(widget, [{~U[2021-01-01T00:00:00Z], nil}])
 
       assert 2 == AlertWidget.tiebreaker_secondary_timeframe(active_now_widget)
-
-      inactive_for_a_while_widget = put_active_period(widget, [{~U[2021-01-10T00:00:00Z], nil}])
-
-      assert 2 == AlertWidget.tiebreaker_secondary_timeframe(inactive_for_a_while_widget)
     end
   end
 


### PR DESCRIPTION
**Asana task**: [[GL E-Ink V2] Filter out upcoming alerts](https://app.asana.com/0/1185117109217413/1203637230901491/f)

This PR changes the Alerts widget logic a bit so that we don't get upcoming alerts from the API. Upcoming alerts should not show on any screen, so there is no need for the CandidateGenerator to create a candidate for them. This means that a lot of logic in the `WidgetInstance.Alert` could be removed. We no longer need any conditional checking if the alert is active. It always will be. 

- [ ] Tests added?
