### PR TITLE
polish: Make DUP 3rd rotation layout depend on whether secondary departures are configured

### DIFF
--- a/lib/screens/v2/widget_instance/dup_alert.ex
+++ b/lib/screens/v2/widget_instance/dup_alert.ex
@@ -81,151 +81,120 @@ defmodule Screens.V2.WidgetInstance.DupAlert do
     end
   end
 
+  @spec valid_candidate?(t()) :: boolean()
   def valid_candidate?(%__MODULE__{} = t) do
     alert_layout(t) != :no_render
   end
 
+  # Inputs/output are stored as a table for readability.
+  # Table is adapted from the one in the product spec: https://www.notion.so/mbta-downtown-crossing/DUP-Alert-Widget-Specification-a82acff850ed4f2eb98a04e5f3e0fe52
+  # Compile-time code converts each table row to a key-value pair in a map.
+  # PrimarySections refers to the number of sections in `primary_departures` of DUP config.
+  #
+  # Delay alerts are handled separately, see `delay_alert_layout` below.
+  # Layouts for rotations one and two are derived from the layout for rotation zero, see `non_delay_alert_layout` below.
+  layout_zero_table = """
+  # INPUTS                                                            || OUTPUT
+  # Effect          Location            AffectedLines PrimarySections || LayoutZero
+    station_closure inside              1             1                  full_screen
+    station_closure inside              1             2                  partial
+    station_closure inside              2             2                  full_screen
+  # "Boundary" location is not possible for station closures.
+    shuttle         inside              1             1                  full_screen
+    shuttle         inside              1             2                  partial
+    shuttle         inside              2             2                  full_screen
+    shuttle         boundary_upstream   1             1                  partial
+    shuttle         boundary_downstream 1             1                  partial
+    shuttle         boundary_upstream   1             2                  partial
+    shuttle         boundary_downstream 1             2                  partial
+    suspension      inside              1             1                  full_screen
+    suspension      inside              1             2                  partial
+    suspension      inside              2             2                  full_screen
+    suspension      boundary_upstream   1             1                  partial
+    suspension      boundary_downstream 1             1                  partial
+    suspension      boundary_upstream   1             2                  partial
+    suspension      boundary_downstream 1             2                  partial
+  """
+
+  @parameters_to_layout_zero layout_zero_table
+                             |> String.split("\n", trim: true)
+                             |> Enum.reject(&String.starts_with?(&1, "#"))
+                             |> Enum.into(%{}, fn line ->
+                               [
+                                 effect,
+                                 location,
+                                 affected_line_count,
+                                 primary_section_count,
+                                 layout_zero
+                               ] = String.split(line, ~r/\s+/, trim: true)
+
+                               # Convert strings to appropriate types
+                               [effect, location, layout_zero] =
+                                 Enum.map(
+                                   [effect, location, layout_zero],
+                                   &String.to_existing_atom/1
+                                 )
+
+                               [affected_line_count, primary_section_count] =
+                                 Enum.map(
+                                   [affected_line_count, primary_section_count],
+                                   &String.to_integer/1
+                                 )
+
+                               parameters = %{
+                                 effect: effect,
+                                 location: location,
+                                 affected_line_count: affected_line_count,
+                                 primary_section_count: primary_section_count
+                               }
+
+                               {parameters, layout_zero}
+                             end)
+
+  defp get_layout_parameters(t) do
+    %{
+      effect: t.alert.effect,
+      location: BaseAlert.location(t),
+      affected_line_count: length(get_affected_lines(t)),
+      primary_section_count: t.primary_section_count
+    }
+  end
+
   @spec alert_layout(t()) :: :full_screen | :partial | :no_render
   defp alert_layout(t) do
-    effect = t.alert.effect
-    location = BaseAlert.location(t)
-    affected_line_count = length(get_affected_lines(t))
-    rotation_index = t.rotation_index
-
-    parameters = {effect, location, affected_line_count, t.primary_section_count, rotation_index}
-
-    special_case = alert_layout_special_case(t, parameters)
-
-    if special_case do
-      special_case
-    else
-      case do_alert_layout(parameters) do
-        :no_render ->
-          log_layout_mismatch(t, parameters, :not_applicable)
-          :no_render
-
-        layout ->
-          layout
-      end
+    case t.alert.effect do
+      :delay -> delay_alert_layout(t)
+      _ -> non_delay_alert_layout(t)
     end
   end
 
