### PR TITLE
Alerts Refactor Investigation: CandidateGenerator

### DIFF
--- a/lib/screens/v2/candidate_generator/widgets/elevator_closures.ex
+++ b/lib/screens/v2/candidate_generator/widgets/elevator_closures.ex
@@ -45,6 +45,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ElevatorClosures do
     end
   end
 
+  # Should live in Screens.Alerts.Alert along with other alert fetches.
   def fetch_elevator_closures do
     case Screens.V3Api.get_json("alerts", %{
            "filter[activity]" => "USING_WHEELCHAIR",
@@ -74,6 +75,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ElevatorClosures do
     end
   end
 
+  # No real reason this function is specific to elevator alerts. Could be placed in a common file.
   defp get_icon_map(elevator_closures, home_parent_station_id) do
     elevator_closures
     |> get_parent_station_ids_from_entities()
@@ -85,6 +87,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ElevatorClosures do
     |> Enum.into(%{})
   end
 
+  # Seems like a good util function that can live in Screens.Alerts.Alert.
   defp get_parent_station_ids_from_entities(alerts) do
     alerts
     |> Enum.flat_map(fn %Alert{informed_entities: informed_entities} ->
@@ -94,6 +97,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ElevatorClosures do
     end)
   end
 
+  # Should probably live in Screens.Routes.Route. Similar code already exists there.
   defp routes_to_icons(routes) do
     routes
     |> Enum.map(fn

--- a/lib/screens/v2/candidate_generator/widgets/reconstructed_alert.ex
+++ b/lib/screens/v2/candidate_generator/widgets/reconstructed_alert.ex
@@ -196,6 +196,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlert do
     end
   end
 
+  # Could be a useful function outside of this file.
   defp is_terminal?(stop_id, stop_sequences) do
     # Can't use Enum.any, because then Govt Center will be seen as a terminal
     # Using all is ok because no station is the terminal of one line and NOT the terminal of another line


### PR DESCRIPTION
I don't see a ton of value in a major refactor of the CandidateGenerators. Each one uses logic that is very specific to the widget it is creating candidates for. They do have some shared workflows (fetch, filter, create instance), but not much outside of that. Even the flagged items are mostly ways to allow other files to use functions that aren't specific to a single CandidateGenerator, not any actually refactoring of duplicated code.