### PR TITLE
feat: DUP v2 handle unreliable predictions - Backend

### DIFF
--- a/assets/src/components/admin/devops.tsx
+++ b/assets/src/components/admin/devops.tsx
@@ -46,7 +46,7 @@ const Devops = () => {
     { name: "Bus", id: "bus" },
     { name: "Subway", id: "subway" },
     { name: "Light Rail", id: "light_rail" },
-    { name: "Commuter Rail", id: "commuter_rail" },
+    { name: "Commuter Rail", id: "rail" },
   ];
 
   return (

--- a/lib/screens/config/devops.ex
+++ b/lib/screens/config/devops.ex
@@ -1,13 +1,13 @@
 defmodule Screens.Config.Devops do
   @moduledoc false
 
-  @typep mode :: :subway | :light_rail | :commuter_rail | :bus | :ferry
+  @typep mode :: :subway | :light_rail | :rail | :bus | :ferry
 
   @type t :: %__MODULE__{
           disabled_modes: [mode]
         }
 
-  @modes ~w[subway light_rail commuter_rail bus ferry]a
+  @modes ~w[subway light_rail rail bus ferry]a
 
   defstruct disabled_modes: []
 

--- a/lib/screens/solari_screen_data.ex
+++ b/lib/screens/solari_screen_data.ex
@@ -101,7 +101,7 @@ defmodule Screens.SolariScreenData do
 
     subway_section? = pill in ~w[red orange blue]a
 
-    commuter_rail_disabled? = State.mode_disabled?(:commuter_rail)
+    commuter_rail_disabled? = State.mode_disabled?(:rail)
     commuter_rail_section? = pill === :cr
 
     light_rail_disabled? = State.mode_disabled?(:light_rail)

--- a/lib/screens/util.ex
+++ b/lib/screens/util.ex
@@ -3,6 +3,8 @@ defmodule Screens.Util do
 
   alias Screens.Config.State
 
+  @sl_route_ids ~w[741 742 743 746 749 751]
+
   def format_time(t) do
     t |> DateTime.truncate(:second) |> DateTime.to_iso8601()
   end
@@ -179,4 +181,22 @@ defmodule Screens.Util do
   def to_set(id) when is_binary(id), do: MapSet.new([id])
   def to_set(ids) when is_list(ids), do: MapSet.new(ids)
   def to_set(%MapSet{} = already_a_set), do: already_a_set
+
+  def get_color_for_route(route_id, route_type \\ nil)
+
+  def get_color_for_route("Red", _), do: :red
+  def get_color_for_route("Mattapan", _), do: :red
+  def get_color_for_route("Orange", _), do: :orange
+  def get_color_for_route("Green" <> _, _), do: :green
+  def get_color_for_route("Blue", _), do: :blue
+  def get_color_for_route("CR-" <> _, _), do: :purple
+  def get_color_for_route("Boat-" <> _, _), do: :teal
+
+  def get_color_for_route(route_id, _)
+      when route_id in @sl_route_ids,
+      do: :silver
+
+  def get_color_for_route(_, :rail), do: :purple
+  def get_color_for_route(_, :ferry), do: :teal
+  def get_color_for_route(_, _), do: :yellow
 end

--- a/lib/screens/util.ex
+++ b/lib/screens/util.ex
@@ -163,7 +163,7 @@ defmodule Screens.Util do
   def route_type_from_id("Red"), do: :subway
   def route_type_from_id("Orange"), do: :subway
   def route_type_from_id("Blue"), do: :subway
-  def route_type_from_id("CR-" <> _), do: :commuter_rail
+  def route_type_from_id("CR-" <> _), do: :rail
   def route_type_from_id("Boat-" <> _), do: :ferry
   def route_type_from_id(_), do: :bus
 

--- a/lib/screens/v2/candidate_generator/dup/departures.ex
+++ b/lib/screens/v2/candidate_generator/dup/departures.ex
@@ -73,7 +73,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
 
     Enum.map(slot_ids, fn slot_id ->
       if Enum.all?(sections, &(&1.type == :no_data_section)) do
-        %DeparturesNoData{screen: config, slot_names: [slot_id]}
+        %DeparturesNoData{screen: config, slot_name: slot_id}
       else
         %DeparturesWidget{
           screen: config,

--- a/lib/screens/v2/candidate_generator/dup/departures.ex
+++ b/lib/screens/v2/candidate_generator/dup/departures.ex
@@ -73,7 +73,11 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
 
     Enum.map(slot_ids, fn slot_id ->
       if Enum.all?(sections, &(&1.type == :no_data_section)) do
-        %DeparturesNoData{screen: config, slot_name: slot_id}
+        %DeparturesNoData{
+          screen: config,
+          slot_name: slot_id,
+          routes: Enum.map(sections, & &1.route.type)
+        }
       else
         %DeparturesWidget{
           screen: config,

--- a/lib/screens/v2/candidate_generator/dup/departures.ex
+++ b/lib/screens/v2/candidate_generator/dup/departures.ex
@@ -76,7 +76,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
         %DeparturesNoData{
           screen: config,
           slot_name: slot_id,
-          routes: Enum.map(sections, & &1.route.type)
+          route_types: Enum.map(sections, & &1.route.type)
         }
       else
         %DeparturesWidget{

--- a/lib/screens/v2/candidate_generator/dup/departures.ex
+++ b/lib/screens/v2/candidate_generator/dup/departures.ex
@@ -104,7 +104,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
 
     Enum.map(slot_ids, fn slot_id ->
       if Enum.all?(sections, &(&1.type == :no_data_section)) do
-        %DeparturesNoData{screen: config, show_alternatives?: true, slot_names: [slot_id]}
+        %DeparturesNoData{screen: config, slot_names: [slot_id]}
       else
         %DeparturesWidget{
           screen: config,

--- a/lib/screens/v2/widget_instance/departures.ex
+++ b/lib/screens/v2/widget_instance/departures.ex
@@ -81,6 +81,15 @@ defmodule Screens.V2.WidgetInstance.Departures do
     %{type: :notice_section, text: text}
   end
 
+  def serialize_section(%{type: :no_data_section, route: route}, _screen, _) do
+    text = %FreeTextLine{
+      icon: Util.get_color_for_route(route.id),
+      text: ["Updates unavailable"]
+    }
+
+    %{type: :no_data_section, text: FreeTextLine.to_json(text)}
+  end
+
   def serialize_section(
         %{type: :headway_section, pill: pill, time_range: {lo, hi}, headsign: headsign},
         _screen,

--- a/lib/screens/v2/widget_instance/departures.ex
+++ b/lib/screens/v2/widget_instance/departures.ex
@@ -82,8 +82,15 @@ defmodule Screens.V2.WidgetInstance.Departures do
   end
 
   def serialize_section(%{type: :no_data_section, route: route}, _screen, _) do
+    icon =
+      case route do
+        %{type: :rail} -> :cr
+        %{type: :bus} -> :bus
+        %{id: id} -> Util.get_color_for_route(id)
+      end
+
     text = %FreeTextLine{
-      icon: Util.get_color_for_route(route.id),
+      icon: icon,
       text: ["Updates unavailable"]
     }
 

--- a/lib/screens/v2/widget_instance/departures.ex
+++ b/lib/screens/v2/widget_instance/departures.ex
@@ -85,6 +85,7 @@ defmodule Screens.V2.WidgetInstance.Departures do
     icon =
       case route do
         %{type: :rail} -> :cr
+        %{short_name: "SL" <> _} -> :silver
         %{type: :bus} -> :bus
         %{id: id} -> Util.get_color_for_route(id)
       end

--- a/lib/screens/v2/widget_instance/departures.ex
+++ b/lib/screens/v2/widget_instance/departures.ex
@@ -88,6 +88,7 @@ defmodule Screens.V2.WidgetInstance.Departures do
         %{short_name: "SL" <> _} -> :silver
         %{type: :bus} -> :bus
         %{id: id} -> Util.get_color_for_route(id)
+        _ -> ""
       end
 
     text = %FreeTextLine{

--- a/lib/screens/v2/widget_instance/departures_no_data.ex
+++ b/lib/screens/v2/widget_instance/departures_no_data.ex
@@ -4,13 +4,13 @@ defmodule Screens.V2.WidgetInstance.DeparturesNoData do
   alias Screens.Config.Screen
   alias Screens.Config.V2.Alerts
 
-  defstruct screen: nil, show_alternatives?: nil, slot_name: nil, routes: []
+  defstruct screen: nil, show_alternatives?: nil, slot_name: nil, route_types: []
 
   @type t :: %__MODULE__{
           screen: Screens.Config.Screen.t(),
           show_alternatives?: boolean(),
           slot_name: atom(),
-          routes: list(atom())
+          route_types: list(atom())
         }
 
   def priority(_instance), do: [2]
@@ -19,7 +19,7 @@ defmodule Screens.V2.WidgetInstance.DeparturesNoData do
     %{
       show_alternatives: instance.show_alternatives?,
       stop_id: stop_id(instance),
-      routes: instance.routes
+      route_types: instance.route_types
     }
   end
 

--- a/lib/screens/v2/widget_instance/departures_no_data.ex
+++ b/lib/screens/v2/widget_instance/departures_no_data.ex
@@ -4,12 +4,12 @@ defmodule Screens.V2.WidgetInstance.DeparturesNoData do
   alias Screens.Config.Screen
   alias Screens.Config.V2.Alerts
 
-  defstruct screen: nil, show_alternatives?: nil, slot_names: []
+  defstruct screen: nil, show_alternatives?: nil, slot_name: nil
 
   @type t :: %__MODULE__{
           screen: Screens.Config.Screen.t(),
           show_alternatives?: boolean(),
-          slot_names: list(atom())
+          slot_name: atom()
         }
 
   def priority(_instance), do: [2]
@@ -18,8 +18,8 @@ defmodule Screens.V2.WidgetInstance.DeparturesNoData do
     %{show_alternatives: instance.show_alternatives?, stop_id: stop_id(instance)}
   end
 
-  def slot_names(%__MODULE__{slot_names: slot_names}) when length(slot_names) > 0,
-    do: slot_names
+  def slot_names(%__MODULE__{slot_name: slot_name}) when not is_nil(slot_name),
+    do: slot_name
 
   def slot_names(%__MODULE__{screen: %Screen{app_id: :gl_eink_v2}}), do: [:full_main_content]
   def slot_names(_instance), do: [:main_content]

--- a/lib/screens/v2/widget_instance/departures_no_data.ex
+++ b/lib/screens/v2/widget_instance/departures_no_data.ex
@@ -4,18 +4,23 @@ defmodule Screens.V2.WidgetInstance.DeparturesNoData do
   alias Screens.Config.Screen
   alias Screens.Config.V2.Alerts
 
-  defstruct screen: nil, show_alternatives?: nil, slot_name: nil
+  defstruct screen: nil, show_alternatives?: nil, slot_name: nil, routes: []
 
   @type t :: %__MODULE__{
           screen: Screens.Config.Screen.t(),
           show_alternatives?: boolean(),
-          slot_name: atom()
+          slot_name: atom(),
+          routes: list(atom())
         }
 
   def priority(_instance), do: [2]
 
   def serialize(%__MODULE__{} = instance) do
-    %{show_alternatives: instance.show_alternatives?, stop_id: stop_id(instance)}
+    %{
+      show_alternatives: instance.show_alternatives?,
+      stop_id: stop_id(instance),
+      routes: instance.routes
+    }
   end
 
   def slot_names(%__MODULE__{slot_name: slot_name}) when not is_nil(slot_name),

--- a/lib/screens/v2/widget_instance/departures_no_data.ex
+++ b/lib/screens/v2/widget_instance/departures_no_data.ex
@@ -19,7 +19,7 @@ defmodule Screens.V2.WidgetInstance.DeparturesNoData do
   end
 
   def slot_names(%__MODULE__{slot_name: slot_name}) when not is_nil(slot_name),
-    do: slot_name
+    do: [slot_name]
 
   def slot_names(%__MODULE__{screen: %Screen{app_id: :gl_eink_v2}}), do: [:full_main_content]
   def slot_names(_instance), do: [:main_content]

--- a/lib/screens/v2/widget_instance/departures_no_data.ex
+++ b/lib/screens/v2/widget_instance/departures_no_data.ex
@@ -4,11 +4,12 @@ defmodule Screens.V2.WidgetInstance.DeparturesNoData do
   alias Screens.Config.Screen
   alias Screens.Config.V2.Alerts
 
-  defstruct screen: nil, show_alternatives?: nil
+  defstruct screen: nil, show_alternatives?: nil, slot_names: []
 
   @type t :: %__MODULE__{
           screen: Screens.Config.Screen.t(),
-          show_alternatives?: boolean()
+          show_alternatives?: boolean(),
+          slot_names: list(atom())
         }
 
   def priority(_instance), do: [2]
@@ -16,6 +17,9 @@ defmodule Screens.V2.WidgetInstance.DeparturesNoData do
   def serialize(%__MODULE__{} = instance) do
     %{show_alternatives: instance.show_alternatives?, stop_id: stop_id(instance)}
   end
+
+  def slot_names(%__MODULE__{slot_names: slot_names}) when length(slot_names) > 0,
+    do: slot_names
 
   def slot_names(%__MODULE__{screen: %Screen{app_id: :gl_eink_v2}}), do: [:full_main_content]
   def slot_names(_instance), do: [:main_content]
@@ -27,6 +31,8 @@ defmodule Screens.V2.WidgetInstance.DeparturesNoData do
        }) do
     stop_id
   end
+
+  defp stop_id(_), do: nil
 
   defimpl Screens.V2.WidgetInstance do
     alias Screens.V2.WidgetInstance.DeparturesNoData

--- a/lib/screens/v2/widget_instance/serializer/route_pill.ex
+++ b/lib/screens/v2/widget_instance/serializer/route_pill.ex
@@ -3,6 +3,7 @@ defmodule Screens.V2.WidgetInstance.Serializer.RoutePill do
 
   alias Screens.Routes.Route
   alias Screens.RouteType
+  alias Screens.Util
 
   @type t :: text_pill() | icon_pill() | slashed_route_pill()
 
@@ -34,8 +35,6 @@ defmodule Screens.V2.WidgetInstance.Serializer.RoutePill do
   @type icon :: :bus | :light_rail | :rail | :boat
 
   @type color :: :red | :orange | :green | :blue | :purple | :yellow | :teal
-
-  @sl_route_ids ~w[741 742 743 746 749 751]
 
   @cr_line_abbreviations %{
     "Haverhill" => "HVL",
@@ -84,7 +83,7 @@ defmodule Screens.V2.WidgetInstance.Serializer.RoutePill do
           do_serialize(route_id, %{route_name: route_name, gl_branch: true})
       end
 
-    Map.put(route, :color, get_color_for_route(route_id, route_type))
+    Map.put(route, :color, Util.get_color_for_route(route_id, route_type))
   end
 
   @spec serialize_for_audio_departure(Route.id(), String.t(), RouteType.t(), pos_integer() | nil) ::
@@ -130,7 +129,7 @@ defmodule Screens.V2.WidgetInstance.Serializer.RoutePill do
   def serialize_route_for_alert(route_id, gl_long \\ true) do
     route = do_serialize(route_id, %{gl_long: gl_long, gl_branch: true, cr_abbrev: true})
 
-    Map.merge(route, %{color: get_color_for_route(route_id)})
+    Map.merge(route, %{color: Util.get_color_for_route(route_id)})
   end
 
   def serialize_route_for_reconstructed_alert(route_id_group, opts \\ %{})
@@ -147,7 +146,7 @@ defmodule Screens.V2.WidgetInstance.Serializer.RoutePill do
 
   def serialize_route_for_reconstructed_alert({route_id, _}, opts) do
     route = do_serialize(route_id, opts)
-    Map.merge(route, %{color: get_color_for_route(route_id)})
+    Map.merge(route, %{color: Util.get_color_for_route(route_id)})
   end
 
   @typep serialize_opts :: %{
@@ -212,22 +211,4 @@ defmodule Screens.V2.WidgetInstance.Serializer.RoutePill do
       text: if(route_name != "", do: route_name, else: route_id)
     }
   end
-
-  defp get_color_for_route(route_id, route_type \\ nil)
-
-  defp get_color_for_route("Red", _), do: :red
-  defp get_color_for_route("Mattapan", _), do: :red
-  defp get_color_for_route("Orange", _), do: :orange
-  defp get_color_for_route("Green" <> _, _), do: :green
-  defp get_color_for_route("Blue", _), do: :blue
-  defp get_color_for_route("CR-" <> _, _), do: :purple
-  defp get_color_for_route("Boat-" <> _, _), do: :teal
-
-  defp get_color_for_route(route_id, _)
-       when route_id in @sl_route_ids,
-       do: :silver
-
-  defp get_color_for_route(_, :rail), do: :purple
-  defp get_color_for_route(_, :ferry), do: :teal
-  defp get_color_for_route(_, _), do: :yellow
 end

--- a/test/fixtures/config.json
+++ b/test/fixtures/config.json
@@ -1,6 +1,6 @@
 {
   "devops": {
-    "disabled_modes": []
+    "disabled_modes": ["ferry"]
   },
   "screens": {
     "111": {
@@ -8,10 +8,7 @@
       "app_params": {
         "direction_id": 1,
         "headway_mode": false,
-        "nearby_departures": [
-          "941",
-          "951"
-        ],
+        "nearby_departures": ["941", "951"],
         "platform_id": "70148",
         "psa_config": {
           "default_list": {
@@ -38,15 +35,14 @@
         "overhead": false,
         "psa_config": {
           "default_list": {
-            "paths": [
-              "solari-feedback.png"
-            ],
+            "paths": ["solari-feedback.png"],
             "type": "slide_in"
           },
           "scheduled_overrides": []
         },
         "section_headers": "normal",
-        "sections": [{
+        "sections": [
+          {
             "arrow": "w",
             "audio": {
               "wayfinding": "Upper Busway"
@@ -63,7 +59,8 @@
                 "paged": true,
                 "routes": {
                   "action": "exclude",
-                  "route_list": [{
+                  "route_list": [
+                    {
                       "direction_id": 0,
                       "route": "90"
                     },
@@ -159,68 +156,67 @@
         "overhead": true,
         "psa_config": {
           "default_list": {
-            "paths": [
-              "solari-feedback.png"
-            ],
+            "paths": ["solari-feedback.png"],
             "type": "slide_in"
           },
           "scheduled_overrides": []
         },
         "section_headers": "normal",
-        "sections": [{
-          "arrow": null,
-          "audio": {
-            "wayfinding": "Platform C"
-          },
-          "headway": {
-            "headsigns": [],
-            "headway_id": null,
-            "sign_ids": []
-          },
-          "layout": {
-            "opts": {
-              "max_minutes": "infinity",
-              "num_rows": 8,
-              "paged": false,
-              "routes": {
-                "action": "include",
-                "route_list": [{
-                    "direction_id": 1,
-                    "route": "14"
-                  },
-                  {
-                    "direction_id": 0,
-                    "route": "41"
-                  },
-                  {
-                    "direction_id": 0,
-                    "route": "42"
-                  },
-                  {
-                    "direction_id": 0,
-                    "route": "66"
-                  }
-                ]
+        "sections": [
+          {
+            "arrow": null,
+            "audio": {
+              "wayfinding": "Platform C"
+            },
+            "headway": {
+              "headsigns": [],
+              "headway_id": null,
+              "sign_ids": []
+            },
+            "layout": {
+              "opts": {
+                "max_minutes": "infinity",
+                "num_rows": 8,
+                "paged": false,
+                "routes": {
+                  "action": "include",
+                  "route_list": [
+                    {
+                      "direction_id": 1,
+                      "route": "14"
+                    },
+                    {
+                      "direction_id": 0,
+                      "route": "41"
+                    },
+                    {
+                      "direction_id": 0,
+                      "route": "42"
+                    },
+                    {
+                      "direction_id": 0,
+                      "route": "66"
+                    }
+                  ]
+                },
+                "visible_rows": 1
               },
-              "visible_rows": 1
+              "type": "upcoming"
             },
-            "type": "upcoming"
-          },
-          "name": "Platform C",
-          "pill": "bus",
-          "query": {
-            "opts": {
-              "include_schedules": false
-            },
-            "params": {
-              "direction_id": "both",
-              "route_ids": [],
-              "stop_ids": [
-                "place-dudly"
-              ]
+            "name": "Platform C",
+            "pill": "bus",
+            "query": {
+              "opts": {
+                "include_schedules": false
+              },
+              "params": {
+                "direction_id": "both",
+                "route_ids": [],
+                "stop_ids": ["place-dudly"]
+              }
             }
           }
-        }],
+        ],
         "station_name": "Nubian"
       },
       "device_id": "SOL04",
@@ -233,20 +229,13 @@
     "10": {
       "app_id": "bus_eink",
       "app_params": {
-        "nearby_connections": [{
-            "routes_at_stop": [
-              "8",
-              "47",
-              "CT3"
-            ],
+        "nearby_connections": [
+          {
+            "routes_at_stop": ["8", "47", "CT3"],
             "stop": "1790"
           },
           {
-            "routes_at_stop": [
-              "SL4",
-              "SL5",
-              "8"
-            ],
+            "routes_at_stop": ["SL4", "SL5", "8"],
             "stop": "5"
           }
         ],
@@ -270,12 +259,12 @@
     "14": {
       "app_id": "bus_eink",
       "app_params": {
-        "nearby_connections": [{
-          "routes_at_stop": [
-            "Orange Line"
-          ],
-          "stop": "place-rcmnl"
-        }],
+        "nearby_connections": [
+          {
+            "routes_at_stop": ["Orange Line"],
+            "stop": "place-rcmnl"
+          }
+        ],
         "psa_config": {
           "default_list": {
             "paths": [],
@@ -300,15 +289,14 @@
         "overhead": false,
         "psa_config": {
           "default_list": {
-            "paths": [
-              "solari-feedback.png"
-            ],
+            "paths": ["solari-feedback.png"],
             "type": "slide_in"
           },
           "scheduled_overrides": []
         },
         "section_headers": "normal",
-        "sections": [{
+        "sections": [
+          {
             "arrow": "e",
             "audio": {
               "wayfinding": "Upper Busway"
@@ -325,7 +313,8 @@
                 "paged": true,
                 "routes": {
                   "action": "exclude",
-                  "route_list": [{
+                  "route_list": [
+                    {
                       "direction_id": 1,
                       "route": "74"
                     },
@@ -360,10 +349,7 @@
               "params": {
                 "direction_id": "both",
                 "route_ids": [],
-                "stop_ids": [
-                  "20761",
-                  "20762"
-                ]
+                "stop_ids": ["20761", "20762"]
               }
             }
           },
@@ -384,7 +370,8 @@
                 "paged": false,
                 "routes": {
                   "action": "exclude",
-                  "route_list": [{
+                  "route_list": [
+                    {
                       "direction_id": 1,
                       "route": "74"
                     },
@@ -419,9 +406,7 @@
               "params": {
                 "direction_id": "both",
                 "route_ids": [],
-                "stop_ids": [
-                  "2076"
-                ]
+                "stop_ids": ["2076"]
               }
             }
           }
@@ -440,13 +425,13 @@
       "app_params": {
         "primary": {
           "header": "Long Wharf South",
-          "sections": [{
-            "pill": "ferry",
-            "route_ids": [],
-            "stop_ids": [
-              "Boat-Long-South"
-            ]
-          }]
+          "sections": [
+            {
+              "pill": "ferry",
+              "route_ids": [],
+              "stop_ids": ["Boat-Long-South"]
+            }
+          ]
         },
         "secondary": {
           "header": "",
@@ -463,18 +448,13 @@
     "12": {
       "app_id": "bus_eink",
       "app_params": {
-        "nearby_connections": [{
-            "routes_at_stop": [
-              "Green Line"
-            ],
+        "nearby_connections": [
+          {
+            "routes_at_stop": ["Green Line"],
             "stop": "place-coecl"
           },
           {
-            "routes_at_stop": [
-              "9",
-              "39",
-              "55"
-            ],
+            "routes_at_stop": ["9", "39", "55"],
             "stop": "175"
           }
         ],
@@ -502,15 +482,14 @@
         "overhead": false,
         "psa_config": {
           "default_list": {
-            "paths": [
-              "solari-feedback.png"
-            ],
+            "paths": ["solari-feedback.png"],
             "type": "slide_in"
           },
           "scheduled_overrides": []
         },
         "section_headers": "none",
-        "sections": [{
+        "sections": [
+          {
             "arrow": "e",
             "audio": {
               "wayfinding": null
@@ -538,10 +517,7 @@
               "params": {
                 "direction_id": "both",
                 "route_ids": [],
-                "stop_ids": [
-                  "70045",
-                  "70046"
-                ]
+                "stop_ids": ["70045", "70046"]
               }
             }
           },
@@ -577,10 +553,7 @@
               "params": {
                 "direction_id": "both",
                 "route_ids": [],
-                "stop_ids": [
-                  "5740",
-                  "57400"
-                ]
+                "stop_ids": ["5740", "57400"]
               }
             }
           }
@@ -597,16 +570,13 @@
     "16": {
       "app_id": "bus_eink",
       "app_params": {
-        "nearby_connections": [{
-            "routes_at_stop": [
-              "44"
-            ],
+        "nearby_connections": [
+          {
+            "routes_at_stop": ["44"],
             "stop": "1346"
           },
           {
-            "routes_at_stop": [
-              "45"
-            ],
+            "routes_at_stop": ["45"],
             "stop": "1583"
           }
         ],
@@ -630,17 +600,13 @@
     "4": {
       "app_id": "bus_eink",
       "app_params": {
-        "nearby_connections": [{
-            "routes_at_stop": [
-              "CR-Fitchburg"
-            ],
+        "nearby_connections": [
+          {
+            "routes_at_stop": ["CR-Fitchburg"],
             "stop": "place-FR-0074"
           },
           {
-            "routes_at_stop": [
-              "74",
-              "75"
-            ],
+            "routes_at_stop": ["74", "75"],
             "stop": "2137"
           }
         ],
@@ -664,19 +630,13 @@
     "8": {
       "app_id": "bus_eink",
       "app_params": {
-        "nearby_connections": [{
-            "routes_at_stop": [
-              "33",
-              "40/50",
-              "50"
-            ],
+        "nearby_connections": [
+          {
+            "routes_at_stop": ["33", "40/50", "50"],
             "stop": "26531"
           },
           {
-            "routes_at_stop": [
-              "CR-Franklin",
-              "CR-Providence"
-            ],
+            "routes_at_stop": ["CR-Franklin", "CR-Providence"],
             "stop": "place-NEC-2203"
           }
         ],
@@ -700,19 +660,13 @@
     "5": {
       "app_id": "bus_eink",
       "app_params": {
-        "nearby_connections": [{
-            "routes_at_stop": [
-              "Red Line",
-              "Bus"
-            ],
+        "nearby_connections": [
+          {
+            "routes_at_stop": ["Red Line", "Bus"],
             "stop": "place-harsq"
           },
           {
-            "routes_at_stop": [
-              "1",
-              "68",
-              "69"
-            ],
+            "routes_at_stop": ["1", "68", "69"],
             "stop": "110"
           }
         ],
@@ -740,15 +694,14 @@
         "overhead": false,
         "psa_config": {
           "default_list": {
-            "paths": [
-              "solari-feedback.png"
-            ],
+            "paths": ["solari-feedback.png"],
             "type": "slide_in"
           },
           "scheduled_overrides": []
         },
         "section_headers": "normal",
-        "sections": [{
+        "sections": [
+          {
             "arrow": "nw",
             "audio": {
               "wayfinding": "Back Bay"
@@ -780,9 +733,7 @@
               "params": {
                 "direction_id": 0,
                 "route_ids": [],
-                "stop_ids": [
-                  "Back Bay"
-                ]
+                "stop_ids": ["Back Bay"]
               }
             }
           },
@@ -818,11 +769,7 @@
               "params": {
                 "direction_id": "both",
                 "route_ids": [],
-                "stop_ids": [
-                  "145",
-                  "1241",
-                  "9983"
-                ]
+                "stop_ids": ["145", "1241", "9983"]
               }
             }
           }
@@ -841,10 +788,7 @@
       "app_params": {
         "direction_id": 1,
         "headway_mode": false,
-        "nearby_departures": [
-          "1276",
-          "1292"
-        ],
+        "nearby_departures": ["1276", "1292"],
         "platform_id": "70230",
         "psa_config": {
           "default_list": {
@@ -867,14 +811,12 @@
     "3": {
       "app_id": "bus_eink",
       "app_params": {
-        "nearby_connections": [{
-          "routes_at_stop": [
-            "99",
-            "105",
-            "106"
-          ],
-          "stop": "5403"
-        }],
+        "nearby_connections": [
+          {
+            "routes_at_stop": ["99", "105", "106"],
+            "stop": "5403"
+          }
+        ],
         "psa_config": {
           "default_list": {
             "paths": [],
@@ -895,19 +837,13 @@
     "19": {
       "app_id": "bus_eink",
       "app_params": {
-        "nearby_connections": [{
-            "routes_at_stop": [
-              "52",
-              "57",
-              "502",
-              "504"
-            ],
+        "nearby_connections": [
+          {
+            "routes_at_stop": ["52", "57", "502", "504"],
             "stop": "900"
           },
           {
-            "routes_at_stop": [
-              "70"
-            ],
+            "routes_at_stop": ["70"],
             "stop": "8297"
           }
         ],
@@ -933,10 +869,7 @@
       "app_params": {
         "direction_id": 0,
         "headway_mode": false,
-        "nearby_departures": [
-          "941",
-          "951"
-        ],
+        "nearby_departures": ["941", "951"],
         "platform_id": "70149",
         "psa_config": {
           "default_list": {
@@ -959,17 +892,13 @@
     "9": {
       "app_id": "bus_eink",
       "app_params": {
-        "nearby_connections": [{
-            "routes_at_stop": [
-              "14",
-              "41"
-            ],
+        "nearby_connections": [
+          {
+            "routes_at_stop": ["14", "41"],
             "stop": "1144"
           },
           {
-            "routes_at_stop": [
-              "Orange Line"
-            ],
+            "routes_at_stop": ["Orange Line"],
             "stop": "place-rcmnl"
           }
         ],
@@ -995,10 +924,7 @@
       "app_params": {
         "direction_id": 0,
         "headway_mode": false,
-        "nearby_departures": [
-          "1276",
-          "1292"
-        ],
+        "nearby_departures": ["1276", "1292"],
         "platform_id": "70229",
         "psa_config": {
           "default_list": {
@@ -1021,16 +947,13 @@
     "7": {
       "app_id": "bus_eink",
       "app_params": {
-        "nearby_connections": [{
-            "routes_at_stop": [
-              "SL3"
-            ],
+        "nearby_connections": [
+          {
+            "routes_at_stop": ["SL3"],
             "stop": "place-belsq"
           },
           {
-            "routes_at_stop": [
-              "CR-Newburyport"
-            ],
+            "routes_at_stop": ["CR-Newburyport"],
             "stop": "place-ER-0046"
           }
         ],
@@ -1056,10 +979,7 @@
       "app_params": {
         "direction_id": 1,
         "headway_mode": false,
-        "nearby_departures": [
-          "1276",
-          "1292"
-        ],
+        "nearby_departures": ["1276", "1292"],
         "platform_id": "70230",
         "psa_config": {
           "default_list": {
@@ -1084,10 +1004,7 @@
       "app_params": {
         "direction_id": 0,
         "headway_mode": false,
-        "nearby_departures": [
-          "51317",
-          "71391"
-        ],
+        "nearby_departures": ["51317", "71391"],
         "platform_id": "70245",
         "psa_config": {
           "default_list": {
@@ -1114,15 +1031,14 @@
         "overhead": false,
         "psa_config": {
           "default_list": {
-            "paths": [
-              "solari-feedback.png"
-            ],
+            "paths": ["solari-feedback.png"],
             "type": "slide_in"
           },
           "scheduled_overrides": []
         },
         "section_headers": "normal",
-        "sections": [{
+        "sections": [
+          {
             "arrow": "e",
             "audio": {
               "wayfinding": "Lower Busway"
@@ -1154,10 +1070,7 @@
               "params": {
                 "direction_id": "both",
                 "route_ids": [],
-                "stop_ids": [
-                  "17862",
-                  "17863"
-                ]
+                "stop_ids": ["17862", "17863"]
               }
             }
           },
@@ -1193,9 +1106,7 @@
               "params": {
                 "direction_id": "both",
                 "route_ids": [],
-                "stop_ids": [
-                  "Ruggles"
-                ]
+                "stop_ids": ["Ruggles"]
               }
             }
           }
@@ -1212,16 +1123,13 @@
     "2": {
       "app_id": "bus_eink",
       "app_params": {
-        "nearby_connections": [{
-            "routes_at_stop": [
-              "16"
-            ],
+        "nearby_connections": [
+          {
+            "routes_at_stop": ["16"],
             "stop": "2923"
           },
           {
-            "routes_at_stop": [
-              "19"
-            ],
+            "routes_at_stop": ["19"],
             "stop": "568"
           }
         ],
@@ -1245,16 +1153,13 @@
     "11": {
       "app_id": "bus_eink",
       "app_params": {
-        "nearby_connections": [{
-            "routes_at_stop": [
-              "Green Line • E"
-            ],
+        "nearby_connections": [
+          {
+            "routes_at_stop": ["Green Line • E"],
             "stop": "place-rvrwy"
           },
           {
-            "routes_at_stop": [
-              "66"
-            ],
+            "routes_at_stop": ["66"],
             "stop": "1314"
           }
         ],
@@ -1278,16 +1183,13 @@
     "15": {
       "app_id": "bus_eink",
       "app_params": {
-        "nearby_connections": [{
-            "routes_at_stop": [
-              "44"
-            ],
+        "nearby_connections": [
+          {
+            "routes_at_stop": ["44"],
             "stop": "1332"
           },
           {
-            "routes_at_stop": [
-              "45"
-            ],
+            "routes_at_stop": ["45"],
             "stop": "1569"
           }
         ],
@@ -1311,16 +1213,13 @@
     "17": {
       "app_id": "bus_eink",
       "app_params": {
-        "nearby_connections": [{
-            "routes_at_stop": [
-              "SL3"
-            ],
+        "nearby_connections": [
+          {
+            "routes_at_stop": ["SL3"],
             "stop": "place-belsq"
           },
           {
-            "routes_at_stop": [
-              "CR-Newburyport"
-            ],
+            "routes_at_stop": ["CR-Newburyport"],
             "stop": "place-ER-0046"
           }
         ],
@@ -1346,17 +1245,13 @@
       "app_params": {
         "primary": {
           "header": "Kenmore",
-          "sections": [{
-            "pill": "green",
-            "route_ids": [
-              "Green-B",
-              "Green-C",
-              "Green-D"
-            ],
-            "stop_ids": [
-              "place-kencl"
-            ]
-          }]
+          "sections": [
+            {
+              "pill": "green",
+              "route_ids": ["Green-B", "Green-C", "Green-D"],
+              "stop_ids": ["place-kencl"]
+            }
+          ]
         },
         "secondary": {
           "header": "",
@@ -1373,17 +1268,13 @@
     "18": {
       "app_id": "bus_eink",
       "app_params": {
-        "nearby_connections": [{
-            "routes_at_stop": [
-              "14",
-              "30"
-            ],
+        "nearby_connections": [
+          {
+            "routes_at_stop": ["14", "30"],
             "stop": "6428"
           },
           {
-            "routes_at_stop": [
-              "CR-Needham"
-            ],
+            "routes_at_stop": ["CR-Needham"],
             "stop": "place-NB-0064"
           }
         ],
@@ -1409,26 +1300,16 @@
       "app_params": {
         "primary": {
           "header": "Haymarket",
-          "sections": [{
+          "sections": [
+            {
               "pill": "green",
-              "route_ids": [
-                "Green-B",
-                "Green-C",
-                "Green-D",
-                "Green-E"
-              ],
-              "stop_ids": [
-                "place-haecl"
-              ]
+              "route_ids": ["Green-B", "Green-C", "Green-D", "Green-E"],
+              "stop_ids": ["place-haecl"]
             },
             {
               "pill": "orange",
-              "route_ids": [
-                "Orange"
-              ],
-              "stop_ids": [
-                "place-haecl"
-              ]
+              "route_ids": ["Orange"],
+              "stop_ids": ["place-haecl"]
             }
           ]
         },
@@ -1451,29 +1332,22 @@
         "overhead": false,
         "psa_config": {
           "default_list": {
-            "paths": [
-              "solari-feedback.png"
-            ],
+            "paths": ["solari-feedback.png"],
             "type": "slide_in"
           },
           "scheduled_overrides": []
         },
         "section_headers": "none",
-        "sections": [{
+        "sections": [
+          {
             "arrow": null,
             "audio": {
               "wayfinding": null
             },
             "headway": {
-              "headsigns": [
-                "Alewife",
-                "Southbound"
-              ],
+              "headsigns": ["Alewife", "Southbound"],
               "headway_id": "red_trunk",
-              "sign_ids": [
-                "central_northbound",
-                "central_southbound"
-              ]
+              "sign_ids": ["central_northbound", "central_southbound"]
             },
             "layout": {
               "opts": {
@@ -1493,10 +1367,7 @@
               "params": {
                 "direction_id": "both",
                 "route_ids": [],
-                "stop_ids": [
-                  "70069",
-                  "70070"
-                ]
+                "stop_ids": ["70069", "70070"]
               }
             }
           },
@@ -1517,7 +1388,8 @@
                 "paged": true,
                 "routes": {
                   "action": "exclude",
-                  "route_list": [{
+                  "route_list": [
+                    {
                       "direction_id": 1,
                       "route": "70"
                     },
@@ -1540,12 +1412,7 @@
               "params": {
                 "direction_id": "both",
                 "route_ids": [],
-                "stop_ids": [
-                  "72",
-                  "102",
-                  "1060",
-                  "1123"
-                ]
+                "stop_ids": ["72", "102", "1060", "1123"]
               }
             }
           }
@@ -1566,58 +1433,50 @@
         "overhead": true,
         "psa_config": {
           "default_list": {
-            "paths": [
-              "solari-feedback.png"
-            ],
+            "paths": ["solari-feedback.png"],
             "type": "slide_in"
           },
           "scheduled_overrides": []
         },
         "section_headers": "normal",
-        "sections": [{
-          "arrow": null,
-          "audio": {
-            "wayfinding": "Platform A"
-          },
-          "headway": {
-            "headsigns": [],
-            "headway_id": null,
-            "sign_ids": []
-          },
-          "layout": {
-            "opts": {
-              "max_minutes": "infinity",
-              "num_rows": 8,
-              "paged": false,
-              "routes": {
-                "action": "exclude",
-                "route_list": []
+        "sections": [
+          {
+            "arrow": null,
+            "audio": {
+              "wayfinding": "Platform A"
+            },
+            "headway": {
+              "headsigns": [],
+              "headway_id": null,
+              "sign_ids": []
+            },
+            "layout": {
+              "opts": {
+                "max_minutes": "infinity",
+                "num_rows": 8,
+                "paged": false,
+                "routes": {
+                  "action": "exclude",
+                  "route_list": []
+                },
+                "visible_rows": 1
               },
-              "visible_rows": 1
+              "type": "upcoming"
             },
-            "type": "upcoming"
-          },
-          "name": "Platform A",
-          "pill": "bus",
-          "query": {
-            "opts": {
-              "include_schedules": false
-            },
-            "params": {
-              "direction_id": 1,
-              "route_ids": [
-                "15",
-                "23",
-                "28",
-                "44",
-                "45"
-              ],
-              "stop_ids": [
-                "place-dudly"
-              ]
+            "name": "Platform A",
+            "pill": "bus",
+            "query": {
+              "opts": {
+                "include_schedules": false
+              },
+              "params": {
+                "direction_id": 1,
+                "route_ids": ["15", "23", "28", "44", "45"],
+                "stop_ids": ["place-dudly"]
+              }
             }
           }
-        }],
+        ],
         "station_name": "Nubian"
       },
       "device_id": "SOL03",
@@ -1634,15 +1493,14 @@
         "overhead": false,
         "psa_config": {
           "default_list": {
-            "paths": [
-              "solari-feedback.png"
-            ],
+            "paths": ["solari-feedback.png"],
             "type": "slide_in"
           },
           "scheduled_overrides": []
         },
         "section_headers": "normal",
-        "sections": [{
+        "sections": [
+          {
             "arrow": "se",
             "audio": {
               "wayfinding": "Busway"
@@ -1659,7 +1517,8 @@
                 "paged": true,
                 "routes": {
                   "action": "exclude",
-                  "route_list": [{
+                  "route_list": [
+                    {
                       "direction_id": 1,
                       "route": "92"
                     },
@@ -1682,9 +1541,7 @@
               "params": {
                 "direction_id": "both",
                 "route_ids": [],
-                "stop_ids": [
-                  "8310"
-                ]
+                "stop_ids": ["8310"]
               }
             }
           },
@@ -1705,10 +1562,12 @@
                 "paged": true,
                 "routes": {
                   "action": "exclude",
-                  "route_list": [{
-                    "direction_id": 0,
-                    "route": "4"
-                  }]
+                  "route_list": [
+                    {
+                      "direction_id": 0,
+                      "route": "4"
+                    }
+                  ]
                 },
                 "visible_rows": 4
               },
@@ -1723,9 +1582,7 @@
               "params": {
                 "direction_id": "both",
                 "route_ids": [],
-                "stop_ids": [
-                  "117"
-                ]
+                "stop_ids": ["117"]
               }
             }
           }
@@ -1765,15 +1622,14 @@
         "overhead": false,
         "psa_config": {
           "default_list": {
-            "paths": [
-              "solari-feedback.png"
-            ],
+            "paths": ["solari-feedback.png"],
             "type": "slide_in"
           },
           "scheduled_overrides": []
         },
         "section_headers": "none",
-        "sections": [{
+        "sections": [
+          {
             "arrow": "w",
             "audio": {
               "wayfinding": null
@@ -1801,9 +1657,7 @@
               "params": {
                 "direction_id": "both",
                 "route_ids": [],
-                "stop_ids": [
-                  "Forest Hills"
-                ]
+                "stop_ids": ["Forest Hills"]
               }
             }
           },
@@ -1839,9 +1693,7 @@
               "params": {
                 "direction_id": "both",
                 "route_ids": [],
-                "stop_ids": [
-                  "10642"
-                ]
+                "stop_ids": ["10642"]
               }
             }
           }
@@ -1860,17 +1712,13 @@
       "app_params": {
         "primary": {
           "header": "Tufts Medical Ctr",
-          "sections": [{
-            "pill": "silver",
-            "route_ids": [
-              "749",
-              "751"
-            ],
-            "stop_ids": [
-              "49002",
-              "6565"
-            ]
-          }]
+          "sections": [
+            {
+              "pill": "silver",
+              "route_ids": ["749", "751"],
+              "stop_ids": ["49002", "6565"]
+            }
+          ]
         },
         "secondary": {
           "header": "",
@@ -1891,15 +1739,14 @@
         "overhead": false,
         "psa_config": {
           "default_list": {
-            "paths": [
-              "solari-feedback.png"
-            ],
+            "paths": ["solari-feedback.png"],
             "type": "slide_in"
           },
           "scheduled_overrides": []
         },
         "section_headers": "normal",
-        "sections": [{
+        "sections": [
+          {
             "arrow": "w",
             "audio": {
               "wayfinding": "South Station"
@@ -1931,9 +1778,7 @@
               "params": {
                 "direction_id": "both",
                 "route_ids": [],
-                "stop_ids": [
-                  "South Station"
-                ]
+                "stop_ids": ["South Station"]
               }
             }
           },
@@ -1965,10 +1810,7 @@
               "params": {
                 "direction_id": "both",
                 "route_ids": [],
-                "stop_ids": [
-                  "70016",
-                  "70017"
-                ]
+                "stop_ids": ["70016", "70017"]
               }
             }
           },
@@ -1986,7 +1828,8 @@
               "opts": {
                 "routes": {
                   "action": "exclude",
-                  "route_list": [{
+                  "route_list": [
+                    {
                       "direction_id": 0,
                       "route": "11"
                     },
@@ -2008,10 +1851,7 @@
               "params": {
                 "direction_id": "both",
                 "route_ids": [],
-                "stop_ids": [
-                  "49002",
-                  "6565"
-                ]
+                "stop_ids": ["49002", "6565"]
               }
             }
           },
@@ -2047,9 +1887,7 @@
               "params": {
                 "direction_id": "both",
                 "route_ids": [],
-                "stop_ids": [
-                  "9983"
-                ]
+                "stop_ids": ["9983"]
               }
             }
           }
@@ -2066,20 +1904,13 @@
     "6": {
       "app_id": "bus_eink",
       "app_params": {
-        "nearby_connections": [{
-            "routes_at_stop": [
-              "1",
-              "66",
-              "68",
-              "69"
-            ],
+        "nearby_connections": [
+          {
+            "routes_at_stop": ["1", "66", "68", "69"],
             "stop": "2168"
           },
           {
-            "routes_at_stop": [
-              "Red Line",
-              "Bus"
-            ],
+            "routes_at_stop": ["Red Line", "Bus"],
             "stop": "place-harsq"
           }
         ],
@@ -2105,13 +1936,13 @@
       "app_params": {
         "primary": {
           "header": "Haymarket",
-          "sections": [{
-            "pill": "bus",
-            "route_ids": [],
-            "stop_ids": [
-              "8310"
-            ]
-          }]
+          "sections": [
+            {
+              "pill": "bus",
+              "route_ids": [],
+              "stop_ids": ["8310"]
+            }
+          ]
         },
         "secondary": {
           "header": "",
@@ -2130,29 +1961,30 @@
       "app_params": {
         "primary": {
           "header": "Aquarium",
-          "sections": [{
-            "pill": "blue",
-            "route_ids": [],
-            "stop_ids": [
-              "place-aqucl"
-            ]
-          }]
+          "sections": [
+            {
+              "pill": "blue",
+              "route_ids": [],
+              "stop_ids": ["place-aqucl"]
+            }
+          ]
         },
         "secondary": {
           "header": "",
           "sections": []
         },
-        "override": [{
+        "override": [
+          {
             "type": "partial",
-            "alerts": [{
-              "color": "blue",
-              "content": {
-                "icon": "warning",
-                "text": [
-                  "No Blue Line service"
-                ]
+            "alerts": [
+              {
+                "color": "blue",
+                "content": {
+                  "icon": "warning",
+                  "text": ["No Blue Line service"]
+                }
               }
-            }]
+            ]
           },
           {
             "type": "fullscreen",
@@ -2161,15 +1993,11 @@
             "color": "blue",
             "issue": {
               "icon": "warning",
-              "text": [
-                "No Blue Line service"
-              ]
+              "text": ["No Blue Line service"]
             },
             "remedy": {
               "icon": "shuttle",
-              "text": [
-                "Use shuttle bus"
-              ]
+              "text": ["Use shuttle bus"]
             }
           }
         ]
@@ -2188,15 +2016,14 @@
         "overhead": false,
         "psa_config": {
           "default_list": {
-            "paths": [
-              "solari-feedback.png"
-            ],
+            "paths": ["solari-feedback.png"],
             "type": "slide_in"
           },
           "scheduled_overrides": []
         },
         "section_headers": "none",
-        "sections": [{
+        "sections": [
+          {
             "arrow": "e",
             "audio": {
               "wayfinding": null
@@ -2228,9 +2055,7 @@
               "params": {
                 "direction_id": "both",
                 "route_ids": [],
-                "stop_ids": [
-                  "70094"
-                ]
+                "stop_ids": ["70094"]
               }
             }
           },
@@ -2266,9 +2091,7 @@
               "params": {
                 "direction_id": "both",
                 "route_ids": [],
-                "stop_ids": [
-                  "70261"
-                ]
+                "stop_ids": ["70261"]
               }
             }
           },
@@ -2304,9 +2127,7 @@
               "params": {
                 "direction_id": "both",
                 "route_ids": [],
-                "stop_ids": [
-                  "334"
-                ]
+                "stop_ids": ["334"]
               }
             }
           }
@@ -2325,10 +2146,7 @@
       "app_params": {
         "direction_id": 0,
         "headway_mode": false,
-        "nearby_departures": [
-          "1276",
-          "1292"
-        ],
+        "nearby_departures": ["1276", "1292"],
         "platform_id": "70229",
         "psa_config": {
           "default_list": {
@@ -2353,10 +2171,7 @@
       "app_params": {
         "direction_id": 0,
         "headway_mode": false,
-        "nearby_departures": [
-          "51317",
-          "71391"
-        ],
+        "nearby_departures": ["51317", "71391"],
         "platform_id": "70245",
         "psa_config": {
           "default_list": {
@@ -2383,15 +2198,14 @@
         "overhead": false,
         "psa_config": {
           "default_list": {
-            "paths": [
-              "solari-feedback.png"
-            ],
+            "paths": ["solari-feedback.png"],
             "type": "slide_in"
           },
           "scheduled_overrides": []
         },
         "section_headers": "none",
-        "sections": [{
+        "sections": [
+          {
             "arrow": "se",
             "audio": {
               "wayfinding": null
@@ -2423,9 +2237,7 @@
               "params": {
                 "direction_id": "both",
                 "route_ids": [],
-                "stop_ids": [
-                  "70059"
-                ]
+                "stop_ids": ["70059"]
               }
             }
           },
@@ -2461,9 +2273,7 @@
               "params": {
                 "direction_id": "both",
                 "route_ids": [],
-                "stop_ids": [
-                  "15795"
-                ]
+                "stop_ids": ["15795"]
               }
             }
           }
@@ -2482,10 +2292,7 @@
       "app_params": {
         "direction_id": 1,
         "headway_mode": false,
-        "nearby_departures": [
-          "941",
-          "951"
-        ],
+        "nearby_departures": ["941", "951"],
         "platform_id": "70148",
         "psa_config": {
           "default_list": {
@@ -2508,17 +2315,13 @@
     "1": {
       "app_id": "bus_eink",
       "app_params": {
-        "nearby_connections": [{
-            "routes_at_stop": [
-              "Mattapan",
-              "Bus"
-            ],
+        "nearby_connections": [
+          {
+            "routes_at_stop": ["Mattapan", "Bus"],
             "stop": "place-matt"
           },
           {
-            "routes_at_stop": [
-              "CR-Fairmount"
-            ],
+            "routes_at_stop": ["CR-Fairmount"],
             "stop": "place-DB-2222"
           }
         ],
@@ -2546,15 +2349,14 @@
         "overhead": false,
         "psa_config": {
           "default_list": {
-            "paths": [
-              "solari-feedback.png"
-            ],
+            "paths": ["solari-feedback.png"],
             "type": "slide_in"
           },
           "scheduled_overrides": []
         },
         "section_headers": "vertical",
-        "sections": [{
+        "sections": [
+          {
             "arrow": "e",
             "audio": {
               "wayfinding": "Upper Busway"
@@ -2586,9 +2388,7 @@
               "params": {
                 "direction_id": "both",
                 "route_ids": [],
-                "stop_ids": [
-                  "10642"
-                ]
+                "stop_ids": ["10642"]
               }
             }
           },
@@ -2624,9 +2424,7 @@
               "params": {
                 "direction_id": "both",
                 "route_ids": [],
-                "stop_ids": [
-                  "875"
-                ]
+                "stop_ids": ["875"]
               }
             }
           }
@@ -2645,10 +2443,7 @@
       "app_params": {
         "direction_id": 0,
         "headway_mode": false,
-        "nearby_departures": [
-          "941",
-          "951"
-        ],
+        "nearby_departures": ["941", "951"],
         "platform_id": "70149",
         "psa_config": {
           "default_list": {
@@ -2673,14 +2468,11 @@
       "app_params": {
         "primary": {
           "header": "Back Bay",
-          "sections": [{
+          "sections": [
+            {
               "pill": "orange",
-              "route_ids": [
-                "Orange"
-              ],
-              "stop_ids": [
-                "place-bbsta"
-              ]
+              "route_ids": ["Orange"],
+              "stop_ids": ["place-bbsta"]
             },
             {
               "pill": "cr",
@@ -2690,9 +2482,7 @@
                 "CR-Needham",
                 "CR-Providence"
               ],
-              "stop_ids": [
-                "place-bbsta"
-              ]
+              "stop_ids": ["place-bbsta"]
             }
           ]
         },
@@ -2712,27 +2502,27 @@
       "app_id": "bus_eink_v2",
       "app_params": {
         "departures": {
-          "sections": [{
-            "filter": null,
-            "headway": {
-              "headway_id": null,
-              "override": null,
-              "sign_ids": []
-            },
-            "query": {
-              "opts": {
-                "include_schedules": false
+          "sections": [
+            {
+              "filter": null,
+              "headway": {
+                "headway_id": null,
+                "override": null,
+                "sign_ids": []
               },
-              "params": {
-                "direction_id": "both",
-                "route_ids": [
-                  "1722"
-                ],
-                "route_type": null,
-                "stop_ids": []
+              "query": {
+                "opts": {
+                  "include_schedules": false
+                },
+                "params": {
+                  "direction_id": "both",
+                  "route_ids": ["1722"],
+                  "route_type": null,
+                  "stop_ids": []
+                }
               }
             }
-          }]
+          ]
         },
         "footer": {
           "stop_id": "1722"
@@ -2755,27 +2545,27 @@
       "app_id": "bus_eink_v2",
       "app_params": {
         "departures": {
-          "sections": [{
-            "filter": null,
-            "headway": {
-              "headway_id": null,
-              "override": null,
-              "sign_ids": []
-            },
-            "query": {
-              "opts": {
-                "include_schedules": false
+          "sections": [
+            {
+              "filter": null,
+              "headway": {
+                "headway_id": null,
+                "override": null,
+                "sign_ids": []
               },
-              "params": {
-                "direction_id": "both",
-                "route_ids": [
-                  "383"
-                ],
-                "route_type": null,
-                "stop_ids": []
+              "query": {
+                "opts": {
+                  "include_schedules": false
+                },
+                "params": {
+                  "direction_id": "both",
+                  "route_ids": ["383"],
+                  "route_type": null,
+                  "stop_ids": []
+                }
               }
             }
-          }]
+          ]
         },
         "footer": {
           "stop_id": "383"
@@ -2798,27 +2588,27 @@
       "app_id": "solari_v2",
       "app_params": {
         "departures": {
-          "sections": [{
-            "filter": null,
-            "headway": {
-              "headway_id": null,
-              "override": null,
-              "sign_ids": []
-            },
-            "query": {
-              "opts": {
-                "include_schedules": false
+          "sections": [
+            {
+              "filter": null,
+              "headway": {
+                "headway_id": null,
+                "override": null,
+                "sign_ids": []
               },
-              "params": {
-                "direction_id": "both",
-                "route_ids": [
-                  "1722"
-                ],
-                "route_type": null,
-                "stop_ids": []
+              "query": {
+                "opts": {
+                  "include_schedules": false
+                },
+                "params": {
+                  "direction_id": "both",
+                  "route_ids": ["1722"],
+                  "route_type": null,
+                  "stop_ids": []
+                }
               }
             }
-          }]
+          ]
         },
         "header": {
           "stop_name": "Ashmont"
@@ -2835,27 +2625,27 @@
       "app_id": "solari_large_v2",
       "app_params": {
         "departures": {
-          "sections": [{
-            "filter": null,
-            "headway": {
-              "headway_id": null,
-              "override": null,
-              "sign_ids": []
-            },
-            "query": {
-              "opts": {
-                "include_schedules": false
+          "sections": [
+            {
+              "filter": null,
+              "headway": {
+                "headway_id": null,
+                "override": null,
+                "sign_ids": []
               },
-              "params": {
-                "direction_id": "both",
-                "route_ids": [
-                  "1722"
-                ],
-                "route_type": null,
-                "stop_ids": []
+              "query": {
+                "opts": {
+                  "include_schedules": false
+                },
+                "params": {
+                  "direction_id": "both",
+                  "route_ids": ["1722"],
+                  "route_type": null,
+                  "stop_ids": []
+                }
               }
             }
-          }]
+          ]
         },
         "header": {
           "stop_name": "Nubian"
@@ -2878,27 +2668,27 @@
           "days_active": []
         },
         "departures": {
-          "sections": [{
-            "filter": null,
-            "headway": {
-              "headway_id": null,
-              "override": null,
-              "sign_ids": []
-            },
-            "query": {
-              "opts": {
-                "include_schedules": false
+          "sections": [
+            {
+              "filter": null,
+              "headway": {
+                "headway_id": null,
+                "override": null,
+                "sign_ids": []
               },
-              "params": {
-                "direction_id": "both",
-                "route_ids": [
-                  "1722"
-                ],
-                "route_type": null,
-                "stop_ids": []
+              "query": {
+                "opts": {
+                  "include_schedules": false
+                },
+                "params": {
+                  "direction_id": "both",
+                  "route_ids": ["1722"],
+                  "route_type": null,
+                  "stop_ids": []
+                }
               }
             }
-          }]
+          ]
         },
         "footer": {
           "stop_id": "1722"

--- a/test/fixtures/config.json
+++ b/test/fixtures/config.json
@@ -1,6 +1,6 @@
 {
   "devops": {
-    "disabled_modes": ["ferry"]
+    "disabled_modes": ["ferry", "light_rail"]
   },
   "screens": {
     "111": {

--- a/test/screens/v2/candidate_generator/dup/departures_test.exs
+++ b/test/screens/v2/candidate_generator/dup/departures_test.exs
@@ -1060,19 +1060,19 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
           screen: config,
           show_alternatives?: nil,
           slot_name: :main_content_zero,
-          routes: [:test]
+          route_types: [:test]
         },
         %DeparturesNoData{
           screen: config,
           show_alternatives?: nil,
           slot_name: :main_content_one,
-          routes: [:test]
+          route_types: [:test]
         },
         %DeparturesNoData{
           screen: config,
           show_alternatives?: nil,
           slot_name: :main_content_two,
-          routes: [:ferry, :light_rail]
+          route_types: [:ferry, :light_rail]
         }
       ]
 

--- a/test/screens/v2/candidate_generator/dup/departures_test.exs
+++ b/test/screens/v2/candidate_generator/dup/departures_test.exs
@@ -1059,17 +1059,17 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
         %DeparturesNoData{
           screen: config,
           show_alternatives?: nil,
-          slot_names: [:main_content_zero]
+          slot_name: :main_content_zero
         },
         %DeparturesNoData{
           screen: config,
           show_alternatives?: nil,
-          slot_names: [:main_content_one]
+          slot_name: :main_content_one
         },
         %DeparturesNoData{
           screen: config,
           show_alternatives?: nil,
-          slot_names: [:main_content_two]
+          slot_name: :main_content_two
         }
       ]
 

--- a/test/screens/v2/candidate_generator/dup/departures_test.exs
+++ b/test/screens/v2/candidate_generator/dup/departures_test.exs
@@ -119,13 +119,16 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
       _ -> []
     end
 
+    create_station_with_routes_map_fn = fn _ -> [%{type: :test}] end
+
     %{
       config_primary_and_secondary: config_primary_and_secondary,
       config_only_primary: config_only_primary,
       config_one_section: config_one_section,
       config_branch_station: config_branch_station,
       fetch_section_departures_fn: fetch_section_departures_fn,
-      fetch_alerts_fn: fetch_alerts_fn
+      fetch_alerts_fn: fetch_alerts_fn,
+      create_station_with_routes_map_fn: create_station_with_routes_map_fn
     }
   end
 
@@ -133,7 +136,8 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
     test "returns primary and secondary departures", %{
       config_primary_and_secondary: config,
       fetch_section_departures_fn: fetch_section_departures_fn,
-      fetch_alerts_fn: fetch_alerts_fn
+      fetch_alerts_fn: fetch_alerts_fn,
+      create_station_with_routes_map_fn: create_station_with_routes_map_fn
     } do
       now = ~U[2020-04-06T10:00:00Z]
 
@@ -225,7 +229,8 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
           config,
           now,
           fetch_section_departures_fn,
-          fetch_alerts_fn
+          fetch_alerts_fn,
+          create_station_with_routes_map_fn
         )
 
       assert Enum.all?(expected_departures, &Enum.member?(actual_instances, &1))
@@ -234,7 +239,8 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
     test "returns only primary departures if secondary is missing", %{
       config_only_primary: config,
       fetch_section_departures_fn: fetch_section_departures_fn,
-      fetch_alerts_fn: fetch_alerts_fn
+      fetch_alerts_fn: fetch_alerts_fn,
+      create_station_with_routes_map_fn: create_station_with_routes_map_fn
     } do
       now = ~U[2020-04-06T10:00:00Z]
 
@@ -330,7 +336,8 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
           config,
           now,
           fetch_section_departures_fn,
-          fetch_alerts_fn
+          fetch_alerts_fn,
+          create_station_with_routes_map_fn
         )
 
       assert Enum.all?(expected_departures, &Enum.member?(actual_instances, &1))
@@ -339,7 +346,8 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
     test "returns 4 departures if only one section", %{
       config_one_section: config,
       fetch_section_departures_fn: fetch_section_departures_fn,
-      fetch_alerts_fn: fetch_alerts_fn
+      fetch_alerts_fn: fetch_alerts_fn,
+      create_station_with_routes_map_fn: create_station_with_routes_map_fn
     } do
       now = ~U[2020-04-06T10:00:00Z]
 
@@ -432,7 +440,8 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
           config,
           now,
           fetch_section_departures_fn,
-          fetch_alerts_fn
+          fetch_alerts_fn,
+          create_station_with_routes_map_fn
         )
 
       assert Enum.all?(expected_departures, &Enum.member?(actual_instances, &1))
@@ -440,7 +449,8 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
 
     test "returns headway sections for temporary terminal", %{
       config_one_section: config,
-      fetch_section_departures_fn: fetch_section_departures_fn
+      fetch_section_departures_fn: fetch_section_departures_fn,
+      create_station_with_routes_map_fn: create_station_with_routes_map_fn
     } do
       now = ~U[2020-04-06T10:00:00Z]
 
@@ -507,7 +517,8 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
           config,
           now,
           fetch_section_departures_fn,
-          fetch_alerts_fn
+          fetch_alerts_fn,
+          create_station_with_routes_map_fn
         )
 
       assert Enum.all?(expected_departures, &Enum.member?(actual_instances, &1))
@@ -515,7 +526,8 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
 
     test "returns normal sections for upcoming alert", %{
       config_one_section: config,
-      fetch_section_departures_fn: fetch_section_departures_fn
+      fetch_section_departures_fn: fetch_section_departures_fn,
+      create_station_with_routes_map_fn: create_station_with_routes_map_fn
     } do
       now = ~U[2020-04-06T10:00:00Z]
 
@@ -627,7 +639,8 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
           config,
           now,
           fetch_section_departures_fn,
-          fetch_alerts_fn
+          fetch_alerts_fn,
+          create_station_with_routes_map_fn
         )
 
       assert Enum.all?(expected_departures, &Enum.member?(actual_instances, &1))
@@ -635,7 +648,8 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
 
     test "returns normal sections for branch station for alert with branch terminal headsign", %{
       config_branch_station: config,
-      fetch_section_departures_fn: fetch_section_departures_fn
+      fetch_section_departures_fn: fetch_section_departures_fn,
+      create_station_with_routes_map_fn: create_station_with_routes_map_fn
     } do
       now = ~U[2020-04-06T10:00:00Z]
 
@@ -752,7 +766,8 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
           config,
           now,
           fetch_section_departures_fn,
-          fetch_alerts_fn
+          fetch_alerts_fn,
+          create_station_with_routes_map_fn
         )
 
       assert Enum.all?(expected_departures, &Enum.member?(actual_instances, &1))
@@ -760,7 +775,8 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
 
     test "returns headway sections for branch station for alert with trunk headsign", %{
       config_branch_station: config,
-      fetch_section_departures_fn: fetch_section_departures_fn
+      fetch_section_departures_fn: fetch_section_departures_fn,
+      create_station_with_routes_map_fn: create_station_with_routes_map_fn
     } do
       now = ~U[2020-04-06T10:00:00Z]
 
@@ -868,7 +884,8 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
           config,
           now,
           fetch_section_departures_fn,
-          fetch_alerts_fn
+          fetch_alerts_fn,
+          create_station_with_routes_map_fn
         )
 
       assert Enum.all?(expected_departures, &Enum.member?(actual_instances, &1))

--- a/test/screens/v2/candidate_generator/dup/departures_test.exs
+++ b/test/screens/v2/candidate_generator/dup/departures_test.exs
@@ -100,11 +100,21 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
               query: %Query{params: %Query.Params{stop_ids: ["Boat"]}},
               filter: nil,
               headway: %Headway{headway_id: "ferry"}
-            },
-            %Section{query: %Query{params: %Query.Params{stop_ids: ["place-A"]}}, filter: nil}
+            }
           ]
         },
-        secondary_departures: %Departures{sections: []}
+        secondary_departures: %Departures{
+          sections: [
+            %Section{
+              query: %Query{params: %Query.Params{stop_ids: ["place-A"], route_ids: ["Orange"]}},
+              filter: nil
+            },
+            %Section{
+              query: %Query{params: %Query.Params{stop_ids: ["place-A"], route_ids: ["Green"]}},
+              filter: nil
+            }
+          ]
+        }
       },
       vendor: :outfront,
       device_id: "TEST",
@@ -142,6 +152,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
 
     create_station_with_routes_map_fn = fn
       "Boat" -> [%{id: "Ferry", type: :ferry}]
+      "place-A" -> [%{id: "Orange", type: :subway}, %{id: "Green", type: :light_rail}]
       _ -> [%{type: :test}]
     end
 
@@ -931,15 +942,6 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
             %{
               type: :no_data_section,
               route: %{id: "Ferry", type: :ferry}
-            },
-            %{
-              type: :normal_section,
-              rows: [
-                %Screens.V2.Departure{
-                  prediction: struct(Prediction, id: "A"),
-                  schedule: nil
-                }
-              ]
             }
           ],
           slot_names: [:main_content_zero]
@@ -950,15 +952,6 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
             %{
               type: :no_data_section,
               route: %{id: "Ferry", type: :ferry}
-            },
-            %{
-              type: :normal_section,
-              rows: [
-                %Screens.V2.Departure{
-                  prediction: struct(Prediction, id: "A"),
-                  schedule: nil
-                }
-              ]
             }
           ],
           slot_names: [:main_content_one]
@@ -967,10 +960,6 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
           screen: config,
           section_data: [
             %{
-              type: :no_data_section,
-              route: %{id: "Ferry", type: :ferry}
-            },
-            %{
               type: :normal_section,
               rows: [
                 %Screens.V2.Departure{
@@ -978,6 +967,10 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
                   schedule: nil
                 }
               ]
+            },
+            %{
+              type: :no_data_section,
+              route: %{id: "Green", type: :light_rail}
             }
           ],
           slot_names: [:main_content_two]

--- a/test/screens/v2/candidate_generator/dup/departures_test.exs
+++ b/test/screens/v2/candidate_generator/dup/departures_test.exs
@@ -1059,17 +1059,20 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
         %DeparturesNoData{
           screen: config,
           show_alternatives?: nil,
-          slot_name: :main_content_zero
+          slot_name: :main_content_zero,
+          routes: [:test]
         },
         %DeparturesNoData{
           screen: config,
           show_alternatives?: nil,
-          slot_name: :main_content_one
+          slot_name: :main_content_one,
+          routes: [:test]
         },
         %DeparturesNoData{
           screen: config,
           show_alternatives?: nil,
-          slot_name: :main_content_two
+          slot_name: :main_content_two,
+          routes: [:ferry, :light_rail]
         }
       ]
 

--- a/test/screens/v2/widget_instance/departures_no_data_test.exs
+++ b/test/screens/v2/widget_instance/departures_no_data_test.exs
@@ -30,7 +30,8 @@ defmodule Screens.V2.WidgetInstance.DeparturesNoDataTest do
 
   describe "serialize/1" do
     test "returns stop ID and `show_alternatives?`", %{widget: widget} do
-      assert %{stop_id: "1", show_alternatives: true} == WidgetInstance.serialize(widget)
+      assert %{stop_id: "1", show_alternatives: true, routes: []} ==
+               WidgetInstance.serialize(widget)
     end
   end
 

--- a/test/screens/v2/widget_instance/departures_no_data_test.exs
+++ b/test/screens/v2/widget_instance/departures_no_data_test.exs
@@ -30,7 +30,7 @@ defmodule Screens.V2.WidgetInstance.DeparturesNoDataTest do
 
   describe "serialize/1" do
     test "returns stop ID and `show_alternatives?`", %{widget: widget} do
-      assert %{stop_id: "1", show_alternatives: true, routes: []} ==
+      assert %{stop_id: "1", show_alternatives: true, route_types: []} ==
                WidgetInstance.serialize(widget)
     end
   end

--- a/test/screens/v2/widget_instance/departures_test.exs
+++ b/test/screens/v2/widget_instance/departures_test.exs
@@ -103,6 +103,58 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
       assert %{type: :headway_section, text: expected_text} ==
                Departures.serialize_section(section, dup_screen, false)
     end
+
+    test "returns serialized no_data_section for subway/light rail", %{
+      dup_screen: dup_screen
+    } do
+      section = %{type: :no_data_section, route: %{id: "Orange", type: :subway}}
+
+      expected_text = %{
+        icon: :orange,
+        text: ["Updates unavailable"]
+      }
+
+      assert %{type: :no_data_section, text: expected_text} ==
+               Departures.serialize_section(section, dup_screen, true)
+
+      section = %{type: :no_data_section, route: %{id: "Green", type: :light_rail}}
+
+      expected_text = %{
+        icon: :green,
+        text: ["Updates unavailable"]
+      }
+
+      assert %{type: :no_data_section, text: expected_text} ==
+               Departures.serialize_section(section, dup_screen, true)
+    end
+
+    test "returns serialized no_data_section for bus", %{
+      dup_screen: dup_screen
+    } do
+      section = %{type: :no_data_section, route: %{id: "555", type: :bus}}
+
+      expected_text = %{
+        icon: :bus,
+        text: ["Updates unavailable"]
+      }
+
+      assert %{type: :no_data_section, text: expected_text} ==
+               Departures.serialize_section(section, dup_screen, true)
+    end
+
+    test "returns serialized no_data_section for CR", %{
+      dup_screen: dup_screen
+    } do
+      section = %{type: :no_data_section, route: %{id: "CR-Test", type: :rail}}
+
+      expected_text = %{
+        icon: :cr,
+        text: ["Updates unavailable"]
+      }
+
+      assert %{type: :no_data_section, text: expected_text} ==
+               Departures.serialize_section(section, dup_screen, true)
+    end
   end
 
   describe "group_consecutive_departures/2" do

--- a/test/screens/v2/widget_instance/departures_test.exs
+++ b/test/screens/v2/widget_instance/departures_test.exs
@@ -142,6 +142,20 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
                Departures.serialize_section(section, dup_screen, true)
     end
 
+    test "returns serialized no_data_section for SL", %{
+      dup_screen: dup_screen
+    } do
+      section = %{type: :no_data_section, route: %{short_name: "SL1", type: :bus}}
+
+      expected_text = %{
+        icon: :silver,
+        text: ["Updates unavailable"]
+      }
+
+      assert %{type: :no_data_section, text: expected_text} ==
+               Departures.serialize_section(section, dup_screen, true)
+    end
+
     test "returns serialized no_data_section for CR", %{
       dup_screen: dup_screen
     } do


### PR DESCRIPTION
**Asana task**: [[DUP v2] Handle unreliable predictions (devops checkboxes)](https://app.asana.com/0/1185117109217413/1204081228664130/f)

Spec [link](https://www.notion.so/mbta-downtown-crossing/Departures-Widget-Specification-20da46cd70a44192a568e49ea47e09ac?pvs=4#cb82633f5d314bcfa8974b721d249bd1)

**Backend only**

This PR adds logic for handling the disabled modes checkboxes in the admin tool. This required a departure (heh) from the way we normally render a no data state for the departures widget.

All other V2 screen types display a single section in its departures widget, and that one section only ever contains one mode. DUPs can have multiple sections and each section can be any mode (but never more than one). This means we do not always want to show a full `DeparturesNoData` widget when one mode is disabled. For example, when subway predictions are disabled, we still want to show CR predictions at Back Bay.

To accomplish this, `Departures` needs to handle a `no_data_section`. This section will render similarly to our headway sections. It will contain a single row with a pill for the route and the text "Updates unavailable".  This will make it very easy to show the most accurate data for each section.

Important note: I did change the value for CR in the devops checkbox. It was set to `:commuter_rail`. While absolutely true, we use `:rail` much more often in other parts of the code. This change makes it easier for the devops config to match up with existing helper functions in other parts of the code.

- [X] Tests added?
