### PR TITLE
polish: Overnight for early morning

### DIFF
--- a/lib/screens/departures/departure.ex
+++ b/lib/screens/departures/departure.ex
@@ -386,7 +386,7 @@ defmodule Screens.Departures.Departure do
   end
 
   defp format_query_param({:date, %DateTime{} = date}) do
-    {"filter[date]", Util.get_service_day_today(date)}
+    {"filter[date]", Util.get_service_date_today(date)}
   end
 
   defp format_query_param({:date, %Date{} = date}) do

--- a/lib/screens/departures/departure.ex
+++ b/lib/screens/departures/departure.ex
@@ -386,8 +386,7 @@ defmodule Screens.Departures.Departure do
   end
 
   defp format_query_param({:date, %DateTime{} = date}) do
-    {:ok, dt_in_local_time} = DateTime.shift_zone(date, "America/New_York")
-    {"filter[date]", Date.to_iso8601(dt_in_local_time)}
+    {"filter[date]", Util.get_service_day_today(date)}
   end
 
   defp format_query_param({:date, %Date{} = date}) do

--- a/lib/screens/util.ex
+++ b/lib/screens/util.ex
@@ -181,23 +181,28 @@ defmodule Screens.Util do
   def to_set(%MapSet{} = already_a_set), do: already_a_set
 
   @doc """
-    Calculates the service day after the given DateTime (which must be in UTC).
+    Calculates the service day for the given DateTime.
     For context, MBTA service days end at 3am, not at midnight.
-    So getting the next service day means adding 21 hours to current date, not 24.
+    So getting the service day means subtracting 3 hours from the current time.
     To avoid duplicate DateTime calculations existing throughout the code,
-    this function will handle the actual calculations needed to get the next service day.
+    this function will handle the actual calculations needed to get the service day.
   """
-  @spec get_service_day_tomorrow(DateTime.t()) :: Date.t()
-  def get_service_day_tomorrow(now) do
+  @spec get_service_date_today(DateTime.t()) :: Date.t()
+  def get_service_date_today(now) do
     {:ok, now_eastern} = DateTime.shift_zone(now, "America/New_York")
 
-    # If it is at least 3am, the current date matches the service date. Adding a day will give the current service day for tomorrow.
+    # If it is at least 3am, the current date matches the service date.
     # If current time is between 12am and 3am, the date has changed but we are still in service for the previous day.
-    # That means the current day represents tomorrow's service day.
+    # That means we need to subtract 1 day to get the current service date.
     if now_eastern.hour >= 3 do
-      Date.add(now_eastern, 1)
-    else
       DateTime.to_date(now_eastern)
+    else
+      Date.add(now_eastern, -1)
     end
+  end
+
+  @spec get_service_date_tomorrow(DateTime.t()) :: Date.t()
+  def get_service_date_tomorrow(now) do
+    Date.add(get_service_date_today(now), 1)
   end
 end

--- a/lib/screens/v2/candidate_generator/dup/departures.ex
+++ b/lib/screens/v2/candidate_generator/dup/departures.ex
@@ -541,7 +541,8 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
         %Departure{schedule: first_schedule_tomorrow}
 
       # After 3am but before the first scheduled trip of the day.
-      DateTime.compare(now, first_schedule_today.departure_time) == :lt ->
+      not is_nil(first_schedule_today) and
+          DateTime.compare(now, first_schedule_today.departure_time) == :lt ->
         %Departure{schedule: first_schedule_today}
 
       true ->

--- a/lib/screens/v2/candidate_generator/dup/departures.ex
+++ b/lib/screens/v2/candidate_generator/dup/departures.ex
@@ -558,8 +558,6 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
     today =
       case fetch_schedules_fn.(fetch_params, now) do
         {:ok, schedules} when schedules != [] ->
-          # We want the last schedules of the current day.
-          # Need to reverse the list of fetched schedules so that List.first/1 looks at the correct time of day.
           Enum.filter(schedules, &(&1.route.id in route_ids_serving_section))
 
         # fetch error or empty schedules

--- a/lib/screens/v2/candidate_generator/dup/departures.ex
+++ b/lib/screens/v2/candidate_generator/dup/departures.ex
@@ -426,7 +426,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
       get_today_tomorrow_schedules(
         Map.from_struct(params),
         fetch_schedules_fn,
-        Util.get_service_day_tomorrow(now),
+        now,
         Enum.map(routes, & &1.id)
       )
 
@@ -439,8 +439,18 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
       # If now is before any of today's schedules or after any of tomorrow's (should never happen but just in case),
       # we do not display overnight mode.
 
+      # This variable will be used when now is after 3am.
+      first_schedule_today =
+        Enum.find(
+          today_schedules,
+          &(&1.route.id == route_id and &1.direction_id == direction_id)
+        )
+
       last_schedule_today =
