### PR TITLE
Hotfix for letter platform codes

### DIFF
--- a/lib/screens/departures/departure.ex
+++ b/lib/screens/departures/departure.ex
@@ -39,7 +39,7 @@ defmodule Screens.Departures.Departure do
           time: DateTime.t(),
           crowding_level: crowding_level,
           inline_badges: list(map()),
-          track_number: pos_integer() | nil
+          track_number: String.t() | nil
         }
 
   @type query_params :: %{

--- a/lib/screens/predictions/parser.ex
+++ b/lib/screens/predictions/parser.ex
@@ -62,7 +62,7 @@ defmodule Screens.Predictions.Parser do
     stop = Map.get(included_data, {"stop", stop_id})
     route = Map.get(included_data, {"route", route_id})
 
-    track_number = parse_track_number(stop_id)
+    track_number = Map.get(included_data, {"stop", stop_id}).platform_code |> parse_platform_code
 
     vehicle =
       case get_in(relationships, ["vehicle", "data", "id"]) do
@@ -101,15 +101,9 @@ defmodule Screens.Predictions.Parser do
     time
   end
 
-  @spec parse_track_number(stop_id :: String.t() | nil) :: pos_integer() | nil
-  defp parse_track_number(nil), do: nil
+  defp parse_platform_code(nil), do: nil
 
-  defp parse_track_number(stop_id) do
-    ~r|^\w+-\w+-(\d+)$|
-    |> Regex.run(stop_id, capture: :all_but_first)
-    |> case do
-      nil -> nil
-      [track_number] -> String.to_integer(track_number)
-    end
+  defp parse_platform_code(platform_code) do
+    String.to_integer(platform_code)
   end
 end

--- a/lib/screens/predictions/parser.ex
+++ b/lib/screens/predictions/parser.ex
@@ -61,8 +61,7 @@ defmodule Screens.Predictions.Parser do
     trip = Map.get(included_data, {"trip", trip_id})
     stop = Map.get(included_data, {"stop", stop_id})
     route = Map.get(included_data, {"route", route_id})
-
-    track_number = Map.get(included_data, {"stop", stop_id}).platform_code |> parse_platform_code
+    track_number = Map.get(included_data, {"stop", stop_id}).platform_code
 
     vehicle =
       case get_in(relationships, ["vehicle", "data", "id"]) do
@@ -99,11 +98,5 @@ defmodule Screens.Predictions.Parser do
   defp parse_time(s) do
     {:ok, time, _} = DateTime.from_iso8601(s)
     time
-  end
-
-  defp parse_platform_code(nil), do: nil
-
-  defp parse_platform_code(platform_code) do
-    String.to_integer(platform_code)
   end
 end

--- a/lib/screens/predictions/prediction.ex
+++ b/lib/screens/predictions/prediction.ex
@@ -24,7 +24,7 @@ defmodule Screens.Predictions.Prediction do
           arrival_time: DateTime.t() | nil,
           departure_time: DateTime.t() | nil,
           stop_headsign: String.t() | nil,
-          track_number: pos_integer() | nil
+          track_number: String.t() | nil
         }
 
   @spec fetch(Departure.query_params()) :: {:ok, list(t())} | :error

--- a/lib/screens/schedules/schedule.ex
+++ b/lib/screens/schedules/schedule.ex
@@ -21,7 +21,7 @@ defmodule Screens.Schedules.Schedule do
           arrival_time: DateTime.t() | nil,
           departure_time: DateTime.t() | nil,
           stop_headsign: String.t() | nil,
-          track_number: pos_integer() | nil,
+          track_number: String.t() | nil,
           direction_id: 0 | 1
         }
 

--- a/lib/screens/stops/parser.ex
+++ b/lib/screens/stops/parser.ex
@@ -1,10 +1,14 @@
 defmodule Screens.Stops.Parser do
   @moduledoc false
 
-  def parse_stop(%{"id" => id, "attributes" => %{"name" => name}}) do
+  def parse_stop(%{
+        "id" => id,
+        "attributes" => %{"name" => name, "platform_code" => platform_code}
+      }) do
     %Screens.Stops.Stop{
       id: id,
-      name: name
+      name: name,
+      platform_code: platform_code
     }
   end
 end

--- a/lib/screens/stops/stop.ex
+++ b/lib/screens/stops/stop.ex
@@ -15,13 +15,15 @@ defmodule Screens.Stops.Stop do
   alias Screens.V3Api
 
   defstruct id: nil,
-            name: nil
+            name: nil,
+            platform_code: nil
 
   @type id :: String.t()
 
   @type t :: %__MODULE__{
           id: id,
-          name: String.t()
+          name: String.t(),
+          platform_code: String.t() | nil
         }
 
   @blue_line_stops [


### PR DESCRIPTION
**Asana task**: [[fix] Use `platform_code` field on stop data to get CR track number](https://app.asana.com/0/1185117109217432/1204204347671395/f)

Description
Hotfix for bug when platform code is a letter. Track "number" is fine to always store as a string since we don't do any arithmetic with it.

Note: The change in logic here will incur an update to the config. In the config, the track numbers are stored as integers in the `wayfinding_arrows` field. What's the best way to go about making that config update?
