### PR TITLE
fix: bidirection with one departure bug

### DIFF
--- a/lib/screens/v2/candidate_generator/dup/departures.ex
+++ b/lib/screens/v2/candidate_generator/dup/departures.ex
@@ -148,7 +148,9 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
          fetch_vehicles_fn
        ) do
     routes_with_live_departures =
-      departures |> Enum.map(&{Departure.route_id(&1), Departure.direction_id(&1)}) |> Enum.uniq()
+      departures
+      |> Enum.map(&{Departure.route_id(&1), Departure.direction_id(&1)})
+      |> Enum.uniq()
 
     overnight_schedules_for_section =
       get_overnight_schedules_for_section(
@@ -274,7 +276,14 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
         Departure.direction_id(departure) === 1 - first_direction_id
       end)
 
-    [first_row] ++ [second_row]
+    # Towards the end of service, there can exist a scenario where one direction is done and the other only has one more departure.
+    # When this happens, the default above is nil because section_departures only has one departure in the list.
+    # In that scenario, only return first_row and let the overnight logic determine what row should be displayed.
+    if is_nil(second_row) do
+      [first_row]
+    else
+      [first_row, second_row]
+    end
   end
 
   defp get_section_entities(

--- a/test/screens/v2/candidate_generator/dup/departures_test.exs
+++ b/test/screens/v2/candidate_generator/dup/departures_test.exs
@@ -193,6 +193,19 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
            }
          ]}
 
+      %Section{query: %Query{params: %Query.Params{stop_ids: ["place-G"]}}} ->
+        {:ok,
+         [
+           %Departure{
+             prediction: %Prediction{
+               id: "G1",
+               trip: %Trip{direction_id: 1},
+               stop: struct(Stop),
+               route: %Route{id: "Test"}
+             }
+           }
+         ]}
+
       %Section{query: %Query{params: %Query.Params{stop_ids: ["place-kencl"]}}} ->
         {:ok,
          [
@@ -744,6 +757,105 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
                       stop: struct(Stop),
                       route: %Route{id: "Test"},
                       trip: struct(Trip)
+                    ),
+                  schedule: nil
+                }
+              ]
+            }
+          ],
+          slot_names: [:main_content_two]
+        }
+      ]
+
+      actual_instances =
+        Dup.Departures.departures_instances(
+          config,
+          now,
+          fetch_section_departures_fn,
+          fetch_alerts_fn,
+          fetch_schedules_fn,
+          create_station_with_routes_map_fn,
+          fetch_vehicles_fn
+        )
+
+      assert Enum.all?(expected_departures, &Enum.member?(actual_instances, &1))
+    end
+
+    test "returns one row for bidirectional departures if only one departure exists", %{
+      config: config,
+      fetch_section_departures_fn: fetch_section_departures_fn,
+      fetch_alerts_fn: fetch_alerts_fn,
+      fetch_schedules_fn: fetch_schedules_fn,
+      create_station_with_routes_map_fn: create_station_with_routes_map_fn,
+      fetch_vehicles_fn: fetch_vehicles_fn
+    } do
+      config =
+        put_primary_departures(config, [
+          %Section{
+            bidirectional: true,
+            query: %Query{params: %Query.Params{stop_ids: ["place-G"]}},
+            filter: nil
+          }
+        ])
+
+      now = ~U[2020-04-06T10:00:00Z]
+
+      expected_departures = [
+        %DeparturesWidget{
+          screen: config,
+          section_data: [
+            %{
+              type: :normal_section,
+              rows: [
+                %Screens.V2.Departure{
+                  prediction:
+                    struct(Prediction,
+                      id: "G1",
+                      stop: struct(Stop),
+                      route: %Route{id: "Test"},
+                      trip: struct(Trip, direction_id: 1)
+                    ),
+                  schedule: nil
+                }
+              ]
+            }
+          ],
+          slot_names: [:main_content_zero]
+        },
+        %DeparturesWidget{
+          screen: config,
+          section_data: [
+            %{
+              type: :normal_section,
+              rows: [
+                %Screens.V2.Departure{
+                  prediction:
+                    struct(Prediction,
+                      id: "G1",
+                      stop: struct(Stop),
+                      route: %Route{id: "Test"},
+                      trip: struct(Trip, direction_id: 1)
+                    ),
+                  schedule: nil
+                }
+              ]
+            }
+          ],
+          slot_names: [:main_content_one]
+        },
+        %DeparturesWidget{
+          screen: config,
+          section_data: [
+            %{
+              type: :normal_section,
+              rows: [
+                %Screens.V2.Departure{
+                  prediction:
+                    struct(Prediction,
+                      id: "G1",
+                      stop: struct(Stop),
+                      route: %Route{id: "Test"},
+                      trip: struct(Trip, direction_id: 1)
                     ),
                   schedule: nil
                 }


### PR DESCRIPTION
**Asana task**: [FunctionClauseError: no function clause matching in Screens.V2.Departure.route_id/1](https://app.asana.com/0/1185117109217422/1204461103486671/f)

See comment in code for description of problem. Only happens on bidirectional sections (was able to deduce this by seeing only Back Bay and Tufts in the Sentry error).

- [X] Tests added?
