### PR TITLE
tweak: Update CR widget to support Porter departures

### DIFF
--- a/assets/css/v2/pre_fare/cr_departures/cr_departures_table.scss
+++ b/assets/css/v2/pre_fare/cr_departures/cr_departures_table.scss
@@ -35,7 +35,7 @@
     font-weight: 800;
     text-align: right;
     line-height: 64px;
-    vertical-align: text-top;
+    vertical-align: middle;
   }
   .track,
   .track-column {

--- a/assets/src/components/v2/cr_departures/cr_departures_table.tsx
+++ b/assets/src/components/v2/cr_departures/cr_departures_table.tsx
@@ -33,20 +33,18 @@ const DeparturesTable: React.ComponentType<Props> = ({
   };
 
   const getStationServiceList = (stationServiceList: StationService[]) => {
-    return stationServiceList.map((station: StationService) => {
-      return (
-        <div className="stops-at-text" key={station.name}>
-          <div className="via-service-icon">
-            <img
-              src={imagePath(
-                station.service ? "cr-service.svg" : "cr-no-service.svg"
-              )}
-            />
-          </div>
-          <div className="via-stop-name">{station.name}</div>
+    return stationServiceList.map((station: StationService) => (
+      <div className="stops-at-text" key={station.name}>
+        <div className="via-service-icon">
+          <img
+            src={imagePath(
+              station.service ? "cr-service.svg" : "cr-no-service.svg"
+            )}
+          />
         </div>
-      );
-    });
+        <div className="via-stop-name">{station.name}</div>
+      </div>
+    ));
   };
 
   const getHeaderDirection = (language: string) => {
@@ -84,9 +82,11 @@ const DeparturesTable: React.ComponentType<Props> = ({
             <tr key={departure.prediction_or_schedule_id}>
               <td className="track">
                 {getArrowOrTbd(departure.arrow)}
-                <div className="track-number-text">
-                  {departure.track_number}
-                </div>
+                {departure.track_number && (
+                  <div className="track-number-text">
+                    {departure.track_number}
+                  </div>
+                )}
               </td>
               <td className="headsign">
                 <div className="headsign-text">

--- a/assets/src/components/v2/cr_departures/overnight_cr_departures.tsx
+++ b/assets/src/components/v2/cr_departures/overnight_cr_departures.tsx
@@ -96,9 +96,11 @@ const OvernightCRDepartures: ComponentType<Props> = ({
               <div className="overnight-cr-departures__schedule-headsign--stop">
                 {lastScheduleHeadsignStop}
               </div>
-              <div className="overnight-cr-departures__schedule-headsign--via">
-                via {lastScheduleHeadsignVia}
-              </div>
+              {lastScheduleHeadsignVia && (
+                <div className="overnight-cr-departures__schedule-headsign--via">
+                  via {lastScheduleHeadsignVia}
+                </div>
+              )}
             </div>
           </div>
           <div className="overnight-cr-departures__footer-hairline"></div>

--- a/lib/screens/v2/candidate_generator/widgets/cr_departures.ex
+++ b/lib/screens/v2/candidate_generator/widgets/cr_departures.ex
@@ -92,7 +92,8 @@ defmodule Screens.V2.CandidateGenerator.Widgets.CRDepartures do
       route_ids: [
         "CR-Franklin",
         "CR-Needham",
-        "CR-Providence"
+        "CR-Providence",
+        "CR-Fitchburg"
       ],
       route_type: :rail,
       stop_ids: [station]
@@ -114,7 +115,8 @@ defmodule Screens.V2.CandidateGenerator.Widgets.CRDepartures do
       route_ids: [
         "CR-Franklin",
         "CR-Needham",
-        "CR-Providence"
+        "CR-Providence",
+        "CR-Fitchburg"
       ],
       route_type: :rail,
       stop_ids: [station],

--- a/lib/screens/v2/widget_instance/overnight_cr_departures.ex
+++ b/lib/screens/v2/widget_instance/overnight_cr_departures.ex
@@ -1,6 +1,7 @@
 defmodule Screens.V2.WidgetInstance.OvernightCRDepartures do
   @moduledoc false
 
+  alias Screens.V2.Departure
   alias Screens.Schedules.Schedule
   alias Screens.V2.WidgetInstance
 
@@ -24,10 +25,15 @@ defmodule Screens.V2.WidgetInstance.OvernightCRDepartures do
   def serialize(%__MODULE__{
         destination: destination,
         direction_to_destination: direction_to_destination,
-        last_tomorrow_schedule: %Schedule{departure_time: departure_time, stop_headsign: headsign}
+        last_tomorrow_schedule:
+          %Schedule{
+            departure_time: departure_time
+          } = schedule
       }) do
     {:ok, local_departure_time} = DateTime.shift_zone(departure_time, "America/New_York")
-    {headsign_stop, headsign_via} = format_headsign(headsign)
+
+    {headsign_stop, headsign_via} =
+      format_headsign(Departure.headsign(%Departure{schedule: schedule}))
 
     %{
       direction: direction_to_destination,
@@ -36,6 +42,8 @@ defmodule Screens.V2.WidgetInstance.OvernightCRDepartures do
       last_schedule_headsign_via: serialize_via_string(destination, headsign_via)
     }
   end
+
+  defp serialize_via_string(_destination, nil), do: nil
 
   defp serialize_via_string(destination, via_string) do
     via_station = String.replace(via_string, "via ", "")

--- a/lib/screens/v2/widget_instance/overnight_cr_departures.ex
+++ b/lib/screens/v2/widget_instance/overnight_cr_departures.ex
@@ -1,8 +1,8 @@
 defmodule Screens.V2.WidgetInstance.OvernightCRDepartures do
   @moduledoc false
 
-  alias Screens.V2.Departure
   alias Screens.Schedules.Schedule
+  alias Screens.V2.Departure
   alias Screens.V2.WidgetInstance
 
   @enforce_keys ~w[destination last_tomorrow_schedule direction_to_destination priority now]a

--- a/lib/screens_web/views/v2/audio/cr_departures_view.ex
+++ b/lib/screens_web/views/v2/audio/cr_departures_view.ex
@@ -114,6 +114,8 @@ defmodule ScreensWeb.V2.Audio.CRDeparturesView do
 
   defp delayed_clause(_), do: ""
 
+  defp render_headsign(%{headsign: headsign, station_service_list: []}), do: ~E|<%= headsign %>|
+
   defp render_headsign(%{headsign: headsign, station_service_list: [station1, station2]}) do
     via_string =
       cond do


### PR DESCRIPTION
**Asana task**: ad-hoc

Minimal changes were needed to get the widget working at Porter. Main changes are bringing in CR-Fitchburg to fetch params and adjusting alignment (Porter won't ever show `via...`). There are still some open design questions, but I wanted to put the changes on someone's radar while we wait for answers.


