### PR TITLE
Making FreeText styles more concise for DUPs

### DIFF
--- a/assets/css/v2/dup/alert/partial_alert.scss
+++ b/assets/css/v2/dup/alert/partial_alert.scss
@@ -1,10 +1,5 @@
-.partial-alerts {
-  position: absolute;
-  bottom: 0;
-  border-top: 6px solid #bfbebb;
-}
-
 .partial-alert {
+  border-top: 6px solid #00000040;
 
   &--green {
     background: $line-color-green;

--- a/assets/css/v2/dup/departures/headway_section.scss
+++ b/assets/css/v2/dup/departures/headway_section.scss
@@ -7,16 +7,4 @@
     padding-left: 72px;
     padding-right: 64px;
   }
-
-  .free-text {
-    color: #171f26 !important;
-  }
-
-  .free-text__route-pill {
-    color: #ffffff;
-  }
-
-  .free-text__text-pill {
-    color: #ffffff;
-  }
 }

--- a/assets/css/v2/dup/free_text.scss
+++ b/assets/css/v2/dup/free_text.scss
@@ -1,3 +1,4 @@
+// General styles for free text / route pills
 .free-text {
   font-family: Inter;
   font-size: 138px;
@@ -15,6 +16,7 @@
   vertical-align: middle;
   text-align: center;
 
+  // Needed if we use a route pill as the leading icon for the row
   .free-text__route-pill {
     margin-top: 30px;
     color: #ffffff;
@@ -37,15 +39,10 @@
   }
 }
 
-.free-text__route-pill {
-  text-align: center;
-}
-
 .free-text__route-pill,
 .free-text__text-pill {
   display: inline-block;
-  font-family: Helvetica, sans-serif;
-  font-weight: 700;
+  text-align: center;
 
   &--green,
   &--green_b,
@@ -82,39 +79,50 @@
   }
 }
 
-.free-text__inline-icon {
-  height: 208px;
-  line-height: 168px;
-}
-
-.free-text__inline-icon-image {
-  height: 139px;
-}
-
 .free-text__route-pill__text,
 .free-text__text-pill__text {
-  display: inline-block;
   font-family: Helvetica, sans-serif;
-  font-weight: 700;
-}
-
-.free-text__route-pill__text {
-  text-align: center;
 
   &--branch {
     font-size: 84px;
   }
 }
 
+.free-text__line {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  // Needed to keep y's from getting cut off!
+  line-height: initial;
+}
+
+.free-text__inline-icon-image {
+  // This is not a Helvetica transform
+  // This is because FreeText centering for inline icons is weird
+  transform: translateY(20px);
+}
+
+.free-text__route-pill {
+  height: 144px;
+  width: 248px;
+  border-radius: 72px;
+  font-size: 96px;
+  line-height: 144px;
+}
+
+.free-text__text-pill {
+  border-radius: 84px;
+  font-size: 126px;
+  line-height: 168px;
+  padding-left: 84px;
+  padding-right: 84px;
+}
+
+// Partial alert and one-line headway have similar styles
 .partial-alert,
 .headway-section:not(:only-child) {
   .free-text__line {
     width: 1608px;
-    overflow: hidden;
-    text-overflow: ellipsis;
     white-space: nowrap;
-    line-height: 208px;
-    font-weight: 400;
   }
 
   .free-text__icon-container {
@@ -123,30 +131,9 @@
   }
 
   .free-text__icon-image {
-    height: 144px;
+    height: 128px;
     padding-top: 40px;
     padding-bottom: 40px;
-  }
-
-  .free-text__route-pill {
-    height: 144px;
-    width: 248px;
-    border-radius: 72px;
-    font-size: 96px;
-    line-height: 144px;
-  }
-
-  .free-text__text-pill {
-    border-radius: 84px;
-    font-size: 126px;
-    line-height: 168px;
-    padding-left: 84px;
-    padding-right: 84px;
-  }
-
-  .free-text__inline-icon {
-    height: 208px;
-    line-height: 208px;
   }
 }
 
