### PR TITLE
DUP V2 alerts frontend, phase 2: Partial & Takeover components

### DIFF
--- a/assets/css/v2/dup/normal_header.scss
+++ b/assets/css/v2/dup/normal_header.scss
@@ -1,8 +1,23 @@
 .normal-header {
   position: relative;
-  height: 100%;
+  height: 248px;
   width: 100%;
   background: rgb(23, 31, 38);
+  &--red {
+    background-color: $line-color-red;
+  }
+  &--orange {
+    background-color: $line-color-orange;
+  }
+  &--green {
+    background-color: $line-color-green;
+  }
+  &--blue {
+    background-color: $line-color-blue;
+  }
+  &--teal {
+    background-color: $line-color-ferry;
+  }
 }
 
 .normal-header-icon {
@@ -51,4 +66,14 @@
   left: 8px;
   color: #ffffff;
   opacity: 0.33;
+}
+
+.normal-header__accent-pattern-container {
+  position: absolute;
+  right: 0;
+  display: inline-block;
+}
+
+.normal-header__accent-pattern-image {
+  height: 248px;
 }

--- a/assets/src/apps/v2/dup.tsx
+++ b/assets/src/apps/v2/dup.tsx
@@ -22,6 +22,8 @@ import RotationTakeover from "Components/v2/dup/rotation_takeover";
 import NormalBody from "Components/v2/dup/normal_body";
 import SplitBody from "Components/v2/dup/split_body";
 import { splitRotationFromPropNames } from "Components/v2/dup/dup_rotation_wrapper";
