### PR TITLE
Empty states for DUPs

### DIFF
--- a/assets/css/dup_v2.scss
+++ b/assets/css/dup_v2.scss
@@ -28,8 +28,8 @@
 
 @import "v2/multi_screen_page";
 @import "v2/dup/simulation";
-@import "v2/dup/debug.scss";
-@import "v2/dup/empty_state.scss";
+@import "v2/dup/debug";
+@import "v2/dup/empty_state";
 
 body {
   margin: 0px;

--- a/assets/css/dup_v2.scss
+++ b/assets/css/dup_v2.scss
@@ -28,6 +28,8 @@
 
 @import "v2/multi_screen_page";
 @import "v2/dup/simulation";
+@import "v2/dup/debug.scss";
+@import "v2/dup/empty_state.scss";
 
 body {
   margin: 0px;

--- a/assets/css/v2/dup/debug.scss
+++ b/assets/css/v2/dup/debug.scss
@@ -1,0 +1,24 @@
+#debug {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  width: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  color: #fff;
+  display: flex;
+  flex-wrap: wrap;
+  flex-direction: column;
+  height: 100%;
+  font-size: 1.5em;
+  z-index: 10000;
+}
+
+#debug p {
+  position: relative;
+  z-index: 9999;
+  font-size: 1.5em;
+  bottom: unset;
+  left: unset;
+  letter-spacing: normal;
+  font-family: Arial;
+}

--- a/assets/css/v2/dup/empty_state.scss
+++ b/assets/css/v2/dup/empty_state.scss
@@ -1,0 +1,73 @@
+.no-data__container,
+.loading__container {
+  background-color: #e6e4e1;
+  height: 100%;
+}
+
+.no-data__body,
+.loading__body {
+  padding-top: 76px;
+}
+
+.no-data__icon-container,
+.loading__icon-container {
+  display: inline-block;
+  width: 312px;
+  vertical-align: top;
+  text-align: center;
+}
+
+.no-data__icon-image,
+.loading__icon-image {
+  width: 160px;
+}
+
+.no-data__message,
+.loading__heading {
+  display: inline-block;
+  width: 1544px;
+  vertical-align: top;
+
+  font-family: Inter, sans-serif;
+  color: #171f26;
+  font-size: 144px;
+  line-height: 160px;
+  font-weight: 800;
+}
+
+.loading__sub-heading {
+  display: inline-block;
+  width: 1544px;
+  vertical-align: top;
+  margin-left: 312px;
+  margin-top: 64px;
+
+  font-family: Inter, sans-serif;
+  color: #171f26;
+  font-size: 112px;
+  line-height: 140px;
+  font-weight: normal;
+}
+
+.no-data__link,
+.loading__link {
+  position: absolute;
+  bottom: 56px;
+  right: 72px;
+}
+
+.no-data__link-arrow,
+.loading__link-arrow {
+  display: inline-block;
+  vertical-align: middle;
+}
+
+.no-data__link-text,
+.loading__link-text {
+  display: inline-block;
+  vertical-align: middle;
+  color: #171f26;
+  font-family: Inter, sans-serif;
+  font-size: 108px;
+  margin-left: 72px;
+}

--- a/assets/src/apps/v2/dup.tsx
+++ b/assets/src/apps/v2/dup.tsx
@@ -26,7 +26,9 @@ import { splitRotationFromPropNames } from "Components/v2/dup/dup_rotation_wrapp
 import PartialAlert from "Components/v2/dup/partial_alert";
 import TakeoverAlert from "Components/v2/dup/takeover_alert";
 import SimulationScreenPage from "Components/v2/simulation_screen_page";
