### PR TITLE
polish: departure row dividers

### DIFF
--- a/assets/css/v2/dup/departures/no_data_section.scss
+++ b/assets/css/v2/dup/departures/no_data_section.scss
@@ -15,16 +15,5 @@
 
   &__row {
     height: 208px;
-    position: relative;
-
-    &:after {
-      content: "";
-      position: absolute;
-      bottom: -2px;
-      left: 312px;
-      height: 4px;
-      width: 1576px;
-      background-color: #cccbc8;
-    }
   }
 }

--- a/assets/css/v2/dup/departures/row.scss
+++ b/assets/css/v2/dup/departures/row.scss
@@ -2,10 +2,10 @@
   position: relative;
   height: 208px;
 
-  &:not(:last-child):after {
+  &:not(:first-child):before {
     content: "";
     position: absolute;
-    bottom: 0px;
+    top: 0px;
     left: 302px;
     height: 4px;
     width: 1586px;

--- a/assets/css/v2/dup/departures/section.scss
+++ b/assets/css/v2/dup/departures/section.scss
@@ -1,6 +1,9 @@
 .departures-section {
   position: relative;
-  height: 416px;
+
+  &:not(:only-child) {
+    height: 416px;
+  }
 
   &:not(:first-child):before {
     content: "";


### PR DESCRIPTION
**Asana task**: [Typical partial alerts are rendered correctly](https://www.notion.so/mbta-downtown-crossing/Typical-partial-alerts-are-rendered-correctly-38f9c0f09f564cb9af5085d435775e0a?pvs=4)

Changed up dividers so they do not show next to a partial alert.

- [ ] Tests added?
