### PR TITLE
polish: destination headsign paging fix

### DIFF
--- a/assets/css/dup_v2.scss
+++ b/assets/css/dup_v2.scss
@@ -1,5 +1,4 @@
-@import url("https://rsms.me/inter/inter.css");
-
+@import "fonts/inter_font_face";
 @import "colors";
 @import "v2/common/widget";
 

--- a/assets/src/components/v2/dup/departures/destination.tsx
+++ b/assets/src/components/v2/dup/departures/destination.tsx
@@ -149,7 +149,7 @@ const Destination = ({ headsign, currentPage }) => {
       <div className="departure-destination__headsign" ref={firstLineRef}>
         {firstLine}
       </div>
-      <div className="departure-destination__variation" ref={secondLineRef}>
+      <div className="departure-destination__headsign" ref={secondLineRef}>
         {secondLine}
       </div>
     </div>


### PR DESCRIPTION
**Notion task**: [No headsigns overflow 1024px / overlap with the following morning’s schedule time](https://www.notion.so/mbta-downtown-crossing/No-headsigns-overflow-1024px-overlap-with-the-following-morning-s-schedule-time-3344c4da7bf744d3b19f71688a3a6495?pvs=4)

An incorrect CSS class was causing text wrapping on some headsigns. Fixing this class fixed the paging issues. 

I also went ahead and change v2 DUPs to use local Inter files.

- [ ] Tests added?
