### PR TITLE
polish: overnight-section text margin

### DIFF
--- a/assets/css/v2/dup/free_text.scss
+++ b/assets/css/v2/dup/free_text.scss
@@ -284,6 +284,7 @@
     font-size: 138px;
     color: #171f26;
     width: 1145px;
+    margin-top: 24px;
   }
 
   .free-text__route-pill {


### PR DESCRIPTION
**Notion task**: [2 sections / both directions done matches design spec](https://www.notion.so/mbta-downtown-crossing/2-sections-both-directions-done-matches-design-spec-eb0cfc74fb0446899d38f304368d72fa?pvs=4)

The scope of this task was text pill alignment (which is fixed), but I see that the text in `overnight-section`s is not in line with the pill. `margin-top: 24px` is actually in the design, so just something that was missed in the original implementation.

Before:
![Screenshot 2023-04-20 at 1 09 42 PM](https://user-images.githubusercontent.com/10713153/233439054-028e3423-95f7-4241-a5ab-d4fec3a68693.png)

After:
![Screenshot 2023-04-20 at 1 09 47 PM](https://user-images.githubusercontent.com/10713153/233439059-7e79a38e-4731-4cde-abfa-db96c5969227.png)

