### PR TITLE
feat: DUP V2 Headway Mode - Backend

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -215,7 +215,16 @@ config :screens,
     "Wickford Junction via Forest Hills" => "Wickford Jct via Forest Hills",
     "Providence & Needham via Forest Hills" => "Providence via Forest Hills",
     "Norwood Central via Ruggles" => "Norwood Cntrl via Ruggles"
-  }
+  },
+  dup_headway_branch_stations: ["place-kencl", "place-jfk", "place-coecl"],
+  dup_headway_branch_terminals: [
+    "Boston College",
+    "Cleveland Circle",
+    "Riverside",
+    "Heath Street",
+    "Ashmont",
+    "Braintree"
+  ]
 
 config :screens, :screens_by_alert,
   cache_module: Screens.ScreensByAlert.GenServer,

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -27,6 +27,7 @@ config :screens,
   config_fetcher: Screens.Config.State.LocalFetch,
   last_deploy_fetcher: Screens.Util.LastDeploy.LocalFetch,
   local_config_file_spec: {:priv, "local.json"},
+  local_signs_ui_config_file_spec: {:priv, "signs_ui_config.json"},
   signs_ui_config_fetcher: Screens.SignsUiConfig.State.LocalFetch
 
 config :screens, ScreensWeb.AuthManager, secret_key: "secret key"

--- a/config/test.exs
+++ b/config/test.exs
@@ -24,6 +24,9 @@ config :screens,
   blue_bikes_api_client: Screens.BlueBikes.FakeClient,
   dup_headsign_replacements: %{
     "Test 1" => "T1"
+  },
+  dup_alert_headsign_matchers: %{
+    "stop B" => [{"stop B", "not_informed", "Test"}]
   }
 
 config :screens, ScreensWeb.AuthManager, secret_key: "test key"

--- a/config/test.exs
+++ b/config/test.exs
@@ -26,7 +26,11 @@ config :screens,
     "Test 1" => "T1"
   },
   dup_alert_headsign_matchers: %{
-    "place-B" => [{"place-B", "not_informed", "Test"}]
+    "place-B" => [{"place-B", "not_informed", "Test"}],
+    "place-kencl" => [
+      {"70211", ~w[70153 70149 70187], "Cleveland Circle"},
+      {"70152", ~w[70148 70212 70186], "Park Street"}
+    ]
   }
 
 config :screens, ScreensWeb.AuthManager, secret_key: "test key"

--- a/config/test.exs
+++ b/config/test.exs
@@ -26,7 +26,7 @@ config :screens,
     "Test 1" => "T1"
   },
   dup_alert_headsign_matchers: %{
-    "stop B" => [{"stop B", "not_informed", "Test"}]
+    "place-B" => [{"place-B", "not_informed", "Test"}]
   }
 
 config :screens, ScreensWeb.AuthManager, secret_key: "test key"

--- a/config/test.exs
+++ b/config/test.exs
@@ -10,6 +10,7 @@ config :screens,
   config_fetcher: Screens.Config.State.LocalFetch,
   last_deploy_fetcher: Screens.Util.LastDeploy.LocalFetch,
   local_config_file_spec: {:test, "config.json"},
+  local_signs_ui_config_file_spec: {:test, "signs_ui_config.json"},
   signs_ui_config_fetcher: Screens.SignsUiConfig.State.LocalFetch,
   # This will help us write testable functions.
   # Functions that request external data cause flaky tests, so to stop us from writing tests that execute API requests,

--- a/lib/screens/config/v2/departures/headway.ex
+++ b/lib/screens/config/v2/departures/headway.ex
@@ -9,12 +9,14 @@ defmodule Screens.Config.V2.Departures.Headway do
   @type t :: %__MODULE__{
           sign_ids: [sign_id],
           headway_id: headway_id,
-          override: override
+          override: override,
+          pill: :red | :orange | :green | :blue
         }
 
   defstruct sign_ids: [],
             headway_id: nil,
-            override: nil
+            override: nil,
+            pill: nil
 
   use Screens.Config.Struct, with_default: true
 

--- a/lib/screens/config/v2/departures/headway.ex
+++ b/lib/screens/config/v2/departures/headway.ex
@@ -2,19 +2,16 @@ defmodule Screens.Config.V2.Departures.Headway do
   @moduledoc false
   # credo:disable-for-this-file Credo.Check.Design.DuplicatedCode
 
-  @typep sign_id :: String.t()
   @typep headway_id :: String.t() | nil
   @typep override :: {pos_integer, pos_integer} | nil
 
   @type t :: %__MODULE__{
-          sign_ids: [sign_id],
           headway_id: headway_id,
           override: override,
           pill: :red | :orange | :green | :blue
         }
 
-  defstruct sign_ids: [],
-            headway_id: nil,
+  defstruct headway_id: nil,
             override: nil,
             pill: nil
 

--- a/lib/screens/config/v2/departures/headway.ex
+++ b/lib/screens/config/v2/departures/headway.ex
@@ -7,13 +7,11 @@ defmodule Screens.Config.V2.Departures.Headway do
 
   @type t :: %__MODULE__{
           headway_id: headway_id,
-          override: override,
-          pill: :red | :orange | :green | :blue
+          override: override
         }
 
   defstruct headway_id: nil,
-            override: nil,
-            pill: nil
+            override: nil
 
   use Screens.Config.Struct, with_default: true
 

--- a/lib/screens/signs_ui_config/state/local_fetch.ex
+++ b/lib/screens/signs_ui_config/state/local_fetch.ex
@@ -4,15 +4,20 @@ defmodule Screens.SignsUiConfig.State.LocalFetch do
   alias Screens.SignsUiConfig.State
   @behaviour Screens.ConfigCache.State.Fetch
 
-  @local_config_path Path.join(:code.priv_dir(:screens), "signs_ui_config.json")
-
   @impl true
   def fetch_config(current_version) do
-    with {:ok, file_contents} <- File.read(@local_config_path),
+    with {:ok, file_contents} <- File.read(local_config_path()),
          {:ok, decoded} <- Jason.decode(file_contents) do
       {:ok, State.Parse.parse_config(decoded), current_version}
     else
       _ -> :error
+    end
+  end
+
+  defp local_config_path do
+    case Application.get_env(:screens, :local_signs_ui_config_file_spec) do
+      {:priv, file_name} -> Path.join(:code.priv_dir(:screens), file_name)
+      {:test, file_name} -> Path.join(~w[#{File.cwd!()} test fixtures #{file_name}])
     end
   end
 end

--- a/lib/screens/util.ex
+++ b/lib/screens/util.ex
@@ -174,4 +174,8 @@ defmodule Screens.Util do
       _ -> DateTime.compare(client_refresh_time, refresh_if_loaded_before_time) == :lt
     end
   end
+
+  def append_if(list, condition, item) do
+    if condition, do: list ++ [item], else: list
+  end
 end

--- a/lib/screens/util.ex
+++ b/lib/screens/util.ex
@@ -178,4 +178,9 @@ defmodule Screens.Util do
   def append_if(list, condition, item) do
     if condition, do: list ++ [item], else: list
   end
+
+  def to_set(nil), do: MapSet.new([])
+  def to_set(id) when is_binary(id), do: MapSet.new([id])
+  def to_set(ids) when is_list(ids), do: MapSet.new(ids)
+  def to_set(%MapSet{} = already_a_set), do: already_a_set
 end

--- a/lib/screens/util.ex
+++ b/lib/screens/util.ex
@@ -175,10 +175,6 @@ defmodule Screens.Util do
     end
   end
 
-  def append_if(list, condition, item) do
-    if condition, do: list ++ [item], else: list
-  end
-
   def to_set(nil), do: MapSet.new([])
   def to_set(id) when is_binary(id), do: MapSet.new([id])
   def to_set(ids) when is_list(ids), do: MapSet.new(ids)

--- a/lib/screens/v2/candidate_generator/dup.ex
+++ b/lib/screens/v2/candidate_generator/dup.ex
@@ -1,11 +1,11 @@
 defmodule Screens.V2.CandidateGenerator.Dup do
   @moduledoc false
 
-  alias Screens.Config.V2.Departures.Query.Params
   alias Screens.Alerts.Alert
   alias Screens.Config.Screen
   alias Screens.Config.V2.Departures
   alias Screens.Config.V2.Departures.{Headway, Query, Section}
+  alias Screens.Config.V2.Departures.Query.Params
   alias Screens.Config.V2.Dup
   alias Screens.Config.V2.Header.CurrentStopId
   alias Screens.SignsUiConfig

--- a/lib/screens/v2/candidate_generator/dup.ex
+++ b/lib/screens/v2/candidate_generator/dup.ex
@@ -3,19 +3,14 @@ defmodule Screens.V2.CandidateGenerator.Dup do
 
   alias Screens.Alerts.Alert
   alias Screens.Config.Screen
-  alias Screens.Config.V2.Departures
-  alias Screens.Config.V2.Departures.{Headway, Query, Section}
-  alias Screens.Config.V2.Departures.Query.Params
   alias Screens.Config.V2.Dup
   alias Screens.Config.V2.Header.CurrentStopId
-  alias Screens.SignsUiConfig
   alias Screens.Stops.Stop
-  alias Screens.Util
   alias Screens.V2.CandidateGenerator
+  alias Screens.V2.CandidateGenerator.Dup.Departures, as: DeparturesInstances
   alias Screens.V2.CandidateGenerator.Widgets
   alias Screens.V2.Template.Builder
-  alias Screens.V2.WidgetInstance.Departures, as: DeparturesWidget
-  alias Screens.V2.WidgetInstance.{DeparturesNoData, NormalHeader, Placeholder}
+  alias Screens.V2.WidgetInstance.{NormalHeader, Placeholder}
 
   @behaviour CandidateGenerator
 
@@ -95,13 +90,14 @@ defmodule Screens.V2.CandidateGenerator.Dup do
         fetch_stop_name_fn \\ &Stop.fetch_stop_name/1,
         fetch_section_departures_fn \\ &Widgets.Departures.fetch_section_departures/1,
         fetch_alerts_fn \\ &Alert.fetch_or_empty_list/1,
-        evergreen_content_instances_fn \\ &Widgets.Evergreen.evergreen_content_instances/1
+        evergreen_content_instances_fn \\ &Widgets.Evergreen.evergreen_content_instances/1,
+        departures_instances_fn \\ &DeparturesInstances.departures_instances/4
       ) do
     [
       fn -> header_instances(config, now, fetch_stop_name_fn) end,
       fn -> placeholder_instances() end,
       fn ->
-        departures_instances(
+        departures_instances_fn.(
           config,
           now,
           fetch_section_departures_fn,
@@ -133,163 +129,6 @@ defmodule Screens.V2.CandidateGenerator.Dup do
 
   ### End Header
 
-  ### Start Departures
-
-  def departures_instances(
-        %Screen{
-          app_params: %Dup{
-            primary_departures: %Departures{sections: primary_sections},
-            secondary_departures: %Departures{sections: secondary_sections}
-          }
-        } = config,
-        now,
-        fetch_section_departures_fn,
-        fetch_alerts_fn
-      ) do
-    primary_sections_data =
-      get_sections_data(
-        primary_sections,
-        fetch_section_departures_fn,
-        fetch_alerts_fn
-      )
-
-    secondary_sections_data =
-      if secondary_sections == [] do
-        primary_sections_data
-      else
-        get_sections_data(
-          secondary_sections,
-          fetch_section_departures_fn,
-          fetch_alerts_fn
-        )
-      end
-
-    primary_departures_instances =
-      sections_data_to_departure_instances(
-        config,
-        primary_sections_data,
-        [:main_content_zero, :main_content_one],
-        now
-      )
-
-    secondary_departures_instances =
-      sections_data_to_departure_instances(
-        config,
-        secondary_sections_data,
-        [:main_content_two],
-        now
-      )
-
-    primary_departures_instances ++ secondary_departures_instances
-  end
-
-  defp sections_data_to_departure_instances(config, sections_data, slot_ids, now) do
-    if Enum.any?(sections_data, &(&1 == :error)) do
-      %DeparturesNoData{screen: config, show_alternatives?: true}
-    else
-      sections =
-        Enum.map(sections_data, fn %{
-                                     departures: departures,
-                                     pill: pill,
-                                     alert: alert,
-                                     headway: headway,
-                                     stop_ids: stop_ids
-                                   } ->
-          visible_departures =
-            if length(sections_data) > 1 do
-              Enum.take(departures, 2)
-            else
-              Enum.take(departures, 4)
-            end
-
-          case get_headway_mode(stop_ids, headway, alert, now) do
-            {:active, time_range, headsign} ->
-              %{type: :headway_section, pill: pill, time_range: time_range, headsign: headsign}
-
-            :inactive ->
-              %{type: :normal_section, rows: visible_departures}
-          end
-        end)
-
-      Enum.map(slot_ids, fn slot_id ->
-        %DeparturesWidget{
-          screen: config,
-          section_data: sections,
-          slot_names: [slot_id]
-        }
-      end)
-    end
-  end
-
-  defp get_sections_data(sections, fetch_section_departures_fn, fetch_alerts_fn) do
-    sections
-    |> Task.async_stream(fn %Section{
-                              query: %Query{
-                                params: %Params{stop_ids: stop_ids} = params
-                              },
-                              headway: headway
-                            } = section ->
-      section_departures =
-        case fetch_section_departures_fn.(section) do
-          {:ok, section_departures} -> section_departures
-          _ -> []
-        end
-
-      section_alert = get_section_alert(params, fetch_alerts_fn)
-
-      section_route = get_section_route_from_alert(stop_ids, section_alert)
-
-      %{
-        departures: section_departures,
-        pill: section_route,
-        alert: section_alert,
-        headway: headway,
-        stop_ids: stop_ids
-      }
-    end)
-    |> Enum.map(fn {:ok, data} -> data end)
-  end
-
-  # Alert will only have a value for sections that are configured for a station's ID
-  defp get_section_route_from_alert(["place-" <> _ = stop_id], %Alert{
-         informed_entities: informed_entities
-       }) do
-    informed_entities
-    |> Enum.find_value(fn
-      %{route: route, stop: ^stop_id} -> route
-      _ -> nil
-    end)
-    |> String.downcase()
-    |> String.to_atom()
-  end
-
-  defp get_section_route_from_alert(_, _), do: nil
-
-  defp get_section_alert(
-         %Params{
-           stop_ids: stop_ids,
-           route_ids: route_ids,
-           direction_id: direction_id
-         },
-         fetch_alerts_fn
-       ) do
-    alert_fetch_params = [
-      direction_id: direction_id,
-      route_ids: route_ids,
-      stop_ids: stop_ids
-    ]
-
-    alert_fetch_params
-    |> fetch_alerts_fn.()
-    |> Enum.filter(fn
-      # Show a headway message only during shuttles and suspensions at temporary terminals.
-      # https://www.notion.so/mbta-downtown-crossing/Departures-Widget-Specification-20da46cd70a44192a568e49ea47e09ac?pvs=4#e43086abaadd465ea8072502d6980d8d
-      %Alert{effect: effect} when effect in [:suspension, :shuttle] -> true
-      _ -> false
-    end)
-    |> List.first()
-  end
-
   defp placeholder_instances do
     [
       %Placeholder{slot_names: [:main_content_one], color: :orange},
@@ -297,81 +136,4 @@ defmodule Screens.V2.CandidateGenerator.Dup do
       %Placeholder{slot_names: [:bottom_pane_two], color: :red}
     ]
   end
-
-  defp get_headway_mode(_, _, nil, _), do: :inactive
-
-  defp get_headway_mode(
-         stop_ids,
-         %Headway{headway_id: headway_id},
-         section_alert,
-         current_time
-       ) do
-    interpreted_alert = interpret_alert(section_alert, stop_ids)
-
-    headway_mode? =
-      temporary_terminal?(interpreted_alert) and
-        not (branch_station?(stop_ids) and branch_alert?(interpreted_alert))
-
-    if headway_mode? do
-      time_ranges = SignsUiConfig.State.time_ranges(headway_id)
-      current_time_period = Screens.Util.time_period(current_time)
-
-      case time_ranges do
-        %{^current_time_period => {lo, hi}} ->
-          {:active, {lo, hi}, interpreted_alert.headsign}
-
-        _ ->
-          :inactive
-      end
-    else
-      :inactive
-    end
-  end
-
-  # NB: There aren't currently any DUPs at permanent terminals, so we assume all
-  # terminals are temporary. In the future, we'll need to check that the boundary
-  # isn't a normal terminal.
-  defp temporary_terminal?(%{region: :boundary}), do: true
-  defp temporary_terminal?(_), do: false
-
-  defp branch_station?(stop_ids) do
-    case stop_ids do
-      [parent_station_id] -> parent_station_id in MapSet.new(@branch_stations)
-      _ -> false
-    end
-  end
-
-  defp branch_alert?(%{headsign: headsign}) do
-    headsign in MapSet.new(@branch_terminals)
-  end
-
-  defp interpret_alert(alert, [parent_stop_id]) do
-    informed_stop_ids = Enum.into(alert.informed_entities, MapSet.new(), & &1.stop)
-
-    {region, headsign} =
-      :screens
-      |> Application.get_env(:dup_alert_headsign_matchers)
-      |> Map.get(parent_stop_id)
-      |> Enum.find_value({:inside, nil}, fn {informed, not_informed, headsign} ->
-        if alert_region_match?(
-             Util.to_set(informed),
-             Util.to_set(not_informed),
-             informed_stop_ids
-           ),
-           do: {:boundary, headsign},
-           else: false
-      end)
-
-    %{
-      region: region,
-      headsign: headsign
-    }
-  end
-
-  defp alert_region_match?(informed, not_informed, informed_stop_ids) do
-    MapSet.subset?(informed, informed_stop_ids) and
-      MapSet.disjoint?(not_informed, informed_stop_ids)
-  end
-
-  ### End Departures
 end

--- a/lib/screens/v2/candidate_generator/dup.ex
+++ b/lib/screens/v2/candidate_generator/dup.ex
@@ -217,16 +217,7 @@ defmodule Screens.V2.CandidateGenerator.Dup do
                             query: %Query{params: %Params{stop_ids: stop_ids} = params},
                             headway: %Headway{pill: pill} = headway
                           } = section ->
-      alert_fetch_params = params |> Map.from_struct() |> Enum.into([])
-
-      section_alert =
-        alert_fetch_params
-        |> fetch_alerts_or_empty_list_fn.()
-        |> Enum.filter(fn
-          %Alert{effect: effect} when effect in [:suspension, :shuttle] -> true
-          _ -> false
-        end)
-        |> List.first()
+      section_alert = get_section_alert(params, fetch_alerts_or_empty_list_fn)
 
       {:ok, section_departures} = section |> fetch_section_departures_fn.()
 
@@ -238,6 +229,22 @@ defmodule Screens.V2.CandidateGenerator.Dup do
         stop_ids: stop_ids
       }
     end)
+  end
+
+  defp get_section_alert(params, fetch_alerts_or_empty_list_fn) do
+    alert_fetch_params =
+      params
+      |> Map.merge(%{route_types: [:light_rail, :subway]})
+      |> Map.from_struct()
+      |> Enum.into([])
+
+    alert_fetch_params
+    |> fetch_alerts_or_empty_list_fn.()
+    |> Enum.filter(fn
+      %Alert{effect: effect} when effect in [:suspension, :shuttle] -> true
+      _ -> false
+    end)
+    |> List.first()
   end
 
   defp placeholder_instances do

--- a/lib/screens/v2/candidate_generator/dup.ex
+++ b/lib/screens/v2/candidate_generator/dup.ex
@@ -299,12 +299,11 @@ defmodule Screens.V2.CandidateGenerator.Dup do
     end
   end
 
-  defp temporary_terminal?(section_alert) do
-    # NB: There aren't currently any DUPs at permanent terminals, so we assume all
-    # terminals are temporary. In the future, we'll need to check that the boundary
-    # isn't a normal terminal.
-    match?(%{region: :boundary}, section_alert)
-  end
+  # NB: There aren't currently any DUPs at permanent terminals, so we assume all
+  # terminals are temporary. In the future, we'll need to check that the boundary
+  # isn't a normal terminal.
+  defp temporary_terminal?(%{region: :boundary}), do: true
+  defp temporary_terminal?(_), do: false
 
   defp branch_station?(stop_ids) do
     case stop_ids do

--- a/lib/screens/v2/candidate_generator/dup.ex
+++ b/lib/screens/v2/candidate_generator/dup.ex
@@ -257,12 +257,9 @@ defmodule Screens.V2.CandidateGenerator.Dup do
        ) do
     interpreted_alert = interpret_alert(section_alert, stop_ids)
 
