### PR TITLE
Cm/fix multi section alert layout

### DIFF
--- a/lib/screens/v2/candidate_generator/dup/alerts.ex
+++ b/lib/screens/v2/candidate_generator/dup/alerts.ex
@@ -96,7 +96,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Alerts do
 
   defp create_alert_widgets(
          {:normal, alerts},
-         config,
+         %Screen{app_params: %Dup{primary_departures: %{sections: sections}}} = config,
          stop_sequences,
          subway_routes_at_stop,
          stop_name
@@ -112,6 +112,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Alerts do
           alert: alert,
           stop_sequences: stop_sequences,
           subway_routes_at_stop: subway_routes_at_stop,
+          primary_section_count: length(sections),
           rotation_index: rotation_index,
           stop_name: stop_name
         }
@@ -119,12 +120,19 @@ defmodule Screens.V2.CandidateGenerator.Dup.Alerts do
     end
   end
 
-  defp relevant_alert?(alert, config, stop_sequences, subway_routes_at_stop, now) do
+  defp relevant_alert?(
+         alert,
+         %Screen{app_params: %Dup{primary_departures: %{sections: sections}}} = config,
+         stop_sequences,
+         subway_routes_at_stop,
+         now
+       ) do
     dup_alert = %DupAlert{
       screen: config,
       alert: alert,
       stop_sequences: stop_sequences,
       subway_routes_at_stop: subway_routes_at_stop,
+      primary_section_count: length(sections),
       rotation_index: :zero,
       stop_name: "A Station"
     }

--- a/lib/screens/v2/widget_instance/dup_alert.ex
+++ b/lib/screens/v2/widget_instance/dup_alert.ex
@@ -139,6 +139,7 @@ defmodule Screens.V2.WidgetInstance.DupAlert do
   # Inputs/outputs are stored as a table for readability.
   # Table is adapted from the one in the product spec: https://www.notion.so/mbta-downtown-crossing/DUP-Alert-Widget-Specification-a82acff850ed4f2eb98a04e5f3e0fe52
   # Compile-time code converts each table row to `do_alert_layout` function clauses.
+  # TotalSections refers to the number of sections in `primary_departures` of DUP configs.
   alert_layout_table = """
   # INPUTS                                                          || OUTPUTS
   # Effect          Location            AffectedLines TotalSections || LayoutZero  LayoutOne   LayoutTwo


### PR DESCRIPTION
**Notion task**: [Station closure, inside, 1/2](https://www.notion.so/mbta-downtown-crossing/Station-closure-inside-1-2-8a2c0d7a2faa471b8878939ac43c152d?pvs=4)

On multi-section screens where the second section is not subway/light rail, we were showing a fullscreen alert instead of a partial alert. Added a new struct attribute that holds the total number of section configured in `primary_departures` in the screen config. I added the config access to the `candidate_generator` because adding it to the `widget_instance` just didn't feel right. Happy to hear any opposing opinions on that.

- [ ] Tests added?
