### PR TITLE
fix: Use defined order for header sizes array

### DIFF
--- a/assets/src/components/v2/normal_header.tsx
+++ b/assets/src/components/v2/normal_header.tsx
@@ -170,7 +170,7 @@ const NormalHeader: ComponentType<Props> = ({
   accentPattern,
 }) => {
   const { ref: headerRef, size: headerSize } = useTextResizer({
-    sizes: Object.keys(TitleSize),
+    sizes: [TitleSize.small, TitleSize.large],
     maxHeight: maxHeight,
     resetDependencies: [text],
   });


### PR DESCRIPTION
**Asana task**: ad hoc

`Object.keys` doesn't guarantee any consistent ordering in the array it returns, so we may have been randomly giving `useTextResizer` its `sizes` array in reverse order here!

- [ ] Tests added?