-    non_branch_temporary_terminal? =
+    headway_mode? =
       temporary_terminal?(interpreted_alert) and
         not (branch_station?(stop_ids) and branch_alert?(interpreted_alert))
-
-    signs_ui_headways? = SignsUiConfig.State.all_signs_in_headway_mode?(sign_ids)
-    headway_mode? = non_branch_temporary_terminal? or signs_ui_headways?
 
     if headway_mode? do
       time_ranges = SignsUiConfig.State.time_ranges(headway_id)

--- a/lib/screens/v2/candidate_generator/dup.ex
+++ b/lib/screens/v2/candidate_generator/dup.ex
@@ -93,7 +93,7 @@ defmodule Screens.V2.CandidateGenerator.Dup do
         now \\ DateTime.utc_now(),
         fetch_stop_name_fn \\ &Stop.fetch_stop_name/1,
         fetch_section_departures_fn \\ &Widgets.Departures.fetch_section_departures/1,
-        fetch_alerts_or_empty_list_fn \\ Alert.fetch_or_empty_list() / 1
+        fetch_alerts_or_empty_list_fn \\ &Alert.fetch_or_empty_list/1
       ) do
     [
       fn -> header_instances(config, now, fetch_stop_name_fn) end,

--- a/lib/screens/v2/candidate_generator/dup.ex
+++ b/lib/screens/v2/candidate_generator/dup.ex
@@ -228,7 +228,7 @@ defmodule Screens.V2.CandidateGenerator.Dup do
           _ -> []
         end
 
-      section_route = get_section_route(route_ids)
+      section_route = get_section_route(route_ids, stop_ids)
 
       section_alert = get_section_alert(params, section_route, fetch_alerts_fn)
 
@@ -243,7 +243,20 @@ defmodule Screens.V2.CandidateGenerator.Dup do
     |> Enum.map(fn {:ok, data} -> data end)
   end
 
-  defp get_section_route(route_ids) do
+  defp get_section_route([], ["place-" <> _ = stop_id]) do
+    case Screens.Stops.Stop.fetch_routes_serving_stop(stop_id) do
+      {:ok, routes} ->
+        routes
+        |> Enum.filter(&(&1.type in [:light_rail, :subway]))
+        |> Enum.map(& &1.id)
+        |> List.first()
+
+      _ ->
+        nil
+    end
+  end
+
+  defp get_section_route(route_ids, _stop_ids) do
     case route_ids do
       ["Orange"] -> :orange
       ["Red"] -> :red

--- a/lib/screens/v2/candidate_generator/dup.ex
+++ b/lib/screens/v2/candidate_generator/dup.ex
@@ -1,7 +1,6 @@
 defmodule Screens.V2.CandidateGenerator.Dup do
   @moduledoc false
 
-  alias Screens.Util
   alias Screens.Alerts.Alert
   alias Screens.Config.Screen
   alias Screens.Config.V2.Departures
@@ -11,6 +10,7 @@ defmodule Screens.V2.CandidateGenerator.Dup do
   alias Screens.Config.V2.Header.CurrentStopId
   alias Screens.SignsUiConfig
   alias Screens.Stops.Stop
+  alias Screens.Util
   alias Screens.V2.CandidateGenerator
   alias Screens.V2.CandidateGenerator.Widgets
   alias Screens.V2.Template.Builder

--- a/lib/screens/v2/candidate_generator/dup.ex
+++ b/lib/screens/v2/candidate_generator/dup.ex
@@ -10,6 +10,7 @@ defmodule Screens.V2.CandidateGenerator.Dup do
   alias Screens.Config.V2.Header.CurrentStopId
   alias Screens.SignsUiConfig
   alias Screens.Stops.Stop
+  alias Screens.Util
   alias Screens.V2.CandidateGenerator
   alias Screens.V2.CandidateGenerator.Widgets
   alias Screens.V2.Template.Builder
@@ -345,22 +346,20 @@ defmodule Screens.V2.CandidateGenerator.Dup do
       |> Application.get_env(:dup_alert_headsign_matchers)
       |> Map.get(parent_stop_id)
       |> Enum.find_value({:inside, nil}, fn {informed, not_informed, headsign} ->
-        if alert_region_match?(to_set(informed), to_set(not_informed), informed_stop_ids),
-          do: {:boundary, headsign},
-          else: false
+        if alert_region_match?(
+             Util.to_set(informed),
+             Util.to_set(not_informed),
+             informed_stop_ids
+           ),
+           do: {:boundary, headsign},
+           else: false
       end)
 
     %{
-      cause: alert.cause,
-      effect: alert.effect,
       region: region,
       headsign: headsign
     }
   end
-
-  defp to_set(stop_id) when is_binary(stop_id), do: MapSet.new([stop_id])
-  defp to_set(stop_ids) when is_list(stop_ids), do: MapSet.new(stop_ids)
-  defp to_set(%MapSet{} = already_a_set), do: already_a_set
 
   defp alert_region_match?(informed, not_informed, informed_stop_ids) do
     MapSet.subset?(informed, informed_stop_ids) and

--- a/lib/screens/v2/candidate_generator/dup.ex
+++ b/lib/screens/v2/candidate_generator/dup.ex
@@ -251,6 +251,7 @@ defmodule Screens.V2.CandidateGenerator.Dup do
       %{route: route, stop: ^stop_id} -> route
       _ -> nil
     end)
+    |> String.downcase()
     |> String.to_atom()
   end
 

--- a/lib/screens/v2/candidate_generator/dup.ex
+++ b/lib/screens/v2/candidate_generator/dup.ex
@@ -131,61 +131,46 @@ defmodule Screens.V2.CandidateGenerator.Dup do
       end
 
     primary_departures_instances =
-      if Enum.any?(primary_sections_data, &(&1 == :error)) do
-        %DeparturesNoData{screen: config, show_alternatives?: true}
-      else
-        sections =
-          Enum.map(primary_sections_data, fn {:ok, departures} ->
-            visible_departures =
-              if length(primary_sections_data) > 1 do
-                Enum.take(departures, 2)
-              else
-                Enum.take(departures, 4)
-              end
-
-            %{type: :normal_section, rows: visible_departures}
-          end)
-
-        [
-          %DeparturesWidget{
-            screen: config,
-            section_data: sections,
-            slot_names: [:main_content_zero]
-          },
-          %DeparturesWidget{
-            screen: config,
-            section_data: sections,
-            slot_names: [:main_content_one]
-          }
-        ]
-      end
+      sections_data_to_departure_instances(
+        config,
+        primary_sections_data,
+        [:main_content_zero, :main_content_one]
+      )
 
     secondary_departures_instances =
-      if Enum.any?(secondary_sections_data, &(&1 == :error)) do
-        %DeparturesNoData{screen: config, show_alternatives?: true}
-      else
-        sections =
-          Enum.map(secondary_sections_data, fn {:ok, departures} ->
-            visible_departures =
-              if length(secondary_sections_data) > 1 do
-                Enum.take(departures, 2)
-              else
-                Enum.take(departures, 4)
-              end
-
-            %{type: :normal_section, rows: visible_departures}
-          end)
-
-        [
-          %DeparturesWidget{
-            screen: config,
-            section_data: sections,
-            slot_names: [:main_content_two]
-          }
-        ]
-      end
+      sections_data_to_departure_instances(
+        config,
+        secondary_sections_data,
+        [:main_content_two]
+      )
 
     primary_departures_instances ++ secondary_departures_instances
+  end
+
+  defp sections_data_to_departure_instances(config, sections_data, slot_ids) do
+    if Enum.any?(sections_data, &(&1 == :error)) do
+      %DeparturesNoData{screen: config, show_alternatives?: true}
+    else
+      sections =
+        Enum.map(sections_data, fn {:ok, departures} ->
+          visible_departures =
+            if length(sections_data) > 1 do
+              Enum.take(departures, 2)
+            else
+              Enum.take(departures, 4)
+            end
+
+          %{type: :normal_section, rows: visible_departures}
+        end)
+
+      Enum.map(slot_ids, fn slot_id ->
+        %DeparturesWidget{
+          screen: config,
+          section_data: sections,
+          slot_names: [slot_id]
+        }
+      end)
+    end
   end
 
   defp placeholder_instances do

--- a/lib/screens/v2/candidate_generator/dup.ex
+++ b/lib/screens/v2/candidate_generator/dup.ex
@@ -244,6 +244,7 @@ defmodule Screens.V2.CandidateGenerator.Dup do
     |> Enum.map(fn {:ok, data} -> data end)
   end
 
+  # Alert will only have a value for sections that are configured for a station's ID
   defp get_section_route_from_alert(["place-" <> _ = stop_id], %Alert{
          informed_entities: informed_entities
        }) do

--- a/lib/screens/v2/candidate_generator/dup.ex
+++ b/lib/screens/v2/candidate_generator/dup.ex
@@ -94,7 +94,7 @@ defmodule Screens.V2.CandidateGenerator.Dup do
         now \\ DateTime.utc_now(),
         fetch_stop_name_fn \\ &Stop.fetch_stop_name/1,
         fetch_section_departures_fn \\ &Widgets.Departures.fetch_section_departures/1,
-        fetch_alerts_or_empty_list_fn \\ &Alert.fetch_or_empty_list/1,
+        fetch_alerts_fn \\ &Alert.fetch_or_empty_list/1,
         evergreen_content_instances_fn \\ &Widgets.Evergreen.evergreen_content_instances/1
       ) do
     [
@@ -105,7 +105,7 @@ defmodule Screens.V2.CandidateGenerator.Dup do
           config,
           now,
           fetch_section_departures_fn,
-          fetch_alerts_or_empty_list_fn
+          fetch_alerts_fn
         )
       end,
       fn -> evergreen_content_instances_fn.(config) end
@@ -138,13 +138,13 @@ defmodule Screens.V2.CandidateGenerator.Dup do
         } = config,
         now,
         fetch_section_departures_fn,
-        fetch_alerts_or_empty_list_fn
+        fetch_alerts_fn
       ) do
     primary_sections_data =
       get_sections_data(
         primary_sections,
         fetch_section_departures_fn,
-        fetch_alerts_or_empty_list_fn
+        fetch_alerts_fn
       )
 
     secondary_sections_data =
@@ -154,7 +154,7 @@ defmodule Screens.V2.CandidateGenerator.Dup do
         get_sections_data(
           secondary_sections,
           fetch_section_departures_fn,
-          fetch_alerts_or_empty_list_fn
+          fetch_alerts_fn
         )
       end
 
@@ -215,13 +215,13 @@ defmodule Screens.V2.CandidateGenerator.Dup do
     end
   end
 
-  defp get_sections_data(sections, fetch_section_departures_fn, fetch_alerts_or_empty_list_fn) do
+  defp get_sections_data(sections, fetch_section_departures_fn, fetch_alerts_fn) do
     sections
     |> Task.async_stream(fn %Section{
                               query: %Query{params: %Params{stop_ids: stop_ids} = params},
                               headway: %Headway{pill: pill} = headway
                             } = section ->
-      section_alert = get_section_alert(params, fetch_alerts_or_empty_list_fn)
+      section_alert = get_section_alert(params, fetch_alerts_fn)
 
       section_departures =
         case fetch_section_departures_fn.(section) do
@@ -247,7 +247,7 @@ defmodule Screens.V2.CandidateGenerator.Dup do
            direction_id: direction_id,
            route_type: route_type
          },
-         fetch_alerts_or_empty_list_fn
+         fetch_alerts_fn
        ) do
     alert_fetch_params = [
       direction_id: direction_id,
@@ -257,7 +257,7 @@ defmodule Screens.V2.CandidateGenerator.Dup do
     ]
 
     alert_fetch_params
