### PR TITLE
fix: Headway headsign logic

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -81,121 +81,121 @@ config :screens,
 
 config :screens,
   # Maps alert informed entity contents to the appropriate headsign to show for that alert.
-  # List elements must be of the shape {informed_stop_ids, not_informed_stop_ids, headsign}.
+  # List elements must be of the shape {informed_stop_ids, not_informed_stop_ids, headsign, headway}.
   # Each set of stop IDs can be either a single string or a list of strings.
   dup_alert_headsign_matchers: %{
     # Kenmore
     "place-kencl" => [
-      {"70149", ~w[70153 70211 70187], "Boston College"},
-      {"70211", ~w[70153 70149 70187], "Cleveland Circle"},
-      {"70187", ~w[70153 70149 70211], "Riverside"},
-      {~w[70149 70211], ~w[70153 70187], "BC/Clev. Circ."},
-      {~w[70149 70187], ~w[70153 70211], "BC/Riverside"},
-      {~w[70211 70187], ~w[70153 70149], "Clev. Circ./Riverside"},
-      {~w[70149 70211 70187], "70153", {:adj, "westbound"}},
-      {"70152", ~w[70148 70212 70186], "Park Street"}
+      {"70149", ~w[70153 70211 70187], "Boston College", nil},
+      {"70211", ~w[70153 70149 70187], "Cleveland Circle", nil},
+      {"70187", ~w[70153 70149 70211], "Riverside", nil},
+      {~w[70149 70211], ~w[70153 70187], "BC/Clev. Circ.", nil},
+      {~w[70149 70187], ~w[70153 70211], "BC/Riverside", nil},
+      {~w[70211 70187], ~w[70153 70149], "Clev. Circ./Riverside", nil},
+      {~w[70149 70211 70187], "70153", {:adj, "westbound"}, "Park Street"},
+      {"70152", ~w[70148 70212 70186], "Park Street", "Westbound"}
     ],
     # Prudential
     "place-prmnl" => [
-      {"70154", "70242", "Park Street"},
-      {"70241", "70155", "Heath Street"}
+      {"70154", "70242", "Park Street", "Heath Street"},
+      {"70241", "70155", "Heath Street", "Park Street"}
     ],
     # Haymarket
     "place-haecl" => [
       # GL
-      {"70205", "70201", "Northbound"},
-      {"70202", "70206", "Copley & West"},
+      {"70205", "70201", "Northbound", "Copley & West"},
+      {"70202", "70206", "Copley & West", "Northbound"},
       # OL
-      {"70027", "70023", "Oak Grove"},
-      {"70022", "70026", "Forest Hills"}
+      {"70027", "70023", "Oak Grove", "Forest Hills"},
+      {"70022", "70026", "Forest Hills", "Oak Grove"}
     ],
     # Back Bay
     "place-bbsta" => [
-      {"70017", "70013", "Oak Grove"},
-      {"70012", "70016", "Forest Hills"}
+      {"70017", "70013", "Oak Grove", "Forest Hills"},
+      {"70012", "70016", "Forest Hills", "Oak Grove"}
     ],
     # Tufts
     "place-tumnl" => [
-      {"70019", "70015", "Oak Grove"},
-      {"70014", "70018", "Forest Hills"}
+      {"70019", "70015", "Oak Grove", "Forest Hills"},
+      {"70014", "70018", "Forest Hills", "Oak Grove"}
     ],
     # Sullivan
     "place-sull" => [
-      {"70279", "70029", "Oak Grove"},
-      {"70028", "70278", "Forest Hills"}
+      {"70279", "70029", "Oak Grove", "Forest Hills"},
+      {"70028", "70278", "Forest Hills", "Oak Grove"}
     ],
     # Malden Center
     "place-mlmnl" => [
-      {"70036", "70033", "Oak Grove"},
-      {"70032", "70036", "Forest Hills"}
+      {"70036", "70033", "Oak Grove", "Forest Hills"},
+      {"70032", "70036", "Forest Hills", "Oak Grove"}
     ],
     # Broadway
     "place-brdwy" => [
-      {"70080", "70084", "Alewife"},
-      {"70083", "70079", "Ashmont/Braintree"}
+      {"70080", "70084", "Alewife", "Ashmont/Braintree"},
+      {"70083", "70079", "Ashmont/Braintree", "Alewife"}
     ],
     # Aquarium
     "place-aqucl" => [
-      {"70046", "70042", "Wonderland"},
-      {"70041", "70045", "Bowdoin"}
+      {"70046", "70042", "Wonderland", "Bowdoin"},
+      {"70041", "70045", "Bowdoin", "Wonderland"}
     ],
     # Airport
     "place-aport" => [
-      {"70050", "70046", "Wonderland"},
-      {"70045", "70049", "Bowdoin"}
+      {"70050", "70046", "Wonderland", "Bowdoin"},
+      {"70045", "70049", "Bowdoin", "Wonderland"}
     ],
     # Quincy Center
     "place-qnctr" => [
-      {"70100", "70104", "Alewife"},
-      {"70103", "70099", "Braintree"}
+      {"70100", "70104", "Alewife", "Braintree"},
+      {"70103", "70099", "Braintree", "Alewife"}
     ]
   },
   prefare_alert_headsign_matchers: %{
     # Government Center
     "place-gover" => [
       # GL
-      {"70203", "70200", "North Station & North"},
-      {~w[70199 70198 70197 70196], "70204", "Copley & West"},
+      {"70203", "70200", "North Station & North", nil},
+      {~w[70199 70198 70197 70196], "70204", "Copley & West", nil},
       # BL
-      {"70042", "70038", "Wonderland"},
-      {"70038", "70041", "Bowdoin"}
+      {"70042", "70038", "Wonderland", nil},
+      {"70038", "70041", "Bowdoin", nil}
     ],
     # Tufts
     "place-tumnl" => [
-      {"70019", "70015", "Oak Grove"},
-      {"70014", "70018", "Forest Hills"}
+      {"70019", "70015", "Oak Grove", nil},
+      {"70014", "70018", "Forest Hills", nil}
     ],
     # Back Bay
     "place-bbsta" => [
-      {"70017", "70013", "Oak Grove"},
-      {"70012", "70016", "Forest Hills"}
+      {"70017", "70013", "Oak Grove", nil},
+      {"70012", "70016", "Forest Hills", nil}
     ],
     # Forest Hills
     "place-forhl" => [
-      {"70003", nil, "Oak Grove"}
+      {"70003", nil, "Oak Grove", nil}
     ],
     # Maverick
     "place-mvbcl" => [
-      {"70048", "70044", "Wonderland"},
-      {"70043", "70047", "Bowdoin"}
+      {"70048", "70044", "Wonderland", nil},
+      {"70043", "70047", "Bowdoin", nil}
     ],
     # Ashmont
     "place-asmnl" => [
-      {"70092", nil, "Alewife"}
+      {"70092", nil, "Alewife", nil}
     ],
     # Charles/MGH
     "place-chmnl" => [
-      {"70072", "70076", "Alewife"},
-      {"70075", "70071", "Ashmont/Braintree"}
+      {"70072", "70076", "Alewife", nil},
+      {"70075", "70071", "Ashmont/Braintree", nil}
     ],
     # Porter
     "place-portr" => [
-      {"70064", "70068", "Alewife"},
-      {"70067", "70063", "Ashmont/Braintree"}
+      {"70064", "70068", "Alewife", nil},
+      {"70067", "70063", "Ashmont/Braintree", nil}
     ],
     "place-welln" => [
-      {"70278", "70034", "Forest Hills"},
-      {"70035", "70279", "Oak Grove"}
+      {"70278", "70034", "Forest Hills", nil},
+      {"70035", "70279", "Oak Grove", nil}
     ]
   },
   dup_headsign_replacements: %{

--- a/config/test.exs
+++ b/config/test.exs
@@ -26,12 +26,15 @@ config :screens,
     "Test 1" => "T1"
   },
   dup_alert_headsign_matchers: %{
-    "place-B" => [{"place-B", "not_informed", "Test"}],
-    "place-kencl" => [
-      {"70211", ~w[70153 70149 70187], "Cleveland Circle"},
-      {"70152", ~w[70148 70212 70186], "Park Street"}
+    "place-B" => [
+      {"place-A", "not_informed", "Test A", "Test B"},
+      {"place-B", "not_informed", "Test B", "Test A"}
     ],
-    "place-overnight" => [{"place-overnight", "not_informed", "Test"}]
+    "place-kencl" => [
+      {~w[70149 70211 70187], "70153", {:adj, "westbound"}, "Park Street"},
+      {"70152", ~w[70148 70212 70186], "Park Street", "Westbound"}
+    ],
+    "place-overnight" => [{"place-overnight", "not_informed", "Test", nil}]
   }
 
 config :screens, ScreensWeb.AuthManager, secret_key: "test key"

--- a/lib/screens/dup_screen_data/data.ex
+++ b/lib/screens/dup_screen_data/data.ex
@@ -15,7 +15,7 @@ defmodule Screens.DupScreenData.Data do
       :screens
       |> Application.get_env(:dup_alert_headsign_matchers)
       |> Map.get(parent_stop_id)
-      |> Enum.find_value({:inside, nil}, fn {informed, not_informed, headsign} ->
+      |> Enum.find_value({:inside, nil}, fn {informed, not_informed, headsign, _} ->
         if alert_region_match?(to_set(informed), to_set(not_informed), informed_stop_ids),
           do: {:boundary, headsign},
           else: false

--- a/lib/screens/v2/candidate_generator/dup/departures.ex
+++ b/lib/screens/v2/candidate_generator/dup/departures.ex
@@ -371,13 +371,14 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
       :screens
       |> Application.get_env(:dup_alert_headsign_matchers)
       |> Map.get(parent_stop_id)
-      |> Enum.find_value({:inside, nil}, fn {informed, not_informed, headsign} ->
+      |> Enum.find_value({:inside, nil}, fn {informed, not_informed, _alert_headsign,
+                                             headway_headsign} ->
         if alert_region_match?(
              Util.to_set(informed),
              Util.to_set(not_informed),
              informed_stop_ids
            ),
-           do: {:boundary, headsign},
+           do: {:boundary, headway_headsign},
            else: false
       end)
 

--- a/lib/screens/v2/widget_instance/common/base_alert.ex
+++ b/lib/screens/v2/widget_instance/common/base_alert.ex
@@ -70,13 +70,13 @@ defmodule Screens.V2.WidgetInstance.Common.BaseAlert do
 
       headsign_matchers
       |> Map.get(SAW.home_stop_id(t))
-      |> Enum.find_value(fn {informed, not_informed, headsign} ->
+      |> Enum.find_value(fn {informed, not_informed, alert_headsign, _headway_headsign} ->
         if alert_region_match?(
              Util.to_set(informed),
              Util.to_set(not_informed),
              informed_stop_ids
            ),
-           do: headsign,
+           do: alert_headsign,
            else: false
       end)
     end

--- a/test/screens/v2/candidate_generator/dup/departures_test.exs
+++ b/test/screens/v2/candidate_generator/dup/departures_test.exs
@@ -986,8 +986,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
             struct(Alert,
               effect: :suspension,
               informed_entities: [
-                %{stop: "place-B", route: "Red"},
-                %{stop: "place-C", route: "Red"}
+                %{stop: "place-B", route: "Red"}
               ],
               active_period: [{~U[2020-04-06T09:00:00Z], nil}]
             )
@@ -1002,7 +1001,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
               type: :headway_section,
               route: "Red",
               time_range: {12, 16},
-              headsign: "Test"
+              headsign: "Test A"
             }
           ],
           slot_names: [:main_content_zero]
@@ -1014,7 +1013,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
               type: :headway_section,
               route: "Red",
               time_range: {12, 16},
-              headsign: "Test"
+              headsign: "Test A"
             }
           ],
           slot_names: [:main_content_one]
@@ -1026,7 +1025,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
               type: :headway_section,
               route: "Red",
               time_range: {12, 16},
-              headsign: "Test"
+              headsign: "Test A"
             }
           ],
           slot_names: [:main_content_two]
