### PR TITLE
Kenmore case allows alert with multiple branches

### DIFF
--- a/lib/screens/v2/candidate_generator/dup/alerts.ex
+++ b/lib/screens/v2/candidate_generator/dup/alerts.ex
@@ -263,12 +263,12 @@ defmodule Screens.V2.CandidateGenerator.Dup.Alerts do
           atom()
   def get_branches_if_entity_matches_stop(%{informed_entities: informed_entities}, stop_matchers) do
     stop_matchers
-    |> Enum.map(fn stop ->
-      Enum.find_value(informed_entities, fn e ->
-        if stop.stop === e.stop, do: Map.get(stop, :branch)
+    |> Enum.filter(fn stop ->
+      Enum.any?(informed_entities, fn e ->
+        stop.stop === e.stop
       end)
     end)
-    |> Enum.reject(&is_nil(&1))
+    |> Enum.map(&Map.get(&1, :branch))
   end
 
   for {effect, key} <- Enum.with_index([:shuttle, :suspension, :station_closure, :detour, :delay]) do

--- a/lib/screens/v2/candidate_generator/dup/alerts.ex
+++ b/lib/screens/v2/candidate_generator/dup/alerts.ex
@@ -260,7 +260,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Alerts do
           Alert.t(),
           list(%{branch: String.t(), stop: String.t()})
         ) ::
-          atom()
+          [String.t()]
   def get_branches_if_entity_matches_stop(%{informed_entities: informed_entities}, stop_matchers) do
     stop_matchers
     |> Enum.filter(fn stop ->


### PR DESCRIPTION
[Polish](https://www.notion.so/mbta-downtown-crossing/4b67fc8f4ef04868901d85a412cdd48f?v=8c5d6c5153b443a58cedcf0d8b9838d7&p=1c9efef552b3449195de4dd64b9909b9&pm=s)

Kenmore case allows either multiple alerts that affect single branches or one alert that affects multiple branches.

Before:
![Screenshot 2023-04-06 at 10 16 35 AM](https://user-images.githubusercontent.com/69368883/230405909-3488a1bb-9274-4daa-9257-6c35d4b8e486.png)
After:
![Screenshot 2023-04-06 at 10 16 14 AM](https://user-images.githubusercontent.com/69368883/230405903-c4e85b91-8388-435e-b347-0c0de2af3563.png)

