### PR TITLE
polish: ashmont braintree headway message

### DIFF
--- a/assets/css/v2/dup/free_text.scss
+++ b/assets/css/v2/dup/free_text.scss
@@ -168,6 +168,11 @@
     line-height: initial;
   }
 
+  .free-text__pill-container {
+    display: inline-block;
+    height: 168px;
+  }
+
   .free-text__icon-container {
     width: 168px;
     height: 168px;
@@ -183,7 +188,7 @@
 
   .free-text__text-pill {
     border-radius: 84px;
-    transform: translateY(-16px);
+    transform: translateY(-18px);
   }
 
   .free-text__text-pill__text {

--- a/lib/screens/v2/widget_instance/departures.ex
+++ b/lib/screens/v2/widget_instance/departures.ex
@@ -100,18 +100,24 @@ defmodule Screens.V2.WidgetInstance.Departures do
 
     text =
       if is_only_section do
+        time_range =
+          if headsign == "Ashmont/Braintree" do
+            [%{format: :bold, text: "#{lo}-#{hi}m"}]
+          else
+            [%{format: :bold, text: "#{lo}-#{hi}"}, "minutes"]
+          end
+
         %FreeTextLine{
           icon: "subway-negative-black",
-          text: [
-            %{
-              color: pill_color,
-              text: "#{String.upcase(route)} LINE"
-            },
-            %{special: :break},
-            "#{headsign} trains every",
-            %{format: :bold, text: "#{lo}-#{hi}"},
-            "minutes"
-          ]
+          text:
+            [
+              %{
+                color: pill_color,
+                text: "#{String.upcase(route)} LINE"
+              },
+              %{special: :break},
+              "#{headsign} trains every"
+            ] ++ time_range
         }
       else
         %FreeTextLine{

--- a/lib/screens/v2/widget_instance/departures.ex
+++ b/lib/screens/v2/widget_instance/departures.ex
@@ -126,7 +126,7 @@ defmodule Screens.V2.WidgetInstance.Departures do
             [
               %{
                 color: pill_color,
-                text: "#{String.upcase(route)} LINE"
+                text: "#{String.upcase(formatted_route)} LINE"
               },
               %{special: :break},
               "#{headsign} trains every"

--- a/lib/screens/v2/widget_instance/departures.ex
+++ b/lib/screens/v2/widget_instance/departures.ex
@@ -26,7 +26,14 @@ defmodule Screens.V2.WidgetInstance.Departures do
 
   @type headway_section :: %{
           type: :headway_section,
-          pill: :red | :orange | :green | :blue
+          route: :red | :orange | :green | :blue,
+          time_range: {integer(), integer()},
+          headsign: String.t()
+        }
+
+  @type overnight_section :: %{
+          type: :overnight_section,
+          routes: list(Route.t())
         }
 
   @type notice :: %{
@@ -35,7 +42,7 @@ defmodule Screens.V2.WidgetInstance.Departures do
 
   @type t :: %__MODULE__{
           screen: Screen.t(),
-          section_data: list(section | notice_section | headway_section()),
+          section_data: list(section | notice_section | headway_section() | overnight_section()),
           slot_names: list(atom())
         }
 

--- a/test/screens/v2/widget_instance/departures_test.exs
+++ b/test/screens/v2/widget_instance/departures_test.exs
@@ -90,6 +90,31 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
                Departures.serialize_section(section, dup_screen, true)
     end
 
+    test "returns serialized headway_section for one configured section with Ashmont/Braintree headsign",
+         %{
+           dup_screen: dup_screen
+         } do
+      section = %{
+        type: :headway_section,
+        route: "Red",
+        time_range: {1, 2},
+        headsign: "Ashmont/Braintree"
+      }
+
+      expected_text = %{
+        icon: "subway-negative-black",
+        text: [
+          %{color: :red, text: "RED LINE"},
+          %{special: :break},
+          "Ashmont/Braintree trains every",
+          %{format: :bold, text: "1-2m"}
+        ]
+      }
+
+      assert %{type: :headway_section, text: expected_text} ==
+               Departures.serialize_section(section, dup_screen, true)
+    end
+
     test "returns serialized headway_section for multiple configured sections", %{
       dup_screen: dup_screen
     } do


### PR DESCRIPTION
**Asana task**: [Multi-line headways accommodate the longest destination](https://www.notion.so/mbta-downtown-crossing/Multi-line-headways-accommodate-the-longest-destination-7de73f5f45064fbbb609d760fb65af66?pvs=4)

Headway messages are too long when headsign is Ashmont/Braintree. Fixed this by condensing `minutes` to `m` for just that headsign. Also fixed some alignment issues for headway pills.

- [ ] Tests added?
