### PR TITLE
Add environment to header for V2 screens in dev and dev-green

### DIFF
--- a/assets/css/bus_eink_v2.scss
+++ b/assets/css/bus_eink_v2.scss
@@ -1,4 +1,5 @@
 @import "fonts/inter_font_face";
+@import "fonts";
 
 @import "v2/bus_eink/screen/normal";
 @import "v2/eink/screen/takeover";

--- a/assets/css/bus_shelter_v2.scss
+++ b/assets/css/bus_shelter_v2.scss
@@ -1,6 +1,7 @@
 @import url("https://rsms.me/inter/inter.css");
 
 @import "colors";
+@import "fonts";
 
 @import "v2/bus_shelter/screen_container";
 

--- a/assets/css/gl_eink_v2.scss
+++ b/assets/css/gl_eink_v2.scss
@@ -1,4 +1,5 @@
 @import "fonts/inter_font_face";
+@import "fonts";
 
 @import "v2/gl_eink/screen/normal";
 @import "v2/eink/screen/takeover";

--- a/assets/css/v2/bus_shelter/normal_header.scss
+++ b/assets/css/v2/bus_shelter/normal_header.scss
@@ -53,3 +53,14 @@
   line-height: 56px;
   color: #ffffff;
 }
+
+.normal-header__environment {
+  @include font--text--75bold;
+  position: relative;
+  padding-left: 40px;
+  padding-top: 10px;
+  font-size: 36px;
+  color: #ffffff;
+  letter-spacing: 0;
+  line-height: 48px;
+}

--- a/assets/css/v2/eink/normal_header.scss
+++ b/assets/css/v2/eink/normal_header.scss
@@ -97,3 +97,14 @@
   width: 25px;
   margin-right: 4px;
 }
+
+.normal-header__environment {
+  @include font--text--75bold;
+  position: relative;
+  padding-left: 40px;
+  padding-top: 10px;
+  font-size: 36px;
+  color: #ffffff;
+  letter-spacing: 0;
+  line-height: 48px;
+}

--- a/assets/css/v2/pre_fare/normal_header.scss
+++ b/assets/css/v2/pre_fare/normal_header.scss
@@ -59,3 +59,14 @@
 .right-screen .normal-header-title {
   display: none;
 }
+
+.normal-header__environment {
+  @include font--text--75bold;
+  position: relative;
+  font-size: 36px;
+  color: #ffffff;
+  letter-spacing: 0;
+  line-height: 48px;
+  padding-top: 10px;
+  margin-left: 48px;
+}

--- a/assets/src/components/v2/normal_header.tsx
+++ b/assets/src/components/v2/normal_header.tsx
@@ -66,8 +66,15 @@ const NormalHeaderTitle: ComponentType<NormalHeaderTitleProps> = forwardRef(
     }
 
     const abbreviatedText = fullName ? text : abbreviateText(text);
+    const environmentName = getDatasetValue("environmentName");
 
     return (
+      <div>
+        <div className="normal-header__environment">
+          {["screens-dev", "screens-dev-green"].includes(environmentName)
+            ? environmentName
+            : ""}
+        </div>
       <div className="normal-header-title">
         {showTo && <div className="normal-header-to__text">TO</div>}
         {icon && <NormalHeaderIcon icon={icon} />}
@@ -76,6 +83,7 @@ const NormalHeaderTitle: ComponentType<NormalHeaderTitleProps> = forwardRef(
           ref={ref}
         >
           {abbreviatedText}
+          </div>
         </div>
       </div>
     );


### PR DESCRIPTION
**Asana task**: [Add env back to top of all v2 screens](https://app.asana.com/0/1185117109217432/1203860696691652/f)

This adds the environment name for V2 screens in `dev` and `dev-green`

Examples:
![Screenshot 2023-03-24 at 8 13 33 PM](https://user-images.githubusercontent.com/16074540/227667285-f9f556a9-8ce0-4ebe-80e3-27601c285bd8.png)
![Screenshot 2023-03-24 at 8 14 23 PM](https://user-images.githubusercontent.com/16074540/227667227-dff7722e-9181-45e7-8dac-9eba7a211a26.png)
![Screenshot 2023-03-24 at 8 14 35 PM](https://user-images.githubusercontent.com/16074540/227667228-a6fcdb26-de0e-4e5f-9926-fe355e25848e.png)
![Screenshot 2023-03-24 at 8 14 42 PM](https://user-images.githubusercontent.com/16074540/227667229-a3feaa30-ce28-4d77-9268-9e6ddc943a1d.png)

I noticed that when the title is long and overflows to the next line, part of the title will start overlapping with the environment name. I thought of putting the environment name somewhere else like underneath the time, but I figured it wouldn't be as noticeable. I think the text overlaps in a similar way for v1 screens currently.