-import { LOADING_LAYOUT, ResponseMapper, ResponseMapperContext } from "Components/v2/screen_container";
+import { ResponseMapper, ResponseMapperContext } from "Components/v2/screen_container";
+import PageLoadNoData from "Components/v2/dup/page_load_no_data";
+import NoData from "Components/v2/dup/no_data";
 
 const TYPE_TO_COMPONENT = {
   screen_normal: NormalScreen,
@@ -49,17 +51,9 @@ const TYPE_TO_COMPONENT = {
   evergreen_content: EvergreenContent,
   partial_alert: PartialAlert,
   takeover_alert: TakeoverAlert,
+  page_load_no_data: PageLoadNoData,
+  no_data: NoData,
 };
-
-const DISABLED_LAYOUT = {
-  full_screen: {
-    type: "no_data",
-    show_alternatives: true,
-  },
-  type: "screen_takeover",
-};
-
-const FAILURE_LAYOUT = DISABLED_LAYOUT;
 
 const responseMapper: ResponseMapper = (apiResponse) => {
   switch (apiResponse.state) {
@@ -67,11 +61,50 @@ const responseMapper: ResponseMapper = (apiResponse) => {
     case "simulation_success":
       return apiResponse.data;
     case "disabled":
-      return DISABLED_LAYOUT;
     case "failure":
-      return FAILURE_LAYOUT;
+      return {
+        rotation_one: {
+          full_rotation: {
+            type: "no_data"
+          },
+          type: "rotation_takeover_one"
+        },
+        rotation_two: {
+          full_rotation: {
+            type: "no_data"
+          },
+          type: "rotation_takeover_two"
+        },
+        rotation_zero: {
+          full_rotation: {
+            type: "no_data"
+          },
+          type: "rotation_takeover_zero"
+        },
+        type: "screen_normal"
+      };
     case "loading":
-      return LOADING_LAYOUT;
+      return {
+        rotation_one: {
+          full_rotation: {
+            type: "page_load_no_data"
+          },
+          type: "rotation_takeover_one"
+        },
+        rotation_two: {
+          full_rotation: {
+            type: "page_load_no_data"
+          },
+          type: "rotation_takeover_two"
+        },
+        rotation_zero: {
+          full_rotation: {
+            type: "page_load_no_data"
+          },
+          type: "rotation_takeover_zero"
+        },
+        type: "screen_normal"
+      };
   }
 };
 

--- a/assets/src/components/v2/dup/no_data.tsx
+++ b/assets/src/components/v2/dup/no_data.tsx
@@ -1,0 +1,41 @@
+import useOutfrontStation from "Hooks/use_outfront_station";
+import React, { ComponentType } from "react";
+import { imagePath } from "Util/util";
+import LinkArrow from "../bundled_svg/link_arrow";
+import NormalHeader from "./normal_header";
+
+// Fix station name tags without rider-facing names
+const REPLACEMENTS = {
+  WTC: "World Trade Center",
+  Malden: "Malden Center",
+} as {[key:string]: string};
+
+const NoData: ComponentType = () => {
+  let stationName = useOutfrontStation() || "Transit information";
+  stationName = REPLACEMENTS[stationName] || stationName;
+
+  return (
+    <div className="no-data__container">
+      <NormalHeader text={stationName} />
+      <div className="no-data__body">
+        <div className="no-data__icon-container">
+          <img
+            className="no-data__icon-image"
+            src={imagePath("live-data-none.svg")}
+          />
+        </div>
+        <div className="no-data__message">
+          Live updates are temporarily unavailable
+        </div>
+      </div>
+      <div className="no-data__link">
+        <div className="no-data__link-arrow">
+          <LinkArrow width={375} colorHex="#a2a3a3" />
+        </div>
+        <div className="no-data__link-text">mbta.com/schedules</div>
+      </div>
+    </div>
+  );
+};
+
+export default NoData;

--- a/assets/src/components/v2/dup/no_data.tsx
+++ b/assets/src/components/v2/dup/no_data.tsx
@@ -5,7 +5,7 @@ import LinkArrow from "../bundled_svg/link_arrow";
 import NormalHeader from "./normal_header";
 
 // Fix station name tags without rider-facing names
-const REPLACEMENTS = {
+export const REPLACEMENTS = {
   WTC: "World Trade Center",
   Malden: "Malden Center",
 } as {[key:string]: string};

--- a/assets/src/components/v2/dup/normal_header.tsx
+++ b/assets/src/components/v2/dup/normal_header.tsx
@@ -8,16 +8,19 @@ interface NormalHeaderProps {
   time?: string;
   color?: string;
   accentPattern?: string;
+  code?: string;
 }
 
-const NormalHeader = ({text, time, color, accentPattern}: NormalHeaderProps) => {
+const NormalHeader = ({text, time, color, accentPattern, code}: NormalHeaderProps) => {
 
   return (
     <DefaultNormalHeader
       icon={Icon.logo}
       text={text}
       time={time}
-      version={DUP_VERSION}
+      // Currently, we don't use different codes that populating this would be useful...
+      // But this was a feature available in v1, so just set it up here.
+      version={DUP_VERSION + (code ? "; Maintenance code: " + code : "")}
       maxHeight={208}
       showTo={false}
       classModifiers={color}

--- a/assets/src/components/v2/dup/page_load_no_data.tsx
+++ b/assets/src/components/v2/dup/page_load_no_data.tsx
@@ -3,12 +3,7 @@ import React, { ComponentType } from "react";
 import LinkArrow from "../bundled_svg/link_arrow";
 import Loading from "../bundled_svg/loading";
 import NormalHeader from "./normal_header";
-
-// Fix station name tags without rider-facing names
-const REPLACEMENTS = {
-  WTC: "World Trade Center",
-  Malden: "Malden Center",
-} as {[key:string]: string};
+import { REPLACEMENTS } from "./no_data";
 
 const PageLoadNoData: ComponentType = () => {
   let stationName = useOutfrontStation() || "Transit information";

--- a/assets/src/components/v2/dup/page_load_no_data.tsx
+++ b/assets/src/components/v2/dup/page_load_no_data.tsx
@@ -1,0 +1,39 @@
+import useOutfrontStation from "Hooks/use_outfront_station";
+import React, { ComponentType } from "react";
+import LinkArrow from "../bundled_svg/link_arrow";
+import Loading from "../bundled_svg/loading";
+import NormalHeader from "./normal_header";
+
+// Fix station name tags without rider-facing names
+const REPLACEMENTS = {
+  WTC: "World Trade Center",
+  Malden: "Malden Center",
+} as {[key:string]: string};
+
+const PageLoadNoData: ComponentType = () => {
+  let stationName = useOutfrontStation() || "Transit information";
+  stationName = REPLACEMENTS[stationName] || stationName;
+  
+  return (
+    <div className="loading__container">
+      <NormalHeader text={stationName} />
+      <div className="loading__body">
+        <div className="loading__icon-container">
+          <Loading colorHex={"#171F26"} />
+        </div>
+        <div className="loading__heading">Loading...</div>
+        <div className="loading__sub-heading">
+          This should only take a moment.
+        </div>
+      </div>
+      <div className="loading__link">
+        <div className="loading__link-arrow">
+          <LinkArrow width={375} colorHex="#a2a3a3" />
+        </div>
+        <div className="loading__link-text">mbta.com/schedules</div>
+      </div>
+    </div>
+  );
+};
+
+export default PageLoadNoData;

--- a/assets/src/components/v2/dup/takeover_alert.tsx
+++ b/assets/src/components/v2/dup/takeover_alert.tsx
@@ -1,54 +1,8 @@
 import React from "react";
+import LinkArrow from "../bundled_svg/link_arrow";
 
 import FreeText, { FreeTextType } from "./dup_free_text";
 import NormalHeader from "./normal_header";
-
-const LinkArrow = ({ width, color }: any) => {
-  const height = 40;
-  const stroke = 8;
-  const headWidth = 40;
-
-  const d = [
-    "M",
-    stroke / 2,
-    height / 2,
-    "L",
-    width - headWidth,
-    height / 2,
-    "L",
-    width - headWidth,
-    stroke / 2,
-    "L",
-    width - stroke / 2,
-    height / 2,
-    "L",
-    width - headWidth,
-    height - stroke / 2,
-    "L",
-    width - headWidth,
-    height / 2,
-    "Z",
-  ].join(" ");
-
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      viewBox={`0 0 ${width} ${height}`}
-      width={`${width}px`}
-      height={`${height}px`}
-      version="1.1"
-    >
-      <path
-        stroke={color}
-        strokeWidth={stroke}
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        fill={color}
-        d={d}
-      />
-    </svg>
-  );
-};
 
 interface TakeoverAlertProps {
   text: FreeTextType,
@@ -75,7 +29,7 @@ const TakeoverAlert = (alert: TakeoverAlertProps) => {
         </div>
         <div className="full-screen-alert__link">
           <div className="full-screen-alert__link-arrow">
-            <LinkArrow width="628" color="#64696e" />
+            <LinkArrow width={628} colorHex="#64696e" />
           </div>
           <div className="full-screen-alert__link-text">mbta.com/alerts</div>
         </div>


### PR DESCRIPTION
**Asana task**: [[DUP v2] No data and disabled states](https://app.asana.com/0/1185117109217413/1204081228664132)

- Added 2 frontend states: loading & disabled/failure states.
- Carried over some functionality from DUP v1: the "debug by printing console logs to the screen" feature and the maintenance code feature (though we aren't using either right now).
- When adding LinkArrow to one of the components, I noticed the LinkArrow in takeover_alert needed fixing.

- [ ] Tests added?