-    |> fetch_alerts_or_empty_list_fn.()
+    |> fetch_alerts_fn.()
     |> Enum.filter(fn
       # Show a headway message only during shuttles and suspensions at temporary terminals.
       # https://www.notion.so/mbta-downtown-crossing/Departures-Widget-Specification-20da46cd70a44192a568e49ea47e09ac?pvs=4#e43086abaadd465ea8072502d6980d8d

--- a/lib/screens/v2/candidate_generator/dup.ex
+++ b/lib/screens/v2/candidate_generator/dup.ex
@@ -114,6 +114,8 @@ defmodule Screens.V2.CandidateGenerator.Dup do
     |> Enum.flat_map(fn {:ok, instances} -> instances end)
   end
 
+  ### Start Header
+
   @impl CandidateGenerator
   def audio_only_instances(_widgets, _config), do: []
 
@@ -128,6 +130,10 @@ defmodule Screens.V2.CandidateGenerator.Dup do
 
     List.duplicate(%NormalHeader{screen: config, icon: :logo, text: stop_name, time: now}, 3)
   end
+
+  ### End Header
+
+  ### Start Departures
 
   def departures_instances(
         %Screen{
@@ -366,4 +372,6 @@ defmodule Screens.V2.CandidateGenerator.Dup do
     MapSet.subset?(informed, informed_stop_ids) and
       MapSet.disjoint?(not_informed, informed_stop_ids)
   end
+
+  ### End Departures
 end

--- a/lib/screens/v2/candidate_generator/dup.ex
+++ b/lib/screens/v2/candidate_generator/dup.ex
@@ -255,6 +255,8 @@ defmodule Screens.V2.CandidateGenerator.Dup do
     alert_fetch_params
     |> fetch_alerts_or_empty_list_fn.()
     |> Enum.filter(fn
+      # Show a headway message only during shuttles and suspensions at temporary terminals.
+      # https://www.notion.so/mbta-downtown-crossing/Departures-Widget-Specification-20da46cd70a44192a568e49ea47e09ac?pvs=4#e43086abaadd465ea8072502d6980d8d
       %Alert{effect: effect} when effect in [:suspension, :shuttle] -> true
       _ -> false
     end)

--- a/lib/screens/v2/candidate_generator/dup.ex
+++ b/lib/screens/v2/candidate_generator/dup.ex
@@ -154,7 +154,11 @@ defmodule Screens.V2.CandidateGenerator.Dup do
               Enum.take(departures, 4)
             end
 
-          %{type: :normal_section, rows: visible_departures}
+          if visible_departures == [] do
+            %{type: :headway_section, pill: pill}
+          else
+            %{type: :normal_section, rows: visible_departures}
+          end
         end)
 
       Enum.map(slot_ids, fn slot_id ->

--- a/lib/screens/v2/candidate_generator/dup.ex
+++ b/lib/screens/v2/candidate_generator/dup.ex
@@ -223,7 +223,11 @@ defmodule Screens.V2.CandidateGenerator.Dup do
                             } = section ->
       section_alert = get_section_alert(params, fetch_alerts_or_empty_list_fn)
 
-      {:ok, section_departures} = section |> fetch_section_departures_fn.()
+      section_departures =
+        case fetch_section_departures_fn.(section) do
+          {:ok, section_departures} -> section_departures
+          _ -> []
+        end
 
       %{
         departures: section_departures,

--- a/lib/screens/v2/candidate_generator/dup.ex
+++ b/lib/screens/v2/candidate_generator/dup.ex
@@ -1,7 +1,6 @@
 defmodule Screens.V2.CandidateGenerator.Dup do
   @moduledoc false
 
-  alias Screens.Alerts.Alert
   alias Screens.Config.Screen
   alias Screens.Config.V2.Dup
   alias Screens.Config.V2.Header.CurrentStopId
@@ -13,16 +12,6 @@ defmodule Screens.V2.CandidateGenerator.Dup do
   alias Screens.V2.WidgetInstance.{NormalHeader, Placeholder}
 
   @behaviour CandidateGenerator
-
-  @branch_stations ["place-kencl", "place-jfk", "place-coecl"]
-  @branch_terminals [
-    "Boston College",
-    "Cleveland Circle",
-    "Riverside",
-    "Heath Street",
-    "Ashmont",
-    "Braintree"
-  ]
 
   @impl CandidateGenerator
   def screen_template do
@@ -88,22 +77,13 @@ defmodule Screens.V2.CandidateGenerator.Dup do
         config,
         now \\ DateTime.utc_now(),
         fetch_stop_name_fn \\ &Stop.fetch_stop_name/1,
-        fetch_section_departures_fn \\ &Widgets.Departures.fetch_section_departures/1,
-        fetch_alerts_fn \\ &Alert.fetch_or_empty_list/1,
         evergreen_content_instances_fn \\ &Widgets.Evergreen.evergreen_content_instances/1,
-        departures_instances_fn \\ &DeparturesInstances.departures_instances/4
+        departures_instances_fn \\ &DeparturesInstances.departures_instances/2
       ) do
     [
       fn -> header_instances(config, now, fetch_stop_name_fn) end,
       fn -> placeholder_instances() end,
-      fn ->
-        departures_instances_fn.(
-          config,
-          now,
-          fetch_section_departures_fn,
-          fetch_alerts_fn
-        )
-      end,
+      fn -> departures_instances_fn.(config, now) end,
       fn -> evergreen_content_instances_fn.(config) end
     ]
     |> Task.async_stream(& &1.(), ordered: false, timeout: :infinity)

--- a/lib/screens/v2/candidate_generator/dup.ex
+++ b/lib/screens/v2/candidate_generator/dup.ex
@@ -1,6 +1,7 @@
 defmodule Screens.V2.CandidateGenerator.Dup do
   @moduledoc false
 
+  alias Screens.Util
   alias Screens.Alerts.Alert
   alias Screens.Config.Screen
   alias Screens.Config.V2.Departures
@@ -231,12 +232,21 @@ defmodule Screens.V2.CandidateGenerator.Dup do
     end)
   end
 
-  defp get_section_alert(params, fetch_alerts_or_empty_list_fn) do
-    alert_fetch_params =
-      params
-      |> Map.merge(%{route_types: [:light_rail, :subway]})
-      |> Map.from_struct()
-      |> Enum.into([])
+  defp get_section_alert(
+         %Params{
+           stop_ids: stop_ids,
+           route_ids: route_ids,
+           direction_id: direction_id,
+           route_type: route_type
+         },
+         fetch_alerts_or_empty_list_fn
+       ) do
+    alert_fetch_params = [
+      direction_id: direction_id,
+      route_ids: route_ids,
+      route_types: Util.append_if([:light_rail, :subway], not is_nil(route_type), route_type),
+      stop_ids: stop_ids
+    ]
 
     alert_fetch_params
     |> fetch_alerts_or_empty_list_fn.()

--- a/lib/screens/v2/candidate_generator/dup.ex
+++ b/lib/screens/v2/candidate_generator/dup.ex
@@ -196,7 +196,7 @@ defmodule Screens.V2.CandidateGenerator.Dup do
               Enum.take(departures, 4)
             end
 
-          case fetch_headway_mode(stop_ids, headway, alert, now) do
+          case get_headway_mode(stop_ids, headway, alert, now) do
             {:active, time_range, headsign} ->
               %{type: :headway_section, pill: pill, time_range: time_range, headsign: headsign}
 
@@ -269,9 +269,9 @@ defmodule Screens.V2.CandidateGenerator.Dup do
     ]
   end
 
-  defp fetch_headway_mode(_, _, nil, _), do: :inactive
+  defp get_headway_mode(_, _, nil, _), do: :inactive
 
