### PR TITLE
feat: Add pre-fare layout for two side-by-side full-screen takeovers

### DIFF
--- a/assets/css/pre_fare_v2.scss
+++ b/assets/css/pre_fare_v2.scss
@@ -14,6 +14,7 @@
 
 @import "v2/pre_fare/screen/normal";
 @import "v2/pre_fare/screen/takeover";
+@import "v2/pre_fare/screen/split_takeover";
 
 @import "v2/pre_fare/body/normal";
 @import "v2/pre_fare/body/takeover";

--- a/assets/css/v2/pre_fare/evergreen/image.scss
+++ b/assets/css/v2/pre_fare/evergreen/image.scss
@@ -18,6 +18,7 @@
 }
 
 .flex-one-large__large {
+
   .evergreen-content-image__container,
   .evergreen-content-image__image {
     width: 1080px;
@@ -28,6 +29,7 @@
 .body-takeover-left__full-body,
 .body-takeover-right__full-body,
 .body-left-normal__main-content {
+
   .evergreen-content-image__container,
   .evergreen-content-image__image {
     width: 1080px;
@@ -36,6 +38,7 @@
 }
 
 .screen-normal__header {
+
   .evergreen-content-image__container,
   .evergreen-content-image__image {
     width: 1080px;
@@ -43,8 +46,18 @@
   }
 }
 
-.screen-takeover-left__full-screen,
-.screen-takeover-right__full-screen {
+.screen-takeover__full-screen {
+
+  .evergreen-content-image__container,
+  .evergreen-content-image__image {
+    width: 2160px;
+    height: 1920px;
+  }
+}
+
+.screen-split-takeover__full-left-screen,
+.screen-split-takeover__full-right-screen {
+
   .evergreen-content-image__container,
   .evergreen-content-image__image {
     width: 1080px;

--- a/assets/css/v2/pre_fare/evergreen/video.scss
+++ b/assets/css/v2/pre_fare/evergreen/video.scss
@@ -32,6 +32,7 @@
 
 .body-takeover-left__full-body,
 .body-takeover-right__full-body {
+
   .evergreen-content-video,
   .looping-video {
     width: 1080px;
@@ -40,6 +41,7 @@
 }
 
 .screen-normal__header {
+
   .evergreen-content-video,
   .looping-video {
     width: 1080px;
@@ -47,8 +49,18 @@
   }
 }
 
-.screen-takeover-left__full-screen,
-.screen-takeover-right__full-screen {
+.screen-takeover__full-screen {
+
+  .evergreen-content-video,
+  .looping-video {
+    width: 2160px;
+    height: 1920px;
+  }
+}
+
+.screen-split-takeover__full-left-screen,
+.screen-split-takeover__full-right-screen {
+
   .evergreen-content-video,
   .looping-video {
     width: 1080px;

--- a/assets/css/v2/pre_fare/screen/split_takeover.scss
+++ b/assets/css/v2/pre_fare/screen/split_takeover.scss
@@ -1,0 +1,21 @@
+.screen-split-takeover {
+  position: relative;
+}
+
+.screen-split-takeover__full-left-screen {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 1080px;
+  height: 1920px;
+  overflow: hidden;
+}
+
+.screen-split-takeover__full-right-screen {
+  position: absolute;
+  top: 0;
+  left: 1080px;
+  width: 1080px;
+  height: 1920px;
+  overflow: hidden;
+}

--- a/assets/src/apps/v2/pre_fare.tsx
+++ b/assets/src/apps/v2/pre_fare.tsx
@@ -32,6 +32,7 @@ import BodyLeftTakeover from "Components/v2/pre_fare/body_left_takeover";
 import BodyRightTakeover from "Components/v2/pre_fare/body_right_takeover";
 import BodyTakeover from "Components/v2/pre_fare/body_takeover";
 import ScreenTakeover from "Components/v2/pre_fare/screen_takeover";
+import ScreenSplitTakeover from "Components/v2/pre_fare/screen_split_takeover";
 import ElevatorStatus from "Components/v2/elevator_status";
 import FullLineMap from "Components/v2/full_line_map";
 import SubwayStatus from "Components/v2/subway_status";
@@ -50,6 +51,7 @@ import BlueBikes from "Components/v2/blue_bikes";
 const TYPE_TO_COMPONENT = {
   screen_normal: NormalScreen,
   screen_takeover: ScreenTakeover,
+  screen_split_takeover: ScreenSplitTakeover,
   body_normal: NormalBody,
   body_takeover: BodyTakeover,
   body_left_normal: NormalBodyLeft,

--- a/assets/src/components/v2/pre_fare/screen_split_takeover.tsx
+++ b/assets/src/components/v2/pre_fare/screen_split_takeover.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+
+import Widget, { WidgetData } from "Components/v2/widget";
+
+interface Props {
+  full_left_screen: WidgetData;
+  full_right_screen: WidgetData;
+}
+
+const ScreenSplitTakeover: React.ComponentType<Props> = ({
+  full_left_screen: fullLeftScreen,
+  full_right_screen: fullRightScreen,
+}) => {
+  return (
+    <div className="screen-split-takeover">
+      <div className="screen-split-takeover__full-left-screen">
+        <Widget data={fullLeftScreen} />
+      </div>
+      <div className="screen-split-takeover__full-right-screen">
+        <Widget data={fullRightScreen} />
+      </div>
+    </div>
+  );
+};
+
+export default ScreenSplitTakeover;

--- a/lib/screens/v2/candidate_generator/pre_fare.ex
+++ b/lib/screens/v2/candidate_generator/pre_fare.ex
@@ -52,7 +52,8 @@ defmodule Screens.V2.CandidateGenerator.PreFare do
             body_takeover: [:full_body]
           }}
        ],
-       screen_takeover: [:full_screen]
+       screen_takeover: [:full_screen],
+       screen_split_takeover: [:full_left_screen, :full_right_screen]
      }}
     |> Builder.build_template()
   end

--- a/test/screens/v2/candidate_generator/pre_fare_test.exs
+++ b/test/screens/v2/candidate_generator/pre_fare_test.exs
@@ -77,7 +77,8 @@ defmodule Screens.V2.CandidateGenerator.PreFareTest do
                      body_takeover: [:full_body]
                    }}
                 ],
-                screen_takeover: [:full_screen]
+                screen_takeover: [:full_screen],
+                screen_split_takeover: [:full_left_screen, :full_right_screen]
               }} == PreFare.screen_template()
     end
   end


### PR DESCRIPTION
**Asana task**: ad hoc

We didn't end up needing this layout option for this weekend's disruption, but I already added the code and we might need it in the future! ...Maybe!

- [x] Tests added?