-  # The widget _should_ always be valid given the constraints of what alerts
-  # we generate DUP alert widgets for, but in case one slips through, we
-  # should know about it!
-  defp log_layout_mismatch(t, parameters, delay_severity) do
-    {effect, location, affected_line_count, total_section_count, rotation_index} = parameters
-
-    labeled_parameters = [
-      effect: effect,
-      delay_severity: delay_severity,
-      location: location,
-      affected_line_count: affected_line_count,
-      total_section_count: total_section_count,
-      rotation_index: rotation_index
-    ]
-
-    identifiers = [alert_id: t.alert.id, stop_ids: Enum.join(t.screen.alerts.stop_ids, ",")]
-    log_fields = identifiers ++ labeled_parameters
-
-    Logger.info(
-      "[DUP alert no matching layout] " <>
-        Enum.map_join(log_fields, " ", fn {label, value} -> "#{label}=#{value}" end)
-    )
-  end
-
-  # Inputs/outputs are stored as a table for readability.
-  # Table is adapted from the one in the product spec: https://www.notion.so/mbta-downtown-crossing/DUP-Alert-Widget-Specification-a82acff850ed4f2eb98a04e5f3e0fe52
-  # Compile-time code converts each table row to `do_alert_layout` function clauses.
-  # TotalSections refers to the number of sections in `primary_departures` of DUP configs.
-  alert_layout_table = """
-  # INPUTS                                                          || OUTPUTS
-  # Effect          Location            AffectedLines TotalSections || LayoutZero  LayoutOne
-    station_closure inside              1             1                full_screen full_screen
-    station_closure inside              1             2                partial     full_screen
-    station_closure inside              2             2                full_screen full_screen
-  # "Boundary" location is not possible for station closures.
-    shuttle         inside              1             1                full_screen full_screen
-    shuttle         inside              1             2                partial     full_screen
-    shuttle         inside              2             2                full_screen full_screen
-    shuttle         boundary_upstream   1             1                partial     full_screen
-    shuttle         boundary_downstream 1             1                partial     full_screen
-    shuttle         boundary_upstream   1             2                partial     full_screen
-    shuttle         boundary_downstream 1             2                partial     full_screen
-    suspension      inside              1             1                full_screen full_screen
-    suspension      inside              1             2                partial     full_screen
-    suspension      inside              2             2                full_screen full_screen
-    suspension      boundary_upstream   1             1                partial     full_screen
-    suspension      boundary_downstream 1             1                partial     full_screen
-    suspension      boundary_upstream   1             2                partial     full_screen
-    suspension      boundary_downstream 1             2                partial     full_screen
-  # Other cases are handled separately, see `alert_layout_special_case` below.
-  """
-
-  parameters_to_layout =
-    alert_layout_table
-    |> String.split("\n", trim: true)
-    |> Enum.reject(&String.starts_with?(&1, "#"))
-    |> Enum.flat_map(fn line ->
-      [effect, location, affected_line_count, total_section_count, layout_zero, layout_one] =
-        String.split(line, ~r/\s+/, trim: true)
-
-      # Convert strings to appropriate types
-      [effect, location, layout_zero, layout_one] =
-        Enum.map(
-          [effect, location, layout_zero, layout_one],
-          &String.to_existing_atom/1
-        )
-
-      [affected_line_count, total_section_count] =
-        Enum.map([affected_line_count, total_section_count], &String.to_integer/1)
-
-      base_parameters = {effect, location, affected_line_count, total_section_count}
-
-      [
-        {Tuple.append(base_parameters, :zero), layout_zero},
-        {Tuple.append(base_parameters, :one), layout_one}
-      ]
-    end)
-    |> Enum.into(%{})
-
-  @type layout_parameters ::
-          {Alert.effect(), location :: atom, affected_line_count :: 1..2,
-           total_section_count :: 1..2, rotation_index}
-
-  # Now, define function clauses for each row in the table.
-  @spec do_alert_layout(layout_parameters) :: :full_screen | :partial | :no_render
-  for {parameters, layout} <- parameters_to_layout do
-    parameters_ast = Macro.escape(parameters)
-    defp do_alert_layout(unquote(parameters_ast)), do: unquote(layout)
-  end
-
-  # If matching inputs aren't found in the table, we assume the alert isn't relevant and do not render it.
-  defp do_alert_layout(_parameters), do: :no_render
-
-  # Handles special cases that don't directly adhere to the table-based approach.
-  # Specifically, this determines the layout for:
-  #  - All delay alerts
-  #  - The third rotation
-  defp alert_layout_special_case(t, parameters) do
-    {effect, _location, _affected_line_count, _total_section_count, rotation_index} = parameters
-
+  defp delay_alert_layout(t) do
     delay_severity = t.alert.severity
 
-    cond do
-      effect == :delay ->
-        if delay_severity >= 5 do
-          # All delays >= 20 minutes get a partial alert on all 3 rotations
-          :partial
-        else
-          # We don't show delays < 20 minutes
-          log_layout_mismatch(t, parameters, delay_severity)
-          :no_render
-        end
+    if delay_severity >= 5 do
+      # All delays >= 20 minutes get a partial alert on all 3 rotations
+      :partial
+    else
+      # We don't show delays < 20 minutes
+      log_layout_mismatch(t, delay_severity)
+      :no_render
+    end
+  end
 
