### PR TITLE
Add retry logic to routes fetch

### DIFF
--- a/lib/screens/stops/stop.ex
+++ b/lib/screens/stops/stop.ex
@@ -10,6 +10,8 @@ defmodule Screens.Stops.Stop do
 
   use Retry.Annotation
 
+  require Logger
+
   alias Screens.Routes
   alias Screens.Stops.StationsWithRoutesAgent
   alias Screens.V3Api
@@ -289,15 +291,45 @@ defmodule Screens.Stops.Stop do
     case StationsWithRoutesAgent.get(station_id) do
       {routes, date} ->
         case fetch_routes_serving_stop(station_id, [{"if-modified-since", date}]) do
-          {:ok, new_routes} -> new_routes
-          :not_modified -> routes
-          :error -> []
+          {:ok, new_routes} ->
+            new_routes
+
+          :not_modified ->
+            routes
+
+          :bad_response ->
+            Logger.error(
+              "[create_station_with_routes_map no routes] Received an empty list from API: stop_id=#{station_id}"
+            )
+
+            []
+
+          :error ->
+            Logger.error(
+              "[create_station_with_routes_map fetch error] Received an error from API: stop_id=#{station_id}"
+            )
+
+            []
         end
 
       nil ->
         case fetch_routes_serving_stop(station_id) do
-          {:ok, new_routes} -> new_routes
-          :error -> []
+          {:ok, new_routes} ->
+            new_routes
+
+          :bad_response ->
+            Logger.error(
+              "[create_station_with_routes_map no routes] Received an empty list from API: stop_id=#{station_id}"
+            )
+
+            []
+
+          :error ->
+            Logger.error(
+              "[create_station_with_routes_map fetch error] Received an error from API: stop_id=#{station_id}"
+            )
+
+            []
         end
     end
   end

--- a/lib/screens/stops/stop.ex
+++ b/lib/screens/stops/stop.ex
@@ -282,7 +282,14 @@ defmodule Screens.Stops.Stop do
   def create_station_with_routes_map(station_id) do
     case StationsWithRoutesAgent.get(station_id) do
       {routes, date} ->
-        case fetch_routes_serving_stop(station_id, [{"if-modified-since", date}]) do
+        headers =
+          if routes == [] do
+            []
+          else
+            [{"if-modified-since", date}]
+          end
+
+        case fetch_routes_serving_stop(station_id, headers) do
           {:ok, new_routes} -> new_routes
           :not_modified -> routes
           :error -> []


### PR DESCRIPTION
**Asana task**: ad-hoc

~~Our `Agent` seems to be saving an empty list at times. When this happens, we still use the `if-modified-since` header which causes the empty list to persist until the response does change. Conditionally adding the header should allow the `Agent` to get back to a good state it somehow saves bad data.~~

Went a different direction. The original logic would still always fail once because we never try again when we get an empty list. New logic adds retries to the fetch. It only retries for empty lists (`v3_api` already has retry logic for failures) up to 3 times. If it's still an issue, we log and the function will still return an empty list. It will not save that empty list to the Agent so in the next refresh it will try fetching again. 

- [ ] Tests added?