-  defp fetch_headway_mode(
+  defp get_headway_mode(
          stop_ids,
          %Headway{headway_id: headway_id},
          section_alert,

--- a/lib/screens/v2/candidate_generator/dup.ex
+++ b/lib/screens/v2/candidate_generator/dup.ex
@@ -216,10 +216,11 @@ defmodule Screens.V2.CandidateGenerator.Dup do
   end
 
   defp get_sections_data(sections, fetch_section_departures_fn, fetch_alerts_or_empty_list_fn) do
-    Enum.map(sections, fn %Section{
-                            query: %Query{params: %Params{stop_ids: stop_ids} = params},
-                            headway: %Headway{pill: pill} = headway
-                          } = section ->
+    sections
+    |> Task.async_stream(fn %Section{
+                              query: %Query{params: %Params{stop_ids: stop_ids} = params},
+                              headway: %Headway{pill: pill} = headway
+                            } = section ->
       section_alert = get_section_alert(params, fetch_alerts_or_empty_list_fn)
 
       {:ok, section_departures} = section |> fetch_section_departures_fn.()
@@ -232,6 +233,7 @@ defmodule Screens.V2.CandidateGenerator.Dup do
         stop_ids: stop_ids
       }
     end)
+    |> Enum.map(fn {:ok, data} -> data end)
   end
 
   defp get_section_alert(

--- a/lib/screens/v2/candidate_generator/dup/departures.ex
+++ b/lib/screens/v2/candidate_generator/dup/departures.ex
@@ -34,39 +34,29 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
         fetch_section_departures_fn \\ &Widgets.Departures.fetch_section_departures/1,
         fetch_alerts_fn \\ &Alert.fetch_or_empty_list/1
       ) do
-    primary_sections_data =
-      get_sections_data(
-        primary_sections,
-        fetch_section_departures_fn,
-        fetch_alerts_fn
-      )
-
-    secondary_sections_data =
-      if secondary_sections == [] do
-        primary_sections_data
-      else
-        get_sections_data(
-          secondary_sections,
-          fetch_section_departures_fn,
-          fetch_alerts_fn
-        )
-      end
-
     primary_departures_instances =
-      sections_data_to_departure_instances(
+      primary_sections
+      |> get_sections_data(fetch_section_departures_fn, fetch_alerts_fn)
+      |> sections_data_to_departure_instances(
         config,
-        primary_sections_data,
+        &1,
         [:main_content_zero, :main_content_one],
         now
       )
 
     secondary_departures_instances =
-      sections_data_to_departure_instances(
-        config,
-        secondary_sections_data,
-        [:main_content_two],
-        now
-      )
+      if secondary_sections == [] do
+        primary_departures_instances
+      else
+        secondary_sections
+        |> get_sections_data(fetch_section_departures_fn, fetch_alerts_fn)
+        |> sections_data_to_departure_instances(
+          config,
+          &1,
+          [:main_content_two],
+          now
+        )
+      end
 
     primary_departures_instances ++ secondary_departures_instances
   end

--- a/lib/screens/v2/candidate_generator/dup/departures.ex
+++ b/lib/screens/v2/candidate_generator/dup/departures.ex
@@ -135,9 +135,9 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
          informed_entities: informed_entities
        }) do
     informed_entities
-    |> Enum.find_value(fn
+    |> Enum.find_value("", fn
       %{route: route, stop: ^stop_id} -> route
-      _ -> ""
+      _ -> nil
     end)
     |> String.downcase()
     |> String.to_atom()

--- a/lib/screens/v2/candidate_generator/dup/departures.ex
+++ b/lib/screens/v2/candidate_generator/dup/departures.ex
@@ -9,8 +9,19 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
   alias Screens.Config.V2.Dup
   alias Screens.SignsUiConfig
   alias Screens.Util
+  alias Screens.V2.CandidateGenerator.Widgets
   alias Screens.V2.WidgetInstance.Departures, as: DeparturesWidget
   alias Screens.V2.WidgetInstance.DeparturesNoData
+
+  @branch_stations ["place-kencl", "place-jfk", "place-coecl"]
+  @branch_terminals [
+    "Boston College",
+    "Cleveland Circle",
+    "Riverside",
+    "Heath Street",
+    "Ashmont",
+    "Braintree"
+  ]
 
   def departures_instances(
         %Screen{
@@ -20,8 +31,8 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
           }
         } = config,
         now,
-        fetch_section_departures_fn,
-        fetch_alerts_fn
+        fetch_section_departures_fn \\ &Widgets.Departures.fetch_section_departures/1,
+        fetch_alerts_fn \\ &Alert.fetch_or_empty_list/1
       ) do
     primary_sections_data =
       get_sections_data(

--- a/lib/screens/v2/candidate_generator/dup/departures.ex
+++ b/lib/screens/v2/candidate_generator/dup/departures.ex
@@ -1,0 +1,244 @@
+defmodule Screens.V2.CandidateGenerator.Dup.Departures do
+  @moduledoc false
+
+  alias Screens.Alerts.Alert
+  alias Screens.Config.Screen
+  alias Screens.Config.V2.Departures
+  alias Screens.Config.V2.Departures.{Headway, Query, Section}
+  alias Screens.Config.V2.Departures.Query.Params
+  alias Screens.Config.V2.Dup
+  alias Screens.SignsUiConfig
+  alias Screens.Util
+  alias Screens.V2.WidgetInstance.Departures, as: DeparturesWidget
+  alias Screens.V2.WidgetInstance.DeparturesNoData
+
+  def departures_instances(
+        %Screen{
+          app_params: %Dup{
+            primary_departures: %Departures{sections: primary_sections},
+            secondary_departures: %Departures{sections: secondary_sections}
+          }
+        } = config,
+        now,
+        fetch_section_departures_fn,
+        fetch_alerts_fn
+      ) do
+    primary_sections_data =
+      get_sections_data(
+        primary_sections,
+        fetch_section_departures_fn,
+        fetch_alerts_fn
+      )
+
+    secondary_sections_data =
+      if secondary_sections == [] do
+        primary_sections_data
+      else
+        get_sections_data(
+          secondary_sections,
+          fetch_section_departures_fn,
+          fetch_alerts_fn
+        )
+      end
+
+    primary_departures_instances =
+      sections_data_to_departure_instances(
+        config,
+        primary_sections_data,
+        [:main_content_zero, :main_content_one],
+        now
+      )
+
+    secondary_departures_instances =
+      sections_data_to_departure_instances(
+        config,
+        secondary_sections_data,
+        [:main_content_two],
+        now
+      )
+
+    primary_departures_instances ++ secondary_departures_instances
+  end
+
+  defp sections_data_to_departure_instances(config, sections_data, slot_ids, now) do
+    if Enum.any?(sections_data, &(&1 == :error)) do
+      %DeparturesNoData{screen: config, show_alternatives?: true}
+    else
+      sections =
+        Enum.map(sections_data, fn %{
+                                     departures: departures,
+                                     pill: pill,
+                                     alert: alert,
+                                     headway: headway,
+                                     stop_ids: stop_ids
+                                   } ->
+          visible_departures =
+            if length(sections_data) > 1 do
+              Enum.take(departures, 2)
+            else
+              Enum.take(departures, 4)
+            end
+
+          case get_headway_mode(stop_ids, headway, alert, now) do
+            {:active, time_range, headsign} ->
+              %{type: :headway_section, pill: pill, time_range: time_range, headsign: headsign}
+
+            :inactive ->
+              %{type: :normal_section, rows: visible_departures}
+          end
+        end)
+
+      Enum.map(slot_ids, fn slot_id ->
+        %DeparturesWidget{
+          screen: config,
+          section_data: sections,
+          slot_names: [slot_id]
+        }
+      end)
+    end
+  end
+
+  defp get_sections_data(sections, fetch_section_departures_fn, fetch_alerts_fn) do
+    sections
+    |> Task.async_stream(fn %Section{
+                              query: %Query{
+                                params: %Params{stop_ids: stop_ids} = params
+                              },
+                              headway: headway
+                            } = section ->
+      section_departures =
+        case fetch_section_departures_fn.(section) do
+          {:ok, section_departures} -> section_departures
+          _ -> []
+        end
+
+      section_alert = get_section_alert(params, fetch_alerts_fn)
+
+      section_route = get_section_route_from_alert(stop_ids, section_alert)
+
+      %{
+        departures: section_departures,
+        pill: section_route,
+        alert: section_alert,
+        headway: headway,
+        stop_ids: stop_ids
+      }
+    end)
+    |> Enum.map(fn {:ok, data} -> data end)
+  end
+
+  # Alert will only have a value for sections that are configured for a station's ID
+  defp get_section_route_from_alert(["place-" <> _ = stop_id], %Alert{
+         informed_entities: informed_entities
+       }) do
+    informed_entities
+    |> Enum.find_value(fn
+      %{route: route, stop: ^stop_id} -> route
+      _ -> nil
+    end)
+    |> String.downcase()
+    |> String.to_atom()
+  end
+
+  defp get_section_route_from_alert(_, _), do: nil
+
+  defp get_section_alert(
+         %Params{
+           stop_ids: stop_ids,
+           route_ids: route_ids,
+           direction_id: direction_id
+         },
+         fetch_alerts_fn
+       ) do
+    alert_fetch_params = [
+      direction_id: direction_id,
+      route_ids: route_ids,
+      stop_ids: stop_ids
+    ]
+
+    alert_fetch_params
+    |> fetch_alerts_fn.()
+    |> Enum.filter(fn
+      # Show a headway message only during shuttles and suspensions at temporary terminals.
+      # https://www.notion.so/mbta-downtown-crossing/Departures-Widget-Specification-20da46cd70a44192a568e49ea47e09ac?pvs=4#e43086abaadd465ea8072502d6980d8d
+      %Alert{effect: effect} when effect in [:suspension, :shuttle] -> true
+      _ -> false
+    end)
+    |> List.first()
+  end
+
+  defp get_headway_mode(_, _, nil, _), do: :inactive
+
+  defp get_headway_mode(
+         stop_ids,
+         %Headway{headway_id: headway_id},
+         section_alert,
+         current_time
+       ) do
+    interpreted_alert = interpret_alert(section_alert, stop_ids)
+
+    headway_mode? =
+      temporary_terminal?(interpreted_alert) and
+        not (branch_station?(stop_ids) and branch_alert?(interpreted_alert))
+
+    if headway_mode? do
+      time_ranges = SignsUiConfig.State.time_ranges(headway_id)
+      current_time_period = Screens.Util.time_period(current_time)
+
+      case time_ranges do
+        %{^current_time_period => {lo, hi}} ->
+          {:active, {lo, hi}, interpreted_alert.headsign}
+
+        _ ->
+          :inactive
+      end
+    else
+      :inactive
+    end
+  end
+
+  # NB: There aren't currently any DUPs at permanent terminals, so we assume all
+  # terminals are temporary. In the future, we'll need to check that the boundary
+  # isn't a normal terminal.
+  defp temporary_terminal?(%{region: :boundary}), do: true
+  defp temporary_terminal?(_), do: false
+
+  defp branch_station?(stop_ids) do
+    case stop_ids do
+      [parent_station_id] -> parent_station_id in MapSet.new(@branch_stations)
+      _ -> false
+    end
+  end
+
+  defp branch_alert?(%{headsign: headsign}) do
+    headsign in MapSet.new(@branch_terminals)
+  end
+
+  defp interpret_alert(alert, [parent_stop_id]) do
+    informed_stop_ids = Enum.into(alert.informed_entities, MapSet.new(), & &1.stop)
+
+    {region, headsign} =
+      :screens
+      |> Application.get_env(:dup_alert_headsign_matchers)
+      |> Map.get(parent_stop_id)
+      |> Enum.find_value({:inside, nil}, fn {informed, not_informed, headsign} ->
+        if alert_region_match?(
+             Util.to_set(informed),
+             Util.to_set(not_informed),
+             informed_stop_ids
+           ),
+           do: {:boundary, headsign},
+           else: false
+      end)
+
+    %{
+      region: region,
+      headsign: headsign
+    }
+  end
+
+  defp alert_region_match?(informed, not_informed, informed_stop_ids) do
+    MapSet.subset?(informed, informed_stop_ids) and
+      MapSet.disjoint?(not_informed, informed_stop_ids)
+  end
+end

--- a/lib/screens/v2/candidate_generator/dup/departures.ex
+++ b/lib/screens/v2/candidate_generator/dup/departures.ex
@@ -83,7 +83,12 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
 
           case get_headway_mode(stop_ids, headway, alert, now) do
             {:active, time_range, headsign} ->
-              %{type: :headway_section, pill: pill, time_range: time_range, headsign: headsign}
+              %{
+                type: :headway_section,
+                pill: get_section_route_from_alert(stop_ids, alert),
+                time_range: time_range,
+                headsign: headsign
+              }
 
             :inactive ->
               %{type: :normal_section, rows: visible_departures}
@@ -116,11 +121,8 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
 
       section_alert = get_section_alert(params, fetch_alerts_fn, now)
 
-      section_route = get_section_route_from_alert(stop_ids, section_alert)
-
       %{
         departures: section_departures,
-        pill: section_route,
         alert: section_alert,
         headway: headway,
         stop_ids: stop_ids

--- a/lib/screens/v2/candidate_generator/dup/departures.ex
+++ b/lib/screens/v2/candidate_generator/dup/departures.ex
@@ -13,16 +13,6 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
   alias Screens.V2.WidgetInstance.Departures, as: DeparturesWidget
   alias Screens.V2.WidgetInstance.DeparturesNoData
 
-  @branch_stations ["place-kencl", "place-jfk", "place-coecl"]
-  @branch_terminals [
-    "Boston College",
-    "Cleveland Circle",
-    "Riverside",
-    "Heath Street",
-    "Ashmont",
-    "Braintree"
-  ]
-
   def departures_instances(
         %Screen{
           app_params: %Dup{
@@ -212,14 +202,17 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
   defp temporary_terminal?(_), do: false
 
   defp branch_station?(stop_ids) do
+    branch_stations = Application.get_env(:screens, :dup_headway_branch_stations)
+
     case stop_ids do
-      [parent_station_id] -> parent_station_id in MapSet.new(@branch_stations)
+      [parent_station_id] -> parent_station_id in MapSet.new(branch_stations)
       _ -> false
     end
   end
 
   defp branch_alert?(%{headsign: headsign}) do
-    headsign in MapSet.new(@branch_terminals)
+    branch_terminals = Application.get_env(:screens, :dup_headway_branch_terminals)
+    headsign in MapSet.new(branch_terminals)
   end
 
   defp interpret_alert(alert, [parent_stop_id]) do

--- a/lib/screens/v2/candidate_generator/dup/departures.ex
+++ b/lib/screens/v2/candidate_generator/dup/departures.ex
@@ -43,12 +43,15 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
         now
       )
 
-    secondary_departures_instances =
+    secondary_sections =
       if secondary_sections == [] do
         primary_sections
       else
         secondary_sections
       end
+
+    secondary_departures_instances =
+      secondary_sections
       |> get_sections_data(fetch_section_departures_fn, fetch_alerts_fn, now)
       |> sections_data_to_departure_instances(
         config,

--- a/lib/screens/v2/candidate_generator/dup/departures.ex
+++ b/lib/screens/v2/candidate_generator/dup/departures.ex
@@ -153,7 +153,8 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
     alert_fetch_params = [
       direction_id: direction_id,
       route_ids: route_ids,
-      stop_ids: stop_ids
+      stop_ids: stop_ids,
+      route_types: [:light_rail, :subway]
     ]
 
     alert_fetch_params

--- a/lib/screens/v2/candidate_generator/dup/departures.ex
+++ b/lib/screens/v2/candidate_generator/dup/departures.ex
@@ -136,7 +136,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
     informed_entities
     |> Enum.find_value(fn
       %{route: route, stop: ^stop_id} -> route
-      _ -> nil
+      _ -> ""
     end)
     |> String.downcase()
     |> String.to_atom()

--- a/lib/screens/v2/candidate_generator/dup/departures.ex
+++ b/lib/screens/v2/candidate_generator/dup/departures.ex
@@ -69,7 +69,6 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
       sections =
         Enum.map(sections_data, fn %{
                                      departures: departures,
-                                     pill: pill,
                                      alert: alert,
                                      headway: headway,
                                      stop_ids: stop_ids

--- a/lib/screens/v2/candidate_generator/dup/departures.ex
+++ b/lib/screens/v2/candidate_generator/dup/departures.ex
@@ -39,7 +39,6 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
       |> get_sections_data(fetch_section_departures_fn, fetch_alerts_fn)
       |> sections_data_to_departure_instances(
         config,
-        &1,
         [:main_content_zero, :main_content_one],
         now
       )
@@ -52,7 +51,6 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
         |> get_sections_data(fetch_section_departures_fn, fetch_alerts_fn)
         |> sections_data_to_departure_instances(
           config,
-          &1,
           [:main_content_two],
           now
         )
@@ -61,7 +59,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
     primary_departures_instances ++ secondary_departures_instances
   end
 
-  defp sections_data_to_departure_instances(config, sections_data, slot_ids, now) do
+  defp sections_data_to_departure_instances(sections_data, config, slot_ids, now) do
     if Enum.any?(sections_data, &(&1 == :error)) do
       %DeparturesNoData{screen: config, show_alternatives?: true}
     else

--- a/lib/screens/v2/widget_instance/departures.ex
+++ b/lib/screens/v2/widget_instance/departures.ex
@@ -95,9 +95,8 @@ defmodule Screens.V2.WidgetInstance.Departures do
               color: pill,
               text: "#{String.capitalize("#{pill}")} Line"
             },
-            "#{headsign} trains",
             %{special: :break},
-            "every",
+            "#{headsign} trains every",
             %{format: :bold, text: "#{lo}-#{hi}"},
             "minutes"
           ]

--- a/lib/screens/v2/widget_instance/departures.ex
+++ b/lib/screens/v2/widget_instance/departures.ex
@@ -75,6 +75,8 @@ defmodule Screens.V2.WidgetInstance.Departures do
     def audio_view(_instance), do: ScreensWeb.V2.Audio.DeparturesView
   end
 
+  def serialize_section(section, screen, is_only_section \\ false)
+
   def serialize_section(%{type: :notice_section, text: text}, _screen, _) do
     %{type: :notice_section, text: text}
   end

--- a/lib/screens/v2/widget_instance/departures.ex
+++ b/lib/screens/v2/widget_instance/departures.ex
@@ -104,7 +104,7 @@ defmodule Screens.V2.WidgetInstance.Departures do
         }
       else
         %FreeTextLine{
-          icon: :orange,
+          icon: pill,
           text: ["every", %{format: :bold, text: "#{lo}-#{hi}"}, "minutes"]
         }
       end

--- a/lib/screens/v2/widget_instance/departures.ex
+++ b/lib/screens/v2/widget_instance/departures.ex
@@ -79,7 +79,11 @@ defmodule Screens.V2.WidgetInstance.Departures do
     %{type: :notice_section, text: text}
   end
 
-  def serialize_section(%{type: :headway_section, pill: pill}, _screen, is_only_section) do
+  def serialize_section(
+        %{type: :headway_section, pill: pill, time_range: {lo, hi}, headsign: headsign},
+        _screen,
+        is_only_section
+      ) do
     text =
       if is_only_section do
         %FreeTextLine{
@@ -89,10 +93,10 @@ defmodule Screens.V2.WidgetInstance.Departures do
               color: pill,
               text: "#{String.capitalize("#{pill}")} Line"
             },
-            "Forest Hills trains",
+            "#{headsign} trains",
             %{special: :break},
             "every",
-            %{format: :bold, text: "2-4"},
+            %{format: :bold, text: "#{lo}-#{hi}"},
             "minutes"
           ]
         }

--- a/lib/screens/v2/widget_instance/departures.ex
+++ b/lib/screens/v2/widget_instance/departures.ex
@@ -101,7 +101,10 @@ defmodule Screens.V2.WidgetInstance.Departures do
           ]
         }
       else
-        %FreeTextLine{icon: :orange, text: ["every", %{format: :bold, text: "2-4"}, "minutes"]}
+        %FreeTextLine{
+          icon: :orange,
+          text: ["every", %{format: :bold, text: "#{lo}-#{hi}"}, "minutes"]
+        }
       end
 
     %{type: :headway_section, text: FreeTextLine.to_json(text)}

--- a/lib/screens/v2/widget_instance/reconstructed_alert.ex
+++ b/lib/screens/v2/widget_instance/reconstructed_alert.ex
@@ -5,6 +5,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
   alias Screens.Config.Screen
   alias Screens.Config.V2.FreeTextLine
   alias Screens.Stops.Stop
+  alias Screens.Util
   alias Screens.V2.WidgetInstance.Alert, as: AlertWidget
   alias Screens.V2.WidgetInstance.Common.BaseAlert
   alias Screens.V2.WidgetInstance.ReconstructedAlert
@@ -122,14 +123,10 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
   end
 
   defp do_get_boundary_headsign({informed, not_informed, headsign}, informed_stop_ids) do
-    if alert_region_match?(to_set(informed), to_set(not_informed), informed_stop_ids),
+    if alert_region_match?(Util.to_set(informed), Util.to_set(not_informed), informed_stop_ids),
       do: headsign,
       else: false
   end
-
-  defp to_set(nil), do: MapSet.new([])
-  defp to_set(stop_id) when is_binary(stop_id), do: MapSet.new([stop_id])
-  defp to_set(stop_ids), do: MapSet.new(stop_ids)
 
   defp alert_region_match?(informed, not_informed, informed_stop_ids) do
     MapSet.subset?(informed, informed_stop_ids) and

--- a/test/fixtures/signs_ui_config.json
+++ b/test/fixtures/signs_ui_config.json
@@ -1,0 +1,95 @@
+{
+  "configured_headways": {
+    "blue_trunk": {
+      "off_peak": {
+        "range_high": 13,
+        "range_low": 9
+      },
+      "peak": {
+        "range_high": 7,
+        "range_low": 5
+      }
+    },
+    "green_d": {
+      "off_peak": {
+        "range_high": 13,
+        "range_low": 7
+      },
+      "peak": {
+        "range_high": 7,
+        "range_low": 6
+      }
+    },
+    "green_e": {
+      "off_peak": {
+        "range_high": 13,
+        "range_low": 7
+      },
+      "peak": {
+        "range_high": 7,
+        "range_low": 6
+      }
+    },
+    "green_trunk": {
+      "off_peak": {
+        "range_high": 13,
+        "range_low": 7
+      },
+      "peak": {
+        "range_high": 7,
+        "range_low": 6
+      }
+    },
+    "mattapan_trunk": {
+      "off_peak": {
+        "range_high": 26,
+        "range_low": 22
+      },
+      "peak": {
+        "range_high": 7,
+        "range_low": 5
+      }
+    },
+    "orange_trunk": {
+      "off_peak": {
+        "range_high": 11,
+        "range_low": 9
+      },
+      "peak": {
+        "range_high": 8,
+        "range_low": 6
+      }
+    },
+    "red_ashmont": {
+      "off_peak": {
+        "range_high": 32,
+        "range_low": 24
+      },
+      "peak": {
+        "range_high": 22,
+        "range_low": 18
+      }
+    },
+    "red_braintree": {
+      "off_peak": {
+        "range_high": 32,
+        "range_low": 24
+      },
+      "peak": {
+        "range_high": 22,
+        "range_low": 18
+      }
+    },
+    "red_trunk": {
+      "off_peak": {
+        "range_high": 16,
+        "range_low": 12
+      },
+      "peak": {
+        "range_high": 11,
+        "range_low": 9
+      }
+    }
+  },
+  "signs": {}
+}

--- a/test/screens/v2/candidate_generator/dup/departures_test.exs
+++ b/test/screens/v2/candidate_generator/dup/departures_test.exs
@@ -1,0 +1,490 @@
+defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
+  use ExUnit.Case, async: true
+
+  alias Screens.Alerts.Alert
+  alias Screens.Config.Screen
+  alias Screens.Config.V2.{Departures, Header}
+  alias Screens.Config.V2.Departures.{Headway, Query, Section}
+  alias Screens.Config.V2.Dup, as: DupConfig
+  alias Screens.Predictions.Prediction
+  alias Screens.V2.Departure
+  alias Screens.V2.CandidateGenerator.Dup
+  alias Screens.V2.WidgetInstance.Departures, as: DeparturesWidget
+
+  setup do
+    config_primary_and_secondary = %Screen{
+      app_params: %DupConfig{
+        header: %Header.CurrentStopId{stop_id: "place-gover"},
+        primary_departures: %Departures{
+          sections: [
+            %Section{query: %Query{params: %Query.Params{stop_ids: ["place-A"]}}, filter: nil},
+            %Section{query: %Query{params: %Query.Params{stop_ids: ["place-B"]}}, filter: nil}
+          ]
+        },
+        secondary_departures: %Departures{
+          sections: [
+            %Section{query: %Query{params: %Query.Params{stop_ids: ["place-C"]}}, filter: nil},
+            %Section{query: %Query{params: %Query.Params{stop_ids: ["place-D"]}}, filter: nil}
+          ]
+        }
+      },
+      vendor: :outfront,
+      device_id: "TEST",
+      name: "TEST",
+      app_id: :dup_v2
+    }
+
+    config_only_primary = %Screen{
+      app_params: %DupConfig{
+        header: %Header.CurrentStopId{stop_id: "place-gover"},
+        primary_departures: %Departures{
+          sections: [
+            %Section{query: %Query{params: %Query.Params{stop_ids: ["place-A"]}}, filter: nil},
+            %Section{query: %Query{params: %Query.Params{stop_ids: ["place-B"]}}, filter: nil}
+          ]
+        },
+        secondary_departures: %Departures{sections: []}
+      },
+      vendor: :outfront,
+      device_id: "TEST",
+      name: "TEST",
+      app_id: :dup_v2
+    }
+
+    config_one_section = %Screen{
+      app_params: %DupConfig{
+        header: %Header.CurrentStopId{stop_id: "place-gover"},
+        primary_departures: %Departures{
+          sections: [
+            %Section{
+              query: %Query{params: %Query.Params{stop_ids: ["place-B"]}},
+              filter: nil,
+              headway: %Headway{headway_id: "red_trunk"}
+            }
+          ]
+        },
+        secondary_departures: %Departures{sections: []}
+      },
+      vendor: :outfront,
+      device_id: "TEST",
+      name: "TEST",
+      app_id: :dup_v2
+    }
+
+    fetch_section_departures_fn = fn
+      %Section{query: %Query{params: %Query.Params{stop_ids: ["place-A"]}}} ->
+        {:ok, [%Departure{prediction: %Prediction{id: "A"}}]}
+
+      %Section{query: %Query{params: %Query.Params{stop_ids: ["place-B"]}}} ->
+        {:ok,
+         [
+           %Departure{prediction: %Prediction{id: "B1"}},
+           %Departure{prediction: %Prediction{id: "B2"}},
+           %Departure{prediction: %Prediction{id: "B3"}},
+           %Departure{prediction: %Prediction{id: "B4"}},
+           %Departure{prediction: %Prediction{id: "B5"}}
+         ]}
+
+      %Section{query: %Query{params: %Query.Params{stop_ids: ["place-C"]}}} ->
+        {:ok, [%Departure{prediction: %Prediction{id: "C"}}]}
+
+      %Section{query: %Query{params: %Query.Params{stop_ids: ["place-D"]}}} ->
+        {:ok, [%Departure{prediction: %Prediction{id: "D"}}]}
+    end
+
+    fetch_alerts_fn = fn
+      _ -> []
+    end
+
+    %{
+      config_primary_and_secondary: config_primary_and_secondary,
+      config_only_primary: config_only_primary,
+      config_one_section: config_one_section,
+      fetch_section_departures_fn: fetch_section_departures_fn,
+      fetch_alerts_fn: fetch_alerts_fn
+    }
+  end
+
+  describe "departures_instances/4" do
+    test "returns primary and secondary departures", %{
+      config_primary_and_secondary: config,
+      fetch_section_departures_fn: fetch_section_departures_fn,
+      fetch_alerts_fn: fetch_alerts_fn
+    } do
+      now = ~U[2020-04-06T10:00:00Z]
+
+      expected_departures = [
+        %DeparturesWidget{
+          screen: config,
+          section_data: [
+            %{
+              type: :normal_section,
+              rows: [
+                %Screens.V2.Departure{
+                  prediction: struct(Prediction, id: "A"),
+                  schedule: nil
+                }
+              ]
+            },
+            %{
+              type: :normal_section,
+              rows: [
+                %Screens.V2.Departure{
+                  prediction: struct(Prediction, id: "B1"),
+                  schedule: nil
+                },
+                %Screens.V2.Departure{
+                  prediction: struct(Prediction, id: "B2"),
+                  schedule: nil
+                }
+              ]
+            }
+          ],
+          slot_names: [:main_content_zero]
+        },
+        %DeparturesWidget{
+          screen: config,
+          section_data: [
+            %{
+              type: :normal_section,
+              rows: [
+                %Screens.V2.Departure{
+                  prediction: struct(Prediction, id: "A"),
+                  schedule: nil
+                }
+              ]
+            },
+            %{
+              type: :normal_section,
+              rows: [
+                %Screens.V2.Departure{
+                  prediction: struct(Prediction, id: "B1"),
+                  schedule: nil
+                },
+                %Screens.V2.Departure{
+                  prediction: struct(Prediction, id: "B2"),
+                  schedule: nil
+                }
+              ]
+            }
+          ],
+          slot_names: [:main_content_one]
+        },
+        %DeparturesWidget{
+          screen: config,
+          section_data: [
+            %{
+              type: :normal_section,
+              rows: [
+                %Screens.V2.Departure{
+                  prediction: struct(Prediction, id: "C"),
+                  schedule: nil
+                }
+              ]
+            },
+            %{
+              type: :normal_section,
+              rows: [
+                %Screens.V2.Departure{
+                  prediction: struct(Prediction, id: "D"),
+                  schedule: nil
+                }
+              ]
+            }
+          ],
+          slot_names: [:main_content_two]
+        }
+      ]
+
+      actual_instances =
+        Dup.Departures.departures_instances(
+          config,
+          now,
+          fetch_section_departures_fn,
+          fetch_alerts_fn
+        )
+
+      assert Enum.all?(expected_departures, &Enum.member?(actual_instances, &1))
+    end
+
+    test "returns only primary departures if secondary is missing", %{
+      config_only_primary: config,
+      fetch_section_departures_fn: fetch_section_departures_fn,
+      fetch_alerts_fn: fetch_alerts_fn
+    } do
+      now = ~U[2020-04-06T10:00:00Z]
+
+      expected_departures = [
+        %DeparturesWidget{
+          screen: config,
+          section_data: [
+            %{
+              type: :normal_section,
+              rows: [
+                %Screens.V2.Departure{
+                  prediction: struct(Prediction, id: "A"),
+                  schedule: nil
+                }
+              ]
+            },
+            %{
+              type: :normal_section,
+              rows: [
+                %Screens.V2.Departure{
+                  prediction: struct(Prediction, id: "B1"),
+                  schedule: nil
+                },
+                %Screens.V2.Departure{
+                  prediction: struct(Prediction, id: "B2"),
+                  schedule: nil
+                }
+              ]
+            }
+          ],
+          slot_names: [:main_content_zero]
+        },
+        %DeparturesWidget{
+          screen: config,
+          section_data: [
+            %{
+              type: :normal_section,
+              rows: [
+                %Screens.V2.Departure{
+                  prediction: struct(Prediction, id: "A"),
+                  schedule: nil
+                }
+              ]
+            },
+            %{
+              type: :normal_section,
+              rows: [
+                %Screens.V2.Departure{
+                  prediction: struct(Prediction, id: "B1"),
+                  schedule: nil
+                },
+                %Screens.V2.Departure{
+                  prediction: struct(Prediction, id: "B2"),
+                  schedule: nil
+                }
+              ]
+            }
+          ],
+          slot_names: [:main_content_one]
+        },
+        %DeparturesWidget{
+          screen: config,
+          section_data: [
+            %{
+              type: :normal_section,
+              rows: [
+                %Screens.V2.Departure{
+                  prediction: struct(Prediction, id: "A"),
+                  schedule: nil
+                }
+              ]
+            },
+            %{
+              type: :normal_section,
+              rows: [
+                %Screens.V2.Departure{
+                  prediction: struct(Prediction, id: "B1"),
+                  schedule: nil
+                },
+                %Screens.V2.Departure{
+                  prediction: struct(Prediction, id: "B2"),
+                  schedule: nil
+                }
+              ]
+            }
+          ],
+          slot_names: [:main_content_two]
+        }
+      ]
+
+      actual_instances =
+        Dup.Departures.departures_instances(
+          config,
+          now,
+          fetch_section_departures_fn,
+          fetch_alerts_fn
+        )
+
+      assert Enum.all?(expected_departures, &Enum.member?(actual_instances, &1))
+    end
+
+    test "returns 4 departures if only one section", %{
+      config_one_section: config,
+      fetch_section_departures_fn: fetch_section_departures_fn,
+      fetch_alerts_fn: fetch_alerts_fn
+    } do
+      now = ~U[2020-04-06T10:00:00Z]
+
+      expected_departures = [
+        %DeparturesWidget{
+          screen: config,
+          section_data: [
+            %{
+              type: :normal_section,
+              rows: [
+                %Screens.V2.Departure{
+                  prediction: struct(Prediction, id: "B1"),
+                  schedule: nil
+                },
+                %Screens.V2.Departure{
+                  prediction: struct(Prediction, id: "B2"),
+                  schedule: nil
+                },
+                %Screens.V2.Departure{
+                  prediction: struct(Prediction, id: "B3"),
+                  schedule: nil
+                },
+                %Screens.V2.Departure{
+                  prediction: struct(Prediction, id: "B4"),
+                  schedule: nil
+                }
+              ]
+            }
+          ],
+          slot_names: [:main_content_zero]
+        },
+        %DeparturesWidget{
+          screen: config,
+          section_data: [
+            %{
+              type: :normal_section,
+              rows: [
+                %Screens.V2.Departure{
+                  prediction: struct(Prediction, id: "B1"),
+                  schedule: nil
+                },
+                %Screens.V2.Departure{
+                  prediction: struct(Prediction, id: "B2"),
+                  schedule: nil
+                },
+                %Screens.V2.Departure{
+                  prediction: struct(Prediction, id: "B3"),
+                  schedule: nil
+                },
+                %Screens.V2.Departure{
+                  prediction: struct(Prediction, id: "B4"),
+                  schedule: nil
+                }
+              ]
+            }
+          ],
+          slot_names: [:main_content_one]
+        },
+        %DeparturesWidget{
+          screen: config,
+          section_data: [
+            %{
+              type: :normal_section,
+              rows: [
+                %Screens.V2.Departure{
+                  prediction: struct(Prediction, id: "B1"),
+                  schedule: nil
+                },
+                %Screens.V2.Departure{
+                  prediction: struct(Prediction, id: "B2"),
+                  schedule: nil
+                },
+                %Screens.V2.Departure{
+                  prediction: struct(Prediction, id: "B3"),
+                  schedule: nil
+                },
+                %Screens.V2.Departure{
+                  prediction: struct(Prediction, id: "B4"),
+                  schedule: nil
+                }
+              ]
+            }
+          ],
+          slot_names: [:main_content_two]
+        }
+      ]
+
+      actual_instances =
+        Dup.Departures.departures_instances(
+          config,
+          now,
+          fetch_section_departures_fn,
+          fetch_alerts_fn
+        )
+
+      assert Enum.all?(expected_departures, &Enum.member?(actual_instances, &1))
+    end
+
+    test "returns headway sections for temporary terminal", %{
+      config_one_section: config,
+      fetch_section_departures_fn: fetch_section_departures_fn
+    } do
+      now = ~U[2020-04-06T10:00:00Z]
+
+      fetch_alerts_fn = fn
+        [
+          direction_id: :both,
+          route_ids: [],
+          stop_ids: ["place-B"]
+        ] ->
+          [
+            struct(Alert,
+              effect: :suspension,
+              informed_entities: [
+                %{stop: "place-B", route: "Red"},
+                %{stop: "place-C", route: "Red"}
+              ]
+            )
+          ]
+      end
+
+      expected_departures = [
+        %DeparturesWidget{
+          screen: config,
+          section_data: [
+            %{
+              type: :headway_section,
+              pill: :red,
+              time_range: {12, 16},
+              headsign: "Test"
+            }
+          ],
+          slot_names: [:main_content_zero]
+        },
+        %DeparturesWidget{
+          screen: config,
+          section_data: [
+            %{
+              type: :headway_section,
+              pill: :red,
+              time_range: {12, 16},
+              headsign: "Test"
+            }
+          ],
+          slot_names: [:main_content_one]
+        },
+        %DeparturesWidget{
+          screen: config,
+          section_data: [
+            %{
+              type: :headway_section,
+              pill: :red,
+              time_range: {12, 16},
+              headsign: "Test"
+            }
+          ],
+          slot_names: [:main_content_two]
+        }
+      ]
+
+      actual_instances =
+        Dup.Departures.departures_instances(
+          config,
+          now,
+          fetch_section_departures_fn,
+          fetch_alerts_fn
+        )
+
+      assert Enum.all?(expected_departures, &Enum.member?(actual_instances, &1))
+    end
+  end
+end

--- a/test/screens/v2/candidate_generator/dup/departures_test.exs
+++ b/test/screens/v2/candidate_generator/dup/departures_test.exs
@@ -432,7 +432,8 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
               informed_entities: [
                 %{stop: "place-B", route: "Red"},
                 %{stop: "place-C", route: "Red"}
-              ]
+              ],
+              active_period: [{~U[2020-04-06T09:00:00Z], nil}]
             )
           ]
       end