@@ -156,20 +143,11 @@
   }
 }
 
-.headway-section:only-child {
-  .free-text__line-container {
-    margin-bottom: 56px;
-    line-height: 144px;
-  }
-
+// Full page headway and Full page alert have similar styles
+.headway-section:only-child,
+.full-screen-alert__body-text {
   .free-text__line {
     width: 1517px;
-    line-height: initial;
-  }
-
-  .free-text__pill-container {
-    display: inline-block;
-    height: 168px;
   }
 
   .free-text__icon-container {
@@ -183,17 +161,55 @@
     width: 100%;
     height: 100%;
     object-fit: contain;
+    padding: 0;
+  }
+}
+
+.headway-section {
+  .free-text {
+    color: #171f26;
+  }
+}
+
+.full-screen-alert__body-text {
+  .free-text__line {
+    width: 1544px;
+    line-height: 156px;
   }
 
-  .free-text__text-pill {
-    border-radius: 84px;
+  .free-text__line-container {
+    margin-bottom: 52px;
   }
 
-  .free-text__text-pill__text {
-    font-size: 126px;
-    line-height: 168px;
-    margin-left: 84px;
-    margin-right: 84px;
+  .free-text__icon-container {
+    margin-right: 64px;
+  }
+
+  .free-text__route-pill {
+    height: 128px;
+    line-height: 128px;
+    vertical-align: bottom;
+    transform: translateY(-10px);
+  }
+}
+
+// No Data and Overnight sections have similar styles
+.no-data-section,
+.overnight-section {
+  .free-text__line {
+    width: 1400px;
+    font-weight: 600;
+    color: #171f26;
+  }
+
+  .free-text__icon-container {
+    width: 312px;
+    height: 208px;
+  }
+
+  .free-text__icon-image {
+    height: 112.5px;
+    margin-top: 15.75px;
   }
 }
 
@@ -201,120 +217,14 @@
   .free-text {
     display: inline-block;
   }
-
-  .free-text__line {
-    width: 1400px;
-    font-weight: 600;
-    line-height: 128px;
-    font-size: 138px;
-    color: #171f26;
-  }
-
-  .free-text__route-pill {
-    height: 144px;
-    width: 248px;
-    border-radius: 72px;
-    font-size: 96px;
-    line-height: 117px;
-  }
-
-  .free-text__route-pill__text {
-    font-size: 96px;
-    font-weight: 700;
-    line-height: 144px;
-  }
-
-  .free-text__icon-container {
-    width: 312px;
-    height: 208px;
-  }
-
-  .free-text__icon-image {
-    height: 112.5px;
-    margin-top: 15.75px;
-  }
-}
-
-.full-screen-alert-text {
-  .free-text__line {
-    width: 1544px;
-  }
-
-  .free-text__line-container {
-    margin-bottom: 56px;
-  }
-
-  .free-text__icon-container {
-    width: 184px;
-    height: 184px;
-    margin-right: 64px;
-    vertical-align: top;
-  }
-
-  .free-text__icon-image {
-    width: 100%;
-    height: 100%;
-    object-fit: contain;
-  }
-
-  .free-text__text-pill {
-    border-radius: 84px;
-    font-size: 126px;
-    line-height: 168px;
-    padding-left: 84px;
-    padding-right: 84px;
-  }
-
-  .free-text__route-pill {
-    height: 128px;
-    width: 248px;
-    border-radius: 72px;
-    font-size: 96px;
-    line-height: 128px;
-    vertical-align: bottom;
-  }
 }
 
 .overnight-section {
-  .free-text {
-    display: inline-block;
-    line-height: unset;
-  }
-
   .free-text__line {
-    font-weight: 600;
-    font-size: 138px;
-    color: #171f26;
-    width: 1145px;
     margin-top: 24px;
   }
 
-  .free-text__route-pill {
-    height: 144px;
-    width: 248px;
-    border-radius: 72px;
-    font-size: 96px;
-    line-height: 144px;
-  }
-
-  .free-text__route-pill__text {
-    font-size: 96px;
-    font-weight: 700;
-    line-height: 144px;
-  }
-
   .free-text__icon-container {
-    width: 312px;
-    height: 208px;
     vertical-align: top;
-  }
-
-  .free-text__icon-image {
-    height: 112.5px;
-    margin-top: 15.75px;
-  }
-
-  .free-text__string {
-    line-height: unset;
   }
 }

--- a/assets/src/components/v2/dup/takeover_alert.tsx
+++ b/assets/src/components/v2/dup/takeover_alert.tsx
@@ -24,7 +24,7 @@ const TakeoverAlert = (alert: TakeoverAlertProps) => {
         accentPattern="dup-accent-pattern.svg"
       />
       <div className="full-screen-alert__body">
-        <div className="full-screen-alert-text">
+        <div className="full-screen-alert__body-text">
           <FreeText lines={[text, remedy]} />
         </div>
         <div className="full-screen-alert__link">

--- a/lib/screens/v2/widget_instance/departures.ex
+++ b/lib/screens/v2/widget_instance/departures.ex
@@ -131,7 +131,8 @@ defmodule Screens.V2.WidgetInstance.Departures do
                 text: "#{String.upcase(formatted_route)} LINE"
               },
               %{special: :break},
-              "#{headsign} trains every"
+              "#{headsign} trains every",
+              %{special: :break},
             ] ++ time_range
         }
       else
