### PR TITLE
fix: Schedules track_number parsing

### DIFF
--- a/lib/screens/schedules/parser.ex
+++ b/lib/screens/schedules/parser.ex
@@ -57,8 +57,7 @@ defmodule Screens.Schedules.Parser do
     trip = Map.get(included_data, {"trip", trip_id})
     stop = Map.get(included_data, {"stop", stop_id})
     route = Map.get(included_data, {"route", route_id})
-
-    track_number = parse_track_number(stop_id)
+    track_number = Map.get(included_data, {"stop", stop_id}).platform_code
 
     %Screens.Schedules.Schedule{
       id: id,
@@ -78,17 +77,5 @@ defmodule Screens.Schedules.Parser do
   defp parse_time(s) do
     {:ok, time, _} = DateTime.from_iso8601(s)
     time
-  end
-
-  @spec parse_track_number(stop_id :: String.t() | nil) :: pos_integer() | nil
-  defp parse_track_number(nil), do: nil
-
-  defp parse_track_number(stop_id) do
-    ~r|^\w+-\w+-(\d+)$|
-    |> Regex.run(stop_id, capture: :all_but_first)
-    |> case do
-      nil -> nil
-      [track_number] -> String.to_integer(track_number)
-    end
   end
 end


### PR DESCRIPTION
**Asana task**: [🐞: platform_code is parsed differently for schedules vs predictions](https://app.asana.com/0/1185117109217422/1204550846355955/f)

`track_number` needs to be parsed the same way for predictions and schedules.

- [ ] Tests added?
