### PR TITLE
Make Polly read 'minutes', not 'meters'

### DIFF
--- a/lib/screens/v2/widget_instance/subway_status.ex
+++ b/lib/screens/v2/widget_instance/subway_status.ex
@@ -261,13 +261,17 @@ defmodule Screens.V2.WidgetInstance.SubwayStatus do
        ) do
     {delay_description, delay_minutes} = Alert.interpret_severity(severity)
 
-    duration_text =
+    {duration_text, duration_audio} =
       case delay_description do
-        :up_to -> "up to #{delay_minutes}m"
-        :more_than -> "over #{delay_minutes}m"
+        :up_to -> {"up to #{delay_minutes}m", "up to #{delay_minutes} minutes"}
+        :more_than -> {"over #{delay_minutes}m", "over #{delay_minutes} minutes"}
       end
 
-    %{status: "Delays #{duration_text}", location: get_location(informed_entities, route_id)}
+    %{
+      status: "Delays #{duration_text}",
+      status_readout: "Delays #{duration_audio}",
+      location: get_location(informed_entities, route_id)
+    }
   end
 
   def get_green_line_branch_status(%Alert{effect: :suspension}), do: "Suspension"

--- a/lib/screens_web/views/v2/audio/subway_status_view.ex
+++ b/lib/screens_web/views/v2/audio/subway_status_view.ex
@@ -29,12 +29,26 @@ defmodule ScreensWeb.V2.Audio.SubwayStatusView do
 
   defp render_intro, do: "Subway service overview"
 
+  defp render_route(%{route: %{color: color}, status_readout: status} = route) do
+    render_route_status(color, status, route)
+  end
+
   defp render_route(%{route: %{color: color}, status: status} = route) do
+    render_route_status(color, status, route)
+  end
+
+  defp render_route_status(color, status, route) do
     "#{color} line: #{status}: #{render_location(route)}"
   end
 
+  defp render_green_line(
+         %{route: %{color: :green}, status_readout: status, type: :single} = route
+       ) do
+    render_gl_status(route, status)
+  end
+
   defp render_green_line(%{route: %{color: :green}, status: status, type: :single} = route) do
-    "Green Line: #{render_branches(route)} #{status}: #{render_location(route)}"
+    render_gl_status(route, status)
   end
 
   defp render_green_line(%{statuses: statuses, type: :multiple}) do
@@ -43,6 +57,10 @@ defmodule ScreensWeb.V2.Audio.SubwayStatusView do
 
   defp render_gl_status([branches, status]) do
     "Green Line: #{render_branches(branches)}: #{status}"
+  end
+
+  defp render_gl_status(route, status) do
+    "Green Line: #{render_branches(route)} #{status}: #{render_location(route)}"
   end
 
   defp render_branches(%{branch: "Green-" <> branch}), do: "#{branch} Branch"


### PR DESCRIPTION
**Asana task**: [🐞[Screens] Polly announces "meters" instead of "minutes"](https://app.asana.com/0/1185117109217432/1203713399498235/f)

Description
Adds essentially an override for the status readout for the subway status widget.