+import PartialAlert from "Components/v2/dup/partial_alert";
+import TakeoverAlert from "Components/v2/dup/takeover_alert";
 
 const TYPE_TO_COMPONENT = {
   screen_normal: NormalScreen,
@@ -40,6 +42,8 @@ const TYPE_TO_COMPONENT = {
   placeholder: Placeholder,
   normal_header: NormalHeader,
   departures: NormalDepartures,
+  partial_alert: PartialAlert,
+  takeover_alert: TakeoverAlert
 };
 
 const App = (): JSX.Element => {

--- a/assets/src/components/v2/dup/dup_free_text.tsx
+++ b/assets/src/components/v2/dup/dup_free_text.tsx
@@ -22,11 +22,11 @@ const iconPaths: { [key: string]: string } = _.mapValues(
   imagePath
 );
 
-const srcForIcon = (icon) => {
+const srcForIcon = (icon: string) => {
   return iconPaths[icon];
 };
 
-const getKey = (elt) => {
+const getKey = (elt: string | FreeTextElementType) => {
   if (typeof elt === "string") {
     return elt;
   } else if (elt.format !== undefined) {
@@ -42,7 +42,7 @@ const getKey = (elt) => {
   }
 };
 
-const Icon = ({ icon }) => {
+const Icon = ({ icon }: {icon: string}) => {
   let iconElt;
 
   if (icon === null) {
@@ -56,7 +56,7 @@ const Icon = ({ icon }) => {
   return <div className="free-text__icon-container">{iconElt}</div>;
 };
 
-const InlineIcon = ({ icon }) => {
+const InlineIcon = ({ icon }: {icon: string}) => {
   return (
     <span className="free-text__element free-text__inline-icon">
       <img className="free-text__inline-icon-image" src={srcForIcon(icon)} />
@@ -64,7 +64,7 @@ const InlineIcon = ({ icon }) => {
   );
 };
 
-const FormatString = ({ format, text }) => {
+const FormatString = ({ format, text }: {format: string, text: string}) => {
   const modifiers = format === null ? [] : [format];
   const className = `free-text__element ${classWithModifiers(
     "free-text__string",
@@ -74,7 +74,7 @@ const FormatString = ({ format, text }) => {
   return <span className={className}>{text}</span>;
 };
 
-const RoutePill = ({ route }) => {
+const RoutePill = ({ route }: {route: string}) => {
   const routeName = {
     red: "RL",
     blue: "BL",
@@ -103,7 +103,7 @@ const RoutePill = ({ route }) => {
   );
 };
 
-const TextPill = ({ color, text }) => {
+const TextPill = ({ color, text }: {color: string, text: string}) => {
   return (
     <span className="free-text__element free-text__pill-container">
       <div className={classWithModifier("free-text__text-pill", color)}>
@@ -113,7 +113,7 @@ const TextPill = ({ color, text }) => {
   );
 };
 
-const Special = ({ data }) => {
+const Special = ({ data }: {data: string}) => {
   if (data === "break") {
     return <br />;
   }
@@ -121,7 +121,16 @@ const Special = ({ data }) => {
   return null;
 };
 
-const FreeTextElement = ({ elt }) => {
+interface FreeTextElementType {
+    text?: string;
+    format?: string;
+    route?: string;
+    color?: string;
+    special?: string;
+    icon?: string;
+}
+
+const FreeTextElement = ({elt}: {elt: string | FreeTextElementType}) => {
   if (typeof elt === "string") {
     return <FormatString text={elt} format={null} />;
   } else if (elt.format !== undefined) {
@@ -139,12 +148,12 @@ const FreeTextElement = ({ elt }) => {
   return null;
 };
 
-const FreeTextLine = ({ icon, text }) => {
+const FreeTextLine = ({ icon, text }: {icon: string, text: (string | FreeTextElementType)[]}) => {
   return (
     <div className="free-text__line-container">
       <Icon icon={icon} />
       <div className="free-text__line">
-        {text.map((elt) => (
+        {text.map((elt: string | FreeTextElementType) => (
           <FreeTextElement elt={elt} key={getKey(elt)} />
         ))}
       </div>
@@ -152,7 +161,16 @@ const FreeTextLine = ({ icon, text }) => {
   );
 };
 
-const FreeText = ({ lines }) => {
+export interface FreeTextType {
+  icon: string;
+  text: FreeTextElementType[]
+}
+
+interface FreeTextProps {
+  lines: FreeTextType | FreeTextType[]
+}
+
+const FreeText = ({lines}: FreeTextProps) => {
   if (Array.isArray(lines)) {
     const [{ icon: icon1, text: text1 }, { icon: icon2, text: text2 }] = lines;
     return (

--- a/assets/src/components/v2/dup/normal_header.tsx
+++ b/assets/src/components/v2/dup/normal_header.tsx
@@ -1,17 +1,27 @@
 import React from "react";
 
-import DefaultNormalHeader from "Components/v2/normal_header";
+import DefaultNormalHeader, { Icon } from "Components/v2/normal_header";
 import { DUP_VERSION } from "Components/dup/version";
 
-const NormalHeader = ({ icon, text, time }) => {
+interface NormalHeaderProps {
+  text: string;
+  time?: string;
+  color?: string;
+  accentPattern?: boolean;
+}
+
+const NormalHeader = ({text, time, color, accentPattern}: NormalHeaderProps) => {
+
   return (
     <DefaultNormalHeader
-      icon={icon}
+      icon={Icon.logo}
       text={text}
       time={time}
       version={DUP_VERSION}
       maxHeight={208}
       showTo={false}
+      classModifiers={color}
+      accentPattern={accentPattern}
     />
   );
 };

--- a/assets/src/components/v2/dup/normal_header.tsx
+++ b/assets/src/components/v2/dup/normal_header.tsx
@@ -7,7 +7,7 @@ interface NormalHeaderProps {
   text: string;
   time?: string;
   color?: string;
-  accentPattern?: boolean;
+  accentPattern?: string;
 }
 
 const NormalHeader = ({text, time, color, accentPattern}: NormalHeaderProps) => {

--- a/assets/src/components/v2/dup/partial_alert.tsx
+++ b/assets/src/components/v2/dup/partial_alert.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+
+import { classWithModifier } from "Util/util";
+import FreeText, { FreeTextType } from "./dup_free_text";
+
+interface PartialAlertProps {
+  text: FreeTextType,
+  color: string
+}
+
+const PartialAlert = (alert: PartialAlertProps) => {
+  const {text, color} = alert
+  
+  return (
+    <div className={classWithModifier("partial-alert", color)}>
+      <FreeText lines={text} />
+    </div>
+  );
+};
+
+export default PartialAlert;

--- a/assets/src/components/v2/dup/takeover_alert.tsx
+++ b/assets/src/components/v2/dup/takeover_alert.tsx
@@ -1,0 +1,90 @@
+import React from "react";
+
+import { Icon } from "../normal_header";
+import FreeText, { FreeTextType } from "./dup_free_text";
+import NormalHeader from "./normal_header";
+
+const LinkArrow = ({ width, color }: any) => {
+  const height = 40;
+  const stroke = 8;
+  const headWidth = 40;
+
+  const d = [
+    "M",
+    stroke / 2,
+    height / 2,
+    "L",
+    width - headWidth,
+    height / 2,
+    "L",
+    width - headWidth,
+    stroke / 2,
+    "L",
+    width - stroke / 2,
+    height / 2,
+    "L",
+    width - headWidth,
+    height - stroke / 2,
+    "L",
+    width - headWidth,
+    height / 2,
+    "Z",
+  ].join(" ");
+
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox={`0 0 ${width} ${height}`}
+      width={`${width}px`}
+      height={`${height}px`}
+      version="1.1"
+    >
+      <path
+        stroke={color}
+        strokeWidth={stroke}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        fill={color}
+        d={d}
+      />
+    </svg>
+  );
+};
+
+interface TakeoverAlertProps {
+  text: FreeTextType,
+  remedy: FreeTextType,
+  header: {
+    icon: Icon,
+    text: string,
+    color: string
+  }
+}
+
+const TakeoverAlert = (alert: TakeoverAlertProps) => {
+  const {text, remedy, header} = alert
+  
+  return (
+    <>
+      <NormalHeader
+        icon={header.icon}
+        text={header.text}
+        color={header.color}
+        accentPattern
+      />
+      <div className="full-screen-alert__body">
+        <div className="full-screen-alert-text">
+          <FreeText lines={[text, remedy]} />
+        </div>
+        <div className="full-screen-alert__link">
+          <div className="full-screen-alert__link-arrow">
+            <LinkArrow width="628" color="#64696e" />
+          </div>
+          <div className="full-screen-alert__link-text">mbta.com/alerts</div>
+        </div>
+      </div>
+      </>
+  );
+};
+
+export default TakeoverAlert;

--- a/assets/src/components/v2/dup/takeover_alert.tsx
+++ b/assets/src/components/v2/dup/takeover_alert.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 
-import { Icon } from "../normal_header";
 import FreeText, { FreeTextType } from "./dup_free_text";
 import NormalHeader from "./normal_header";
 
@@ -55,7 +54,6 @@ interface TakeoverAlertProps {
   text: FreeTextType,
   remedy: FreeTextType,
   header: {
-    icon: Icon,
     text: string,
     color: string
   }
@@ -67,10 +65,9 @@ const TakeoverAlert = (alert: TakeoverAlertProps) => {
   return (
     <>
       <NormalHeader
-        icon={header.icon}
         text={header.text}
         color={header.color}
-        accentPattern
+        accentPattern="dup-accent-pattern.svg"
       />
       <div className="full-screen-alert__body">
         <div className="full-screen-alert-text">

--- a/assets/src/components/v2/normal_header.tsx
+++ b/assets/src/components/v2/normal_header.tsx
@@ -4,7 +4,7 @@ import React, {
   ComponentType
 } from "react";
 
-import { classWithModifiers, formatTimeString, imagePath } from "Util/util";
+import { classWithModifier, classWithModifiers, formatTimeString, imagePath } from "Util/util";
 
 enum Icon {
   green_b = "green_b",
@@ -115,15 +115,23 @@ const NormalHeaderVersion: ComponentType<NormalHeaderVersionProps> = ({ version 
   return <div className="normal-header-version">{version}</div>;
 };
 
+const NormalHeaderAccent = () => (
+  <div className="normal-header__accent-pattern-container">
+    <img className="normal-header__accent-pattern-image" src={imagePath(`dup-accent-pattern.svg`)} />
+  </div>
+)
+
 interface Props {
   icon?: Icon;
   text: string;
-  time: string;
+  time?: string;
   showUpdated?: boolean;
   version?: string;
   maxHeight: number;
   showTo?: boolean;
   fullName?: boolean;
+  classModifiers?: string;
+  accentPattern?: boolean
 }
 
 const NormalHeader: ComponentType<Props> = ({
@@ -135,6 +143,8 @@ const NormalHeader: ComponentType<Props> = ({
   maxHeight,
   showTo = false,
   fullName = false,
+  classModifiers,
+  accentPattern = false,
 }) => {
 
   const { ref: headerRef, size: headerSize } = useTextResizer({
@@ -143,7 +153,7 @@ const NormalHeader: ComponentType<Props> = ({
     resetDependencies: [text],
   });
   return (
-    <div className="normal-header">
+    <div className={classWithModifier("normal-header", classModifiers)}>
       <NormalHeaderTitle
         icon={icon}
         text={text}
@@ -152,9 +162,10 @@ const NormalHeader: ComponentType<Props> = ({
         showTo={showTo}
         fullName={fullName}
       />
-      <NormalHeaderTime time={time} />
+      {time && <NormalHeaderTime time={time} />}
       {version && <NormalHeaderVersion version={version} />}
       {showUpdated && <NormalHeaderUpdated />}
+      {accentPattern && <NormalHeaderAccent />}
     </div>
   );
 };

--- a/assets/src/components/v2/normal_header.tsx
+++ b/assets/src/components/v2/normal_header.tsx
@@ -115,9 +115,9 @@ const NormalHeaderVersion: ComponentType<NormalHeaderVersionProps> = ({ version 
   return <div className="normal-header-version">{version}</div>;
 };
 
-const NormalHeaderAccent = () => (
+const NormalHeaderAccent = ({accentPatternFile}: {accentPatternFile: string}) => (
   <div className="normal-header__accent-pattern-container">
-    <img className="normal-header__accent-pattern-image" src={imagePath(`dup-accent-pattern.svg`)} />
+    <img className="normal-header__accent-pattern-image" src={imagePath(accentPatternFile)} />
   </div>
 )
 
@@ -131,7 +131,7 @@ interface Props {
   showTo?: boolean;
   fullName?: boolean;
   classModifiers?: string;
-  accentPattern?: boolean
+  accentPattern?: string;
 }
 
 const NormalHeader: ComponentType<Props> = ({
@@ -144,7 +144,7 @@ const NormalHeader: ComponentType<Props> = ({
   showTo = false,
   fullName = false,
   classModifiers,
-  accentPattern = false,
+  accentPattern,
 }) => {
 
   const { ref: headerRef, size: headerSize } = useTextResizer({
@@ -165,7 +165,7 @@ const NormalHeader: ComponentType<Props> = ({
       {time && <NormalHeaderTime time={time} />}
       {version && <NormalHeaderVersion version={version} />}
       {showUpdated && <NormalHeaderUpdated />}
-      {accentPattern && <NormalHeaderAccent />}
+      {accentPattern && <NormalHeaderAccent accentPatternFile={accentPattern}/>}
     </div>
   );
 };

--- a/docs/tech_specs/dup_v2_alert_widget_backend.md
+++ b/docs/tech_specs/dup_v2_alert_widget_backend.md
@@ -157,3 +157,20 @@ This approach would require giving the `CandidateGenerator` business logic neede
 [^2]: A `partial` alert takes up only a small amount of the screen to allow for other departures to remain visible.
 [^3]: A `takeover` alert displays over the whole screen including the departures.
 [^4]: Priority for DUP alerts is pick a shuttle alert if present. Otherwise, pick the first in the list.
+
+# Addendums
+
+2.7.23: The DUP spec has been adjusted, so the takeover alert serialization function was adjusted. 
+
+`serialize_takeover_alert/1` returns:
+
+```
+%{
+    alert_text: %FreeTextLine{icon: :warning, text: ...},
+    remedy: %FreeTextLine{icon: :shuttle | nil, text: ...},
+    header: %{
+        text: String.t(),
+        color: :red | :orange | :green | :blue
+    }
+}
+```


### PR DESCRIPTION
**Asana task**: [[DUP v2] Partial + Takeover Alerts Frontend](https://app.asana.com/0/1185117109217413/1203830054341502)

![Screenshot 2023-02-14 at 8 59 30 AM](https://user-images.githubusercontent.com/69368883/218759623-1e0ebe1b-227b-4139-8f4c-328b541904d8.png)

To visually test, need to:
- In lib/screens/v2/candidate_generator/dup.ex, need to comment out departures and header instances. Add `%Placeholder{slot_names: [:full_rotation_one], color: :blue}` to the placeholder instances array.
- Make dummy data in lib/screens/v2/widget_instance/placeholder.ex. I added:
```
    def serialize(%Placeholder{color: :blue}), do: %{
      text: FreeTextLine.to_json(%FreeTextLine{icon: :warning, text: ["No", %{format: :bold, text: "Ferry service"}, "due to dock repairs"]}),
      remedy: FreeTextLine.to_json(%FreeTextLine{icon: :shuttle, text: [%{format: :bold, text: "Resumes Oct 12"}]}),
      header: %{
        text: "Long Wharf South",
        color: :teal # | :orange | :green | :blue
      }
    }
    def serialize(%Placeholder{color: :red}), do: %{
      text: FreeTextLine.to_json(%FreeTextLine{icon: :warning, text: ["No", %{format: :bold, text: "Blue Line" }, "trains"]}),
      color: :blue
    }
    def widget_type(%Placeholder{color: :blue}), do: :takeover_alert
    def widget_type(%Placeholder{color: :red}), do: :partial_alert
```

And then this alias is needed: `alias Screens.Config.V2.FreeTextLine`