-      rotation_index == :two ->
-        # For the third rotation, the layout depends on whether or not
-        # the screen has secondary departures configured.
+  defp non_delay_alert_layout(t) do
+    parameters = get_layout_parameters(t)
+
+    case {t.rotation_index, Map.fetch(@parameters_to_layout_zero, parameters)} do
+      {:zero, {:ok, layout_zero}} ->
+        # The first page's layout maps directly from `parameters`.
+        layout_zero
+
+      {:one, {:ok, _layout_zero}} ->
+        # The second page always uses full-screen layout, as long as the alert is relevant.
+        :full_screen
+
+      {:two, {:ok, layout_zero}} ->
+        # The third page's layout depends on whether or not the screen has secondary departures configured.
         #
         # If the screen has secondary departures configured, it always gets a partial alert.
         # If the screen does not have secondary departures configured, it gets the same layout as the first rotation.
@@ -235,11 +204,34 @@ defmodule Screens.V2.WidgetInstance.DupAlert do
 
         if has_secondary_departures,
           do: :partial,
-          else: alert_layout(%{t | rotation_index: :zero})
+          else: layout_zero
 
-      true ->
-        false
+      {_rotation_index, :error} ->
+        # We don't know what to do under these conditions.
+        # Log it, and prevent the alert from appearing.
+        log_layout_mismatch(t, :not_applicable)
+        :no_render
     end
+  end
+
+  # The widget _should_ always be valid given the constraints of what alerts
+  # we generate DUP alert widgets for, but in case one slips through, we
+  # should know about it!
+  defp log_layout_mismatch(t, delay_severity) do
+    log_fields =
+      t
+      |> get_layout_parameters()
+      |> Map.merge(%{
+        delay_severity: delay_severity,
+        rotation_index: t.rotation_index,
+        alert_id: t.alert.id,
+        stop_id: t.screen.app_params.alerts.stop_id
+      })
+
+    Logger.warn(
+      "[DUP alert no matching layout] " <>
+        Enum.map_join(log_fields, " ", fn {label, value} -> "#{label}=#{value}" end)
+    )
   end
 
   def get_affected_lines(t) do

--- a/lib/screens/v2/widget_instance/dup_alert.ex
+++ b/lib/screens/v2/widget_instance/dup_alert.ex
@@ -208,7 +208,7 @@ defmodule Screens.V2.WidgetInstance.DupAlert do
   #  - All delay alerts
   #  - The third rotation
   defp alert_layout_special_case(t, parameters) do
-    {effect, _location, _affected_line_count, _total_line_count, rotation_index} = parameters
+    {effect, _location, _affected_line_count, _total_section_count, rotation_index} = parameters
 
     delay_severity = t.alert.severity
 

--- a/lib/screens/v2/widget_instance/dup_alert.ex
+++ b/lib/screens/v2/widget_instance/dup_alert.ex
@@ -162,10 +162,9 @@ defmodule Screens.V2.WidgetInstance.DupAlert do
 
   @spec alert_layout(t()) :: :full_screen | :partial | :no_render
   defp alert_layout(t) do
-    case t.alert.effect do
-      :delay -> delay_alert_layout(t)
-      _ -> non_delay_alert_layout(t)
-    end
+    if t.alert.effect == :delay,
+      do: delay_alert_layout(t),
+      else: non_delay_alert_layout(t)
   end
 
   defp delay_alert_layout(t) do
@@ -184,7 +183,9 @@ defmodule Screens.V2.WidgetInstance.DupAlert do
   defp non_delay_alert_layout(t) do
     parameters = get_layout_parameters(t)
 
-    case {t.rotation_index, Map.fetch(@parameters_to_layout_zero, parameters)} do
+    lookup_result = Map.fetch(@parameters_to_layout_zero, parameters)
+
+    case {t.rotation_index, lookup_result} do
       {:zero, {:ok, layout_zero}} ->
         # The first page's layout maps directly from `parameters`.
         layout_zero

--- a/lib/screens/v2/widget_instance/dup_alert.ex
+++ b/lib/screens/v2/widget_instance/dup_alert.ex
@@ -198,7 +198,7 @@ defmodule Screens.V2.WidgetInstance.DupAlert do
         # The third page's layout depends on whether or not the screen has secondary departures configured.
         #
         # If the screen has secondary departures configured, it always gets a partial alert.
-        # If the screen does not have secondary departures configured, it gets the same layout as the first rotation.
+        # If the screen does not have secondary departures configured, it gets the same layout as the first page.
         #
         # This is because we do not want to hide secondary departures (e.g. bus, CR) if they exist.
         has_secondary_departures = t.screen.app_params.secondary_departures.sections != []


### PR DESCRIPTION
**Asana task**: [Page 3/3 layout should match that of page 1/3 when there are no secondary departures configured](https://www.notion.so/mbta-downtown-crossing/Station-closure-inside-1-1-f46b843e4eb842ba9043f3623a420dc6?pvs=4)

[Relevant slack thread](https://mbta.slack.com/archives/C02SXM166N8/p1680186465521599)

I moved the special case for delay alerts, as well as this, into one function to try and avoid confusion.

I'm very open to suggestions on how to organize this logic better, though—does the table approach no longer make sense since the layout for page 2/3 is always full-screen, and the layout for page 3/3 is handled specially?

- [ ] Tests added?
