### PR TITLE
refactor: Define new SingleAlertWidget protocol and refactor BaseAlert to use it

### DIFF
--- a/lib/screens/v2/alert_widget_instance.ex
+++ b/lib/screens/v2/alert_widget_instance.ex
@@ -1,7 +1,0 @@
-defprotocol Screens.V2.AlertWidgetInstance do
-  @type alert_id :: String.t()
-
-  @doc "Gets the ID(s) of the alert(s) that this widget shows."
-  @spec alert_ids(t) :: list(alert_id())
-  def alert_ids(widget)
-end

--- a/lib/screens/v2/alerts_widget.ex
+++ b/lib/screens/v2/alerts_widget.ex
@@ -1,0 +1,19 @@
+defprotocol Screens.V2.AlertsWidget do
+  @moduledoc """
+  Protocol for a widget that models zero or more alerts.
+  """
+
+  # https://hexdocs.pm/elixir/Protocol.html#module-fallback-to-any
+  @fallback_to_any true
+
+  @type alert_id :: String.t()
+
+  @doc "Gets the ID(s) of the alert(s) that this widget shows."
+  @spec alert_ids(t) :: list(alert_id())
+  def alert_ids(widget)
+end
+
+# https://hexdocs.pm/elixir/Protocol.html#module-fallback-to-any
+defimpl Screens.V2.AlertsWidget, for: Any do
+  def alert_ids(_), do: []
+end

--- a/lib/screens/v2/alerts_widget.ex
+++ b/lib/screens/v2/alerts_widget.ex
@@ -1,6 +1,11 @@
 defprotocol Screens.V2.AlertsWidget do
   @moduledoc """
   Protocol for a widget that models zero or more alerts.
+
+  This includes but is not limited to:
+  - `Screens.V2.WidgetInstance.Alert`
+  - `Screens.V2.WidgetInstance.ReconstructedAlert`
+  - `Screens.V2.WidgetInstance.ElevatorStatus`
   """
 
   # https://hexdocs.pm/elixir/Protocol.html#module-fallback-to-any

--- a/lib/screens/v2/candidate_generator/widgets/reconstructed_alert.ex
+++ b/lib/screens/v2/candidate_generator/widgets/reconstructed_alert.ex
@@ -169,7 +169,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlert do
 
   defp get_stations(alert, fetch_stop_name_fn) do
     stop_ids =
