### PR TITLE
Detect, log to Sentry, and discard directional shuttle/suspension alerts

### DIFF
--- a/lib/screens/v2/candidate_generator/dup/alerts.ex
+++ b/lib/screens/v2/candidate_generator/dup/alerts.ex
@@ -170,7 +170,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Alerts do
         Sentry.capture_message(
           "DUP logic encountered a directional shuttle or suspension alert. Discarding.",
           level: "warning",
-          extra: %{alert_id: alert.id, alert_effect: Atom.to_string(alert.effect)}
+          extra: %{alert_id: alert.id, alert_effect: alert.effect}
         )
       end
 

--- a/lib/screens/v2/candidate_generator/dup/alerts.ex
+++ b/lib/screens/v2/candidate_generator/dup/alerts.ex
@@ -138,7 +138,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Alerts do
     }
 
     relevant_effect?(alert, config) and Alert.happening_now?(alert, now) and
-      relevant_location?(dup_alert)
+      relevant_location?(dup_alert) and not directional_shuttle_or_suspension?(alert)
   end
 
   defp relevant_effect?(%{effect: :delay, severity: severity}, _) do
@@ -158,6 +158,21 @@ defmodule Screens.V2.CandidateGenerator.Dup.Alerts do
 
   defp relevant_location?(dup_alert) do
     BaseAlert.location(dup_alert) in [:inside, :boundary_upstream, :boundary_downstream]
+  end
+
+  defp directional_shuttle_or_suspension?(alert) do
+    directional =
+      alert.effect in [:shuttle, :suspension] and
+        Enum.any?(alert.informed_entities, &(&1.direction_id in 0..1))
+
+    if directional do
+      Sentry.capture_message(
+        "DUP logic encountered a directional shuttle or suspension alert. Discarding. alert_id=#{alert.id} alert_effect=#{alert.effect}",
+        level: "warning"
+      )
+    end
+
+    directional
   end
 
   # If this is a special case, this function returns the widgets that should be used for it.

--- a/lib/screens/v2/candidate_generator/dup/alerts.ex
+++ b/lib/screens/v2/candidate_generator/dup/alerts.ex
@@ -165,12 +165,13 @@ defmodule Screens.V2.CandidateGenerator.Dup.Alerts do
       alert.effect in [:shuttle, :suspension] and
         Enum.any?(alert.informed_entities, &(&1.direction_id in 0..1))
 
-    if directional do
-      Sentry.capture_message(
-        "DUP logic encountered a directional shuttle or suspension alert. Discarding. alert_id=#{alert.id} alert_effect=#{alert.effect}",
-        level: "warning"
-      )
-    end
+    _ =
+      if directional do
+        Sentry.capture_message(
+          "DUP logic encountered a directional shuttle or suspension alert. Discarding. alert_id=#{alert.id} alert_effect=#{alert.effect}",
+          level: "warning"
+        )
+      end
 
     directional
   end

--- a/lib/screens/v2/candidate_generator/dup/alerts.ex
+++ b/lib/screens/v2/candidate_generator/dup/alerts.ex
@@ -168,8 +168,9 @@ defmodule Screens.V2.CandidateGenerator.Dup.Alerts do
     _ =
       if directional do
         Sentry.capture_message(
-          "DUP logic encountered a directional shuttle or suspension alert. Discarding. alert_id=#{alert.id} alert_effect=#{alert.effect}",
-          level: "warning"
+          "DUP logic encountered a directional shuttle or suspension alert. Discarding.",
+          level: "warning",
+          extra: %{alert_id: alert.id, alert_effect: Atom.to_string(alert.effect)}
         )
       end
 

--- a/lib/screens/v2/widget_instance/dup_alert/serialize.ex
+++ b/lib/screens/v2/widget_instance/dup_alert/serialize.ex
@@ -156,7 +156,9 @@ defmodule Screens.V2.WidgetInstance.DupAlert.Serialize do
     headsign = BaseAlert.get_headsign_from_informed_entities(t)
 
     if is_nil(headsign) do
-      raise("[DUP v2 no headsign] Could not determine headsign for DUP alert")
+      raise(
+        "[DUP v2 no headsign] Could not determine headsign for DUP alert alert_id=#{t.alert.id}"
+      )
     end
 
     case headsign do


### PR DESCRIPTION
**Asana task**: [Shuttle, boundary, 1/2](https://www.notion.so/mbta-downtown-crossing/Shuttle-boundary-1-2-911e04408bda44fcaa16ea00db43ed53?pvs=4)

We don't think these types of alerts can happen, but if they do and the directional alert "ends" at a station with a DUP screen, it causes the code for that screen to raise due to not finding an appropriate headsign. (Also, we're not sure what we should display for directional alerts ending at a station since riders can still board trains in both directions there.)

For now, we will have Sentry tell us if this scenario happens, but ignore the alert to be safe. If it does happen IRL, we'll come back and adjust the code to handle directional alerts.

- [ ] Tests added?
