### PR TITLE
Add type annotations to v2 app header components

### DIFF
--- a/assets/src/components/v2/dup/normal_header.tsx
+++ b/assets/src/components/v2/dup/normal_header.tsx
@@ -9,9 +9,9 @@ const NormalHeader = ({ icon, text, time }) => {
       icon={icon}
       text={text}
       time={time}
-      showUpdated={false}
-      versionNumber={DUP_VERSION}
+      version={DUP_VERSION}
       maxHeight={208}
+      showTo={false}
     />
   );
 };

--- a/assets/src/components/v2/eink/normal_header.tsx
+++ b/assets/src/components/v2/eink/normal_header.tsx
@@ -1,6 +1,6 @@
 import React, { ComponentType } from "react";
 
-import DefaultNormalHeader from "Components/v2/normal_header";
+import DefaultNormalHeader, { Icon } from "Components/v2/normal_header";
 
 interface Props {
   icon: Icon;
@@ -9,21 +9,13 @@ interface Props {
   show_to: boolean;
 }
 
-type Icon =
-  | "logo"
-  | "x"
-  | "green_b"
-  | "green_c"
-  | "green_d"
-  | "green_e";
-
 const NormalHeader: ComponentType<Props> = ({ icon, text, time, show_to: showTo }) => {
   return (
     <DefaultNormalHeader
       icon={icon}
       text={text}
       time={time}
-      showUpdated={true}
+      showUpdated
       maxHeight={208}
       showTo={showTo}
     />

--- a/assets/src/components/v2/lcd/normal_header.tsx
+++ b/assets/src/components/v2/lcd/normal_header.tsx
@@ -8,7 +8,6 @@ const NormalHeader = ({ icon, text, time }) => {
       icon={icon}
       text={text}
       time={time}
-      showUpdated={false}
       maxHeight={208}
     />
   );

--- a/assets/src/components/v2/normal_header.tsx
+++ b/assets/src/components/v2/normal_header.tsx
@@ -1,15 +1,25 @@
 import useTextResizer from "Hooks/v2/use_text_resizer";
 import React, {
   forwardRef,
-  useEffect,
-  useLayoutEffect,
-  useRef,
-  useState,
+  ComponentType
 } from "react";
 
 import { classWithModifiers, formatTimeString, imagePath } from "Util/util";
 
-const ICON_TO_SRC = {
+enum Icon {
+  green_b = "green_b",
+  green_c = "green_c",
+  green_d = "green_d",
+  green_e = "green_e",
+  logo = "logo"
+}
+
+enum TitleSize {
+  small = "small",
+  large = "large"
+}
+
+const ICON_TO_SRC: Record<Icon, string> = {
   green_b: "GL-B.svg",
   green_c: "GL-C.svg",
   green_d: "GL-D.svg",
@@ -17,7 +27,7 @@ const ICON_TO_SRC = {
   logo: "logo-white.svg",
 };
 
-const abbreviateText = (text) => {
+const abbreviateText = (text: string) => {
   if (text === "Government Center") {
     return "Government Ctr";
   }
@@ -25,7 +35,11 @@ const abbreviateText = (text) => {
   return text;
 };
 
-const NormalHeaderIcon = ({ icon }) => {
+interface NormalHeaderIconProps {
+  icon: Icon;
+}
+
+const NormalHeaderIcon: ComponentType<NormalHeaderIconProps> = ({ icon }) => {
   return (
     <div className="normal-header-icon">
       <img
@@ -36,9 +50,17 @@ const NormalHeaderIcon = ({ icon }) => {
   );
 };
 
-const NormalHeaderTitle = forwardRef(
+interface NormalHeaderTitleProps {
+  icon?: Icon;
+  text: string;
+  size: TitleSize;
+  showTo: boolean;
+  fullName: boolean;
+}
+
+const NormalHeaderTitle: ComponentType<NormalHeaderTitleProps> = forwardRef(
   ({ icon, text, size, showTo, fullName }, ref) => {
-    const modifiers = [size];
+    const modifiers: string[] = [size];
     if (icon) {
       modifiers.push("with-icon");
     }
@@ -60,7 +82,11 @@ const NormalHeaderTitle = forwardRef(
   }
 );
 
-const NormalHeaderTime = ({ time }) => {
+interface NormalHeaderTimeProps {
+  time: string;
+}
+
+const NormalHeaderTime: ComponentType<NormalHeaderTimeProps> = ({ time }) => {
   const currentTime = formatTimeString(time);
   return <div className="normal-header-time">{currentTime}</div>;
 };
@@ -81,23 +107,38 @@ const NormalHeaderUpdated = () => {
   );
 };
 
-const NormalHeaderVersion = ({ versionNumber }) => {
-  return <div className="normal-header-version">{versionNumber}</div>;
+interface NormalHeaderVersionProps {
+  version: string;
+}
+
+const NormalHeaderVersion: ComponentType<NormalHeaderVersionProps> = ({ version }) => {
+  return <div className="normal-header-version">{version}</div>;
 };
 
-const NormalHeader = ({
+interface Props {
+  icon?: Icon;
+  text: string;
+  time: string;
+  showUpdated?: boolean;
+  version?: string;
+  maxHeight: number;
+  showTo?: boolean;
+  fullName?: boolean;
+}
+
+const NormalHeader: ComponentType<Props> = ({
   icon,
   text,
   time,
-  showUpdated,
-  versionNumber,
+  showUpdated = false,
+  version,
   maxHeight,
-  showTo,
-  fullName,
+  showTo = false,
+  fullName = false,
 }) => {
-  const SIZES = ["small", "large"];
+
   const { ref: headerRef, size: headerSize } = useTextResizer({
-    sizes: SIZES,
+    sizes: Object.keys(TitleSize),
     maxHeight: maxHeight,
     resetDependencies: [text],
   });
@@ -106,16 +147,17 @@ const NormalHeader = ({
       <NormalHeaderTitle
         icon={icon}
         text={text}
-        size={headerSize}
+        size={headerSize as TitleSize}
         ref={headerRef}
         showTo={showTo}
         fullName={fullName}
       />
       <NormalHeaderTime time={time} />
-      {versionNumber && <NormalHeaderVersion versionNumber={versionNumber} />}
+      {version && <NormalHeaderVersion version={version} />}
       {showUpdated && <NormalHeaderUpdated />}
     </div>
   );
 };
 
 export default NormalHeader;
+export { Icon };

--- a/assets/src/components/v2/pre_fare/normal_header.tsx
+++ b/assets/src/components/v2/pre_fare/normal_header.tsx
@@ -8,7 +8,6 @@ const NormalHeader = ({ icon, text, time }) => {
       icon={icon}
       text={text}
       time={time}
-      showUpdated={false}
       maxHeight={104}
       fullName
     />

--- a/assets/src/util/util.tsx
+++ b/assets/src/util/util.tsx
@@ -16,7 +16,7 @@ export const classWithModifiers = (baseClass, modifiers) => {
   }
 };
 
-export const formatTimeString = (timeString) =>
+export const formatTimeString = (timeString: string) =>
   moment(timeString).tz("America/New_York").format("h:mm");
 
 export const isDup = () => location.href.startsWith("file:");

--- a/lib/screens/v2/widget_instance/normal_header.ex
+++ b/lib/screens/v2/widget_instance/normal_header.ex
@@ -10,7 +10,7 @@ defmodule Screens.V2.WidgetInstance.NormalHeader do
             text: nil,
             time: nil
 
-  @type icon :: :logo | :x | :green_b | :green_c | :green_d | :green_e
+  @type icon :: :logo | :green_b | :green_c | :green_d | :green_e
   @type t :: %__MODULE__{
           screen: Screens.Config.Screen.t(),
           icon: icon | nil,


### PR DESCRIPTION
**Asana task**: ad hoc

I did some cleanup while working on the DUP header task, and thought it would be easier to review in a separate PR.

This adds type annotations to the base `NormalHeader` component, and updates related code that uses it.
TypeScript still complains about the `ref` prop on some internal components—I wasn't able to resolve this without making a mess of the code, so I'm leaving it alone.

One small "bug" the new type annotations revealed: the base component does not support `"x"` as an icon name, but the e-ink header component permitted it. I double checked, and this icon isn't used anywhere, so I removed it from the permitted values.

- [ ] Tests added?