@@ -1447,13 +1446,6 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
                   facility: nil,
                   route: "Green-C",
                   route_type: 0,
-                  stop: "70150"
-                },
-                %{
-                  direction_id: nil,
-                  facility: nil,
-                  route: "Green-C",
-                  route_type: 0,
                   stop: "70151"
                 },
                 %{
@@ -1468,7 +1460,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
                   facility: nil,
                   route: "Green-C",
                   route_type: 0,
-                  stop: "70153"
+                  stop: "place-kencl"
                 },
                 %{
                   direction_id: nil,
@@ -1476,13 +1468,6 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
                   route: "Green-C",
                   route_type: 0,
                   stop: "place-hymnl"
-                },
-                %{
-                  direction_id: nil,
-                  facility: nil,
-                  route: "Green-C",
-                  route_type: 0,
-                  stop: "place-kencl"
                 }
               ],
               active_period: [{~U[2020-04-06T09:00:00Z], nil}]
@@ -1498,10 +1483,10 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
               type: :headway_section,
               route: "Green",
               time_range: {7, 13},
-              headsign: "Park Street"
+              headsign: "Westbound"
             }
           ],
-          slot_names: [:main_content_zero]
+          slot_names: [:main_content_reduced_zero]
         },
         %DeparturesWidget{
           screen: config,
@@ -1510,10 +1495,10 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
               type: :headway_section,
               route: "Green",
               time_range: {7, 13},
-              headsign: "Park Street"
+              headsign: "Westbound"
             }
           ],
