### PR TITLE
Hotfix: Stop trying to convert track number from integer to string

### DIFF
--- a/lib/screens_web/views/v2/audio/cr_departures_view.ex
+++ b/lib/screens_web/views/v2/audio/cr_departures_view.ex
@@ -54,7 +54,7 @@ defmodule ScreensWeb.V2.Audio.CRDeparturesView do
 
     track =
       cond do
-        track_number -> "on track " <> Integer.to_string(track_number) <> ". "
+        track_number -> "on track " <> track_number <> ". "
         # Omit track number at Forest Hills
         station === "place-forhl" -> ". "
         true -> ". We will announce the track for this train soon. "

--- a/lib/screens_web/views/v2/audio/cr_departures_view.ex
+++ b/lib/screens_web/views/v2/audio/cr_departures_view.ex
@@ -54,7 +54,7 @@ defmodule ScreensWeb.V2.Audio.CRDeparturesView do
 
     track =
       cond do
-        track_number -> "on track " <> track_number <> ". "
+        track_number -> "on track #{track_number}. "
         # Omit track number at Forest Hills
         station === "place-forhl" -> ". "
         true -> ". We will announce the track for this train soon. "


### PR DESCRIPTION
Hotfix to address Sentry alert caused by attempt to call `Integer.to_string/1` on a string