@@ -162,7 +163,11 @@ defmodule Screens.V2.WidgetInstance.Departures do
 
     text = %FreeTextLine{
       icon: route_pill,
-      text: ["Service resumes in the morning"]
+      text: [
+        "Service resumes",
+        %{special: :break},
+        "in the morning"
+      ]
     }
 
     %{type: :overnight_section, text: FreeTextLine.to_json(text)}

--- a/lib/screens/v2/widget_instance/departures.ex
+++ b/lib/screens/v2/widget_instance/departures.ex
@@ -132,7 +132,7 @@ defmodule Screens.V2.WidgetInstance.Departures do
               },
               %{special: :break},
               "#{headsign} trains every",
-              %{special: :break},
+              %{special: :break}
             ] ++ time_range
         }
       else

--- a/lib/screens/v2/widget_instance/dup_alert/serialize.ex
+++ b/lib/screens/v2/widget_instance/dup_alert/serialize.ex
@@ -156,13 +156,10 @@ defmodule Screens.V2.WidgetInstance.DupAlert.Serialize do
   end
 
   defp remedy_free_text(t) do
-    text =
-      case t.alert.effect do
-        :shuttle -> "Use shuttle bus"
-        _ -> "Seek alternate route"
-      end
-
-    [bold(text)]
+    case t.alert.effect do
+      :shuttle -> [bold("Use shuttle bus")]
+      _ -> ["Seek alternate route"]
+    end
   end
 
   defp get_headsign(t) do

--- a/test/screens/v2/widget_instance/departures_test.exs
+++ b/test/screens/v2/widget_instance/departures_test.exs
@@ -128,6 +128,7 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
           %{color: :red, text: "RED LINE"},
           %{special: :break},
           "Test trains every",
+          %{special: :break},
           %{format: :bold, text: "1-2"},
           "minutes"
         ]
@@ -154,6 +155,7 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
           %{color: :red, text: "RED LINE"},
           %{special: :break},
           "Ashmont/Braintree trains every",
+          %{special: :break},
           %{format: :bold, text: "1-2m"}
         ]
       }


### PR DESCRIPTION
Adhoc.

Ok, tried to make styles for FreeText more robust for DUPs, but not sure whether it is clearly cleaner. Thoughts?

Adjacent changes:
- Removed styles from other files that refer to DUP free text
- Added line breaks to free text in cases where we want it, instead of doing it with css (more brittle)
- Added border to partial alert because someone noticed it was missing (turns out it was a later change, but oh well, it's added now.)
- Made "seek alternate route" unbold (another late change, but I didn't realize that until I updated it)