-          slot_names: [:main_content_one]
+          slot_names: [:main_content_reduced_one]
         },
         %DeparturesWidget{
           screen: config,
@@ -1522,10 +1507,10 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
               type: :headway_section,
               route: "Green",
               time_range: {7, 13},
-              headsign: "Park Street"
+              headsign: "Westbound"
             }
           ],
-          slot_names: [:main_content_two]
+          slot_names: [:main_content_reduced_two]
         }
       ]
 


### PR DESCRIPTION
**Notion task**: [Multi-line headways include the correct destination](https://www.notion.so/mbta-downtown-crossing/Multi-line-headways-include-the-correct-destination-48251b33f716474db75396ab7257613c?pvs=4)

Something I did not think about when implementing headway mode was how to headsign matchers are there to determine the direction of the affected range of an alert. This means that headway needs the opposite direction's headsign (sounds so obvious now so not sure how I didn't think about this).

This PR adds an additional element to the headsign matcher tuples. I would rather solve this in the logic, but that seems risky because we are looking at `platform_id`s. Directional alerts may cause an ID we expect not to be present (or vice-versa). Because we know that the headsign matcher works for alerts, if we also hardcode the headsign for headway we will know for sure that the logic is correct.

Biggest concern: this affects anything that implements the `SingleAlertWidget` protocol. The upside is it can just ignore the fourth element if it does not have headway mode (which is every existing alert since headway is handled in departures).

- [ ] Tests added?
