### PR TITLE
Polish: Yellow DUP alerts

### DIFF
--- a/assets/css/v2/dup/free_text.scss
+++ b/assets/css/v2/dup/free_text.scss
@@ -151,6 +151,12 @@
   }
 }
 
+.partial-alert--yellow {
+  .free-text {
+    color: #171f26;
+  }
+}
+
 .headway-section:only-child {
   .free-text__line-container {
     margin-bottom: 56px;

--- a/assets/css/v2/dup/normal_header.scss
+++ b/assets/css/v2/dup/normal_header.scss
@@ -21,6 +21,9 @@
   &--silver {
     background-color: $line-color-silver;
   }
+  &--yellow {
+    background-color: $alert-yellow;
+  }
 }
 
 .normal-header-icon {
@@ -87,7 +90,6 @@
 }
 
 .normal-header--yellow {
-  background-color: $alert-yellow;
   .normal-header-title__text {
     color: #171F26;
   }

--- a/assets/css/v2/dup/normal_header.scss
+++ b/assets/css/v2/dup/normal_header.scss
@@ -85,3 +85,10 @@
   color: white;
   position: absolute;
 }
+
+.normal-header--yellow {
+  background-color: $alert-yellow;
+  .normal-header-title__text {
+    color: #1C1E23;
+  }
+}

--- a/assets/css/v2/dup/normal_header.scss
+++ b/assets/css/v2/dup/normal_header.scss
@@ -89,6 +89,6 @@
 .normal-header--yellow {
   background-color: $alert-yellow;
   .normal-header-title__text {
-    color: #1C1E23;
+    color: #171F26;
   }
 }

--- a/assets/src/components/v2/dup/normal_header.tsx
+++ b/assets/src/components/v2/dup/normal_header.tsx
@@ -20,7 +20,7 @@ const NormalHeader = ({
 }: NormalHeaderProps) => {
   return (
     <DefaultNormalHeader
-      icon={Icon.logo}
+      icon={color === 'yellow' ? Icon.logo_negative : Icon.logo}
       text={text}
       time={time}
       // Currently, we don't use different codes that populating this would be useful...

--- a/assets/src/components/v2/free_text.tsx
+++ b/assets/src/components/v2/free_text.tsx
@@ -9,6 +9,7 @@ const iconPills = ["cr", "bus"];
 const iconPaths: { [key: string]: string } = _.mapValues(
   {
     warning: "alert.svg",
+    warning_negative: "alert-black.svg",
     x: "no-service-white.svg",
     shuttle: "bus-white.svg",
     subway: "subway-white.svg",

--- a/assets/src/components/v2/normal_header.tsx
+++ b/assets/src/components/v2/normal_header.tsx
@@ -15,6 +15,7 @@ enum Icon {
   green_d = "green_d",
   green_e = "green_e",
   logo = "logo",
+  logo_negative = "logo_negative"
 }
 
 enum TitleSize {
@@ -28,6 +29,7 @@ const ICON_TO_SRC: Record<Icon, string> = {
   green_d: "GL-D.svg",
   green_e: "GL-E.svg",
   logo: "logo-white.svg",
+  logo_negative: "logo-black.svg"
 };
 
 const abbreviateText = (text: string) => {

--- a/lib/screens/v2/widget_instance/dup_alert/serialize.ex
+++ b/lib/screens/v2/widget_instance/dup_alert/serialize.ex
@@ -105,7 +105,9 @@ defmodule Screens.V2.WidgetInstance.DupAlert.Serialize do
   end
 
   defp partial_alert_icon(t) when t.alert.effect == :delay, do: :delay
-  defp partial_alert_icon(t), do: if line_color(t) === :yellow, do: :warning_negative, else: :warning
+
+  defp partial_alert_icon(t),
+    do: if(line_color(t) === :yellow, do: :warning_negative, else: :warning)
 
   defp issue_free_text(t) do
     build_line_text = get_line_text_builder(t)

--- a/lib/screens/v2/widget_instance/dup_alert/serialize.ex
+++ b/lib/screens/v2/widget_instance/dup_alert/serialize.ex
@@ -105,7 +105,7 @@ defmodule Screens.V2.WidgetInstance.DupAlert.Serialize do
   end
 
   defp partial_alert_icon(t) when t.alert.effect == :delay, do: :delay
-  defp partial_alert_icon(_t), do: :warning
+  defp partial_alert_icon(t), do: if line_color(t) === :yellow, do: :warning_negative, else: :warning
 
   defp issue_free_text(t) do
     build_line_text = get_line_text_builder(t)


### PR DESCRIPTION
[Polish](https://www.notion.so/mbta-downtown-crossing/4b67fc8f4ef04868901d85a412cdd48f?v=8c5d6c5153b443a58cedcf0d8b9838d7&p=e39ce62f5a69401bb88dfd633b262aba&pm=s)

When an alert affects multiple station lines and yellow is used, the svg and fonts are dark.
