### PR TITLE
DUP Polish: if all branches have no service, show trunk headways

### DIFF
--- a/lib/screens/v2/candidate_generator/dup/departures.ex
+++ b/lib/screens/v2/candidate_generator/dup/departures.ex
@@ -12,7 +12,6 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
   alias Screens.Routes.Route
   alias Screens.SignsUiConfig
   alias Screens.Util
-  alias Screens.V2.CandidateGenerator.Dup.Alerts, as: AlertsInstances
   alias Screens.V2.CandidateGenerator.Widgets
   alias Screens.V2.Departure
   alias Screens.V2.WidgetInstance.Departures, as: DeparturesWidget
@@ -137,7 +136,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
   defp get_departure_instance_for_section(
          %{
            departures: departures,
-           alert: alert,
+           alert_informed_entities: alert_informed_entities,
            headway: headway,
            stop_ids: stop_ids,
            routes: routes,
@@ -156,13 +155,13 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
         routes_with_live_departures,
         params,
         routes,
-        alert,
+        alert_informed_entities,
         now,
         fetch_schedules_fn,
         fetch_vehicles_fn
       )
 
-    headway_mode = get_headway_mode(stop_ids, headway, alert, now)
+    headway_mode = get_headway_mode(stop_ids, headway, alert_informed_entities, now)
 
     cond do
       # All routes in section are overnight
@@ -182,11 +181,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
             Enum.take(departures, 2)
           end
 
-        if visible_departures == [] do
-          %{type: :no_data_section, route: List.first(routes)}
-        else
-          %{type: :normal_section, rows: visible_departures}
-        end
+        %{type: :normal_section, rows: visible_departures}
 
       # Headway mode
       true ->
@@ -194,7 +189,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
 
         %{
           type: :headway_section,
-          route: get_section_route_from_alert(stop_ids, alert),
+          route: get_section_route_from_entities(stop_ids, alert_informed_entities),
           time_range: time_range,
           headsign: headsign
         }
@@ -243,11 +238,11 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
               []
           end
 
-        section_alert = get_section_alert(params, fetch_alerts_fn, now)
+        alert_informed_entities = get_section_entities(params, fetch_alerts_fn, now)
 
         %{
           departures: section_departures,
-          alert: section_alert,
+          alert_informed_entities: alert_informed_entities,
           headway: headway,
           stop_ids: stop_ids,
           routes: routes,
@@ -258,10 +253,9 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
     |> Enum.map(fn {:ok, data} -> data end)
   end
 
-  # Alert will only have a value for sections that are configured for a station's ID
-  defp get_section_route_from_alert(
+  defp get_section_route_from_entities(
          ["place-" <> _ = stop_id],
-         %Alert{informed_entities: informed_entities}
+         informed_entities
        ) do
     Enum.find_value(informed_entities, "", fn
       %{route: "Green" <> _, stop: ^stop_id} -> "Green"
@@ -270,7 +264,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
     end)
   end
 
-  defp get_section_route_from_alert(_, _), do: nil
+  defp get_section_route_from_entities(_, _), do: nil
 
   defp get_bidirectional_departures(section_departures) do
     first_row = List.first(section_departures)
@@ -284,7 +278,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
     [first_row] ++ [second_row]
   end
 
-  defp get_section_alert(
+  defp get_section_entities(
          %Params{
            stop_ids: stop_ids,
            route_ids: route_ids,
@@ -311,18 +305,26 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
       _ ->
         false
     end)
-    |> AlertsInstances.choose_alert()
+    # Condense all alerts into just a list of informed entities
+    # This will help us decide whether a headway in one direction is still useful
+    # if there are two alerts that could be in different directions.
+    |> Enum.reduce([], fn alert, acc -> acc ++ alert.informed_entities end)
+    |> Enum.dedup()
   end
 
-  defp get_headway_mode(_, _, nil, _), do: :inactive
+  defp get_headway_mode(_, _, [], _), do: :inactive
 
   defp get_headway_mode(
          stop_ids,
          %Headway{headway_id: headway_id},
-         section_alert,
+         informed_entities,
          current_time
        ) do
-    interpreted_alert = interpret_alert(section_alert, stop_ids)
+    # Use all informed_entities from relevant alerts to decide whether there's
+    # any reason to go into headway mode.
+    # For example, a NB suspension and SB shuttle from Aquarium shouldn't use headway mode
+    # but if all the WB branches are shuttling at Kenmore, there should be a headway
+    interpreted_alert = interpret_entities(informed_entities, stop_ids)
 
     headway_mode? =
       temporary_terminal?(interpreted_alert) and
@@ -364,8 +366,8 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
     headsign in MapSet.new(branch_terminals)
   end
 
-  defp interpret_alert(alert, [parent_stop_id]) do
-    informed_stop_ids = Enum.into(alert.informed_entities, MapSet.new(), & &1.stop)
+  defp interpret_entities(entities, [parent_stop_id]) do
+    informed_stop_ids = Enum.into(entities, MapSet.new(), & &1.stop)
 
     {region, headsign} =
       :screens
@@ -406,7 +408,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
          stops_with_live_departures,
          stop_ids,
          routes_serving_section,
-         alert,
+         alert_informed_entities,
          now,
          fetch_schedules_fn,
          fetch_vehicles_fn
@@ -476,13 +478,13 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
          stops_with_live_departures,
          params,
          [%{type: type} | _] = routes,
-         alert,
+         alert_informed_entities,
          now,
          fetch_schedules_fn,
          fetch_vehicles_fn
        )
        when type in [:subway, :light_rail] do
-    informed_route = get_section_route_from_alert(params.stop_ids, alert)
+    informed_route = get_section_route_from_entities(params.stop_ids, alert_informed_entities)
     # If there are no vehicles operating on the route, assume we are overnight.
     if not is_nil(informed_route) and fetch_vehicles_fn.(informed_route, nil) == [] do
       get_overnight_schedules_for_section(

--- a/lib/screens/v2/candidate_generator/dup/departures.ex
+++ b/lib/screens/v2/candidate_generator/dup/departures.ex
@@ -147,7 +147,6 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
          fetch_schedules_fn,
          fetch_vehicles_fn
        ) do
-        departures = Enum.filter(departures, fn departures -> if departures.prediction, do: departures.prediction.route.type != :ferry, else: departures.schedule.route.type != :ferry end)
     routes_with_live_departures =
       departures |> Enum.map(&{Departure.route_id(&1), Departure.direction_id(&1)}) |> Enum.uniq()
 

--- a/lib/screens/v2/candidate_generator/dup/departures.ex
+++ b/lib/screens/v2/candidate_generator/dup/departures.ex
@@ -311,7 +311,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
     # This will help us decide whether a headway in one direction is still useful
     # if there are two alerts that could be in different directions.
     |> Enum.reduce([], fn alert, acc -> acc ++ alert.informed_entities end)
-    |> Enum.dedup()
+    |> Enum.uniq()
   end
 
   defp get_headway_mode(_, _, [], _), do: :inactive

--- a/test/screens/v2/candidate_generator/dup/departures_test.exs
+++ b/test/screens/v2/candidate_generator/dup/departures_test.exs
@@ -15,7 +15,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
   alias Screens.V2.Departure
   alias Screens.V2.CandidateGenerator.Dup
   alias Screens.V2.WidgetInstance.Departures, as: DeparturesWidget
-  alias Screens.V2.WidgetInstance.{DeparturesNoData, OvernightDepartures}
+  alias Screens.V2.WidgetInstance.OvernightDepartures
 
   defp put_primary_departures(widget, primary_departures_sections) do
     %{
@@ -1654,7 +1654,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
       assert Enum.all?(expected_departures, &Enum.member?(actual_instances, &1))
     end
 
-    test "returns DeparturesNoData if all sections have no data", %{
+    test "returns empty departures list if sections have no departures", %{
       config: config,
       fetch_section_departures_fn: fetch_section_departures_fn,
       fetch_alerts_fn: fetch_alerts_fn,
@@ -1684,23 +1684,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
 
       now = ~U[2020-04-06T10:00:00Z]
 
-      expected_departures = [
-        %DeparturesNoData{
-          screen: config,
-          show_alternatives?: nil,
-          slot_name: :main_content_zero
-        },
-        %DeparturesNoData{
-          screen: config,
-          show_alternatives?: nil,
-          slot_name: :main_content_one
-        },
-        %DeparturesNoData{
-          screen: config,
-          show_alternatives?: nil,
-          slot_name: :main_content_two
-        }
-      ]
+      expected_departures = []
 
       actual_instances =
         Dup.Departures.departures_instances(


### PR DESCRIPTION
[Main task](https://www.notion.so/mbta-downtown-crossing/4b67fc8f4ef04868901d85a412cdd48f?v=8c5d6c5153b443a58cedcf0d8b9838d7&p=c2a4d8f16e04413b88339f371ce82814&pm=s) and small [added task](https://www.notion.so/mbta-downtown-crossing/4b67fc8f4ef04868901d85a412cdd48f?v=8c5d6c5153b443a58cedcf0d8b9838d7&p=fa794a94178b4582b420a7f83a0241dc&pm=s)

Deciding to show headway or not is decided in the departures candidate_generator, by fetching relevant Alerts for that station, only choosing the first one, and looking at the informed entities. Problem is, we don't simply choose the first alert in the special case at Kenmore; we do some complex logic in the `alert_instances` function. So I could have executed that function again in departure_instances, but I tried something different...

The only attribute we need from alerts in the whole departures candidate_generator is the informed_entities of our chosen alert. What if instead of only looking at the informed_entities of the first alert, we compiled all the alerts' informed_entities into one list and used that to decide to show the headway or not?

This helps works just fine at Kenmore. This also slightly improves on the spec in other situations: for example, consider a NB suspension and SB shuttle at Aquarium. According to the spec, we'd prioritize one alert, dump the other, and show headways in a direction where there are no trains traveling. With this new logic, there will be no headway mode, just blank departures -- which Paul H confirms is better than showing wrong information.

![Screenshot 2023-04-11 at 4 27 52 PM](https://user-images.githubusercontent.com/69368883/231280743-3e236e60-8736-4970-a4b1-f465414ddf99.png)

![Screenshot 2023-04-11 at 4 27 42 PM](https://user-images.githubusercontent.com/69368883/231280784-9986b98b-9e83-4809-8883-3839025bc731.png)

OLD VERSION and misleading
![Screenshot 2023-04-11 at 4 27 29 PM](https://user-images.githubusercontent.com/69368883/231280817-4406d8aa-975a-48f0-b00c-4a43c75cc7a4.png)

- [ ] Tests added?
