### PR TITLE
Use platform code to get CR track number

### DIFF
--- a/lib/screens/predictions/parser.ex
+++ b/lib/screens/predictions/parser.ex
@@ -62,7 +62,7 @@ defmodule Screens.Predictions.Parser do
     stop = Map.get(included_data, {"stop", stop_id})
     route = Map.get(included_data, {"route", route_id})
 
-    track_number = parse_track_number(stop_id)
+    track_number = Map.get(included_data, {"stop", stop_id}).platform_code |> parse_platform_code
 
     vehicle =
       case get_in(relationships, ["vehicle", "data", "id"]) do
@@ -101,15 +101,9 @@ defmodule Screens.Predictions.Parser do
     time
   end
 
-  @spec parse_track_number(stop_id :: String.t() | nil) :: pos_integer() | nil
-  defp parse_track_number(nil), do: nil
+  defp parse_platform_code(nil), do: nil
 
-  defp parse_track_number(stop_id) do
-    ~r|^\w+-\w+-(\d+)$|
-    |> Regex.run(stop_id, capture: :all_but_first)
-    |> case do
-      nil -> nil
-      [track_number] -> String.to_integer(track_number)
-    end
+  defp parse_platform_code(platform_code) do
+    String.to_integer(platform_code)
   end
 end

--- a/lib/screens/stops/parser.ex
+++ b/lib/screens/stops/parser.ex
@@ -1,10 +1,14 @@
 defmodule Screens.Stops.Parser do
   @moduledoc false
 
-  def parse_stop(%{"id" => id, "attributes" => %{"name" => name}}) do
+  def parse_stop(%{
+        "id" => id,
+        "attributes" => %{"name" => name, "platform_code" => platform_code}
+      }) do
     %Screens.Stops.Stop{
       id: id,
-      name: name
+      name: name,
+      platform_code: platform_code
     }
   end
 end

--- a/lib/screens/stops/stop.ex
+++ b/lib/screens/stops/stop.ex
@@ -15,13 +15,15 @@ defmodule Screens.Stops.Stop do
   alias Screens.V3Api
 
   defstruct id: nil,
-            name: nil
+            name: nil,
+            platform_code: nil
 
   @type id :: String.t()
 
   @type t :: %__MODULE__{
           id: id,
-          name: String.t()
+          name: String.t(),
+          platform_code: String.t() | nil
         }
 
   @blue_line_stops [


### PR DESCRIPTION
**Asana task**: [[fix] Use `platform_code` field on stop data to get CR track number](https://app.asana.com/0/1185117109217432/1204204347671395/f)

Description

This change makes it so that we parse the track number using the `platform_code` field rather than parsing it out of the stop_id.

![Screenshot 2023-04-27 at 5 43 46 PM](https://user-images.githubusercontent.com/16074540/234997809-fd5e5a13-4f54-4103-ae2c-5caaaeacaa08.png)