### PR TITLE
feat: Report elevator closure alerts to screens-by-alert

### DIFF
--- a/lib/screens/v2/alert_widget_instance.ex
+++ b/lib/screens/v2/alert_widget_instance.ex
@@ -1,7 +1,7 @@
 defprotocol Screens.V2.AlertWidgetInstance do
   @type alert_id :: String.t()
 
-  @doc "Gets the ID of the alert that this widget shows."
-  @spec alert_id(t) :: alert_id()
-  def alert_id(widget)
+  @doc "Gets the ID(s) of the alert(s) that this widget shows."
+  @spec alert_ids(t) :: list(alert_id())
+  def alert_ids(widget)
 end

--- a/lib/screens/v2/screen_data.ex
+++ b/lib/screens/v2/screen_data.ex
@@ -487,7 +487,7 @@ defmodule Screens.V2.ScreenData do
       |> Enum.filter(fn widget_struct ->
         not is_nil(AlertWidgetInstance.impl_for(widget_struct))
       end)
-      |> Enum.map(fn alert_widget_struct -> AlertWidgetInstance.alert_id(alert_widget_struct) end)
+      |> Enum.flat_map(&AlertWidgetInstance.alert_ids/1)
 
     :ok = ScreensByAlert.put_data(screen_id, alert_ids)
   end

--- a/lib/screens/v2/widget_instance/alert.ex
+++ b/lib/screens/v2/widget_instance/alert.ex
@@ -444,7 +444,7 @@ defmodule Screens.V2.WidgetInstance.Alert do
 
   def audio_view(_instance), do: ScreensWeb.V2.Audio.AlertView
 
-  def alert_id(%__MODULE__{} = instance), do: instance.alert.id
+  def alert_ids(%__MODULE__{} = instance), do: [instance.alert.id]
 
   defimpl Screens.V2.WidgetInstance do
     alias Screens.V2.WidgetInstance.Alert
@@ -463,6 +463,6 @@ defmodule Screens.V2.WidgetInstance.Alert do
   defimpl Screens.V2.AlertWidgetInstance do
     alias Screens.V2.WidgetInstance.Alert
 
-    def alert_id(instance), do: Alert.alert_id(instance)
+    def alert_ids(instance), do: Alert.alert_ids(instance)
   end
 end

--- a/lib/screens/v2/widget_instance/reconstructed_alert.ex
+++ b/lib/screens/v2/widget_instance/reconstructed_alert.ex
@@ -734,7 +734,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
       else: :reconstructed_large_alert
   end
 
-  def alert_id(%__MODULE__{} = t), do: t.alert.id
+  def alert_ids(%__MODULE__{} = t), do: [t.alert.id]
 
   def temporarily_override_alert(%__MODULE__{} = t) do
     # All screens that would show either of the following alerts
@@ -756,6 +756,6 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
   end
 
   defimpl Screens.V2.AlertWidgetInstance do
-    def alert_id(t), do: ReconstructedAlert.alert_id(t)
+    def alert_ids(t), do: ReconstructedAlert.alert_ids(t)
   end
 end

--- a/lib/screens/v3_api.ex
+++ b/lib/screens/v3_api.ex
@@ -69,11 +69,18 @@ defmodule Screens.V3Api do
   end
 
   defp build_url(route, params) when map_size(params) == 0 do
-    base_url() <> route
+    base_url()
+    |> URI.parse()
+    |> URI.merge(route)
+    |> URI.to_string()
   end
 
   defp build_url(route, params) do
-    "#{base_url()}#{route}?#{URI.encode_query(params)}"
+    base_url()
+    |> URI.parse()
+    |> URI.merge(route)
+    |> URI.to_string()
+    |> then(&"#{&1}?#{URI.encode_query(params)}")
   end
 
   defp base_url do

--- a/test/screens/v2/widget_instance/alert_test.exs
+++ b/test/screens/v2/widget_instance/alert_test.exs
@@ -684,7 +684,7 @@ defmodule Screens.V2.WidgetInstance.AlertTest do
 
   describe "alert_id/1" do
     test "returns alert_id", %{widget: widget} do
-      assert widget.alert.id == AlertWidgetInstance.alert_id(widget)
+      assert [widget.alert.id] == AlertWidgetInstance.alert_ids(widget)
     end
   end
 end

