### PR TITLE
polish: Add header types DUP v2

### DIFF
--- a/lib/screens/config/v2/dup.ex
+++ b/lib/screens/config/v2/dup.ex
@@ -33,14 +33,10 @@ defmodule Screens.Config.V2.Dup do
   end
 
   defp value_to_json(:header, %CurrentStopId{} = header) do
-    header
-    |> CurrentStopId.to_json()
-    |> Map.put(:type, :current_stop_id)
+    CurrentStopId.to_json(header)
   end
 
   defp value_to_json(:header, %CurrentStopName{} = header) do
-    header
-    |> CurrentStopName.to_json()
-    |> Map.put(:type, :current_stop_name)
+    CurrentStopName.to_json(header)
   end
 end

--- a/lib/screens/config/v2/dup.ex
+++ b/lib/screens/config/v2/dup.ex
@@ -24,12 +24,12 @@ defmodule Screens.Config.V2.Dup do
       evergreen_content: {:list, EvergreenContentItem}
     ]
 
-  defp value_from_json("header", %{"stop_id" => _} = header) do
-    CurrentStopId.from_json(header)
-  end
-
   defp value_from_json("header", %{"stop_name" => _} = header) do
     CurrentStopName.from_json(header)
+  end
+
+  defp value_from_json("header", %{"stop_id" => _} = header) do
+    CurrentStopId.from_json(header)
   end
 
   defp value_to_json(:header, %CurrentStopId{} = header) do

--- a/lib/screens/config/v2/dup.ex
+++ b/lib/screens/config/v2/dup.ex
@@ -24,17 +24,12 @@ defmodule Screens.Config.V2.Dup do
       evergreen_content: {:list, EvergreenContentItem}
     ]
 
-  defp value_from_json("header", %{"type" => "current_stop_id"} = header) do
+  defp value_from_json("header", %{"stop_id" => _} = header) do
     CurrentStopId.from_json(header)
   end
 
-  defp value_from_json("header", %{"type" => "current_stop_name"} = header) do
+  defp value_from_json("header", %{"stop_name" => _} = header) do
     CurrentStopName.from_json(header)
-  end
-
-  # When no type is provided, default to current_stop_id
-  defp value_from_json("header", header) do
-    CurrentStopId.from_json(header)
   end
 
   defp value_to_json(:header, %CurrentStopId{} = header) do

--- a/lib/screens/config/v2/dup.ex
+++ b/lib/screens/config/v2/dup.ex
@@ -1,11 +1,11 @@
 defmodule Screens.Config.V2.Dup do
   @moduledoc false
 
-  alias Screens.Config.V2.Header.CurrentStopId
+  alias Screens.Config.V2.Header.{CurrentStopId, CurrentStopName}
   alias Screens.Config.V2.{Departures, EvergreenContentItem}
 
   @type t :: %__MODULE__{
-          header: CurrentStopId.t(),
+          header: CurrentStopId.t() | CurrentStopName.t(),
           evergreen_content: list(EvergreenContentItem.t()),
           primary_departures: Departures.t(),
           secondary_departures: Departures.t()
@@ -21,7 +21,31 @@ defmodule Screens.Config.V2.Dup do
     children: [
       primary_departures: Departures,
       secondary_departures: Departures,
-      header: CurrentStopId,
       evergreen_content: {:list, EvergreenContentItem}
     ]
+
+  defp value_from_json("header", %{"type" => "current_stop_id"} = header) do
+    CurrentStopId.from_json(header)
+  end
+
+  defp value_from_json("header", %{"type" => "current_stop_name"} = header) do
+    CurrentStopName.from_json(header)
+  end
+
+  # When no type is provided, default to current_stop_id
+  defp value_from_json("header", header) do
+    CurrentStopId.from_json(header)
+  end
+
+  defp value_to_json(:header, %CurrentStopId{} = header) do
+    header
+    |> CurrentStopId.to_json()
+    |> Map.put(:type, :current_stop_id)
+  end
+
+  defp value_to_json(:header, %CurrentStopName{} = header) do
+    header
+    |> CurrentStopName.to_json()
+    |> Map.put(:type, :current_stop_name)
+  end
 end

--- a/lib/screens/v2/candidate_generator/dup.ex
+++ b/lib/screens/v2/candidate_generator/dup.ex
@@ -3,7 +3,7 @@ defmodule Screens.V2.CandidateGenerator.Dup do
 
   alias Screens.Config.Screen
   alias Screens.Config.V2.Dup
-  alias Screens.Config.V2.Header.CurrentStopId
+  alias Screens.Config.V2.Header.{CurrentStopId, CurrentStopName}
   alias Screens.Stops.Stop
   alias Screens.V2.CandidateGenerator
   alias Screens.V2.CandidateGenerator.Dup.Departures, as: DeparturesInstances
@@ -100,9 +100,19 @@ defmodule Screens.V2.CandidateGenerator.Dup do
         now,
         fetch_stop_name_fn
       ) do
