### PR TITLE
Updated DUP simulation for v2

### DIFF
--- a/assets/css/dup_v2.scss
+++ b/assets/css/dup_v2.scss
@@ -22,11 +22,12 @@
 @import "v2/dup/departures/alerts";
 @import "v2/dup/departures/route_pill";
 
-@import "v2/dup/alert/partial_alert.scss";
-@import "v2/dup/alert/full_screen_alert.scss";
-@import "v2/dup/alert/free_text.scss";
+@import "v2/dup/alert/partial_alert";
+@import "v2/dup/alert/full_screen_alert";
+@import "v2/dup/alert/free_text";
 
 @import "v2/multi_screen_page";
+@import "v2/dup/simulation";
 
 body {
   margin: 0px;

--- a/assets/css/v2/dup/simulation.scss
+++ b/assets/css/v2/dup/simulation.scss
@@ -1,0 +1,53 @@
+.simulation-screen-centering-container {
+  display: flex;
+  justify-content: center;
+  background: #3d5366;
+}
+
+.simulation-screen-scrolling-container {
+  scrollbar-color: #607180 #2E3F4D;
+
+  &::-webkit-scrollbar {
+    width: 12px;
+  }
+  &::-webkit-scrollbar-thumb {
+    background-color: #607180;
+    border-radius: 12px;
+    border: 2px solid #2E3F4D;
+  }
+  &::-webkit-scrollbar-track {
+    -webkit-box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.3);
+    border-radius: 12px;
+    background-color: #2E3F4D;
+  }
+}
+
+.simulation-screen-scrolling-container {
+  overflow-x: auto;
+  padding-bottom: 20px;
+
+  .screen-normal {
+    height: unset;
+    width: unset;
+  }
+
+  .projection {
+    display: grid;
+    grid-template-columns: 280px 280px 280px;
+    background: #2e3f4d;
+    border: 8px solid #2e3f4d;
+    border-radius: 8px;
+    width: 816px;
+    height: 144px;
+    overflow: hidden;
+    .widget-slot {
+      position: initial;
+    }
+
+    & > * {
+      transform-origin: top left;
+      transform: scale(13.33%);
+      margin-right: 24px;
+    }
+  }
+}

--- a/assets/src/apps/v2/dup.tsx
+++ b/assets/src/apps/v2/dup.tsx
@@ -11,7 +11,7 @@ import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
 import ScreenPage from "Components/v2/screen_page";
 import { MappingContext } from "Components/v2/widget";
 
-import NormalScreen from "Components/v2/dup/normal_screen";
+import NormalScreen, { NormalSimulation } from "Components/v2/dup/normal_screen";
 import Placeholder from "Components/v2/placeholder";
 import NormalHeader from "Components/v2/dup/normal_header";
 import NormalDepartures from "Components/v2/dup/departures/normal_departures";
@@ -25,9 +25,12 @@ import SplitBody from "Components/v2/dup/split_body";
 import { splitRotationFromPropNames } from "Components/v2/dup/dup_rotation_wrapper";
 import PartialAlert from "Components/v2/dup/partial_alert";
 import TakeoverAlert from "Components/v2/dup/takeover_alert";
