### PR TITLE
fix: Add headsign matcher for Wellington.

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -192,6 +192,10 @@ config :screens,
     "place-portr" => [
       {"70064", "70068", "Alewife"},
       {"70067", "70063", "Ashmont/Braintree"}
+    ],
+    "place-welln" => [
+      {"70278", "70034", "Forest Hills"},
+      {"70035", "70279", "Oak Grove"}
     ]
   },
   dup_headsign_replacements: %{


### PR DESCRIPTION
**Asana task**: ad-hoc (https://mbta.slack.com/archives/C039ARUM48H/p1679976317919639)

A shuttle alert from Wellington to North Station is crashing the screen because we don't have a headsign matcher for that station. Adding this allows the alert to show correctly with the proper headsign.

- [ ] Tests added?
