### PR TITLE
Only store alerts that are valid for Screenplay in memcached

### DIFF
--- a/lib/screens/screens_by_alert.ex
+++ b/lib/screens/screens_by_alert.ex
@@ -38,10 +38,11 @@ defmodule Screens.ScreensByAlert do
   end
 
   @impl true
-  def put_data(screen_id, alert_ids) do
+  def put_data(screen_id, alert_ids, store_screen_id \\ false) do
     @cache_module.put_data(
       screen_id,
-      alert_ids
+      alert_ids,
+      store_screen_id
     )
   end
 

--- a/lib/screens/screens_by_alert/memcache.ex
+++ b/lib/screens/screens_by_alert/memcache.ex
@@ -148,7 +148,7 @@ defmodule Screens.ScreensByAlert.Memcache do
           timestamp + @screens_ttl < now
         end)
 
-      if store_screen_id, do: [new_timestamped_screen_id | unexpired_ids], else: [unexpired_ids]
+      if store_screen_id, do: [new_timestamped_screen_id | unexpired_ids], else: unexpired_ids
     end
   end
 


### PR DESCRIPTION
Notion [task](https://www.notion.so/mbta-downtown-crossing/Screenplay-Alerts-Polish-d3f44e3eec4346a19f31f24f75fa1ae6?p=369ad44cc004411b8d9a173ae80b07ff&pm=s).

We want Screenplay to track:
- Which alerts are actually currently visible on screens
- Which alerts are valid candidates on screens (though they may not have been picked because there's no room on the screen)

Basically, DON'T cache any alerts that are invalid candidates.

This is an attempt to save not-visible-but-yes-valid candidates to the cache as alerts with an empty screen list. Is that too wonky?

- [ ] Tests added?
