### PR TITLE
polish: GL overnight with alert

### DIFF
--- a/lib/screens/v2/candidate_generator/dup/departures.ex
+++ b/lib/screens/v2/candidate_generator/dup/departures.ex
@@ -264,7 +264,6 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
          %Alert{informed_entities: informed_entities}
        ) do
     Enum.find_value(informed_entities, "", fn
-      %{route: "Green" <> _, stop: ^stop_id} -> "Green"
       %{route: route, stop: ^stop_id} -> route
       _ -> nil
     end)

--- a/lib/screens/v2/widget_instance/departures.ex
+++ b/lib/screens/v2/widget_instance/departures.ex
@@ -98,6 +98,12 @@ defmodule Screens.V2.WidgetInstance.Departures do
       ) do
     pill_color = Route.get_color_for_route(route)
 
+    formatted_route =
+      case route do
+        "Green" <> _ -> "Green"
+        route -> route
+      end
+
     text =
       if is_only_section do
         %FreeTextLine{
@@ -105,7 +111,7 @@ defmodule Screens.V2.WidgetInstance.Departures do
           text: [
             %{
               color: pill_color,
-              text: "#{String.upcase(route)} LINE"
+              text: "#{String.upcase(formatted_route)} LINE"
             },
             %{special: :break},
             "#{headsign} trains every",

--- a/test/screens/v2/candidate_generator/dup/departures_test.exs
+++ b/test/screens/v2/candidate_generator/dup/departures_test.exs
@@ -1481,7 +1481,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
           section_data: [
             %{
               type: :headway_section,
-              route: "Green",
+              route: "Green-C",
               time_range: {7, 13},
               headsign: "Westbound"
             }
@@ -1493,7 +1493,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
           section_data: [
             %{
               type: :headway_section,
-              route: "Green",
+              route: "Green-C",
               time_range: {7, 13},
               headsign: "Westbound"
             }
@@ -1505,7 +1505,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
           section_data: [
             %{
               type: :headway_section,
-              route: "Green",
+              route: "Green-C",
               time_range: {7, 13},
               headsign: "Westbound"
             }


### PR DESCRIPTION
**Notion task**: ad-hoc

For GL (mainly Prudential), I noticed that overnight was kicking in when there are no departures and vehicles are still serving trips. This was because we were formatting routes too early. I moved that logic to the `widget_instance` so it is formatted just before sending a response.