### PR TITLE
polish: DUP v2 all screen URL

### DIFF
--- a/assets/src/apps/v2/dup.tsx
+++ b/assets/src/apps/v2/dup.tsx
@@ -122,7 +122,10 @@ const App = (): JSX.Element => {
     <Router>
       <Switch>
         <Route exact path="/v2/screen/dup_v2">
-          <MultiScreenPage components={TYPE_TO_COMPONENT} />
+          <MultiScreenPage
+            components={TYPE_TO_COMPONENT}
+            responseMapper={responseMapper}
+          />
         </Route>
         <Route exact path="/v2/screen/:id/simulation">
           <MappingContext.Provider value={TYPE_TO_COMPONENT}>


### PR DESCRIPTION
**Notion task**: ad-hoc

`responseMapper` was missing in the `MultiScreenPage` props, which was causing some layout issues. Adding it renders the page correctly.

- [ ] Tests added?
