### PR TITLE
Remove unneeded log/atom

### DIFF
--- a/lib/screens/config/state/s3_fetch.ex
+++ b/lib/screens/config/state/s3_fetch.ex
@@ -9,11 +9,6 @@ defmodule Screens.Config.State.S3Fetch do
 
   @impl true
   def fetch_config(current_version) do
-    # Temp fix: "bring into existence" a slot ID that has been renamed,
-    # so that the app doesn't crash when using `String.to_existing_atom/1`
-    # during parsing of old config.
-    _ = Logger.info("ignore_this_log atom=#{inspect(:medium_flex)}")
-
     with {:ok, body, new_version} <- get_config(current_version),
          {:ok, parsed} <- Jason.decode(body) do
       {:ok, Config.from_json(parsed), new_version}


### PR DESCRIPTION
**Asana task**: ad hoc

Just a little cleanup.

This reverts a change made a while back to address a temporary issue. I've confirmed that the slot name `medium_flex` is no longer used anywhere in our config.
See #1144, #1145

- [ ] Tests added?