--- a/test/screens/v2/widget_instance/elevator_status_test.exs
+++ b/test/screens/v2/widget_instance/elevator_status_test.exs
@@ -343,6 +343,7 @@ defmodule WidgetInstance.ElevatorStatusTest do
               elevator_closures: [
                 %{
                   description: nil,
+                  alert_id: nil,
                   elevator_id: "1",
                   elevator_name: "Elevator 1",
                   timeframe: %{
@@ -366,6 +367,7 @@ defmodule WidgetInstance.ElevatorStatusTest do
                 elevator_closures: [
                   %{
                     description: nil,
+                    alert_id: nil,
                     elevator_id: "1",
                     elevator_name: "Elevator 1",
                     timeframe: %{
@@ -400,6 +402,7 @@ defmodule WidgetInstance.ElevatorStatusTest do
               elevator_closures: [
                 %{
                   description: nil,
+                  alert_id: nil,
                   elevator_id: "1",
                   elevator_name: "Elevator 1",
                   timeframe: %{
@@ -422,6 +425,7 @@ defmodule WidgetInstance.ElevatorStatusTest do
               elevator_closures: [
                 %{
                   description: nil,
+                  alert_id: nil,
                   elevator_id: "5",
                   elevator_name: "Elevator 5",
                   timeframe: %{
@@ -445,6 +449,7 @@ defmodule WidgetInstance.ElevatorStatusTest do
                 elevator_closures: [
                   %{
                     description: nil,
+                    alert_id: nil,
                     elevator_id: "1",
                     elevator_name: "Elevator 1",
                     timeframe: %{
@@ -458,6 +463,7 @@ defmodule WidgetInstance.ElevatorStatusTest do
                   },
                   %{
                     description: nil,
+                    alert_id: nil,
                     elevator_id: "5",
                     elevator_name: "Elevator 5",
                     timeframe: %{
@@ -492,6 +498,7 @@ defmodule WidgetInstance.ElevatorStatusTest do
               elevator_closures: [
                 %{
                   description: nil,
+                  alert_id: nil,
                   elevator_id: "1",
                   elevator_name: "Elevator 1",
                   timeframe: %{
@@ -514,6 +521,7 @@ defmodule WidgetInstance.ElevatorStatusTest do
               elevator_closures: [
                 %{
                   description: nil,
+                  alert_id: nil,
                   elevator_id: "5",
                   elevator_name: "Elevator 5",
                   timeframe: %{
@@ -537,6 +545,7 @@ defmodule WidgetInstance.ElevatorStatusTest do
                 elevator_closures: [
                   %{
                     description: nil,
+                    alert_id: nil,
                     elevator_id: "1",
                     elevator_name: "Elevator 1",
                     timeframe: %{
@@ -550,6 +559,7 @@ defmodule WidgetInstance.ElevatorStatusTest do
                   },
                   %{
                     description: nil,
+                    alert_id: nil,
                     elevator_id: "5",
                     elevator_name: "Elevator 5",
                     timeframe: %{
@@ -570,6 +580,7 @@ defmodule WidgetInstance.ElevatorStatusTest do
                 elevator_closures: [
                   %{
                     description: nil,
+                    alert_id: nil,
                     elevator_id: "2",
                     elevator_name: "Elevator 2",
                     timeframe: %{
@@ -583,6 +594,7 @@ defmodule WidgetInstance.ElevatorStatusTest do
                   },
                   %{
                     description: nil,
+                    alert_id: nil,
                     elevator_id: "6",
                     elevator_name: "Elevator 6",
                     timeframe: %{
@@ -603,6 +615,7 @@ defmodule WidgetInstance.ElevatorStatusTest do
                 elevator_closures: [
                   %{
                     description: nil,
+                    alert_id: nil,
                     elevator_id: "3",
                     elevator_name: "Elevator 3",
                     timeframe: %{
@@ -616,6 +629,7 @@ defmodule WidgetInstance.ElevatorStatusTest do
                   },
                   %{
                     description: nil,
+                    alert_id: nil,
                     elevator_id: "7",
                     elevator_name: "Elevator 7",
                     timeframe: %{
@@ -651,6 +665,7 @@ defmodule WidgetInstance.ElevatorStatusTest do
               elevator_closures: [
                 %{
                   description: nil,
+                  alert_id: nil,
                   elevator_id: "1",
                   elevator_name: "Elevator 1",
                   header_text: nil,
@@ -674,6 +689,7 @@ defmodule WidgetInstance.ElevatorStatusTest do
                 elevator_closures: [
                   %{
                     description: nil,
+                    alert_id: nil,
                     elevator_id: "1",
                     elevator_name: "Elevator 1",
                     header_text: nil,
@@ -694,6 +710,7 @@ defmodule WidgetInstance.ElevatorStatusTest do
                 elevator_closures: [
                   %{
                     description: nil,
+                    alert_id: nil,
                     elevator_id: "2",
                     elevator_name: "Elevator 2",
                     header_text: nil,
@@ -714,6 +731,7 @@ defmodule WidgetInstance.ElevatorStatusTest do
                 elevator_closures: [
                   %{
                     description: nil,
+                    alert_id: nil,
                     elevator_id: "3",
                     elevator_name: "Elevator 3",
                     header_text: nil,
@@ -734,6 +752,7 @@ defmodule WidgetInstance.ElevatorStatusTest do
                 elevator_closures: [
                   %{
                     description: nil,
+                    alert_id: nil,
                     elevator_id: "4",
                     elevator_name: "Elevator 4",
                     header_text: nil,
@@ -765,6 +784,7 @@ defmodule WidgetInstance.ElevatorStatusTest do
               elevator_closures: [
                 %{
                   description: nil,
+                  alert_id: nil,
                   elevator_id: "1",
                   elevator_name: "Elevator 1",
                   header_text: nil,
@@ -788,6 +808,7 @@ defmodule WidgetInstance.ElevatorStatusTest do
                 elevator_closures: [
                   %{
                     description: nil,
+                    alert_id: nil,
                     elevator_id: "1",
                     elevator_name: "Elevator 1",
                     header_text: nil,
@@ -808,6 +829,7 @@ defmodule WidgetInstance.ElevatorStatusTest do
                 elevator_closures: [
                   %{
                     description: nil,
+                    alert_id: nil,
                     elevator_id: "2",
                     elevator_name: "Elevator 2",
                     header_text: nil,
@@ -821,6 +843,7 @@ defmodule WidgetInstance.ElevatorStatusTest do
                   },
                   %{
                     description: nil,
+                    alert_id: nil,
                     elevator_id: "6",
                     elevator_name: "Elevator 6",
                     header_text: nil,
@@ -841,6 +864,7 @@ defmodule WidgetInstance.ElevatorStatusTest do
                 elevator_closures: [
                   %{
                     description: nil,
+                    alert_id: nil,
                     elevator_id: "3",
                     elevator_name: "Elevator 3",
                     header_text: nil,
@@ -854,6 +878,7 @@ defmodule WidgetInstance.ElevatorStatusTest do
                   },
                   %{
                     description: nil,
+                    alert_id: nil,
                     elevator_id: "7",
                     elevator_name: "Elevator 7",
                     header_text: nil,
@@ -878,6 +903,7 @@ defmodule WidgetInstance.ElevatorStatusTest do
                 elevator_closures: [
                   %{
                     description: nil,
+                    alert_id: nil,
                     elevator_id: "1",
                     elevator_name: "Elevator 1",
                     header_text: nil,
@@ -898,6 +924,7 @@ defmodule WidgetInstance.ElevatorStatusTest do
                 elevator_closures: [
                   %{
                     description: nil,
+                    alert_id: nil,
                     elevator_id: "4",
                     elevator_name: "Elevator 4",
                     header_text: nil,
@@ -911,6 +938,7 @@ defmodule WidgetInstance.ElevatorStatusTest do
                   },
                   %{
                     description: nil,
+                    alert_id: nil,
                     elevator_id: "8",
                     elevator_name: "Elevator 8",
                     header_text: nil,
@@ -924,6 +952,7 @@ defmodule WidgetInstance.ElevatorStatusTest do
                   },
                   %{
                     description: nil,
+                    alert_id: nil,
                     elevator_id: "9",
                     elevator_name: "Elevator 9",
                     header_text: nil,
@@ -962,6 +991,7 @@ defmodule WidgetInstance.ElevatorStatusTest do
               elevator_closures: [
                 %{
                   description: nil,
+                  alert_id: nil,
                   elevator_id: "1",
                   elevator_name: "Elevator 1",
                   timeframe: %{
@@ -998,6 +1028,7 @@ defmodule WidgetInstance.ElevatorStatusTest do
               elevator_closures: [
                 %{
                   description: nil,
+                  alert_id: nil,
                   elevator_id: "1",
                   elevator_name: "Elevator 1",
                   header_text: nil,
@@ -1020,6 +1051,7 @@ defmodule WidgetInstance.ElevatorStatusTest do
               elevator_closures: [
                 %{
                   description: nil,
+                  alert_id: nil,
                   elevator_id: "5",
                   elevator_name: "Elevator 5",
                   header_text: nil,
@@ -1054,6 +1086,7 @@ defmodule WidgetInstance.ElevatorStatusTest do
                 elevator_closures: [
                   %{
                     description: nil,
+                    alert_id: nil,
                     elevator_id: "2",
                     elevator_name: "Elevator 2",
                     timeframe: %{
@@ -1077,6 +1110,7 @@ defmodule WidgetInstance.ElevatorStatusTest do
               elevator_closures: [
                 %{
                   description: nil,
+                  alert_id: nil,
                   elevator_id: "2",
                   elevator_name: "Elevator 2",
                   timeframe: %{
@@ -1111,6 +1145,7 @@ defmodule WidgetInstance.ElevatorStatusTest do
                 elevator_closures: [
                   %{
                     description: nil,
+                    alert_id: nil,
                     elevator_id: "3",
                     elevator_name: "Elevator 3",
                     timeframe: %{
@@ -1143,6 +1178,7 @@ defmodule WidgetInstance.ElevatorStatusTest do
                 elevator_closures: [
                   %{
                     description: nil,
+                    alert_id: nil,
                     elevator_id: "2",
                     elevator_name: "Elevator 2",
                     header_text: nil,
@@ -1156,6 +1192,7 @@ defmodule WidgetInstance.ElevatorStatusTest do
                   },
                   %{
                     description: nil,
+                    alert_id: nil,
                     elevator_id: "6",
                     elevator_name: "Elevator 6",
                     header_text: nil,
@@ -1176,6 +1213,7 @@ defmodule WidgetInstance.ElevatorStatusTest do
                 elevator_closures: [
                   %{
                     description: nil,
+                    alert_id: nil,
                     elevator_id: "3",
                     elevator_name: "Elevator 3",
                     header_text: nil,
@@ -1189,6 +1227,7 @@ defmodule WidgetInstance.ElevatorStatusTest do
                   },
                   %{
                     description: nil,
+                    alert_id: nil,
                     elevator_id: "7",
                     elevator_name: "Elevator 7",
                     header_text: nil,
@@ -1209,6 +1248,7 @@ defmodule WidgetInstance.ElevatorStatusTest do
                 elevator_closures: [
                   %{
                     description: nil,
+                    alert_id: nil,
                     elevator_id: "4",
                     elevator_name: "Elevator 4",
                     header_text: nil,
@@ -1222,6 +1262,7 @@ defmodule WidgetInstance.ElevatorStatusTest do
                   },
                   %{
                     description: nil,
+                    alert_id: nil,
                     elevator_id: "8",
                     elevator_name: "Elevator 8",
                     header_text: nil,
@@ -1235,6 +1276,7 @@ defmodule WidgetInstance.ElevatorStatusTest do
                   },
                   %{
                     description: nil,
+                    alert_id: nil,
                     elevator_id: "9",
                     elevator_name: "Elevator 9",
                     header_text: nil,
@@ -1258,6 +1300,7 @@ defmodule WidgetInstance.ElevatorStatusTest do
               elevator_closures: [
                 %{
                   description: nil,
+                  alert_id: nil,
                   elevator_id: "2",
                   elevator_name: "Elevator 2",
                   header_text: nil,
@@ -1280,6 +1323,7 @@ defmodule WidgetInstance.ElevatorStatusTest do
               elevator_closures: [
                 %{
                   description: nil,
+                  alert_id: nil,
                   elevator_id: "6",
                   elevator_name: "Elevator 6",
                   header_text: nil,
@@ -1324,6 +1368,7 @@ defmodule WidgetInstance.ElevatorStatusTest do
                 elevator_closures: [
                   %{
                     description: nil,
+                    alert_id: nil,
                     elevator_id: "2",
                     elevator_name: "Elevator 2",
                     header_text: nil,
@@ -1344,6 +1389,7 @@ defmodule WidgetInstance.ElevatorStatusTest do
                 elevator_closures: [
                   %{
                     description: nil,
+                    alert_id: nil,
                     elevator_id: "3",
                     elevator_name: "Elevator 3",
                     header_text: nil,
@@ -1364,6 +1410,7 @@ defmodule WidgetInstance.ElevatorStatusTest do
                 elevator_closures: [
                   %{
                     description: nil,
+                    alert_id: nil,
                     elevator_id: "4",
                     elevator_name: "Elevator 4",
                     header_text: nil,
@@ -1377,6 +1424,7 @@ defmodule WidgetInstance.ElevatorStatusTest do
                   },
                   %{
                     description: nil,
+                    alert_id: nil,
                     elevator_id: "9",
                     elevator_name: "Elevator 9",
                     header_text: nil,
@@ -1400,6 +1448,7 @@ defmodule WidgetInstance.ElevatorStatusTest do
               elevator_closures: [
                 %{
                   description: nil,
+                  alert_id: nil,
                   elevator_id: "2",
                   elevator_name: "Elevator 2",
                   header_text: nil,
@@ -1447,6 +1496,7 @@ defmodule WidgetInstance.ElevatorStatusTest do
               elevator_closures: [
                 %{
                   description: nil,
+                  alert_id: nil,
                   elevator_id: "1",
                   elevator_name: "Elevator 1",
                   header_text: nil,
@@ -1472,6 +1522,7 @@ defmodule WidgetInstance.ElevatorStatusTest do
                 elevator_closures: [
                   %{
                     description: nil,
+                    alert_id: nil,
                     elevator_id: "2",
                     elevator_name: "Elevator 2",
                     header_text: nil,
@@ -1485,6 +1536,7 @@ defmodule WidgetInstance.ElevatorStatusTest do
                   },
                   %{
                     description: nil,
+                    alert_id: nil,
                     elevator_id: "6",
                     elevator_name: "Elevator 6",
                     header_text: nil,
@@ -1505,6 +1557,7 @@ defmodule WidgetInstance.ElevatorStatusTest do
                 elevator_closures: [
                   %{
                     description: nil,
+                    alert_id: nil,
                     elevator_id: "3",
                     elevator_name: "Elevator 3",
                     header_text: nil,
@@ -1518,6 +1571,7 @@ defmodule WidgetInstance.ElevatorStatusTest do
                   },
                   %{
                     description: nil,
+                    alert_id: nil,
                     elevator_id: "7",
                     elevator_name: "Elevator 7",
                     header_text: nil,
@@ -1542,6 +1596,7 @@ defmodule WidgetInstance.ElevatorStatusTest do
                 elevator_closures: [
                   %{
                     description: nil,
+                    alert_id: nil,
                     elevator_id: "4",
                     elevator_name: "Elevator 4",
                     header_text: nil,
@@ -1555,6 +1610,7 @@ defmodule WidgetInstance.ElevatorStatusTest do
                   },
                   %{
                     description: nil,
+                    alert_id: nil,
                     elevator_id: "8",
                     elevator_name: "Elevator 8",
                     header_text: nil,
@@ -1568,6 +1624,7 @@ defmodule WidgetInstance.ElevatorStatusTest do
                   },
                   %{
                     description: nil,
+                    alert_id: nil,
                     elevator_id: "9",
                     elevator_name: "Elevator 9",
                     header_text: nil,

--- a/test/screens/v2/widget_instance/reconstructed_alert_test.exs
+++ b/test/screens/v2/widget_instance/reconstructed_alert_test.exs
@@ -1136,7 +1136,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
 
   describe "alert_id/1" do
     test "returns alert_id", %{widget: widget} do
-      assert widget.alert.id == AlertWidgetInstance.alert_id(widget)
+      assert [widget.alert.id] == AlertWidgetInstance.alert_ids(widget)
     end
   end
 


### PR DESCRIPTION
**Asana task**: [Add elevator closure alerts to Screenplay](https://app.asana.com/0/1185117109217413/1203785095165730/f)

The Elevator Status widget now reports the IDs of all alerts that make it onto its limited number of pages.

Since Elevator Status has a kind of mini-version of the overall page serialization logic, where some content gets "cut" under certain conditions, we're forced to serialize the widget a second time to get an accurate picture of which alerts it's showing.

---

Due to recent changes that came from Screenplay, I needed to adjust the V3Api module to standardize how it builds the API's url. It now properly forms the url even when the base URL doesn't have a trailing `/`.

- [x] Tests added?