-      %{alert: alert}
+      %ReconstructedAlert{alert: alert}
       |> BaseAlert.informed_entities()
       |> Enum.flat_map(fn %{stop: stop_id} ->
         case stop_id do

--- a/lib/screens/v2/screen_data.ex
+++ b/lib/screens/v2/screen_data.ex
@@ -5,7 +5,7 @@ defmodule Screens.V2.ScreenData do
 
   alias Screens.ScreensByAlert
   alias Screens.Util
-  alias Screens.V2.AlertWidgetInstance
+  alias Screens.V2.AlertsWidget
   alias Screens.V2.ScreenData.Parameters
   alias Screens.V2.Template
   alias Screens.V2.WidgetInstance
@@ -484,10 +484,7 @@ defmodule Screens.V2.ScreenData do
     alert_ids =
       instance_map
       |> Map.values()
-      |> Enum.filter(fn widget_struct ->
-        not is_nil(AlertWidgetInstance.impl_for(widget_struct))
-      end)
-      |> Enum.flat_map(&AlertWidgetInstance.alert_ids/1)
+      |> Enum.flat_map(&AlertsWidget.alert_ids/1)
 
     :ok = ScreensByAlert.put_data(screen_id, alert_ids)
   end

--- a/lib/screens/v2/single_alert_widget.ex
+++ b/lib/screens/v2/single_alert_widget.ex
@@ -1,0 +1,49 @@
+defprotocol Screens.V2.SingleAlertWidget do
+  @moduledoc """
+  Protocol for a widget that models exactly one alert.
+  """
+
+  alias Screens.Alerts.Alert
+  alias Screens.Config.Screen
+
+  @type alert_id :: String.t()
+  @type stop_id :: String.t()
+  @type route_id :: String.t()
+
+  @doc """
+  Gets the Screens.Alerts.Alert struct that this widget contains.
+  """
+  @spec alert(t()) :: Alert.t()
+  def alert(widget)
+
+  @doc """
+  Gets the Screens.Config.Screen struct describing the screen that this widget appears on.
+  """
+  @spec screen(t()) :: Screen.t()
+  def screen(widget)
+
+  @doc """
+  Gets the home stop ID of this widget, usually from screen configuration.
+
+  **The stop ID should be in the same format as the stop sequences--either parent station ID or child stop ID.**
+  """
+  @spec home_stop_id(t()) :: stop_id()
+  def home_stop_id(widget)
+
+  @doc """
+  Gets the list of routes that serve this widget's home stop.
+  """
+  @spec routes_at_stop(t()) :: list(%{route_id: route_id(), active?: boolean()})
+  def routes_at_stop(widget)
+
+  @doc """
+  """
+  @spec stop_sequences(t()) :: list(list(stop_id()))
+  def stop_sequences(widget)
+
+  @doc """
+  Gets the headsign matchers mapping for this widget, or nil if headsigns are not used.
+  """
+  @spec headsign_matchers(t()) :: %{stop_id() => list(tuple())} | nil
+  def headsign_matchers(widget)
+end

--- a/lib/screens/v2/single_alert_widget.ex
+++ b/lib/screens/v2/single_alert_widget.ex
@@ -1,6 +1,11 @@
 defprotocol Screens.V2.SingleAlertWidget do
   @moduledoc """
   Protocol for a widget that models exactly one alert.
+
+  This includes but is not limited to:
+  - `Screens.V2.WidgetInstance.Alert`
+  - `Screens.V2.WidgetInstance.ReconstructedAlert`
+  - `Screens.V2.WidgetInstance.DupAlert`
   """
 
   alias Screens.Alerts.Alert

--- a/lib/screens/v2/widget_instance/alert.ex
+++ b/lib/screens/v2/widget_instance/alert.ex
@@ -460,7 +460,23 @@ defmodule Screens.V2.WidgetInstance.Alert do
     def audio_view(instance), do: Alert.audio_view(instance)
   end
 
-  defimpl Screens.V2.AlertWidgetInstance do
+  defimpl Screens.V2.SingleAlertWidget do
+    alias Screens.V2.WidgetInstance.Alert
+
+    def alert(instance), do: instance.alert
+
+    def screen(instance), do: instance.screen
+
+    def home_stop_id(instance), do: instance.screen.app_params.alerts.stop_id
+
+    def routes_at_stop(instance), do: instance.routes_at_stop
+
+    def stop_sequences(instance), do: instance.stop_sequences
+
+    def headsign_matchers(_instance), do: nil
+  end
+
+  defimpl Screens.V2.AlertsWidget do
     alias Screens.V2.WidgetInstance.Alert
 
     def alert_ids(instance), do: Alert.alert_ids(instance)

--- a/lib/screens/v2/widget_instance/elevator_status.ex
+++ b/lib/screens/v2/widget_instance/elevator_status.ex
@@ -18,7 +18,7 @@ defmodule Screens.V2.WidgetInstance.ElevatorStatus do
 
     defstruct station: nil
 
-    defimpl Screens.V2.AlertWidgetInstance do
+    defimpl Screens.V2.AlertsWidget do
       def alert_ids(page) do
         Enum.map(page.station.elevator_closures, & &1.alert_id)
       end
@@ -38,7 +38,7 @@ defmodule Screens.V2.WidgetInstance.ElevatorStatus do
 
     defstruct stations: nil
 
-    defimpl Screens.V2.AlertWidgetInstance do
+    defimpl Screens.V2.AlertsWidget do
       def alert_ids(page) do
         Enum.flat_map(page.stations, fn station ->
           Enum.map(station.elevator_closures, & &1.alert_id)
@@ -79,7 +79,7 @@ defmodule Screens.V2.WidgetInstance.ElevatorStatus do
   alias Screens.Alerts.Alert
   alias Screens.Config.Screen
   alias Screens.Config.V2.{ElevatorStatus, PreFare}
-  alias Screens.V2.AlertWidgetInstance
+  alias Screens.V2.AlertsWidget
 
   defstruct screen: nil,
             now: nil,
@@ -564,7 +564,7 @@ defmodule Screens.V2.WidgetInstance.ElevatorStatus do
     %{pages: pages} = serialize(t)
 
     pages
-    |> Enum.flat_map(&AlertWidgetInstance.alert_ids/1)
+    |> Enum.flat_map(&AlertsWidget.alert_ids/1)
     |> Enum.uniq()
   end
 
@@ -582,7 +582,7 @@ defmodule Screens.V2.WidgetInstance.ElevatorStatus do
     def audio_view(instance), do: ElevatorStatus.audio_view(instance)
   end
 
-  defimpl Screens.V2.AlertWidgetInstance do
+  defimpl Screens.V2.AlertsWidget do
     alias Screens.V2.WidgetInstance.ElevatorStatus
 
     def alert_ids(instance), do: ElevatorStatus.alert_ids(instance)

--- a/lib/screens/v2/widget_instance/reconstructed_alert.ex
+++ b/lib/screens/v2/widget_instance/reconstructed_alert.ex
@@ -5,7 +5,6 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
   alias Screens.Config.Screen
   alias Screens.Config.V2.FreeTextLine
   alias Screens.Stops.Stop
-  alias Screens.Util
   alias Screens.V2.WidgetInstance.Alert, as: AlertWidget
   alias Screens.V2.WidgetInstance.Common.BaseAlert
   alias Screens.V2.WidgetInstance.ReconstructedAlert

--- a/test/screens/v2/widget_instance/alert_test.exs
+++ b/test/screens/v2/widget_instance/alert_test.exs
@@ -4,7 +4,7 @@ defmodule Screens.V2.WidgetInstance.AlertTest do
   alias Screens.Alerts.Alert
   alias Screens.Config.Screen
   alias Screens.Config.V2.{BusEink, BusShelter, GlEink, Solari}
-  alias Screens.V2.AlertWidgetInstance
+  alias Screens.V2.AlertsWidget
   alias Screens.V2.WidgetInstance.Alert, as: AlertWidget
 
   setup :setup_base
@@ -684,7 +684,7 @@ defmodule Screens.V2.WidgetInstance.AlertTest do
 
   describe "alert_id/1" do
     test "returns alert_id", %{widget: widget} do
-      assert [widget.alert.id] == AlertWidgetInstance.alert_ids(widget)
+      assert [widget.alert.id] == AlertsWidget.alert_ids(widget)
     end
   end
 end

--- a/test/screens/v2/widget_instance/reconstructed_alert_test.exs
+++ b/test/screens/v2/widget_instance/reconstructed_alert_test.exs
@@ -6,7 +6,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
   alias Screens.Config.V2.{PreFare}
   alias Screens.Config.V2.Header.CurrentStopId
   alias Screens.Stops.Stop
-  alias Screens.V2.AlertWidgetInstance
+  alias Screens.V2.AlertsWidget
   alias Screens.V2.CandidateGenerator
   alias Screens.V2.WidgetInstance
   alias Screens.V2.WidgetInstance.ReconstructedAlert
@@ -1136,7 +1136,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
 
   describe "alert_id/1" do
     test "returns alert_id", %{widget: widget} do
-      assert [widget.alert.id] == AlertWidgetInstance.alert_ids(widget)
+      assert [widget.alert.id] == AlertsWidget.alert_ids(widget)
     end
   end
 


### PR DESCRIPTION
**Asana task**: ad hoc

This adds a new protocol for widgets that model a single alert.
The BaseAlert functions now access widget properties exclusively through these functions, so that it has a clearly defined set of requirements for its input values.

The `SingleAlertWidget` and `BaseAlert` protocol & module pair can be thought of as analogous to elixir's [`Enumerable` and `Enum`](https://github.com/elixir-lang/elixir/blob/main/lib/elixir/lib/enum.ex)—the protocol defines the contract for what types of values the module can work with.

- [ ] Tests added?
