### PR TITLE
polish: Empty section height

### DIFF
--- a/assets/src/components/v2/dup/departures/normal_section.tsx
+++ b/assets/src/components/v2/dup/departures/normal_section.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from "react";
+import React from "react";
 
 import DepartureRow from "Components/v2/dup/departures/departure_row";
 import NoticeRow from "Components/v2/departures/notice_row";
@@ -6,17 +6,22 @@ import useCurrentPage from "Hooks/use_current_dup_page";
 
 const NormalSection = ({ rows }) => {
   const currentPage = useCurrentPage();
+
   return (
-    <div className="departures-section">
-      {rows.map((row, index) => {
-        const { id, type, ...data } = row;
-        if (type === "departure_row") {
-          return <DepartureRow {...data} key={id} currentPage={currentPage} />;
-        } else if (type === "notice_row") {
-          return <NoticeRow row={row} key={"notice" + index} />;
-        }
-      })}
-    </div>
+    rows.length > 0 && (
+      <div className="departures-section">
+        {rows.map((row, index) => {
+          const { id, type, ...data } = row;
+          if (type === "departure_row") {
+            return (
+              <DepartureRow {...data} key={id} currentPage={currentPage} />
+            );
+          } else if (type === "notice_row") {
+            return <NoticeRow row={row} key={"notice" + index} />;
+          }
+        })}
+      </div>
+    )
   );
 };
 


### PR DESCRIPTION
**Notion task**: [Empty section takes up two rows](https://www.notion.so/mbta-downtown-crossing/Empty-section-takes-up-two-rows-9cc6df8eb1284285a0878464bb8abb3c?pvs=4)

Instead of playing with height values for empty sections, we can just not render it if there is nothing to show. 

- [ ] Tests added?