-        Enum.find(today_schedules, &(&1.route.id == route_id and &1.direction_id == direction_id))
+        Enum.find(
+          Enum.reverse(today_schedules),
+          &(&1.route.id == route_id and &1.direction_id == direction_id)
+        )
 
       first_schedule_tomorrow =
         Enum.find(
@@ -459,9 +469,14 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
 
           nil
 
+        # Before 3am and between the `departure_time` for today's last schedule and tomorrow's first schedule
         DateTime.compare(now, last_schedule_today.departure_time) == :gt and
             DateTime.compare(now, first_schedule_tomorrow.departure_time) == :lt ->
           %Departure{schedule: first_schedule_tomorrow}
+
+        # After 3am but before the first scheduled trip of the day.
+        DateTime.compare(now, first_schedule_today.departure_time) == :lt ->
+          %Departure{schedule: first_schedule_today}
 
         true ->
           nil
@@ -504,20 +519,15 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
   defp get_today_tomorrow_schedules(
          fetch_params,
          fetch_schedules_fn,
-         tomorrow,
+         now,
          route_ids_serving_section
        ) do
     today =
-      case fetch_schedules_fn.(fetch_params, nil) do
+      case fetch_schedules_fn.(fetch_params, now) do
         {:ok, schedules} when schedules != [] ->
           # We want the last schedules of the current day.
           # Need to reverse the list of fetched schedules so that List.first/1 looks at the correct time of day.
-          schedules
-          |> Enum.reverse()
-          |> Enum.filter(&(&1.route.id in route_ids_serving_section))
-          |> Enum.uniq_by(fn %{route: %{id: route_id}, direction_id: direction_id} ->
-            {route_id, direction_id}
-          end)
+          Enum.filter(schedules, &(&1.route.id in route_ids_serving_section))
 
         # fetch error or empty schedules
         _ ->
@@ -525,13 +535,9 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
       end
 
     tomorrow =
-      case fetch_schedules_fn.(fetch_params, tomorrow) do
+      case fetch_schedules_fn.(fetch_params, Util.get_service_date_tomorrow(now)) do
         {:ok, schedules} when schedules != [] ->
-          schedules
-          |> Enum.filter(&(&1.route.id in route_ids_serving_section))
-          |> Enum.uniq_by(fn %{route: %{id: route_id}, direction_id: direction_id} ->
-            {route_id, direction_id}
-          end)
+          Enum.filter(schedules, &(&1.route.id in route_ids_serving_section))
 
         # fetch error or empty schedules
         _ ->

--- a/lib/screens/v2/widget_instance/departures.ex
+++ b/lib/screens/v2/widget_instance/departures.ex
@@ -407,7 +407,7 @@ defmodule Screens.V2.WidgetInstance.Departures do
     hour = 1 + Integer.mod(local_time.hour - 1, 12)
     minute = local_time.minute
     am_pm = if local_time.hour >= 12, do: :pm, else: :am
-    show_am_pm = Util.get_service_day_tomorrow(now).day == local_time.day
+    show_am_pm = Util.get_service_date_tomorrow(now).day == local_time.day
     %{type: :timestamp, hour: hour, minute: minute, am_pm: am_pm, show_am_pm: show_am_pm}
   end
 

--- a/test/screens/util_test.exs
+++ b/test/screens/util_test.exs
@@ -102,19 +102,19 @@ defmodule Screens.UtilTest do
     end
   end
 
-  describe "get_service_day_tomorrow/1" do
-    test "returns the next day if current day matches service day" do
+  describe "get_service_date_today/1" do
+    test "returns the current date if after 3am" do
       now_eastern = DateTime.new!(~D[2022-01-01], ~T[09:00:00], "America/New_York")
       now = DateTime.shift_zone!(now_eastern, "Etc/UTC")
-      expected = ~D[2022-01-02]
-      assert(expected == get_service_day_tomorrow(now))
+      expected = ~D[2022-01-01]
+      assert(expected == get_service_date_today(now))
     end
 
-    test "returns the current day if between 12am and 3am" do
+    test "returns the yesterday's date if between 12am and 3am" do
       now_eastern = DateTime.new!(~D[2022-01-01], ~T[00:00:00], "America/New_York")
       now = DateTime.shift_zone!(now_eastern, "Etc/UTC")
-      expected = ~D[2022-01-01]
-      assert expected == get_service_day_tomorrow(now)
+      expected = ~D[2021-12-31]
+      assert expected == get_service_date_today(now)
     end
   end
 end


### PR DESCRIPTION
**Notion task**: [Outstanding issues with overnight mode](https://www.notion.so/mbta-downtown-crossing/Outstanding-issues-with-overnight-mode-040f5c0849ee446d9135409871b50674?pvs=4)

When we change service day at 3am, we were incorrectly switching to a no data state instead of continuing to display overnight mode. To correct this, an extra conditional has been added to check that `now` is before the first schedule of the day. 

- [ ] Tests added?
