### PR TITLE
fix: headway-section only-child styling

### DIFF
--- a/assets/css/v2/dup/departures/headway_section.scss
+++ b/assets/css/v2/dup/departures/headway_section.scss
@@ -1,7 +1,7 @@
 .departures-section.headway-section {
   height: 208px;
 
-  &:only-child {
+  &.headway-section--full_screen {
     height: 416px;
     padding-top: 72px;
     padding-left: 72px;

--- a/assets/css/v2/dup/free_text.scss
+++ b/assets/css/v2/dup/free_text.scss
@@ -123,7 +123,7 @@
 
 // Partial alert and one-line headway have similar styles
 .partial-alert,
-.headway-section:not(:only-child) {
+.headway-section--row {
   .free-text__line {
     width: 1608px;
     white-space: nowrap;
@@ -149,14 +149,22 @@
   }
 
   // slight edits for partial alert because of the top border
-  .free-text__icon-container {height: 202px;}
-  .free-text__icon-image {padding-top: 37px;}
-  .free-text__line {height: 202px;}
-  .free-text__element{vertical-align: middle;}
+  .free-text__icon-container {
+    height: 202px;
+  }
+  .free-text__icon-image {
+    padding-top: 37px;
+  }
+  .free-text__line {
+    height: 202px;
+  }
+  .free-text__element {
+    vertical-align: middle;
+  }
 }
 
 // Full page headway and Full page alert have similar styles
-.headway-section:only-child,
+.headway-section--full_screen,
 .full-screen-alert__body-text {
   .free-text__line {
     width: 1517px;

--- a/assets/src/components/v2/dup/departures/headway_section.tsx
+++ b/assets/src/components/v2/dup/departures/headway_section.tsx
@@ -1,9 +1,15 @@
 import React from "react";
 import FreeText from "Components/v2/free_text";
+import { classWithModifier } from "Util/util";
 
-const HeadwaySection = ({ text }) => {
+const HeadwaySection = ({ text, layout }) => {
   return (
-    <div className="departures-section headway-section">
+    <div
+      className={`departures-section ${classWithModifier(
+        "headway-section",
+        layout
+      )}`}
+    >
       <FreeText lines={text} />
     </div>
   );

--- a/assets/src/components/v2/dup/departures/normal_departures.tsx
+++ b/assets/src/components/v2/dup/departures/normal_departures.tsx
@@ -17,7 +17,9 @@ const NormalDepartures = ({ sections }) => {
             case "notice_section":
               return <NoticeSection {...data} key={i} />;
             case "headway_section":
-              return <HeadwaySection text={data.text} key={i} />;
+              return (
+                <HeadwaySection text={data.text} layout={data.layout} key={i} />
+              );
             case "no_data_section":
               return <NoDataSection text={data.text} key={i} />;
             case "overnight_section":

--- a/lib/screens/v2/widget_instance/departures.ex
+++ b/lib/screens/v2/widget_instance/departures.ex
@@ -106,6 +106,7 @@ defmodule Screens.V2.WidgetInstance.Departures do
         is_only_section
       ) do
     pill_color = Route.get_color_for_route(route)
+    layout = if is_only_section, do: :full_screen, else: :row
 
     formatted_route =
       case route do
@@ -141,7 +142,7 @@ defmodule Screens.V2.WidgetInstance.Departures do
         }
       end
 
-    %{type: :headway_section, text: FreeTextLine.to_json(text)}
+    %{type: :headway_section, text: FreeTextLine.to_json(text), layout: layout}
   end
 
   def serialize_section(%{type: :normal_section, rows: departures}, screen, _) do

--- a/test/screens/v2/widget_instance/departures_test.exs
+++ b/test/screens/v2/widget_instance/departures_test.exs
@@ -133,7 +133,7 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
         ]
       }
 
-      assert %{type: :headway_section, text: expected_text} ==
+      assert %{type: :headway_section, text: expected_text, layout: :full_screen} ==
                Departures.serialize_section(section, dup_screen, true)
     end
 
@@ -158,7 +158,7 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
         ]
       }
 
-      assert %{type: :headway_section, text: expected_text} ==
+      assert %{type: :headway_section, text: expected_text, layout: :full_screen} ==
                Departures.serialize_section(section, dup_screen, true)
     end
 
@@ -172,7 +172,7 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
         text: ["every", %{format: :bold, text: "1-2"}, "minutes"]
       }
 
-      assert %{type: :headway_section, text: expected_text} ==
+      assert %{type: :headway_section, text: expected_text, layout: :row} ==
                Departures.serialize_section(section, dup_screen, false)
     end
 


### PR DESCRIPTION
**Asana task**: ad-hoc

When the change was made to conditional render sections that have something to show, it broke headway `only-child` CSS selectors. When a `headway-section` is displayed with a blank section on the same page, incorrect styles were being applied. I added a new prop to `headway_section`s so we are more confident which style of headway we are showing.

- [ ] Tests added?
