### PR TITLE
polish: DUP Header undefined modifier

### DIFF
--- a/assets/src/components/v2/dup/normal_header.tsx
+++ b/assets/src/components/v2/dup/normal_header.tsx
@@ -6,13 +6,16 @@ import { DUP_VERSION } from "Components/dup/version";
 interface NormalHeaderProps {
   text: string;
   time?: string;
-  color?: string;
   accentPattern?: string;
   code?: string;
 }
 
-const NormalHeader = ({text, time, color, accentPattern, code}: NormalHeaderProps) => {
-
+const NormalHeader = ({
+  text,
+  time,
+  accentPattern,
+  code,
+}: NormalHeaderProps) => {
   return (
     <DefaultNormalHeader
       icon={Icon.logo}
@@ -23,7 +26,6 @@ const NormalHeader = ({text, time, color, accentPattern, code}: NormalHeaderProp
       version={DUP_VERSION + (code ? "; Maintenance code: " + code : "")}
       maxHeight={208}
       showTo={false}
-      classModifiers={color}
       accentPattern={accentPattern}
     />
   );

--- a/assets/src/components/v2/dup/normal_header.tsx
+++ b/assets/src/components/v2/dup/normal_header.tsx
@@ -6,6 +6,7 @@ import { DUP_VERSION } from "Components/dup/version";
 interface NormalHeaderProps {
   text: string;
   time?: string;
+  color?: string;
   accentPattern?: string;
   code?: string;
 }
@@ -13,6 +14,7 @@ interface NormalHeaderProps {
 const NormalHeader = ({
   text,
   time,
+  color,
   accentPattern,
   code,
 }: NormalHeaderProps) => {
@@ -26,6 +28,7 @@ const NormalHeader = ({
       version={DUP_VERSION + (code ? "; Maintenance code: " + code : "")}
       maxHeight={208}
       showTo={false}
+      classModifiers={color}
       accentPattern={accentPattern}
     />
   );

--- a/assets/src/util/util.tsx
+++ b/assets/src/util/util.tsx
@@ -3,7 +3,11 @@ import "moment-timezone";
 import { getDatasetValue } from "Util/dataset";
 
 export const classWithModifier = (baseClass, modifier) => {
-  return `${baseClass} ${baseClass}--${modifier}`;
+  if (!modifier) {
+    return baseClass;
+  } else {
+    return `${baseClass} ${baseClass}--${modifier}`;
+  }
 };
 
 export const classWithModifiers = (baseClass, modifiers) => {


### PR DESCRIPTION
**Notion task**: [Undefined class name on header](https://www.notion.so/mbta-downtown-crossing/Undefined-class-name-on-header-3a91f1a43a6e4e65943583b78dc06297?pvs=4)

The default header for DUPs does not use the `color` prop so the `div` was getting an `undefined` modifier for the CSS class. I changed the util function to only use the modifier if it is a string. 

- [ ] Tests added?
