### PR TITLE
polish: DUP v2 admin header config

### DIFF
--- a/assets/src/components/admin/admin_tables.tsx
+++ b/assets/src/components/admin/admin_tables.tsx
@@ -454,6 +454,14 @@ const DupV2ScreensTable = (): JSX.Element => {
   const columns = [
     { Header: "Screen ID", accessor: "id", Filter: DefaultColumnFilter },
     {
+      Header: "Header",
+      accessor: buildAppParamAccessor("header"),
+      mutator: buildAppParamMutator("header"),
+      Cell: EditableTextarea,
+      disableFilters: true,
+      FormCell: FormTextarea,
+    },
+    {
       Header: "Primary Departures",
       accessor: buildAppParamAccessor("primary_departures"),
       mutator: buildAppParamMutator("primary_departures"),

--- a/lib/screens/config/v2/dup.ex
+++ b/lib/screens/config/v2/dup.ex
@@ -17,7 +17,6 @@ defmodule Screens.Config.V2.Dup do
 
   use Screens.Config.Struct,
     children: [
-      header: CurrentStopId,
       primary_departures: Departures,
       secondary_departures: Departures,
       alerts: Alerts,

--- a/lib/screens/v2/candidate_generator/dup/alerts.ex
+++ b/lib/screens/v2/candidate_generator/dup/alerts.ex
@@ -32,9 +32,20 @@ defmodule Screens.V2.CandidateGenerator.Dup.Alerts do
     # - Check for special cases. If there is one, just use that. Otherwise:
     # - Select one alert
     # - Create 3 candidate structs from the alert, one for each rotation
-    %Screen{app_params: %Dup{alerts: %AlertsConfig{stop_id: stop_id}}} = config
+    %Screen{app_params: %Dup{alerts: %AlertsConfig{stop_id: stop_id}, header: header_config}} =
+      config
 
-    stop_name = fetch_stop_name_fn.(config.app_params.header.stop_id)
+    stop_name =
+      case header_config do
+        %{stop_id: stop_id} ->
+          case fetch_stop_name_fn.(stop_id) do
+            nil -> []
+            stop_name -> stop_name
+          end
+
+        %{stop_name: stop_name} ->
+          stop_name
+      end
 
     route_type_filter = get_route_type_filter(stop_id)
 


### PR DESCRIPTION
**Notion task**: [Long station name “Tufts Medical Ctr” is abbreviated correctly](https://www.notion.so/mbta-downtown-crossing/Long-station-name-Tufts-Medical-Ctr-is-abbreviated-correctly-dbe9b4057bcb4320afd97bdece726907?pvs=4)

Header config was missing from admin tool.

I also fixed the DUP v2 header config so it can use `stop_name`. `CandidateGenerator.Dup.Alerts` was assuming the header config was always given a `stop_id` (which was true when that task was started). Now that it can be a `stop_name`, it needs to check which is being first.

- [ ] Tests added?