+import SimulationScreenPage from "Components/v2/simulation_screen_page";
+import { LOADING_LAYOUT, ResponseMapper, ResponseMapperContext } from "Components/v2/screen_container";
 
 const TYPE_TO_COMPONENT = {
   screen_normal: NormalScreen,
+  simulation_screen_normal: NormalSimulation,
   rotation_normal_zero: splitRotationFromPropNames(RotationNormal, "zero"),
   rotation_normal_one: splitRotationFromPropNames(RotationNormal, "one"),
   rotation_normal_two: splitRotationFromPropNames(RotationNormal, "two"),
@@ -48,6 +51,30 @@ const TYPE_TO_COMPONENT = {
   takeover_alert: TakeoverAlert,
 };
 
+const DISABLED_LAYOUT = {
+  full_screen: {
+    type: "no_data",
+    show_alternatives: true,
+  },
+  type: "screen_takeover",
+};
+
+const FAILURE_LAYOUT = DISABLED_LAYOUT;
+
+const responseMapper: ResponseMapper = (apiResponse) => {
+  switch (apiResponse.state) {
+    case "success":
+    case "simulation_success":
+      return apiResponse.data;
+    case "disabled":
+      return DISABLED_LAYOUT;
+    case "failure":
+      return FAILURE_LAYOUT;
+    case "loading":
+      return LOADING_LAYOUT;
+  }
+};
+
 const App = (): JSX.Element => {
   return (
     <Router>
@@ -55,11 +82,20 @@ const App = (): JSX.Element => {
         <Route exact path="/v2/screen/dup_v2">
           <MultiScreenPage components={TYPE_TO_COMPONENT} />
         </Route>
+        <Route exact path="/v2/screen/:id/simulation">
+          <MappingContext.Provider value={TYPE_TO_COMPONENT}>
+            <ResponseMapperContext.Provider value={responseMapper}>
+              <SimulationScreenPage opts={{alternateView: true}} />
+            </ResponseMapperContext.Provider>
+          </MappingContext.Provider>
+        </Route>
         <Route path="/v2/screen/:id">
           <MappingContext.Provider value={TYPE_TO_COMPONENT}>
-            <Viewport>
-              <ScreenPage />
-            </Viewport>
+            <ResponseMapperContext.Provider value={responseMapper}>
+              <Viewport>
+                <ScreenPage />
+              </Viewport>
+            </ResponseMapperContext.Provider>
           </MappingContext.Provider>
         </Route>
       </Switch>

--- a/assets/src/components/v2/dup/normal_screen.tsx
+++ b/assets/src/components/v2/dup/normal_screen.tsx
@@ -22,4 +22,21 @@ const NormalScreen: React.ComponentType<Props> = ({
   );
 };
 
+export const NormalSimulation: React.ComponentType<Props> = ({
+  rotation_zero: rotationZero,
+  rotation_one: rotationOne,
+  rotation_two: rotationTwo,
+}) => {
+  return (
+    <div className="screen-normal">
+      <div className="projection">
+        <Widget data={rotationZero} />
+        <Widget data={rotationOne} />
+        <Widget data={rotationTwo} />
+      </div>
+      
+    </div>
+  );
+};
+
 export default NormalScreen;

--- a/assets/src/components/v2/simulation_screen_container.tsx
+++ b/assets/src/components/v2/simulation_screen_container.tsx
@@ -11,7 +11,7 @@ import {
 
 interface SimulationScreenLayoutProps {
   apiResponse: ApiResponse;
-  opts: {[key: string]: any}
+  opts: { [key: string]: any };
 }
 
 const SimulationScreenLayout: ComponentType<SimulationScreenLayoutProps> = ({
@@ -21,17 +21,19 @@ const SimulationScreenLayout: ComponentType<SimulationScreenLayoutProps> = ({
   const responseMapper = useContext(ResponseMapperContext);
   const data = responseMapper(apiResponse);
   const { fullPage, flexZone } = data;
-  
-  // If "alternatePage" was provided as an option, we use the simulation version of screen normal
+
+  // If "alternateView" was provided as an option, we use the simulation version of screen normal
   // Currently only applies to DUPs
-  const alternatePage = {...fullPage, type: "simulation_screen_normal"}   
+  const widgetData = opts.alternateView
+    ? { ...fullPage, type: "simulation_screen_normal" }
+    : { fullPage };
 
   return (
     <div className="simulation-screen-centering-container">
       <div className="simulation-screen-scrolling-container">
         {apiResponse && (
           <div className="simulation__full-page">
-            { opts.alternateView ? <Widget data={alternatePage} /> : <Widget data={fullPage ?? data} /> }
+            <Widget data={widgetData} />
           </div>
         )}
         {flexZone?.length > 0 && (
@@ -53,7 +55,13 @@ const SimulationScreenLayout: ComponentType<SimulationScreenLayoutProps> = ({
   );
 };
 
-const SimulationScreenContainer = ({ id, opts = {} }: {id: string, opts?: {[key: string]: any}}) => {
+const SimulationScreenContainer = ({
+  id,
+  opts = {},
+}: {
+  id: string;
+  opts?: { [key: string]: any };
+}) => {
   const { apiResponse, lastSuccess } = useSimulationApiResponse({ id });
 
   return (

--- a/assets/src/components/v2/simulation_screen_container.tsx
+++ b/assets/src/components/v2/simulation_screen_container.tsx
@@ -11,21 +11,27 @@ import {
 
 interface SimulationScreenLayoutProps {
   apiResponse: ApiResponse;
+  opts: {[key: string]: any}
 }
 
 const SimulationScreenLayout: ComponentType<SimulationScreenLayoutProps> = ({
   apiResponse,
+  opts,
 }) => {
   const responseMapper = useContext(ResponseMapperContext);
   const data = responseMapper(apiResponse);
   const { fullPage, flexZone } = data;
+  
+  // If "alternatePage" was provided as an option, we use the simulation version of screen normal
+  // Currently only applies to DUPs
+  const alternatePage = {...fullPage, type: "simulation_screen_normal"}   
 
   return (
     <div className="simulation-screen-centering-container">
       <div className="simulation-screen-scrolling-container">
         {apiResponse && (
           <div className="simulation__full-page">
-            <Widget data={fullPage ?? data} />
+            { opts.alternateView ? <Widget data={alternatePage} /> : <Widget data={fullPage ?? data} /> }
           </div>
         )}
         {flexZone?.length > 0 && (
@@ -47,12 +53,12 @@ const SimulationScreenLayout: ComponentType<SimulationScreenLayoutProps> = ({
   );
 };
 
-const SimulationScreenContainer = ({ id }) => {
+const SimulationScreenContainer = ({ id, opts = {} }: {id: string, opts?: {[key: string]: any}}) => {
   const { apiResponse, lastSuccess } = useSimulationApiResponse({ id });
 
   return (
     <LastFetchContext.Provider value={lastSuccess}>
-      <SimulationScreenLayout apiResponse={apiResponse} />
+      <SimulationScreenLayout apiResponse={apiResponse} opts={opts} />
     </LastFetchContext.Provider>
   );
 };

--- a/assets/src/components/v2/simulation_screen_page.tsx
+++ b/assets/src/components/v2/simulation_screen_page.tsx
@@ -2,9 +2,9 @@ import React from "react";
 import { useParams } from "react-router-dom";
 import SimulationScreenContainer from "./simulation_screen_container";
 
-const SimulationScreenPage = () => {
-  const { id } = useParams();
-  return <SimulationScreenContainer id={id} />;
+const SimulationScreenPage = ({opts = {}}) => {
+  const { id } = useParams() as { id: string };
+  return <SimulationScreenContainer id={id} opts={opts} />;
 };
 
 export default SimulationScreenPage;


### PR DESCRIPTION
**Asana task**: [[DUP v2] Make v2 DUP screens show up correctly in Screenplay](https://app.asana.com/0/1185117109217413/1203885464554557)

Adjusted the SimulationPage component to watch for an `alternateView` option, which adjusts the type of the widget from `screen_normal` to `simulation_screen_normal`. Might come in handy with other screens in the future.

This is the main work of the task, and there will be a small Screenplay task to follow.

- [ ] Tests added?
