### PR TITLE
refactor: Alerts CandidateGenerator behaviour

### DIFF
--- a/lib/screens/alerts/alert.ex
+++ b/lib/screens/alerts/alert.ex
@@ -224,8 +224,12 @@ defmodule Screens.Alerts.Alert do
   you're looking for.
   https://app.asana.com/0/0/1200476247539238/f
   """
-  @spec fetch_by_stop_and_route(list(Stop.id()), list(Route.id())) :: {:ok, list(t())} | :error
-  def fetch_by_stop_and_route(stop_ids, route_ids, get_json_fn \\ &V3Api.get_json/2) do
+  @spec fetch_by_stop_and_route(stop_ids: list(Stop.id()), route_ids: list(Route.id())) ::
+          {:ok, list(t())} | :error
+  def fetch_by_stop_and_route(opts, get_json_fn \\ &V3Api.get_json/2) do
+    stop_ids = opts[:stop_ids]
+    route_ids = opts[:route_ids]
+
     with {:ok, stop_based_alerts} <-
            fetch([stop_ids: stop_ids, route_ids: route_ids], get_json_fn),
          {:ok, route_based_alerts} <- fetch([route_ids: route_ids], get_json_fn) do

--- a/lib/screens/alerts/alert.ex
+++ b/lib/screens/alerts/alert.ex
@@ -240,6 +240,18 @@ defmodule Screens.Alerts.Alert do
     end
   end
 
+  def fetch_with_facilities(opts \\ [], get_json_fn \\ &V3Api.get_json/2) do
+    query_opts = opts ++ [include: ~w[facilities]]
+
+    case fetch(query_opts, get_json_fn) do
+      {:ok, {alerts, facilities}} ->
+        {:ok, alerts, facilities}
+
+      _ ->
+        :error
+    end
+  end
+
   defp format_query_param({:fields, fields}) when is_list(fields) do
     [
       {"fields[alert]", Enum.join(fields, ",")}
@@ -278,6 +290,14 @@ defmodule Screens.Alerts.Alert do
 
   defp format_query_param({:route_types, route_type}) do
     format_query_param({:route_types, [route_type]})
+  end
+
+  defp format_query_param({:activity, activity}) do
+    [{"activity", activity}]
+  end
+
+  defp format_query_param({:include, relationships}) do
+    [{"include", Enum.join(relationships, ",")}]
   end
 
   defp format_query_param(_), do: []

--- a/lib/screens/alerts/parser.ex
+++ b/lib/screens/alerts/parser.ex
@@ -1,6 +1,17 @@
 defmodule Screens.Alerts.Parser do
   @moduledoc false
 
+  def parse_result(%{"data" => data, "included" => included}) when is_list(data) do
+    facility_data = parse_facility_data(included)
+
+    alerts =
+      data
+      |> Enum.map(&parse_alert/1)
+      |> Enum.reject(&is_nil/1)
+
+    {alerts, facility_data}
+  end
+
   def parse_result(%{"data" => data}) when is_list(data) do
     data
     |> Enum.map(&parse_alert/1)
@@ -170,5 +181,15 @@ defmodule Screens.Alerts.Parser do
 
   defp parse_cause(cause) do
     Map.get(@causes, cause, :unknown)
+  end
+
+  defp parse_facility_data(nil), do: %{}
+
+  defp parse_facility_data(facilities) do
+    facilities
+    |> Enum.map(fn %{"attributes" => %{"short_name" => short_name}, "id" => id} ->
+      {id, short_name}
+    end)
+    |> Enum.into(%{})
   end
 end

--- a/lib/screens/v2/alerts_candidate_generator_behaviour.ex
+++ b/lib/screens/v2/alerts_candidate_generator_behaviour.ex
@@ -1,0 +1,28 @@
+defmodule Screens.V2.AlertsCandidateGeneratorBehaviour do
+  @moduledoc """
+  Behavior for fetching and filtering alerts in a CandidateGenerator.
+
+  - `fetch(opts, fetch_alerts_fn)` is called fetch alerts.
+  - `relevant_alerts(alerts, config, opts)` filters the list of alerts.
+  """
+
+  # Parameters
+  @type opts :: keyword()
+  @type fetch_alerts_fn :: fun()
+  @type config :: Screens.Config.Screen.t()
+
+  # Returns
+  @type alerts :: list()
+  @type facilities :: map()
+  @type fetch_result :: alerts() | {alerts(), facilities()}
+
+  @doc """
+  Fetches a list of alerts using the function provided in parameters.
+  """
+  @callback fetch(opts(), fetch_alerts_fn()) :: {:ok, fetch_result()}
+
+  @doc """
+  Filters alerts so only relevant alerts are considered when creating a WidgetInstance struct.
+  """
+  @callback relevant_alerts(alerts(), config(), opts()) :: alerts()
+end

--- a/lib/screens/v2/candidate_generator/widgets/elevator_closures.ex
+++ b/lib/screens/v2/candidate_generator/widgets/elevator_closures.ex
@@ -9,6 +9,8 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ElevatorClosures do
   alias Screens.Stops.Stop
   alias Screens.V2.WidgetInstance.ElevatorStatus, as: ElevatorStatusWidget
 
+  @behaviour Screens.V2.AlertsCandidateGeneratorBehaviour
+
   def elevator_status_instances(
         %Screen{
           app_params: %PreFare{
@@ -28,8 +30,8 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ElevatorClosures do
            ),
          {:ok, parent_station_map} <- Stop.fetch_parent_station_name_map(),
          {:ok, alerts, facility_id_to_name} <-
-           fetch_with_facilities_fn.(activity: "USING_WHEELCHAIR") do
-      elevator_closures = relevant?(alerts)
+           fetch([activity: "USING_WHEELCHAIR"], fetch_with_facilities_fn) do
+      elevator_closures = relevant_alerts(alerts, config)
       icon_map = get_icon_map(elevator_closures, parent_station_id)
 
       [
@@ -48,7 +50,11 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ElevatorClosures do
     end
   end
 
-  def relevant?(alerts) do
+  @impl true
+  def fetch(opts, fetch_fn), do: fetch_fn.(opts)
+
+  @impl true
+  def relevant_alerts(alerts, _config, _opts \\ []) do
     Enum.filter(alerts, fn
       %Alert{effect: :elevator_closure} = alert -> alert
       _ -> false

--- a/test/screens/alerts/alert_test.exs
+++ b/test/screens/alerts/alert_test.exs
@@ -23,7 +23,7 @@ defmodule Screens.Alerts.AlertTest do
     }
   end
 
-  describe "fetch_by_stop_and_route/3" do
+  describe "fetch_by_stop_and_route/2" do
     setup do
       stop_based_alerts = [alert_json("1"), alert_json("2"), alert_json("3")]
       route_based_alerts = [alert_json("4"), alert_json("3"), alert_json("5")]
@@ -35,8 +35,7 @@ defmodule Screens.Alerts.AlertTest do
       route_ids_param = Enum.join(route_ids, ",")
 
       %{
-        stop_ids: ~w[1265 1266 10413 11413 17411],
-        route_ids: ~w[22 29 44],
+        opts: [stop_ids: ~w[1265 1266 10413 11413 17411], route_ids: ~w[22 29 44]],
         get_json_fn: fn
           _, %{"filter[stop]" => ^stop_ids_param, "filter[route]" => ^route_ids_param} ->
             {:ok, %{"data" => stop_based_alerts}}
@@ -60,8 +59,7 @@ defmodule Screens.Alerts.AlertTest do
 
     test "returns {:ok, merged_alerts} if fetch function succeeds in both cases", context do
       %{
-        stop_ids: stop_ids,
-        route_ids: route_ids,
+        opts: opts,
         get_json_fn: get_json_fn
       } = context
 
@@ -72,19 +70,18 @@ defmodule Screens.Alerts.AlertTest do
                 %Alert{id: "3"},
                 %Alert{id: "4"},
                 %Alert{id: "5"}
-              ]} = Alert.fetch_by_stop_and_route(stop_ids, route_ids, get_json_fn)
+              ]} = Alert.fetch_by_stop_and_route(opts, get_json_fn)
     end
 
     test "returns :error if fetch function returns :error", context do
       %{
-        stop_ids: stop_ids,
-        route_ids: route_ids,
+        opts: opts,
         x_get_json_fn1: x_get_json_fn1,
         x_get_json_fn2: x_get_json_fn2
       } = context
 
-      assert :error == Alert.fetch_by_stop_and_route(stop_ids, route_ids, x_get_json_fn1)
-      assert :error == Alert.fetch_by_stop_and_route(stop_ids, route_ids, x_get_json_fn2)
+      assert :error == Alert.fetch_by_stop_and_route(opts, x_get_json_fn1)
+      assert :error == Alert.fetch_by_stop_and_route(opts, x_get_json_fn2)
     end
   end
 end

--- a/test/screens/v2/candidate_generator/widgets/alerts_test.exs
+++ b/test/screens/v2/candidate_generator/widgets/alerts_test.exs
@@ -64,10 +64,10 @@ defmodule Screens.V2.CandidateGenerator.Widgets.AlertsTest do
         now: now,
         fetch_simplified_routes_at_stop_fn: fn _, _ -> {:ok, routes_at_stop} end,
         fetch_stop_sequences_fn: fn _ -> {:ok, stop_sequences} end,
-        fetch_alerts_fn: fn _, _ -> {:ok, alerts} end,
+        fetch_alerts_fn: fn _ -> {:ok, alerts} end,
         x_fetch_simplified_routes_at_stop_fn: fn _, _ -> :error end,
         x_fetch_stop_sequences_fn: fn _ -> :error end,
-        x_fetch_alerts_fn: fn _, _ -> :error end
+        x_fetch_alerts_fn: fn _ -> :error end
       }
     end
 
@@ -185,19 +185,21 @@ defmodule Screens.V2.CandidateGenerator.Widgets.AlertsTest do
     end
   end
 
-  describe "filter_alerts/4" do
+  describe "relevant_alerts/3" do
     setup do
       %{
         stop_ids: ~w[1 2 3],
         route_ids: ~w[11 22 33],
-        now: DateTime.utc_now()
+        now: DateTime.utc_now(),
+        config: struct(Screen)
       }
     end
 
     test "filters out alerts that inform routes that do not serve the home stop", %{
       stop_ids: stop_ids,
       route_ids: route_ids,
-      now: now
+      now: now,
+      config: config
     } do
       alerts = [
         %Alert{
@@ -233,13 +235,14 @@ defmodule Screens.V2.CandidateGenerator.Widgets.AlertsTest do
       ]
 
       assert [%Alert{id: "1"}, %Alert{id: "2"}, %Alert{id: "3"}] =
-               filter_alerts(alerts, stop_ids, route_ids, now)
+               relevant_alerts(alerts, config, stop_ids: stop_ids, route_ids: route_ids, now: now)
     end
 
     test "filters out alerts that inform stops that are not downstream of the home stop", %{
       stop_ids: stop_ids,
       route_ids: route_ids,
-      now: now
+      now: now,
+      config: config
     } do
       alerts = [
         %Alert{
@@ -275,13 +278,14 @@ defmodule Screens.V2.CandidateGenerator.Widgets.AlertsTest do
       ]
 
       assert [%Alert{id: "1"}, %Alert{id: "2"}, %Alert{id: "3"}] =
-               filter_alerts(alerts, stop_ids, route_ids, now)
+               relevant_alerts(alerts, config, stop_ids: stop_ids, route_ids: route_ids, now: now)
     end
 
     test "keeps alerts that inform an entire route type", %{
       stop_ids: stop_ids,
       route_ids: route_ids,
-      now: now
+      now: now,
+      config: config
     } do
       alerts = [
         %Alert{
@@ -304,13 +308,15 @@ defmodule Screens.V2.CandidateGenerator.Widgets.AlertsTest do
         }
       ]
 
-      assert [%Alert{id: "1"}] = filter_alerts(alerts, stop_ids, route_ids, now)
+      assert [%Alert{id: "1"}] =
+               relevant_alerts(alerts, config, stop_ids: stop_ids, route_ids: route_ids, now: now)
     end
 
     test "filters out alerts with other informed entities", %{
       stop_ids: stop_ids,
       route_ids: route_ids,
-      now: now
+      now: now,
+      config: config
     } do
       alerts = [
         %Alert{
@@ -321,13 +327,15 @@ defmodule Screens.V2.CandidateGenerator.Widgets.AlertsTest do
         }
       ]
 
-      assert [] = filter_alerts(alerts, stop_ids, route_ids, now)
+      assert [] =
+               relevant_alerts(alerts, config, stop_ids: stop_ids, route_ids: route_ids, now: now)
     end
 
     test "filters out alerts that do not have a relevant effect", %{
       stop_ids: stop_ids,
       route_ids: route_ids,
-      now: now
+      now: now,
+      config: config
     } do
       alerts = [
         %Alert{
@@ -338,13 +346,15 @@ defmodule Screens.V2.CandidateGenerator.Widgets.AlertsTest do
         }
       ]
 
-      assert [] = filter_alerts(alerts, stop_ids, route_ids, now)
+      assert [] =
+               relevant_alerts(alerts, config, stop_ids: stop_ids, route_ids: route_ids, now: now)
     end
 
     test "filters out upcoming alerts", %{
       stop_ids: stop_ids,
       route_ids: route_ids,
-      now: now
+      now: now,
+      config: config
     } do
       alerts = [
         %Alert{
@@ -355,7 +365,8 @@ defmodule Screens.V2.CandidateGenerator.Widgets.AlertsTest do
         }
       ]
 
-      assert [] = filter_alerts(alerts, stop_ids, route_ids, now)
+      assert [] =
+               relevant_alerts(alerts, config, stop_ids: stop_ids, route_ids: route_ids, now: now)
     end
   end
 end


### PR DESCRIPTION
**Asana task**: [Explore using a Behaviour to enforce CG naming conventions](https://app.asana.com/0/0/1204505661047502/f)

Two big things in this PR:
1. Refactored `ElevatorClosures` so it uses a fetch function in `Screens.Alerts.Alert` instead of handling all fetch logic on its own. Was the only module that took that approach. This makes the module testable (tech debt task [here](https://app.asana.com/0/1185117109217422/1204506798439485/f)).
2. Refactored `ElevatorClosures`, `Alert`, `Dup.Alert`, and `ReconstructedAlert` so they implement a new behaviour `AlertsCandidateGeneratorBehaviour`. This behaviour will help standardize function names and parameters.

- [ ] Tests added?