@@ -470,6 +471,125 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
               pill: :red,
               time_range: {12, 16},
               headsign: "Test"
+            }
+          ],
+          slot_names: [:main_content_two]
+        }
+      ]
+
+      actual_instances =
+        Dup.Departures.departures_instances(
+          config,
+          now,
+          fetch_section_departures_fn,
+          fetch_alerts_fn
+        )
+
+      assert Enum.all?(expected_departures, &Enum.member?(actual_instances, &1))
+    end
+
+    test "returns normal sections for upcoming alert", %{
+      config_one_section: config,
+      fetch_section_departures_fn: fetch_section_departures_fn
+    } do
+      now = ~U[2020-04-06T10:00:00Z]
+
+      fetch_alerts_fn = fn
+        [
+          direction_id: :both,
+          route_ids: [],
+          stop_ids: ["place-B"]
+        ] ->
+          [
+            struct(Alert,
+              effect: :suspension,
+              informed_entities: [
+                %{stop: "place-B", route: "Red"},
+                %{stop: "place-C", route: "Red"}
+              ],
+              active_period: [{~U[2020-05-06T09:00:00Z], nil}]
+            )
+          ]
+      end
+
+      expected_departures = [
+        %DeparturesWidget{
+          screen: config,
+          section_data: [
+            %{
+              type: :normal_section,
+              rows: [
+                %Screens.V2.Departure{
+                  prediction: struct(Prediction, id: "B1"),
+                  schedule: nil
+                },
+                %Screens.V2.Departure{
+                  prediction: struct(Prediction, id: "B2"),
+                  schedule: nil
+                },
+                %Screens.V2.Departure{
+                  prediction: struct(Prediction, id: "B3"),
+                  schedule: nil
+                },
+                %Screens.V2.Departure{
+                  prediction: struct(Prediction, id: "B4"),
+                  schedule: nil
+                }
+              ]
+            }
+          ],
+          slot_names: [:main_content_zero]
+        },
+        %DeparturesWidget{
+          screen: config,
+          section_data: [
+            %{
+              type: :normal_section,
+              rows: [
+                %Screens.V2.Departure{
+                  prediction: struct(Prediction, id: "B1"),
+                  schedule: nil
+                },
+                %Screens.V2.Departure{
+                  prediction: struct(Prediction, id: "B2"),
+                  schedule: nil
+                },
+                %Screens.V2.Departure{
+                  prediction: struct(Prediction, id: "B3"),
+                  schedule: nil
+                },
+                %Screens.V2.Departure{
+                  prediction: struct(Prediction, id: "B4"),
+                  schedule: nil
+                }
+              ]
+            }
+          ],
+          slot_names: [:main_content_one]
+        },
+        %DeparturesWidget{
+          screen: config,
+          section_data: [
+            %{
+              type: :normal_section,
+              rows: [
+                %Screens.V2.Departure{
+                  prediction: struct(Prediction, id: "B1"),
+                  schedule: nil
+                },
+                %Screens.V2.Departure{
+                  prediction: struct(Prediction, id: "B2"),
+                  schedule: nil
+                },
+                %Screens.V2.Departure{
+                  prediction: struct(Prediction, id: "B3"),
+                  schedule: nil
+                },
+                %Screens.V2.Departure{
+                  prediction: struct(Prediction, id: "B4"),
+                  schedule: nil
+                }
+              ]
             }
           ],
           slot_names: [:main_content_two]

--- a/test/screens/v2/candidate_generator/dup/departures_test.exs
+++ b/test/screens/v2/candidate_generator/dup/departures_test.exs
@@ -71,6 +71,26 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
       app_id: :dup_v2
     }
 
+    config_branch_station = %Screen{
+      app_params: %DupConfig{
+        header: %Header.CurrentStopId{stop_id: "place-kencl"},
+        primary_departures: %Departures{
+          sections: [
+            %Section{
+              query: %Query{params: %Query.Params{stop_ids: ["place-kencl"]}},
+              filter: nil,
+              headway: %Headway{headway_id: "green_trunk"}
+            }
+          ]
+        },
+        secondary_departures: %Departures{sections: []}
+      },
+      vendor: :outfront,
+      device_id: "TEST",
+      name: "TEST",
+      app_id: :dup_v2
+    }
+
     fetch_section_departures_fn = fn
       %Section{query: %Query{params: %Query.Params{stop_ids: ["place-A"]}}} ->
         {:ok, [%Departure{prediction: %Prediction{id: "A"}}]}
@@ -90,6 +110,9 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
 
       %Section{query: %Query{params: %Query.Params{stop_ids: ["place-D"]}}} ->
         {:ok, [%Departure{prediction: %Prediction{id: "D"}}]}
+
+      %Section{query: %Query{params: %Query.Params{stop_ids: ["place-kencl"]}}} ->
+        {:ok, [%Departure{prediction: %Prediction{id: "Kenmore"}}]}
     end
 
     fetch_alerts_fn = fn
@@ -100,6 +123,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
       config_primary_and_secondary: config_primary_and_secondary,
       config_only_primary: config_only_primary,
       config_one_section: config_one_section,
+      config_branch_station: config_branch_station,
       fetch_section_departures_fn: fetch_section_departures_fn,
       fetch_alerts_fn: fetch_alerts_fn
     }
@@ -605,6 +629,248 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
           fetch_section_departures_fn,
           fetch_alerts_fn
         )
+
+      assert Enum.all?(expected_departures, &Enum.member?(actual_instances, &1))
+    end
+
+    test "returns normal sections for branch station for alert with branch terminal headsign", %{
+      config_branch_station: config,
+      fetch_section_departures_fn: fetch_section_departures_fn
+    } do
+      now = ~U[2020-04-06T10:00:00Z]
+
+      fetch_alerts_fn = fn
+        [
+          direction_id: :both,
+          route_ids: [],
+          stop_ids: ["place-kencl"],
+          route_types: [:light_rail, :subway]
+        ] ->
+          [
+            # Suspension alert from Kenmore to Saint Mary's Street
+            struct(Alert,
+              effect: :suspension,
+              informed_entities: [
+                %{
+                  direction_id: nil,
+                  facility: nil,
+                  route: "Green-C",
+                  route_type: 0,
+                  stop: "70150"
+                },
+                %{
+                  direction_id: nil,
+                  facility: nil,
+                  route: "Green-C",
+                  route_type: 0,
+                  stop: "70151"
+                },
+                %{
+                  direction_id: nil,
+                  facility: nil,
+                  route: "Green-C",
+                  route_type: 0,
+                  stop: "70211"
+                },
+                %{
+                  direction_id: nil,
+                  facility: nil,
+                  route: "Green-C",
+                  route_type: 0,
+                  stop: "70212"
+                },
+                %{
+                  direction_id: nil,
+                  facility: nil,
+                  route: "Green-C",
+                  route_type: 0,
+                  stop: "place-kencl"
+                },
+                %{
+                  direction_id: nil,
+                  facility: nil,
+                  route: "Green-C",
+                  route_type: 0,
+                  stop: "place-smary"
+                }
+              ],
+              active_period: [{~U[2020-04-06T09:00:00Z], nil}]
+            )
+          ]
+      end
+
+      expected_departures = [
+        %DeparturesWidget{
+          screen: config,
+          section_data: [
+            %{
+              type: :normal_section,
+              rows: [
+                %Screens.V2.Departure{
+                  prediction: struct(Prediction, id: "Kenmore"),
+                  schedule: nil
+                }
+              ]
+            }
+          ],
+          slot_names: [:main_content_zero]
+        },
+        %DeparturesWidget{
+          screen: config,
+          section_data: [
+            %{
+              type: :normal_section,
+              rows: [
+                %Screens.V2.Departure{
+                  prediction: struct(Prediction, id: "Kenmore"),
+                  schedule: nil
+                }
+              ]
+            }
+          ],
+          slot_names: [:main_content_one]
+        },
+        %DeparturesWidget{
+          screen: config,
+          section_data: [
+            %{
+              type: :normal_section,
+              rows: [
+                %Screens.V2.Departure{
+                  prediction: struct(Prediction, id: "Kenmore"),
+                  schedule: nil
+                }
+              ]
+            }
+          ],
+          slot_names: [:main_content_two]
+        }
+      ]
+
+      actual_instances =
+        Dup.Departures.departures_instances(
+          config,
+          now,
+          fetch_section_departures_fn,
+          fetch_alerts_fn
+        )
+
+      assert Enum.all?(expected_departures, &Enum.member?(actual_instances, &1))
+    end
+
+    test "returns headway sections for branch station for alert with trunk headsign", %{
+      config_branch_station: config,
+      fetch_section_departures_fn: fetch_section_departures_fn
+    } do
+      now = ~U[2020-04-06T10:00:00Z]
+
+      fetch_alerts_fn = fn
+        [
+          direction_id: :both,
+          route_ids: [],
+          stop_ids: ["place-kencl"],
+          route_types: [:light_rail, :subway]
+        ] ->
+          [
+            # Suspension alert from Kenmore to Hynes
+            struct(Alert,
+              effect: :suspension,
+              informed_entities: [
+                %{
+                  direction_id: nil,
+                  facility: nil,
+                  route: "Green-C",
+                  route_type: 0,
+                  stop: "70150"
+                },
+                %{
+                  direction_id: nil,
+                  facility: nil,
+                  route: "Green-C",
+                  route_type: 0,
+                  stop: "70151"
+                },
+                %{
+                  direction_id: nil,
+                  facility: nil,
+                  route: "Green-C",
+                  route_type: 0,
+                  stop: "70152"
+                },
+                %{
+                  direction_id: nil,
+                  facility: nil,
+                  route: "Green-C",
+                  route_type: 0,
+                  stop: "70153"
+                },
+                %{
+                  direction_id: nil,
+                  facility: nil,
+                  route: "Green-C",
+                  route_type: 0,
+                  stop: "place-hymnl"
+                },
+                %{
+                  direction_id: nil,
+                  facility: nil,
+                  route: "Green-C",
+                  route_type: 0,
+                  stop: "place-kencl"
+                }
+              ],
+              active_period: [{~U[2020-04-06T09:00:00Z], nil}]
+            )
+          ]
+      end
+
+      expected_departures = [
+        %DeparturesWidget{
+          screen: config,
+          section_data: [
+            %{
+              type: :headway_section,
+              pill: :"green-c",
+              time_range: {7, 13},
+              headsign: "Park Street"
+            }
+          ],
+          slot_names: [:main_content_zero]
+        },
+        %DeparturesWidget{
+          screen: config,
+          section_data: [
+            %{
+              type: :headway_section,
+              pill: :"green-c",
+              time_range: {7, 13},
+              headsign: "Park Street"
+            }
+          ],
+          slot_names: [:main_content_one]
+        },
+        %DeparturesWidget{
+          screen: config,
+          section_data: [
+            %{
+              type: :headway_section,
+              pill: :"green-c",
+              time_range: {7, 13},
+              headsign: "Park Street"
+            }
+          ],
+          slot_names: [:main_content_two]
+        }
+      ]
+
+      actual_instances =
+        Dup.Departures.departures_instances(
+          config,
+          now,
+          fetch_section_departures_fn,
+          fetch_alerts_fn
+        )
+        |> IO.inspect()
 
       assert Enum.all?(expected_departures, &Enum.member?(actual_instances, &1))
     end

