### PR TITLE
fix: Use route type atoms, not integer IDs, in all API query filters

### DIFF
--- a/lib/screens/v2/candidate_generator/widgets/elevator_closures.ex
+++ b/lib/screens/v2/candidate_generator/widgets/elevator_closures.ex
@@ -17,7 +17,8 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ElevatorClosures do
         } = config,
         now
       ) do
-    with {:ok, routes_at_stop} <- Route.fetch_routes_by_stop(parent_station_id, now, [0, 1]),
+    with {:ok, routes_at_stop} <-
+           Route.fetch_routes_by_stop(parent_station_id, now, [:light_rail, :subway]),
          route_ids_at_stop = Enum.map(routes_at_stop, & &1.route_id),
          {:ok, stop_sequences} <-
            RoutePattern.fetch_parent_station_sequences_through_stop(

--- a/lib/screens/v2/candidate_generator/widgets/reconstructed_alert.ex
+++ b/lib/screens/v2/candidate_generator/widgets/reconstructed_alert.ex
@@ -29,7 +29,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlert do
         fetch_stop_name_fn \\ &Stop.fetch_stop_name/1
       ) do
     # Filtering by subway and light_rail types
-    with {:ok, routes_at_stop} <- fetch_routes_by_stop_fn.(stop_id, now, [0, 1]),
+    with {:ok, routes_at_stop} <- fetch_routes_by_stop_fn.(stop_id, now, [:light_rail, :subway]),
          route_ids_at_stop =
            routes_at_stop
            |> Enum.map(& &1.route_id)


### PR DESCRIPTION
**Asana task**: ad hoc

A follow-up fix from the DUP alert backend changes!

- [ ] Tests added?
