### PR TITLE
Bidirectional departure sections (for DUP)

### DIFF
--- a/lib/screens/config/v2/departures/section.ex
+++ b/lib/screens/config/v2/departures/section.ex
@@ -6,13 +6,15 @@ defmodule Screens.Config.V2.Departures.Section do
   @type t :: %__MODULE__{
           query: Query.t(),
           filter: Filter.t() | nil,
-          headway: Headway.t()
+          headway: Headway.t(),
+          bidirectional: boolean() | nil
         }
 
   @enforce_keys [:query]
   defstruct query: nil,
             filter: nil,
-            headway: Headway.from_json(:default)
+            headway: Headway.from_json(:default),
+            bidirectional: false
 
   use Screens.Config.Struct, children: [query: Query, filter: Filter, headway: Headway]
 

--- a/lib/screens/v2/candidate_generator/dup/departures.ex
+++ b/lib/screens/v2/candidate_generator/dup/departures.ex
@@ -11,6 +11,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
   alias Screens.Stops.Stop
   alias Screens.Util
   alias Screens.V2.CandidateGenerator.Widgets
+  alias Screens.V2.Departure
   alias Screens.V2.WidgetInstance.Departures, as: DeparturesWidget
   alias Screens.V2.WidgetInstance.DeparturesNoData
 
@@ -138,7 +139,8 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
                               query: %Query{
                                 params: %Params{stop_ids: stop_ids, route_ids: route_ids} = params
                               },
-                              headway: headway
+                              headway: headway,
+                              bidirectional: is_bidirectional
                             } = section ->
       route =
         get_primary_route_for_section(stop_ids, route_ids, create_station_with_routes_map_fn)
@@ -149,8 +151,15 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
       else
         section_departures =
           case fetch_section_departures_fn.(section) do
-            {:ok, section_departures} -> section_departures
-            _ -> []
+            {:ok, section_departures} ->
+              # If the section is configured as bidirectional, 
+              # it needs to show one departure in each direction
+              if is_bidirectional,
+                do: get_bidirectional_departures(section_departures),
+                else: section_departures
+
+            _ ->
+              []
           end
 
         section_alert = get_section_alert(params, fetch_alerts_fn, now)
@@ -181,6 +190,18 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
   end
 
   defp get_section_route_from_alert(_, _), do: nil
+
+  defp get_bidirectional_departures(section_departures) do
+    first_row = List.first(section_departures)
+    first_direction_id = Departure.direction_id(first_row)
+
+    second_row =
+      Enum.find(section_departures, Enum.at(section_departures, 1), fn departure ->
+        Departure.direction_id(departure) === 1 - first_direction_id
+      end)
+
+    [first_row] ++ [second_row]
+  end
 
   defp get_section_alert(
          %Params{

--- a/lib/screens/v2/candidate_generator/dup/departures.ex
+++ b/lib/screens/v2/candidate_generator/dup/departures.ex
@@ -152,7 +152,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
         section_departures =
           case fetch_section_departures_fn.(section) do
             {:ok, section_departures} ->
-              # If the section is configured as bidirectional, 
+              # If the section is configured as bidirectional,
               # it needs to show one departure in each direction
               if is_bidirectional,
                 do: get_bidirectional_departures(section_departures),

--- a/test/screens/v2/candidate_generator/dup/departures_test.exs
+++ b/test/screens/v2/candidate_generator/dup/departures_test.exs
@@ -58,7 +58,11 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
         header: %Header.CurrentStopId{stop_id: "place-gover"},
         primary_departures: %Departures{
           sections: [
-            %Section{bidirectional: true, query: %Query{params: %Query.Params{stop_ids: ["place-F"]}}, filter: nil},
+            %Section{
+              bidirectional: true,
+              query: %Query{params: %Query.Params{stop_ids: ["place-F"]}},
+              filter: nil
+            },
             %Section{query: %Query{params: %Query.Params{stop_ids: ["place-A"]}}, filter: nil}
           ]
         },
@@ -201,13 +205,13 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
 
       %Section{query: %Query{params: %Query.Params{stop_ids: ["place-F"]}}} ->
         {:ok,
-          [
-            %Departure{prediction: %Prediction{id: "F1", trip: %Trip{direction_id: 0}}},
-            %Departure{prediction: %Prediction{id: "F2", trip: %Trip{direction_id: 0}}},
-            %Departure{prediction: %Prediction{id: "F3", trip: %Trip{direction_id: 0}}},
-            %Departure{prediction: %Prediction{id: "F4", trip: %Trip{direction_id: 1}}},
-            %Departure{prediction: %Prediction{id: "F5", trip: %Trip{direction_id: 1}}}
-          ]}
+         [
+           %Departure{prediction: %Prediction{id: "F1", trip: %Trip{direction_id: 0}}},
+           %Departure{prediction: %Prediction{id: "F2", trip: %Trip{direction_id: 0}}},
+           %Departure{prediction: %Prediction{id: "F3", trip: %Trip{direction_id: 0}}},
+           %Departure{prediction: %Prediction{id: "F4", trip: %Trip{direction_id: 1}}},
+           %Departure{prediction: %Prediction{id: "F5", trip: %Trip{direction_id: 1}}}
+         ]}
 
       %Section{query: %Query{params: %Query.Params{stop_ids: ["place-kencl"]}}} ->
         {:ok, [%Departure{prediction: %Prediction{id: "Kenmore"}}]}


### PR DESCRIPTION
**Asana task**: [[DUP v2] Add ability to configure bidirectional departures](https://app.asana.com/0/1185117109217413/1204083894737787)

`"bidirectional": true,` can be an attribute on a primary_departure section. The RL is easiest to test with, because you'll frequently see an Ashmont train back-to-back with a Braintree train, or two Alewife trains back-to-back. But the bidirectional feature only works for 2-row sections, not 4-row. So you'll need to make a fake configuration. (Just copy the secondary bus departures from the Broadway screen to the bottom of the primary_departures screen.)

- [x] Tests added?
