### PR TITLE
Bug: styling for full headway on dups

### DIFF
--- a/assets/css/v2/dup/free_text.scss
+++ b/assets/css/v2/dup/free_text.scss
@@ -17,8 +17,9 @@
   text-align: center;
 
   // Needed if we use a route pill as the leading icon for the row
+  // which we do for one-row headways
   .free-text__route-pill {
-    margin-top: 30px;
+    margin-top: 35px;
     color: #ffffff;
   }
 }
@@ -93,6 +94,9 @@
   text-overflow: ellipsis;
   // Needed to keep y's from getting cut off!
   line-height: initial;
+  .free-text__element {
+    line-height: initial;
+  }
 }
 
 .free-text__inline-icon-image {
@@ -137,10 +141,18 @@
   }
 }
 
-.partial-alert--yellow {
-  .free-text {
-    color: #171f26;
+.partial-alert {
+  &--yellow {
+    .free-text {
+      color: #171f26;
+    }
   }
+
+  // slight edits for partial alert because of the top border
+  .free-text__icon-container {height: 202px;}
+  .free-text__icon-image {padding-top: 37px;}
+  .free-text__line {height: 202px;}
+  .free-text__element{vertical-align: middle;}
 }
 
 // Full page headway and Full page alert have similar styles
@@ -169,6 +181,9 @@
   .free-text {
     color: #171f26;
   }
+  .free-text__text-pill {
+    color: #ffffff;
+  }
 }
 
 .full-screen-alert__body-text {
@@ -178,7 +193,7 @@
   }
 
   .free-text__line-container {
-    margin-bottom: 52px;
+    margin-bottom: 40px;
   }
 
   .free-text__icon-container {

--- a/lib/screens/v2/widget_instance/departures.ex
+++ b/lib/screens/v2/widget_instance/departures.ex
@@ -132,7 +132,6 @@ defmodule Screens.V2.WidgetInstance.Departures do
               },
               %{special: :break},
               "#{headsign} trains every",
-              %{special: :break}
             ] ++ time_range
         }
       else


### PR DESCRIPTION
- Full screen headway fixed
- Partial alert centered
- Prevent 'y' from getting cut off. It messes with line-height elsewhere, so I adjusted a margin, notified design.