-    %Screen{app_params: %Dup{header: %CurrentStopId{stop_id: stop_id}}} = config
+    %Screen{app_params: %Dup{header: header_config}} = config
 
-    stop_name = fetch_stop_name_fn.(stop_id)
+    stop_name =
+      case header_config do
+        %CurrentStopId{stop_id: stop_id} ->
+          case fetch_stop_name_fn.(stop_id) do
+            nil -> []
+            stop_name -> stop_name
+          end
+
+        %CurrentStopName{stop_name: stop_name} ->
+          stop_name
+      end
 
     List.duplicate(%NormalHeader{screen: config, icon: :logo, text: stop_name, time: now}, 3)
   end

--- a/test/screens/v2/candidate_generator/dup_test.exs
+++ b/test/screens/v2/candidate_generator/dup_test.exs
@@ -20,7 +20,19 @@ defmodule Screens.V2.CandidateGenerator.DupTest do
       app_id: :dup_v2
     }
 
-    %{config: config}
+    config_stop_name = %Screen{
+      app_params: %DupConfig{
+        header: %Header.CurrentStopName{stop_name: "Gov Center"},
+        primary_departures: struct(Departures),
+        secondary_departures: struct(Departures)
+      },
+      vendor: :outfront,
+      device_id: "TEST",
+      name: "TEST",
+      app_id: :dup_v2
+    }
+
+    %{config: config, config_stop_name: config_stop_name}
   end
 
   describe "screen_template/0" do
@@ -101,7 +113,7 @@ defmodule Screens.V2.CandidateGenerator.DupTest do
   end
 
   describe "header_instances/3" do
-    test "returns expected header", %{config: config} do
+    test "returns expected header for stop_id", %{config: config} do
       now = ~U[2020-04-06T10:00:00Z]
       fetch_stop_name_fn = fn _ -> "Test Stop" end
 
@@ -110,6 +122,29 @@ defmodule Screens.V2.CandidateGenerator.DupTest do
           screen: config,
           icon: :logo,
           text: "Test Stop",
+          time: now
+        }
+        |> List.duplicate(3)
+
+      actual_instances =
+        Dup.header_instances(
+          config,
+          now,
+          fetch_stop_name_fn
+        )
+
+      Enum.all?(expected_headers, &Enum.member?(actual_instances, &1))
+    end
+
+    test "returns expected header for stop_name", %{config_stop_name: config} do
+      now = ~U[2020-04-06T10:00:00Z]
+      fetch_stop_name_fn = fn _ -> nil end
+
+      expected_headers =
+        %NormalHeader{
+          screen: config,
+          icon: :logo,
+          text: "Gov Center",
           time: now
         }
         |> List.duplicate(3)


### PR DESCRIPTION
**Asana task**: ad-hoc

WTC and Tufts overflow into the time when in the 12 o'clock hours. To prevent this, the header config can now be the string to display on the screen instead of just a `stop_id`. This gives us the flexibility needed to abbreviate words to make headers fit.

- [X] Tests added?