--- a/test/screens/v2/candidate_generator/dup/departures_test.exs
+++ b/test/screens/v2/candidate_generator/dup/departures_test.exs
@@ -870,7 +870,6 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
           fetch_section_departures_fn,
           fetch_alerts_fn
         )
-        |> IO.inspect()
 
       assert Enum.all?(expected_departures, &Enum.member?(actual_instances, &1))
     end

--- a/test/screens/v2/candidate_generator/dup/departures_test.exs
+++ b/test/screens/v2/candidate_generator/dup/departures_test.exs
@@ -424,7 +424,8 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
         [
           direction_id: :both,
           route_ids: [],
-          stop_ids: ["place-B"]
+          stop_ids: ["place-B"],
+          route_types: [:light_rail, :subway]
         ] ->
           [
             struct(Alert,
@@ -498,7 +499,8 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
         [
           direction_id: :both,
           route_ids: [],
-          stop_ids: ["place-B"]
+          stop_ids: ["place-B"],
+          route_types: [:light_rail, :subway]
         ] ->
           [
             struct(Alert,

--- a/test/screens/v2/candidate_generator/dup_test.exs
+++ b/test/screens/v2/candidate_generator/dup_test.exs
@@ -58,9 +58,9 @@ defmodule Screens.V2.CandidateGenerator.DupTest do
         primary_departures: %Departures{
           sections: [
             %Section{
-              query: %Query{params: %Query.Params{stop_ids: ["stop B"]}},
+              query: %Query{params: %Query.Params{stop_ids: ["stop B"], route_ids: ["Red"]}},
               filter: nil,
-              headway: %Headway{headway_id: "red_trunk", pill: :red}
+              headway: %Headway{headway_id: "red_trunk"}
             }
           ]
         },
@@ -562,8 +562,7 @@ defmodule Screens.V2.CandidateGenerator.DupTest do
       fetch_alerts_fn = fn
         [
           direction_id: :both,
-          route_ids: [],
-          route_types: [:light_rail, :subway],
+          route_ids: ["Red"],
           stop_ids: ["stop B"]
         ] ->
           [

--- a/test/screens/v2/candidate_generator/dup_test.exs
+++ b/test/screens/v2/candidate_generator/dup_test.exs
@@ -3,6 +3,7 @@ defmodule Screens.V2.CandidateGenerator.DupTest do
 
   alias Screens.Config.Screen
   alias Screens.Config.V2.{Departures, Header}
+  alias Screens.Config.V2.Departures.{Section, Query}
   alias Screens.Config.V2.Dup, as: DupConfig
   alias Screens.Predictions.Prediction
   alias Screens.V2.Departure
@@ -16,14 +17,14 @@ defmodule Screens.V2.CandidateGenerator.DupTest do
         header: %Header.CurrentStopId{stop_id: "place-gover"},
         primary_departures: %Departures{
           sections: [
-            %Departures.Section{query: "query A", filter: nil},
-            %Departures.Section{query: "query B", filter: nil}
+            %Section{query: %Query{params: %Query.Params{stop_ids: ["stop A"]}}, filter: nil},
+            %Section{query: %Query{params: %Query.Params{stop_ids: ["stop B"]}}, filter: nil}
           ]
         },
         secondary_departures: %Departures{
           sections: [
-            %Departures.Section{query: "query C", filter: nil},
-            %Departures.Section{query: "query D", filter: nil}
+            %Section{query: %Query{params: %Query.Params{stop_ids: ["stop C"]}}, filter: nil},
+            %Section{query: %Query{params: %Query.Params{stop_ids: ["stop D"]}}, filter: nil}
           ]
         }
       },
@@ -38,8 +39,8 @@ defmodule Screens.V2.CandidateGenerator.DupTest do
         header: %Header.CurrentStopId{stop_id: "place-gover"},
         primary_departures: %Departures{
           sections: [
-            %Departures.Section{query: "query A", filter: nil},
-            %Departures.Section{query: "query B", filter: nil}
+            %Section{query: %Query{params: %Query.Params{stop_ids: ["stop A"]}}, filter: nil},
+            %Section{query: %Query{params: %Query.Params{stop_ids: ["stop B"]}}, filter: nil}
           ]
         },
         secondary_departures: %Departures{sections: []}
@@ -55,7 +56,7 @@ defmodule Screens.V2.CandidateGenerator.DupTest do
         header: %Header.CurrentStopId{stop_id: "place-gover"},
         primary_departures: %Departures{
           sections: [
-            %Departures.Section{query: "query B", filter: nil}
+            %Section{query: %Query{params: %Query.Params{stop_ids: ["stop B"]}}, filter: nil}
           ]
         },
         secondary_departures: %Departures{sections: []}
@@ -67,10 +68,10 @@ defmodule Screens.V2.CandidateGenerator.DupTest do
     }
 
     fetch_section_departures_fn = fn
-      %Departures.Section{query: "query A"} ->
+      %Section{query: %Query{params: %Query.Params{stop_ids: ["stop A"]}}} ->
         {:ok, [%Departure{prediction: %Prediction{id: "A"}}]}
 
-      %Departures.Section{query: "query B"} ->
+      %Section{query: %Query{params: %Query.Params{stop_ids: ["stop B"]}}} ->
         {:ok,
          [
            %Departure{prediction: %Prediction{id: "B1"}},
@@ -80,10 +81,10 @@ defmodule Screens.V2.CandidateGenerator.DupTest do
            %Departure{prediction: %Prediction{id: "B5"}}
          ]}
 
-      %Departures.Section{query: "query C"} ->
+      %Section{query: %Query{params: %Query.Params{stop_ids: ["stop C"]}}} ->
         {:ok, [%Departure{prediction: %Prediction{id: "C"}}]}
 
-      %Departures.Section{query: "query D"} ->
+      %Section{query: %Query{params: %Query.Params{stop_ids: ["stop D"]}}} ->
         {:ok, [%Departure{prediction: %Prediction{id: "D"}}]}
     end
 
@@ -149,10 +150,10 @@ defmodule Screens.V2.CandidateGenerator.DupTest do
       fetch_stop_fn = fn "place-gover" -> "Government Center" end
 
       fetch_section_departures_fn = fn
-        %Departures.Section{query: "query A"} -> {:ok, []}
-        %Departures.Section{query: "query B"} -> {:ok, []}
-        %Departures.Section{query: "query C"} -> {:ok, []}
-        %Departures.Section{query: "query D"} -> {:ok, []}
+        %Section{query: %Query{params: %Query.Params{stop_ids: ["stop A"]}}} -> {:ok, []}
+        %Section{query: %Query{params: %Query.Params{stop_ids: ["stop B"]}}} -> {:ok, []}
+        %Section{query: %Query{params: %Query.Params{stop_ids: ["stop C"]}}} -> {:ok, []}
+        %Section{query: %Query{params: %Query.Params{stop_ids: ["stop D"]}}} -> {:ok, []}
       end
 
       expected_headers =

--- a/test/screens/v2/candidate_generator/dup_test.exs
+++ b/test/screens/v2/candidate_generator/dup_test.exs
@@ -1,26 +1,29 @@
 defmodule Screens.V2.CandidateGenerator.DupTest do
   use ExUnit.Case, async: true
 
-  alias Screens.Config.{Screen, V2}
+  alias Screens.Config.Screen
+  alias Screens.Config.V2.{Departures, Header}
+  alias Screens.Config.V2.Dup, as: DupConfig
   alias Screens.Predictions.Prediction
   alias Screens.V2.Departure
   alias Screens.V2.CandidateGenerator.Dup
-  alias Screens.V2.WidgetInstance.{Departures, NormalHeader}
+  alias Screens.V2.WidgetInstance.Departures, as: DeparturesWidget
+  alias Screens.V2.WidgetInstance.NormalHeader
 
   setup do
     config_primary_and_secondary = %Screen{
-      app_params: %V2.Dup{
-        header: %V2.Header.CurrentStopId{stop_id: "place-gover"},
-        primary_departures: %V2.Departures{
+      app_params: %DupConfig{
+        header: %Header.CurrentStopId{stop_id: "place-gover"},
+        primary_departures: %Departures{
           sections: [
-            %V2.Departures.Section{query: "query A", filter: nil},
-            %V2.Departures.Section{query: "query B", filter: nil}
+            %Departures.Section{query: "query A", filter: nil},
+            %Departures.Section{query: "query B", filter: nil}
           ]
         },
-        secondary_departures: %V2.Departures{
+        secondary_departures: %Departures{
           sections: [
-            %V2.Departures.Section{query: "query C", filter: nil},
-            %V2.Departures.Section{query: "query D", filter: nil}
+            %Departures.Section{query: "query C", filter: nil},
+            %Departures.Section{query: "query D", filter: nil}
           ]
         }
       },
@@ -31,15 +34,15 @@ defmodule Screens.V2.CandidateGenerator.DupTest do
     }
 
     config_only_primary = %Screen{
-      app_params: %V2.Dup{
-        header: %V2.Header.CurrentStopId{stop_id: "place-gover"},
-        primary_departures: %V2.Departures{
+      app_params: %DupConfig{
+        header: %Header.CurrentStopId{stop_id: "place-gover"},
+        primary_departures: %Departures{
           sections: [
-            %V2.Departures.Section{query: "query A", filter: nil},
-            %V2.Departures.Section{query: "query B", filter: nil}
+            %Departures.Section{query: "query A", filter: nil},
+            %Departures.Section{query: "query B", filter: nil}
           ]
         },
-        secondary_departures: %V2.Departures{sections: []}
+        secondary_departures: %Departures{sections: []}
       },
       vendor: :outfront,
       device_id: "TEST",
@@ -48,14 +51,14 @@ defmodule Screens.V2.CandidateGenerator.DupTest do
     }
 
     config_one_section = %Screen{
-      app_params: %V2.Dup{
-        header: %V2.Header.CurrentStopId{stop_id: "place-gover"},
-        primary_departures: %V2.Departures{
+      app_params: %DupConfig{
+        header: %Header.CurrentStopId{stop_id: "place-gover"},
+        primary_departures: %Departures{
           sections: [
-            %V2.Departures.Section{query: "query B", filter: nil}
+            %Departures.Section{query: "query B", filter: nil}
           ]
         },
-        secondary_departures: %V2.Departures{sections: []}
+        secondary_departures: %Departures{sections: []}
       },
       vendor: :outfront,
       device_id: "TEST",
@@ -64,10 +67,10 @@ defmodule Screens.V2.CandidateGenerator.DupTest do
     }
 
     fetch_section_departures_fn = fn
-      %V2.Departures.Section{query: "query A"} ->
+      %Departures.Section{query: "query A"} ->
         {:ok, [%Departure{prediction: %Prediction{id: "A"}}]}
 
-      %V2.Departures.Section{query: "query B"} ->
+      %Departures.Section{query: "query B"} ->
         {:ok,
          [
            %Departure{prediction: %Prediction{id: "B1"}},
@@ -77,10 +80,10 @@ defmodule Screens.V2.CandidateGenerator.DupTest do
            %Departure{prediction: %Prediction{id: "B5"}}
          ]}
 
-      %V2.Departures.Section{query: "query C"} ->
+      %Departures.Section{query: "query C"} ->
         {:ok, [%Departure{prediction: %Prediction{id: "C"}}]}
 
-      %V2.Departures.Section{query: "query D"} ->
+      %Departures.Section{query: "query D"} ->
         {:ok, [%Departure{prediction: %Prediction{id: "D"}}]}
     end
 
@@ -146,10 +149,10 @@ defmodule Screens.V2.CandidateGenerator.DupTest do
       fetch_stop_fn = fn "place-gover" -> "Government Center" end
 
       fetch_section_departures_fn = fn
-        %V2.Departures.Section{query: "query A"} -> {:ok, []}
-        %V2.Departures.Section{query: "query B"} -> {:ok, []}
-        %V2.Departures.Section{query: "query C"} -> {:ok, []}
-        %V2.Departures.Section{query: "query D"} -> {:ok, []}
+        %Departures.Section{query: "query A"} -> {:ok, []}
+        %Departures.Section{query: "query B"} -> {:ok, []}
+        %Departures.Section{query: "query C"} -> {:ok, []}
+        %Departures.Section{query: "query D"} -> {:ok, []}
       end
 
       expected_headers =
@@ -164,7 +167,7 @@ defmodule Screens.V2.CandidateGenerator.DupTest do
         )
 
       expected_departures = [
-        %Departures{
+        %DeparturesWidget{
           screen: config,
           section_data: [
             %{type: :normal_section, rows: []},
@@ -172,7 +175,7 @@ defmodule Screens.V2.CandidateGenerator.DupTest do
           ],
           slot_names: [:main_content_zero]
         },
-        %Departures{
+        %DeparturesWidget{
           screen: config,
           section_data: [
             %{type: :normal_section, rows: []},
@@ -180,7 +183,7 @@ defmodule Screens.V2.CandidateGenerator.DupTest do
           ],
           slot_names: [:main_content_one]
         },
-        %Departures{
+        %DeparturesWidget{
           screen: config,
           section_data: [
             %{type: :normal_section, rows: []},
@@ -234,7 +237,7 @@ defmodule Screens.V2.CandidateGenerator.DupTest do
       fetch_section_departures_fn: fetch_section_departures_fn
     } do
       expected_departures = [
-        %Departures{
+        %DeparturesWidget{
           screen: config,
           section_data: [
             %{
@@ -262,7 +265,7 @@ defmodule Screens.V2.CandidateGenerator.DupTest do
           ],
           slot_names: [:main_content_zero]
         },
-        %Departures{
+        %DeparturesWidget{
           screen: config,
           section_data: [
             %{
@@ -290,7 +293,7 @@ defmodule Screens.V2.CandidateGenerator.DupTest do
           ],
           slot_names: [:main_content_one]
         },
-        %Departures{
+        %DeparturesWidget{
           screen: config,
           section_data: [
             %{
@@ -330,7 +333,7 @@ defmodule Screens.V2.CandidateGenerator.DupTest do
       fetch_section_departures_fn: fetch_section_departures_fn
     } do
       expected_departures = [
-        %Departures{
+        %DeparturesWidget{
           screen: config,
           section_data: [
             %{
@@ -358,7 +361,7 @@ defmodule Screens.V2.CandidateGenerator.DupTest do
           ],
           slot_names: [:main_content_zero]
         },
-        %Departures{
+        %DeparturesWidget{
           screen: config,
           section_data: [
             %{
@@ -386,7 +389,7 @@ defmodule Screens.V2.CandidateGenerator.DupTest do
           ],
           slot_names: [:main_content_one]
         },
-        %Departures{
+        %DeparturesWidget{
           screen: config,
           section_data: [
             %{
@@ -430,7 +433,7 @@ defmodule Screens.V2.CandidateGenerator.DupTest do
       fetch_section_departures_fn: fetch_section_departures_fn
     } do
       expected_departures = [
-        %Departures{
+        %DeparturesWidget{
           screen: config,
           section_data: [
             %{
@@ -457,7 +460,7 @@ defmodule Screens.V2.CandidateGenerator.DupTest do
           ],
           slot_names: [:main_content_zero]
         },
-        %Departures{
+        %DeparturesWidget{
           screen: config,
           section_data: [
             %{
@@ -484,7 +487,7 @@ defmodule Screens.V2.CandidateGenerator.DupTest do
           ],
           slot_names: [:main_content_one]
         },
-        %Departures{
+        %DeparturesWidget{
           screen: config,
           section_data: [
             %{

--- a/test/screens/v2/candidate_generator/dup_test.exs
+++ b/test/screens/v2/candidate_generator/dup_test.exs
@@ -93,7 +93,7 @@ defmodule Screens.V2.CandidateGenerator.DupTest do
         {:ok, [%Departure{prediction: %Prediction{id: "D"}}]}
     end
 
-    fetch_alerts_or_empty_list_fn = fn
+    fetch_alerts_fn = fn
       _ -> []
     end
 
@@ -102,7 +102,7 @@ defmodule Screens.V2.CandidateGenerator.DupTest do
       config_only_primary: config_only_primary,
       config_one_section: config_one_section,
       fetch_section_departures_fn: fetch_section_departures_fn,
-      fetch_alerts_or_empty_list_fn: fetch_alerts_or_empty_list_fn
+      fetch_alerts_fn: fetch_alerts_fn
     }
   end
 
@@ -155,7 +155,7 @@ defmodule Screens.V2.CandidateGenerator.DupTest do
   describe "candidate_instances/4" do
     test "returns expected header and departures", %{
       config_primary_and_secondary: config,
-      fetch_alerts_or_empty_list_fn: fetch_alerts_or_empty_list_fn
+      fetch_alerts_fn: fetch_alerts_fn
     } do
       now = ~U[2020-04-06T10:00:00Z]
       fetch_stop_fn = fn "place-gover" -> "Government Center" end
@@ -211,7 +211,7 @@ defmodule Screens.V2.CandidateGenerator.DupTest do
           now,
           fetch_stop_fn,
           fetch_section_departures_fn,
-          fetch_alerts_or_empty_list_fn
+          fetch_alerts_fn
         )
 
       assert Enum.all?(expected_headers, &Enum.member?(actual_instances, &1))
@@ -248,7 +248,7 @@ defmodule Screens.V2.CandidateGenerator.DupTest do
     test "returns primary and secondary departures", %{
       config_primary_and_secondary: config,
       fetch_section_departures_fn: fetch_section_departures_fn,
-      fetch_alerts_or_empty_list_fn: fetch_alerts_or_empty_list_fn
+      fetch_alerts_fn: fetch_alerts_fn
     } do
       now = ~U[2020-04-06T10:00:00Z]
 
@@ -340,7 +340,7 @@ defmodule Screens.V2.CandidateGenerator.DupTest do
           config,
           now,
           fetch_section_departures_fn,
-          fetch_alerts_or_empty_list_fn
+          fetch_alerts_fn
         )
 
       assert Enum.all?(expected_departures, &Enum.member?(actual_instances, &1))
@@ -349,7 +349,7 @@ defmodule Screens.V2.CandidateGenerator.DupTest do
     test "returns only primary departures if secondary is missing", %{
       config_only_primary: config,
       fetch_section_departures_fn: fetch_section_departures_fn,
-      fetch_alerts_or_empty_list_fn: fetch_alerts_or_empty_list_fn
+      fetch_alerts_fn: fetch_alerts_fn
     } do
       now = ~U[2020-04-06T10:00:00Z]
 
@@ -445,7 +445,7 @@ defmodule Screens.V2.CandidateGenerator.DupTest do
           config,
           now,
           fetch_section_departures_fn,
-          fetch_alerts_or_empty_list_fn
+          fetch_alerts_fn
         )
 
       assert Enum.all?(expected_departures, &Enum.member?(actual_instances, &1))
@@ -454,7 +454,7 @@ defmodule Screens.V2.CandidateGenerator.DupTest do
     test "returns 4 departures if only one section", %{
       config_one_section: config,
       fetch_section_departures_fn: fetch_section_departures_fn,
-      fetch_alerts_or_empty_list_fn: fetch_alerts_or_empty_list_fn
+      fetch_alerts_fn: fetch_alerts_fn
     } do
       now = ~U[2020-04-06T10:00:00Z]
 
@@ -547,7 +547,7 @@ defmodule Screens.V2.CandidateGenerator.DupTest do
           config,
           now,
           fetch_section_departures_fn,
-          fetch_alerts_or_empty_list_fn
+          fetch_alerts_fn
         )
 
       assert Enum.all?(expected_departures, &Enum.member?(actual_instances, &1))
@@ -559,7 +559,7 @@ defmodule Screens.V2.CandidateGenerator.DupTest do
     } do
       now = ~U[2020-04-06T10:00:00Z]
 
-      fetch_alerts_or_empty_list_fn = fn
+      fetch_alerts_fn = fn
         [
           direction_id: :both,
           route_ids: [],
@@ -618,7 +618,7 @@ defmodule Screens.V2.CandidateGenerator.DupTest do
           config,
           now,
           fetch_section_departures_fn,
-          fetch_alerts_or_empty_list_fn
+          fetch_alerts_fn
         )
 
       assert Enum.all?(expected_departures, &Enum.member?(actual_instances, &1))

--- a/test/screens/v2/candidate_generator/dup_test.exs
+++ b/test/screens/v2/candidate_generator/dup_test.exs
@@ -4,7 +4,7 @@ defmodule Screens.V2.CandidateGenerator.DupTest do
   alias Screens.Alerts.Alert
   alias Screens.Config.Screen
   alias Screens.Config.V2.{Departures, Header}
-  alias Screens.Config.V2.Departures.{Headway, Section, Query}
+  alias Screens.Config.V2.Departures.{Headway, Query, Section}
   alias Screens.Config.V2.Dup, as: DupConfig
   alias Screens.Predictions.Prediction
   alias Screens.V2.Departure

--- a/test/screens/v2/candidate_generator/dup_test.exs
+++ b/test/screens/v2/candidate_generator/dup_test.exs
@@ -560,7 +560,13 @@ defmodule Screens.V2.CandidateGenerator.DupTest do
       now = ~U[2020-04-06T10:00:00Z]
 
       fetch_alerts_or_empty_list_fn = fn
-        [direction_id: :both, route_ids: [], route_type: nil, stop_ids: ["stop B"]] ->
+        [
+          direction_id: :both,
+          route_ids: [],
+          route_type: nil,
+          route_types: [:light_rail, :subway],
+          stop_ids: ["stop B"]
+        ] ->
           [
             struct(Alert,
               effect: :suspension,

--- a/test/screens/v2/candidate_generator/dup_test.exs
+++ b/test/screens/v2/candidate_generator/dup_test.exs
@@ -18,14 +18,14 @@ defmodule Screens.V2.CandidateGenerator.DupTest do
         header: %Header.CurrentStopId{stop_id: "place-gover"},
         primary_departures: %Departures{
           sections: [
-            %Section{query: %Query{params: %Query.Params{stop_ids: ["stop A"]}}, filter: nil},
-            %Section{query: %Query{params: %Query.Params{stop_ids: ["stop B"]}}, filter: nil}
+            %Section{query: %Query{params: %Query.Params{stop_ids: ["place-A"]}}, filter: nil},
+            %Section{query: %Query{params: %Query.Params{stop_ids: ["place-B"]}}, filter: nil}
           ]
         },
         secondary_departures: %Departures{
           sections: [
-            %Section{query: %Query{params: %Query.Params{stop_ids: ["stop C"]}}, filter: nil},
-            %Section{query: %Query{params: %Query.Params{stop_ids: ["stop D"]}}, filter: nil}
+            %Section{query: %Query{params: %Query.Params{stop_ids: ["place-C"]}}, filter: nil},
+            %Section{query: %Query{params: %Query.Params{stop_ids: ["place-D"]}}, filter: nil}
           ]
         }
       },
@@ -40,8 +40,8 @@ defmodule Screens.V2.CandidateGenerator.DupTest do
         header: %Header.CurrentStopId{stop_id: "place-gover"},
         primary_departures: %Departures{
           sections: [
-            %Section{query: %Query{params: %Query.Params{stop_ids: ["stop A"]}}, filter: nil},
-            %Section{query: %Query{params: %Query.Params{stop_ids: ["stop B"]}}, filter: nil}
+            %Section{query: %Query{params: %Query.Params{stop_ids: ["place-A"]}}, filter: nil},
+            %Section{query: %Query{params: %Query.Params{stop_ids: ["place-B"]}}, filter: nil}
           ]
         },
         secondary_departures: %Departures{sections: []}
@@ -58,7 +58,7 @@ defmodule Screens.V2.CandidateGenerator.DupTest do
         primary_departures: %Departures{
           sections: [
             %Section{
-              query: %Query{params: %Query.Params{stop_ids: ["stop B"], route_ids: ["Red"]}},
+              query: %Query{params: %Query.Params{stop_ids: ["place-B"]}},
               filter: nil,
               headway: %Headway{headway_id: "red_trunk"}
             }
@@ -73,10 +73,10 @@ defmodule Screens.V2.CandidateGenerator.DupTest do
     }
 
     fetch_section_departures_fn = fn
-      %Section{query: %Query{params: %Query.Params{stop_ids: ["stop A"]}}} ->
+      %Section{query: %Query{params: %Query.Params{stop_ids: ["place-A"]}}} ->
         {:ok, [%Departure{prediction: %Prediction{id: "A"}}]}
 
-      %Section{query: %Query{params: %Query.Params{stop_ids: ["stop B"]}}} ->
+      %Section{query: %Query{params: %Query.Params{stop_ids: ["place-B"]}}} ->
         {:ok,
          [
            %Departure{prediction: %Prediction{id: "B1"}},
@@ -86,10 +86,10 @@ defmodule Screens.V2.CandidateGenerator.DupTest do
            %Departure{prediction: %Prediction{id: "B5"}}
          ]}
 
-      %Section{query: %Query{params: %Query.Params{stop_ids: ["stop C"]}}} ->
+      %Section{query: %Query{params: %Query.Params{stop_ids: ["place-C"]}}} ->
         {:ok, [%Departure{prediction: %Prediction{id: "C"}}]}
 
-      %Section{query: %Query{params: %Query.Params{stop_ids: ["stop D"]}}} ->
+      %Section{query: %Query{params: %Query.Params{stop_ids: ["place-D"]}}} ->
         {:ok, [%Departure{prediction: %Prediction{id: "D"}}]}
     end
 
@@ -161,10 +161,10 @@ defmodule Screens.V2.CandidateGenerator.DupTest do
       fetch_stop_fn = fn "place-gover" -> "Government Center" end
 
       fetch_section_departures_fn = fn
-        %Section{query: %Query{params: %Query.Params{stop_ids: ["stop A"]}}} -> {:ok, []}
-        %Section{query: %Query{params: %Query.Params{stop_ids: ["stop B"]}}} -> {:ok, []}
-        %Section{query: %Query{params: %Query.Params{stop_ids: ["stop C"]}}} -> {:ok, []}
-        %Section{query: %Query{params: %Query.Params{stop_ids: ["stop D"]}}} -> {:ok, []}
+        %Section{query: %Query{params: %Query.Params{stop_ids: ["place-A"]}}} -> {:ok, []}
+        %Section{query: %Query{params: %Query.Params{stop_ids: ["place-B"]}}} -> {:ok, []}
+        %Section{query: %Query{params: %Query.Params{stop_ids: ["place-C"]}}} -> {:ok, []}
+        %Section{query: %Query{params: %Query.Params{stop_ids: ["place-D"]}}} -> {:ok, []}
       end
 
       expected_headers =
@@ -562,13 +562,16 @@ defmodule Screens.V2.CandidateGenerator.DupTest do
       fetch_alerts_fn = fn
         [
           direction_id: :both,
-          route_ids: ["Red"],
-          stop_ids: ["stop B"]
+          route_ids: [],
+          stop_ids: ["place-B"]
         ] ->
           [
             struct(Alert,
               effect: :suspension,
-              informed_entities: [%{stop: "stop B"}, %{stop: "stop C"}]
+              informed_entities: [
+                %{stop: "place-B", route: "Red"},
+                %{stop: "place-C", route: "Red"}
+              ]
             )
           ]
       end

--- a/test/screens/v2/candidate_generator/dup_test.exs
+++ b/test/screens/v2/candidate_generator/dup_test.exs
@@ -88,11 +88,18 @@ defmodule Screens.V2.CandidateGenerator.DupTest do
         {:ok, [%Departure{prediction: %Prediction{id: "D"}}]}
     end
 
+    # params = Map.from_struct(struct(Query.Params))
+
+    fetch_alerts_or_empty_list_fn = fn
+      _ -> []
+    end
+
     %{
       config_primary_and_secondary: config_primary_and_secondary,
       config_only_primary: config_only_primary,
       config_one_section: config_one_section,
-      fetch_section_departures_fn: fetch_section_departures_fn
+      fetch_section_departures_fn: fetch_section_departures_fn,
+      fetch_alerts_or_empty_list_fn: fetch_alerts_or_empty_list_fn
     }
   end
 
@@ -144,7 +151,8 @@ defmodule Screens.V2.CandidateGenerator.DupTest do
 
   describe "candidate_instances/4" do
     test "returns expected header and departures", %{
-      config_primary_and_secondary: config
+      config_primary_and_secondary: config,
+      fetch_alerts_or_empty_list_fn: fetch_alerts_or_empty_list_fn
     } do
       now = ~U[2020-04-06T10:00:00Z]
       fetch_stop_fn = fn "place-gover" -> "Government Center" end
@@ -199,7 +207,8 @@ defmodule Screens.V2.CandidateGenerator.DupTest do
           config,
           now,
           fetch_stop_fn,
-          fetch_section_departures_fn
+          fetch_section_departures_fn,
+          fetch_alerts_or_empty_list_fn
         )
 
       assert Enum.all?(expected_headers, &Enum.member?(actual_instances, &1))
@@ -232,11 +241,14 @@ defmodule Screens.V2.CandidateGenerator.DupTest do
     end
   end
 
-  describe "departures_instances/2" do
+  describe "departures_instances/4" do
     test "returns primary and secondary departures", %{
       config_primary_and_secondary: config,
-      fetch_section_departures_fn: fetch_section_departures_fn
+      fetch_section_departures_fn: fetch_section_departures_fn,
+      fetch_alerts_or_empty_list_fn: fetch_alerts_or_empty_list_fn
     } do
+      now = ~U[2020-04-06T10:00:00Z]
+
       expected_departures = [
         %DeparturesWidget{
           screen: config,
@@ -323,7 +335,9 @@ defmodule Screens.V2.CandidateGenerator.DupTest do
       actual_instances =
         Dup.departures_instances(
           config,
-          fetch_section_departures_fn
+          now,
+          fetch_section_departures_fn,
+          fetch_alerts_or_empty_list_fn
         )
 
       assert Enum.all?(expected_departures, &Enum.member?(actual_instances, &1))
@@ -331,8 +345,11 @@ defmodule Screens.V2.CandidateGenerator.DupTest do
 
     test "returns only primary departures if secondary is missing", %{
       config_only_primary: config,
-      fetch_section_departures_fn: fetch_section_departures_fn
+      fetch_section_departures_fn: fetch_section_departures_fn,
+      fetch_alerts_or_empty_list_fn: fetch_alerts_or_empty_list_fn
     } do
+      now = ~U[2020-04-06T10:00:00Z]
+
       expected_departures = [
         %DeparturesWidget{
           screen: config,
@@ -423,7 +440,9 @@ defmodule Screens.V2.CandidateGenerator.DupTest do
       actual_instances =
         Dup.departures_instances(
           config,
-          fetch_section_departures_fn
+          now,
+          fetch_section_departures_fn,
+          fetch_alerts_or_empty_list_fn
         )
 
       assert Enum.all?(expected_departures, &Enum.member?(actual_instances, &1))
@@ -431,8 +450,11 @@ defmodule Screens.V2.CandidateGenerator.DupTest do
 
     test "returns 4 departures if only one section", %{
       config_one_section: config,
-      fetch_section_departures_fn: fetch_section_departures_fn
+      fetch_section_departures_fn: fetch_section_departures_fn,
+      fetch_alerts_or_empty_list_fn: fetch_alerts_or_empty_list_fn
     } do
+      now = ~U[2020-04-06T10:00:00Z]
+
       expected_departures = [
         %DeparturesWidget{
           screen: config,
@@ -520,7 +542,9 @@ defmodule Screens.V2.CandidateGenerator.DupTest do
       actual_instances =
         Dup.departures_instances(
           config,
-          fetch_section_departures_fn
+          now,
+          fetch_section_departures_fn,
+          fetch_alerts_or_empty_list_fn
         )
 
       assert Enum.all?(expected_departures, &Enum.member?(actual_instances, &1))

--- a/test/screens/v2/candidate_generator/dup_test.exs
+++ b/test/screens/v2/candidate_generator/dup_test.exs
@@ -563,7 +563,6 @@ defmodule Screens.V2.CandidateGenerator.DupTest do
         [
           direction_id: :both,
           route_ids: [],
-          route_type: nil,
           route_types: [:light_rail, :subway],
           stop_ids: ["stop B"]
         ] ->

--- a/test/screens/v2/candidate_generator/dup_test.exs
+++ b/test/screens/v2/candidate_generator/dup_test.exs
@@ -1,33 +1,18 @@
 defmodule Screens.V2.CandidateGenerator.DupTest do
   use ExUnit.Case, async: true
 
-  alias Screens.Alerts.Alert
   alias Screens.Config.Screen
   alias Screens.Config.V2.{Departures, Header}
-  alias Screens.Config.V2.Departures.{Headway, Query, Section}
   alias Screens.Config.V2.Dup, as: DupConfig
-  alias Screens.Predictions.Prediction
-  alias Screens.V2.Departure
   alias Screens.V2.CandidateGenerator.Dup
-  alias Screens.V2.WidgetInstance.Departures, as: DeparturesWidget
   alias Screens.V2.WidgetInstance.NormalHeader
 
   setup do
-    config_primary_and_secondary = %Screen{
+    config = %Screen{
       app_params: %DupConfig{
         header: %Header.CurrentStopId{stop_id: "place-gover"},
-        primary_departures: %Departures{
-          sections: [
-            %Section{query: %Query{params: %Query.Params{stop_ids: ["place-A"]}}, filter: nil},
-            %Section{query: %Query{params: %Query.Params{stop_ids: ["place-B"]}}, filter: nil}
-          ]
-        },
-        secondary_departures: %Departures{
-          sections: [
-            %Section{query: %Query{params: %Query.Params{stop_ids: ["place-C"]}}, filter: nil},
-            %Section{query: %Query{params: %Query.Params{stop_ids: ["place-D"]}}, filter: nil}
-          ]
-        }
+        primary_departures: struct(Departures),
+        secondary_departures: struct(Departures)
       },
       vendor: :outfront,
       device_id: "TEST",
@@ -35,75 +20,7 @@ defmodule Screens.V2.CandidateGenerator.DupTest do
       app_id: :dup_v2
     }
 
-    config_only_primary = %Screen{
-      app_params: %DupConfig{
-        header: %Header.CurrentStopId{stop_id: "place-gover"},
-        primary_departures: %Departures{
-          sections: [
-            %Section{query: %Query{params: %Query.Params{stop_ids: ["place-A"]}}, filter: nil},
-            %Section{query: %Query{params: %Query.Params{stop_ids: ["place-B"]}}, filter: nil}
-          ]
-        },
-        secondary_departures: %Departures{sections: []}
-      },
-      vendor: :outfront,
-      device_id: "TEST",
-      name: "TEST",
-      app_id: :dup_v2
-    }
-
-    config_one_section = %Screen{
-      app_params: %DupConfig{
-        header: %Header.CurrentStopId{stop_id: "place-gover"},
-        primary_departures: %Departures{
-          sections: [
-            %Section{
-              query: %Query{params: %Query.Params{stop_ids: ["place-B"]}},
-              filter: nil,
-              headway: %Headway{headway_id: "red_trunk"}
-            }
-          ]
-        },
-        secondary_departures: %Departures{sections: []}
-      },
-      vendor: :outfront,
-      device_id: "TEST",
-      name: "TEST",
-      app_id: :dup_v2
-    }
-
-    fetch_section_departures_fn = fn
-      %Section{query: %Query{params: %Query.Params{stop_ids: ["place-A"]}}} ->
-        {:ok, [%Departure{prediction: %Prediction{id: "A"}}]}
-
-      %Section{query: %Query{params: %Query.Params{stop_ids: ["place-B"]}}} ->
-        {:ok,
-         [
-           %Departure{prediction: %Prediction{id: "B1"}},
-           %Departure{prediction: %Prediction{id: "B2"}},
-           %Departure{prediction: %Prediction{id: "B3"}},
-           %Departure{prediction: %Prediction{id: "B4"}},
-           %Departure{prediction: %Prediction{id: "B5"}}
-         ]}
-
-      %Section{query: %Query{params: %Query.Params{stop_ids: ["place-C"]}}} ->
-        {:ok, [%Departure{prediction: %Prediction{id: "C"}}]}
-
-      %Section{query: %Query{params: %Query.Params{stop_ids: ["place-D"]}}} ->
-        {:ok, [%Departure{prediction: %Prediction{id: "D"}}]}
-    end
-
-    fetch_alerts_fn = fn
-      _ -> []
-    end
-
-    %{
-      config_primary_and_secondary: config_primary_and_secondary,
-      config_only_primary: config_only_primary,
-      config_one_section: config_one_section,
-      fetch_section_departures_fn: fetch_section_departures_fn,
-      fetch_alerts_fn: fetch_alerts_fn
-    }
+    %{config: config}
   end
 
   describe "screen_template/0" do
@@ -153,19 +70,11 @@ defmodule Screens.V2.CandidateGenerator.DupTest do
   end
 
   describe "candidate_instances/4" do
-    test "returns expected header and departures", %{
-      config_primary_and_secondary: config,
-      fetch_alerts_fn: fetch_alerts_fn
-    } do
+    test "returns expected header", %{config: config} do
       now = ~U[2020-04-06T10:00:00Z]
       fetch_stop_fn = fn "place-gover" -> "Government Center" end
-
-      fetch_section_departures_fn = fn
-        %Section{query: %Query{params: %Query.Params{stop_ids: ["place-A"]}}} -> {:ok, []}
-        %Section{query: %Query{params: %Query.Params{stop_ids: ["place-B"]}}} -> {:ok, []}
-        %Section{query: %Query{params: %Query.Params{stop_ids: ["place-C"]}}} -> {:ok, []}
-        %Section{query: %Query{params: %Query.Params{stop_ids: ["place-D"]}}} -> {:ok, []}
-      end
+      departures_instances_fn = fn _, _ -> [] end
+      evergreen_content_instances_fn = fn _ -> [] end
 
       expected_headers =
         List.duplicate(
@@ -178,49 +87,21 @@ defmodule Screens.V2.CandidateGenerator.DupTest do
           3
         )
 
-      expected_departures = [
-        %DeparturesWidget{
-          screen: config,
-          section_data: [
-            %{type: :normal_section, rows: []},
-            %{type: :normal_section, rows: []}
-          ],
-          slot_names: [:main_content_zero]
-        },
-        %DeparturesWidget{
-          screen: config,
-          section_data: [
-            %{type: :normal_section, rows: []},
-            %{type: :normal_section, rows: []}
-          ],
-          slot_names: [:main_content_one]
-        },
-        %DeparturesWidget{
-          screen: config,
-          section_data: [
-            %{type: :normal_section, rows: []},
-            %{type: :normal_section, rows: []}
-          ],
-          slot_names: [:main_content_two]
-        }
-      ]
-
       actual_instances =
         Dup.candidate_instances(
           config,
           now,
           fetch_stop_fn,
-          fetch_section_departures_fn,
-          fetch_alerts_fn
+          evergreen_content_instances_fn,
+          departures_instances_fn
         )
 
       assert Enum.all?(expected_headers, &Enum.member?(actual_instances, &1))
-      assert Enum.all?(expected_departures, &Enum.member?(actual_instances, &1))
     end
   end
 
   describe "header_instances/3" do
-    test "returns expected header", %{config_primary_and_secondary: config} do
+    test "returns expected header", %{config: config} do
       now = ~U[2020-04-06T10:00:00Z]
       fetch_stop_name_fn = fn _ -> "Test Stop" end
 
@@ -241,389 +122,6 @@ defmodule Screens.V2.CandidateGenerator.DupTest do
         )
 
       Enum.all?(expected_headers, &Enum.member?(actual_instances, &1))
-    end
-  end
-
-  describe "departures_instances/4" do
-    test "returns primary and secondary departures", %{
-      config_primary_and_secondary: config,
-      fetch_section_departures_fn: fetch_section_departures_fn,
-      fetch_alerts_fn: fetch_alerts_fn
-    } do
-      now = ~U[2020-04-06T10:00:00Z]
-
-      expected_departures = [
-        %DeparturesWidget{
-          screen: config,
-          section_data: [
-            %{
-              type: :normal_section,
-              rows: [
-                %Screens.V2.Departure{
-                  prediction: struct(Prediction, id: "A"),
-                  schedule: nil
-                }
-              ]
-            },
-            %{
-              type: :normal_section,
-              rows: [
-                %Screens.V2.Departure{
-                  prediction: struct(Prediction, id: "B1"),
-                  schedule: nil
-                },
-                %Screens.V2.Departure{
-                  prediction: struct(Prediction, id: "B2"),
-                  schedule: nil
-                }
-              ]
-            }
-          ],
-          slot_names: [:main_content_zero]
-        },
-        %DeparturesWidget{
-          screen: config,
-          section_data: [
-            %{
-              type: :normal_section,
-              rows: [
-                %Screens.V2.Departure{
-                  prediction: struct(Prediction, id: "A"),
-                  schedule: nil
-                }
-              ]
-            },
-            %{
-              type: :normal_section,
-              rows: [
-                %Screens.V2.Departure{
-                  prediction: struct(Prediction, id: "B1"),
-                  schedule: nil
-                },
-                %Screens.V2.Departure{
-                  prediction: struct(Prediction, id: "B2"),
-                  schedule: nil
-                }
-              ]
-            }
-          ],
-          slot_names: [:main_content_one]
-        },
-        %DeparturesWidget{
-          screen: config,
-          section_data: [
-            %{
-              type: :normal_section,
-              rows: [
-                %Screens.V2.Departure{
-                  prediction: struct(Prediction, id: "C"),
-                  schedule: nil
-                }
-              ]
-            },
-            %{
-              type: :normal_section,
-              rows: [
-                %Screens.V2.Departure{
-                  prediction: struct(Prediction, id: "D"),
-                  schedule: nil
-                }
-              ]
-            }
-          ],
-          slot_names: [:main_content_two]
-        }
-      ]
-
-      actual_instances =
-        Dup.departures_instances(
-          config,
-          now,
-          fetch_section_departures_fn,
-          fetch_alerts_fn
-        )
-
-      assert Enum.all?(expected_departures, &Enum.member?(actual_instances, &1))
-    end
-
-    test "returns only primary departures if secondary is missing", %{
-      config_only_primary: config,
-      fetch_section_departures_fn: fetch_section_departures_fn,
-      fetch_alerts_fn: fetch_alerts_fn
-    } do
-      now = ~U[2020-04-06T10:00:00Z]
-
-      expected_departures = [
-        %DeparturesWidget{
-          screen: config,
-          section_data: [
-            %{
-              type: :normal_section,
-              rows: [
-                %Screens.V2.Departure{
-                  prediction: struct(Prediction, id: "A"),
-                  schedule: nil
-                }
-              ]
-            },
-            %{
-              type: :normal_section,
-              rows: [
-                %Screens.V2.Departure{
-                  prediction: struct(Prediction, id: "B1"),
-                  schedule: nil
-                },
-                %Screens.V2.Departure{
-                  prediction: struct(Prediction, id: "B2"),
-                  schedule: nil
-                }
-              ]
-            }
-          ],
-          slot_names: [:main_content_zero]
-        },
-        %DeparturesWidget{
-          screen: config,
-          section_data: [
-            %{
-              type: :normal_section,
-              rows: [
-                %Screens.V2.Departure{
-                  prediction: struct(Prediction, id: "A"),
-                  schedule: nil
-                }
-              ]
-            },
-            %{
-              type: :normal_section,
-              rows: [
-                %Screens.V2.Departure{
-                  prediction: struct(Prediction, id: "B1"),
-                  schedule: nil
-                },
-                %Screens.V2.Departure{
-                  prediction: struct(Prediction, id: "B2"),
-                  schedule: nil
-                }
-              ]
-            }
-          ],
-          slot_names: [:main_content_one]
-        },
-        %DeparturesWidget{
-          screen: config,
-          section_data: [
-            %{
-              type: :normal_section,
-              rows: [
-                %Screens.V2.Departure{
-                  prediction: struct(Prediction, id: "A"),
-                  schedule: nil
-                }
-              ]
-            },
-            %{
-              type: :normal_section,
-              rows: [
-                %Screens.V2.Departure{
-                  prediction: struct(Prediction, id: "B1"),
-                  schedule: nil
-                },
-                %Screens.V2.Departure{
-                  prediction: struct(Prediction, id: "B2"),
-                  schedule: nil
-                }
-              ]
-            }
-          ],
-          slot_names: [:main_content_two]
-        }
-      ]
-
-      actual_instances =
-        Dup.departures_instances(
-          config,
-          now,
-          fetch_section_departures_fn,
-          fetch_alerts_fn
-        )
-
-      assert Enum.all?(expected_departures, &Enum.member?(actual_instances, &1))
-    end
-
-    test "returns 4 departures if only one section", %{
-      config_one_section: config,
-      fetch_section_departures_fn: fetch_section_departures_fn,
-      fetch_alerts_fn: fetch_alerts_fn
-    } do
-      now = ~U[2020-04-06T10:00:00Z]
-
-      expected_departures = [
-        %DeparturesWidget{
-          screen: config,
-          section_data: [
-            %{
-              type: :normal_section,
-              rows: [
-                %Screens.V2.Departure{
-                  prediction: struct(Prediction, id: "B1"),
-                  schedule: nil
-                },
-                %Screens.V2.Departure{
-                  prediction: struct(Prediction, id: "B2"),
-                  schedule: nil
-                },
-                %Screens.V2.Departure{
-                  prediction: struct(Prediction, id: "B3"),
-                  schedule: nil
-                },
-                %Screens.V2.Departure{
-                  prediction: struct(Prediction, id: "B4"),
-                  schedule: nil
-                }
-              ]
-            }
-          ],
-          slot_names: [:main_content_zero]
-        },
-        %DeparturesWidget{
-          screen: config,
-          section_data: [
-            %{
-              type: :normal_section,
-              rows: [
-                %Screens.V2.Departure{
-                  prediction: struct(Prediction, id: "B1"),
-                  schedule: nil
-                },
-                %Screens.V2.Departure{
-                  prediction: struct(Prediction, id: "B2"),
-                  schedule: nil
-                },
-                %Screens.V2.Departure{
-                  prediction: struct(Prediction, id: "B3"),
-                  schedule: nil
-                },
-                %Screens.V2.Departure{
-                  prediction: struct(Prediction, id: "B4"),
-                  schedule: nil
-                }
-              ]
-            }
-          ],
-          slot_names: [:main_content_one]
-        },
-        %DeparturesWidget{
-          screen: config,
-          section_data: [
-            %{
-              type: :normal_section,
-              rows: [
-                %Screens.V2.Departure{
-                  prediction: struct(Prediction, id: "B1"),
-                  schedule: nil
-                },
-                %Screens.V2.Departure{
-                  prediction: struct(Prediction, id: "B2"),
-                  schedule: nil
-                },
-                %Screens.V2.Departure{
-                  prediction: struct(Prediction, id: "B3"),
-                  schedule: nil
-                },
-                %Screens.V2.Departure{
-                  prediction: struct(Prediction, id: "B4"),
-                  schedule: nil
-                }
-              ]
-            }
-          ],
-          slot_names: [:main_content_two]
-        }
-      ]
-
-      actual_instances =
-        Dup.departures_instances(
-          config,
-          now,
-          fetch_section_departures_fn,
-          fetch_alerts_fn
-        )
-
-      assert Enum.all?(expected_departures, &Enum.member?(actual_instances, &1))
-    end
-
-    test "returns headway sections for temporary terminal", %{
-      config_one_section: config,
-      fetch_section_departures_fn: fetch_section_departures_fn
-    } do
-      now = ~U[2020-04-06T10:00:00Z]
-
-      fetch_alerts_fn = fn
-        [
-          direction_id: :both,
-          route_ids: [],
-          stop_ids: ["place-B"]
-        ] ->
-          [
-            struct(Alert,
-              effect: :suspension,
-              informed_entities: [
-                %{stop: "place-B", route: "Red"},
-                %{stop: "place-C", route: "Red"}
-              ]
-            )
-          ]
-      end
-
-      expected_departures = [
-        %DeparturesWidget{
-          screen: config,
-          section_data: [
-            %{
-              type: :headway_section,
-              pill: :red,
-              time_range: {12, 16},
-              headsign: "Test"
-            }
-          ],
-          slot_names: [:main_content_zero]
-        },
-        %DeparturesWidget{
-          screen: config,
-          section_data: [
-            %{
-              type: :headway_section,
-              pill: :red,
-              time_range: {12, 16},
-              headsign: "Test"
-            }
-          ],
-          slot_names: [:main_content_one]
-        },
-        %DeparturesWidget{
-          screen: config,
-          section_data: [
-            %{
-              type: :headway_section,
-              pill: :red,
-              time_range: {12, 16},
-              headsign: "Test"
-            }
-          ],
-          slot_names: [:main_content_two]
-        }
-      ]
-
-      actual_instances =
-        Dup.departures_instances(
-          config,
-          now,
-          fetch_section_departures_fn,
-          fetch_alerts_fn
-        )
-
-      assert Enum.all?(expected_departures, &Enum.member?(actual_instances, &1))
     end
   end
 end

--- a/test/screens/v2/widget_instance/departures_test.exs
+++ b/test/screens/v2/widget_instance/departures_test.exs
@@ -79,9 +79,8 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
         icon: "subway-negative-black",
         text: [
           %{color: :red, text: "Red Line"},
-          "Test trains",
           %{special: :break},
-          "every",
+          "Test trains every",
           %{format: :bold, text: "1-2"},
           "minutes"
         ]

--- a/test/screens/v2/widget_instance/departures_test.exs
+++ b/test/screens/v2/widget_instance/departures_test.exs
@@ -20,7 +20,7 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
     end
   end
 
-  describe "serialize_section/1" do
+  describe "serialize_section/2" do
     setup do
       %{
         bus_shelter_screen: %Screen{

--- a/test/screens/v2/widget_instance/departures_test.exs
+++ b/test/screens/v2/widget_instance/departures_test.exs
@@ -57,6 +57,55 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
     end
   end
 
+  describe "serialize_section/3" do
+    setup do
+      %{
+        dup_screen: %Screen{
+          app_id: :dup_v2,
+          vendor: :outfront,
+          device_id: "TEST",
+          name: "TEST",
+          app_params: nil
+        }
+      }
+    end
+
+    test "returns serialized headway_section for one configured section", %{
+      dup_screen: dup_screen
+    } do
+      section = %{type: :headway_section, pill: :red, time_range: {1, 2}, headsign: "Test"}
+
+      expected_text = %{
+        icon: "subway-negative-black",
+        text: [
+          %{color: :red, text: "Red Line"},
+          "Test trains",
+          %{special: :break},
+          "every",
+          %{format: :bold, text: "1-2"},
+          "minutes"
+        ]
+      }
+
+      assert %{type: :headway_section, text: expected_text} ==
+               Departures.serialize_section(section, dup_screen, true)
+    end
+
+    test "returns serialized headway_section for multiple configured sections", %{
+      dup_screen: dup_screen
+    } do
+      section = %{type: :headway_section, pill: :red, time_range: {1, 2}, headsign: "Test"}
+
+      expected_text = %{
+        icon: :red,
+        text: ["every", %{format: :bold, text: "1-2"}, "minutes"]
+      }
+
+      assert %{type: :headway_section, text: expected_text} ==
+               Departures.serialize_section(section, dup_screen, false)
+    end
+  end
+
   describe "group_consecutive_departures/2" do
     setup do
       %{


### PR DESCRIPTION
**Asana task**: [[DUP v2] Add headway mode to departures](https://app.asana.com/0/1185117109217413/1203876538101493/f)

This is part 1 to the task above. Only backend is implemented here. This includes test. Two important config values needed here are in the `headway` map of each `section`. One is `headway_id`. This maps to the headway values in `signs_ui_config.json`. The other is `pill`. This is a new value and is used to determine what route pill to show in the headway message. 

As usual, feel free to reach out if you need help testing.

- [x] Tests added?
