### PR TITLE
Alerts refactor, step 2: Add location context to all WidgetInstances

### DIFF
--- a/lib/screens/alerts/alert.ex
+++ b/lib/screens/alerts/alert.ex
@@ -230,9 +230,6 @@ defmodule Screens.Alerts.Alert do
     end
   end
 
-  # credo:disable-for-next-line
-  # Todo: These private format_query_params are the same in Departures and Route
-  # Consolidate? Doesn't matter?
   defp format_query_param({:fields, fields}) when is_list(fields) do
     [
       {"fields[alert]", Enum.join(fields, ",")}

--- a/lib/screens/alerts/alert.ex
+++ b/lib/screens/alerts/alert.ex
@@ -549,4 +549,10 @@ defmodule Screens.Alerts.Alert do
       true -> {:up_to, 5 * (severity - 1)}
     end
   end
+
+  def informed_entities(%{alert: %__MODULE__{informed_entities: informed_entities}}) do
+    informed_entities
+  end
+
+  def effect(%{alert: %__MODULE__{effect: effect}}), do: effect
 end

--- a/lib/screens/routes/route.ex
+++ b/lib/screens/routes/route.ex
@@ -145,6 +145,9 @@ defmodule Screens.Routes.Route do
     end
   end
 
+  @spec route_ids(list(%{route_id: id(), active?: boolean()})) :: list(id())
+  def route_ids(routes), do: Enum.map(routes, & &1.route_id)
+
   def get_color_for_route(route_id, route_type \\ nil)
 
   def get_color_for_route("Red", _), do: :red

--- a/lib/screens/stops/stop.ex
+++ b/lib/screens/stops/stop.ex
@@ -439,31 +439,30 @@ defmodule Screens.Stops.Stop do
   def fetch_location_context(app, stop_id, now) do
     with alert_route_types <- get_route_type_filter(app, stop_id),
          {:ok, routes_at_stop} <- Route.fetch_routes_by_stop(stop_id, now, alert_route_types),
-         route_ids_at_stop <- Enum.map(routes_at_stop, & &1.route_id),
+         route_ids <- Route.route_ids(routes_at_stop),
          {:ok, stop_sequences} <-
-            (cond do
+           (cond do
               app in [BusEink, BusShelter, GlEink] ->
                 RoutePattern.fetch_stop_sequences_through_stop(stop_id)
-            
+
               app in [PreFare, Dup] ->
-                RoutePattern.fetch_parent_station_sequences_through_stop(stop_id, route_ids_at_stop)
-            end)
-          do
+                RoutePattern.fetch_parent_station_sequences_through_stop(stop_id, route_ids)
+            end) do
       {:ok,
-        %LocationContext{
-          home_stop: stop_id,
-          stop_sequences: stop_sequences,
-          upstream_stops: upstream_stop_id_set(stop_id, stop_sequences),
-          downstream_stops: downstream_stop_id_set(stop_id, stop_sequences),
-          routes: routes_at_stop,
-          route_ids_at_stop: route_ids_at_stop,
-          alert_route_types: alert_route_types
-        }}
+       %LocationContext{
+         home_stop: stop_id,
+         stop_sequences: stop_sequences,
+         upstream_stops: upstream_stop_id_set(stop_id, stop_sequences),
+         downstream_stops: downstream_stop_id_set(stop_id, stop_sequences),
+         routes: routes_at_stop,
+         alert_route_types: alert_route_types
+       }}
     else
       :error ->
         Logger.error(
           "[fetch_location_context fetch error] Failed to get location context for an alert: stop_id=#{stop_id}"
         )
+
         :error
     end
   end

--- a/lib/screens/stops/stop.ex
+++ b/lib/screens/stops/stop.ex
@@ -463,6 +463,8 @@ defmodule Screens.Stops.Stop do
           list(atom())
   def get_route_type_filter(app, _) when app in [BusEink, BusShelter], do: [:bus]
   def get_route_type_filter(GlEink, _), do: [:light_rail]
+  # Ashmont should not show Mattapan alerts for PreFare or DUP
+  def get_route_type_filter(_, "place-asmnl"), do: [:subway]
   def get_route_type_filter(PreFare, _), do: [:light_rail, :subway]
   # WTC is a special bus-only case
   def get_route_type_filter(Dup, "place-wtcst"), do: [:bus]

--- a/lib/screens/stops/stop.ex
+++ b/lib/screens/stops/stop.ex
@@ -31,6 +31,8 @@ defmodule Screens.Stops.Stop do
           platform_code: String.t() | nil
         }
 
+  @type screen_type :: BusEink | BusShelter | GlEink | PreFare | Dup
+
   @blue_line_stops [
     {"place-wondl", {"Wonderland", "Wonderland"}},
     {"place-rbmnl", {"Revere Beach", "Revere Bch"}},
@@ -430,7 +432,7 @@ defmodule Screens.Stops.Stop do
   Fetches all the location context for a screen given its app type, stop id, and time
   """
   @spec fetch_location_context(
-          BusEink | BusShelter | GlEink | PreFare | Dup,
+          screen_type(),
           id(),
           DateTime.t()
         ) :: {:ok, LocationContext.t()}
@@ -459,7 +461,7 @@ defmodule Screens.Stops.Stop do
   end
 
   # Returns the route types we care about for the alerts of this screen type / place
-  @spec get_route_type_filter(BusEink | BusShelter | GlEink | PreFare | Dup, String.t()) ::
+  @spec get_route_type_filter(screen_type(), String.t()) ::
           list(atom())
   def get_route_type_filter(app, _) when app in [BusEink, BusShelter], do: [:bus]
   def get_route_type_filter(GlEink, _), do: [:light_rail]

--- a/lib/screens/stops/stop.ex
+++ b/lib/screens/stops/stop.ex
@@ -427,19 +427,19 @@ defmodule Screens.Stops.Stop do
     |> Enum.into(%{})
   end
 
+  @doc """
+  Fetches all the location context for a screen given its app type, stop id, and time
+  """
   @spec fetch_location_context(BusEink | BusShelter | GlEink | PreFare | Dup, DateTime.t(), list(atom())) :: LocationContext.t()
   def fetch_location_context(app, stop_id, now) do
     alert_route_types = get_route_type_filter(app, stop_id)
     {:ok, routes_at_stop} = Route.fetch_routes_by_stop(stop_id, now, alert_route_types)
     route_ids_at_stop = Enum.map(routes_at_stop, & &1.route_id)
-    # doesn't work for bus
     {:ok, stop_sequences} = if app in [BusEink, BusShelter, GlEink] do
       RoutePattern.fetch_stop_sequences_through_stop(stop_id)
     else
       RoutePattern.fetch_parent_station_sequences_through_stop(stop_id, route_ids_at_stop)
     end
-
-    IO.inspect(stop_sequences, label: "stop sequences")
     
     alert_route_types = if alert_route_types === [] do
       routes_at_stop
@@ -460,8 +460,10 @@ defmodule Screens.Stops.Stop do
     }
   end
 
+  @doc """
+  Returns the route types we care about for the alerts of this screen type / place
+  """
   @spec get_route_type_filter(BusEink | BusShelter | GlEink | PreFare | Dup, String.t()) :: list(atom())
-  # The route types we care about for alerts at this screen
   defp get_route_type_filter(app, _) when app in [BusEink, BusShelter], do: [:bus]
   defp get_route_type_filter(GlEink, _), do: [:light_rail]
   defp get_route_type_filter(PreFare, _), do: [:light_rail, :subway]

--- a/lib/screens/stops/stop.ex
+++ b/lib/screens/stops/stop.ex
@@ -435,7 +435,7 @@ defmodule Screens.Stops.Stop do
           screen_type(),
           id(),
           DateTime.t()
-        ) :: {:ok, LocationContext.t()}
+        ) :: {:ok, LocationContext.t()} | :error
   def fetch_location_context(app, stop_id, now) do
     with alert_route_types <- get_route_type_filter(app, stop_id),
          {:ok, routes_at_stop} <- Route.fetch_routes_by_stop(stop_id, now, alert_route_types),

--- a/lib/screens/stops/stop.ex
+++ b/lib/screens/stops/stop.ex
@@ -465,8 +465,8 @@ defmodule Screens.Stops.Stop do
           list(atom())
   def get_route_type_filter(app, _) when app in [BusEink, BusShelter], do: [:bus]
   def get_route_type_filter(GlEink, _), do: [:light_rail]
-  # Ashmont should not show Mattapan alerts for PreFare or DUP
-  def get_route_type_filter(_, "place-asmnl"), do: [:subway]
+  # Ashmont should not show Mattapan alerts for PreFare or Dup
+  def get_route_type_filter(app, "place-asmnl") when app in [PreFare, Dup], do: [:subway]
   def get_route_type_filter(PreFare, _), do: [:light_rail, :subway]
   # WTC is a special bus-only case
   def get_route_type_filter(Dup, "place-wtcst"), do: [:bus]

--- a/lib/screens/v2/candidate_generator/dup/alerts.ex
+++ b/lib/screens/v2/candidate_generator/dup/alerts.ex
@@ -45,7 +45,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Alerts do
           stop_name
       end
 
-    with location_context <- fetch_location_context_fn.(Dup, stop_id, now),
+    with {:ok, location_context} <- fetch_location_context_fn.(Dup, stop_id, now),
          # TODO: check to see if mattapan ids are passing to alerts fetch
          {:ok, alerts} <- fetch_alerts_fn.(route_ids: location_context.route_ids_at_stop) do
       alerts

--- a/lib/screens/v2/candidate_generator/dup/alerts.ex
+++ b/lib/screens/v2/candidate_generator/dup/alerts.ex
@@ -10,7 +10,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Alerts do
   alias Screens.LocationContext
   alias Screens.Routes.Route
   alias Screens.Stops.Stop
-  alias Screens.V2.WidgetInstance.Common.BaseAlert
+  alias Screens.V2.LocalizedAlert
   alias Screens.V2.WidgetInstance.{DupAlert, DupSpecialCaseAlert}
 
   require Logger
@@ -113,17 +113,9 @@ defmodule Screens.V2.CandidateGenerator.Dup.Alerts do
          location_context,
          now
        ) do
-    dup_alert = %DupAlert{
-      screen: config,
-      alert: alert,
-      location_context: location_context,
-      primary_section_count: length(sections),
-      rotation_index: :zero,
-      stop_name: "A Station"
-    }
-
     relevant_effect?(alert, config) and Alert.happening_now?(alert, now) and
-      relevant_location?(dup_alert) and not directional_shuttle_or_suspension?(alert)
+      relevant_location?(alert, location_context) and
+      not directional_shuttle_or_suspension?(alert)
   end
 
   defp relevant_effect?(%{effect: :delay, severity: severity}, _) do
@@ -141,11 +133,13 @@ defmodule Screens.V2.CandidateGenerator.Dup.Alerts do
     effect in [:station_closure, :shuttle, :suspension]
   end
 
-  # TODO: This is using a "WidgetInstance" function in the candidate_generator
-  # Does this mean we should move some BaseAlert utils to just the Alert util func?
-  @spec relevant_location?(DupAlert.t()) :: boolean()
-  defp relevant_location?(dup_alert) do
-    BaseAlert.location(dup_alert) in [:inside, :boundary_upstream, :boundary_downstream]
+  @spec relevant_location?(Alert.t(), LocationContext.t()) :: boolean()
+  defp relevant_location?(alert, location_context) do
+    LocalizedAlert.location(%{alert: alert, location_context: location_context}) in [
+      :inside,
+      :boundary_upstream,
+      :boundary_downstream
+    ]
   end
 
   defp directional_shuttle_or_suspension?(alert) do

--- a/lib/screens/v2/candidate_generator/dup/alerts.ex
+++ b/lib/screens/v2/candidate_generator/dup/alerts.ex
@@ -8,6 +8,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Alerts do
   alias Screens.Config.V2.Alerts, as: AlertsConfig
   alias Screens.Config.V2.Dup
   alias Screens.LocationContext
+  alias Screens.Routes.Route
   alias Screens.Stops.Stop
   alias Screens.V2.WidgetInstance.Common.BaseAlert
   alias Screens.V2.WidgetInstance.{DupAlert, DupSpecialCaseAlert}
@@ -46,8 +47,8 @@ defmodule Screens.V2.CandidateGenerator.Dup.Alerts do
       end
 
     with {:ok, location_context} <- fetch_location_context_fn.(Dup, stop_id, now),
-         # TODO: check to see if mattapan ids are passing to alerts fetch
-         {:ok, alerts} <- fetch_alerts_fn.(route_ids: location_context.route_ids_at_stop) do
+         route_ids <- Route.route_ids(location_context.routes),
+         {:ok, alerts} <- fetch_alerts_fn.(route_ids: route_ids) do
       alerts
       |> Enum.filter(&relevant_alert?(&1, config, location_context, now))
       |> alert_special_cases(config)

--- a/lib/screens/v2/candidate_generator/dup/alerts.ex
+++ b/lib/screens/v2/candidate_generator/dup/alerts.ex
@@ -46,7 +46,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Alerts do
       end
 
     with location_context <- fetch_location_context_fn.(Dup, stop_id, now),
-        # TODO: check to see if mattapan ids are passing to alerts fetch
+         # TODO: check to see if mattapan ids are passing to alerts fetch
          {:ok, alerts} <- fetch_alerts_fn.(route_ids: location_context.route_ids_at_stop) do
       alerts
       |> Enum.filter(&relevant_alert?(&1, config, location_context, now))
@@ -142,6 +142,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Alerts do
 
   # TODO: This is using a "WidgetInstance" function in the candidate_generator
   # Does this mean we should move some BaseAlert utils to just the Alert util func?
+  @spec relevant_location?(DupAlert.t()) :: boolean()
   defp relevant_location?(dup_alert) do
     BaseAlert.location(dup_alert) in [:inside, :boundary_upstream, :boundary_downstream]
   end

--- a/lib/screens/v2/candidate_generator/dup/alerts.ex
+++ b/lib/screens/v2/candidate_generator/dup/alerts.ex
@@ -45,17 +45,9 @@ defmodule Screens.V2.CandidateGenerator.Dup.Alerts do
           stop_name
       end
 
-    # route_type_filter = get_route_type_filter(stop_id)
-
     with location_context <- fetch_location_context_fn.(Dup, stop_id, now),
-    # {:ok, subway_routes_at_stop} <-
-    #        fetch_routes_by_stop_fn.(stop_id, now, route_type_filter),
-        #  subway_route_ids_at_stop =
-        #    for(%{route_id: id} <- subway_routes_at_stop, id != "Mattapan", do: id),
         # TODO: check to see if mattapan ids are passing to alerts fetch
          {:ok, alerts} <- fetch_alerts_fn.(route_ids: location_context.route_ids_at_stop) do
-        #  {:ok, stop_sequences} <-
-        #    fetch_parent_station_sequences_fn.(stop_id, subway_route_ids_at_stop) do
       alerts
       |> Enum.filter(&relevant_alert?(&1, config, location_context, now))
       |> alert_special_cases(config)
@@ -64,11 +56,6 @@ defmodule Screens.V2.CandidateGenerator.Dup.Alerts do
       :error -> []
     end
   end
-
-  # @spec get_route_type_filter(String.t()) :: list(atom())
-  # # WTC is a special bus-only case
-  # defp get_route_type_filter("place-wtcst"), do: [:bus]
-  # defp get_route_type_filter(_stop_id), do: [:light_rail, :subway]
 
   @doc """
   Chooses the most "important" alert to show on a DUP screen when there are several.
@@ -153,8 +140,8 @@ defmodule Screens.V2.CandidateGenerator.Dup.Alerts do
     effect in [:station_closure, :shuttle, :suspension]
   end
 
-  # This is using a "WidgetInstance" function in the candidate_generator
-  # Does this mean we should move BaseAlert utils to just the Alert util func?
+  # TODO: This is using a "WidgetInstance" function in the candidate_generator
+  # Does this mean we should move some BaseAlert utils to just the Alert util func?
   defp relevant_location?(dup_alert) do
     BaseAlert.location(dup_alert) in [:inside, :boundary_upstream, :boundary_downstream]
   end

--- a/lib/screens/v2/candidate_generator/dup/alerts.ex
+++ b/lib/screens/v2/candidate_generator/dup/alerts.ex
@@ -107,12 +107,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Alerts do
   end
 
   @spec relevant_alert?(Alert.t(), Screen.t(), LocationContext.t(), DateTime.t()) :: boolean()
-  defp relevant_alert?(
-         alert,
-         %Screen{app_params: %Dup{primary_departures: %{sections: sections}}} = config,
-         location_context,
-         now
-       ) do
+  defp relevant_alert?(alert, config, location_context, now) do
     relevant_effect?(alert, config) and Alert.happening_now?(alert, now) and
       relevant_location?(alert, location_context) and
       not directional_shuttle_or_suspension?(alert)

--- a/lib/screens/v2/candidate_generator/widgets/alerts.ex
+++ b/lib/screens/v2/candidate_generator/widgets/alerts.ex
@@ -23,9 +23,13 @@ defmodule Screens.V2.CandidateGenerator.Widgets.Alerts do
       )
       when app in @alert_supporting_screen_types do
     with location_context <- fetch_location_context_fn.(app, stop_id, now),
-         reachable_stop_ids = local_and_downstream_stop_ids(location_context.stop_sequences, stop_id),
+         reachable_stop_ids =
+           local_and_downstream_stop_ids(location_context.stop_sequences, stop_id),
          {:ok, alerts} <-
-           fetch_alerts_by_stop_and_route_fn.(reachable_stop_ids, location_context.route_ids_at_stop) do
+           fetch_alerts_by_stop_and_route_fn.(
+             reachable_stop_ids,
+             location_context.route_ids_at_stop
+           ) do
       alerts
       |> filter_alerts(reachable_stop_ids, location_context.route_ids_at_stop, now)
       |> Enum.map(fn alert ->

--- a/lib/screens/v2/candidate_generator/widgets/alerts.ex
+++ b/lib/screens/v2/candidate_generator/widgets/alerts.ex
@@ -18,20 +18,12 @@ defmodule Screens.V2.CandidateGenerator.Widgets.Alerts do
   def alert_instances(
         %Screen{app_params: %app{alerts: %Alerts{stop_id: stop_id}}} = config,
         now \\ DateTime.utc_now(),
-        # By making generic, I ended up changing 2 things
-        #    - swapped to fetch_routes_by_stop instead of fetch_simplified_routes_at_stop
-        #    - swapped to fetch_parent_station_sequences_through_stop instead of fetch_stop_sequences_through_stop
-        # Make sure that's fine
         fetch_alerts_by_stop_and_route_fn \\ &Alert.fetch_by_stop_and_route/2,
         fetch_location_context_fn \\ &Stop.fetch_location_context/3
       )
       when app in @alert_supporting_screen_types do
     with location_context <- fetch_location_context_fn.(app, stop_id, now),
-        
-         # {:ok, routes_at_stop} <- fetch_simplified_routes_at_stop_fn.(stop_id, now),
-         # {:ok, stop_sequences} <- fetch_stop_sequences_through_stop_fn.(stop_id),
          reachable_stop_ids = local_and_downstream_stop_ids(location_context.stop_sequences, stop_id),
-         # route_ids_at_stop = Enum.map(routes_at_stop, & &1.route_id),
          {:ok, alerts} <-
            fetch_alerts_by_stop_and_route_fn.(reachable_stop_ids, location_context.route_ids_at_stop) do
       alerts
@@ -41,8 +33,6 @@ defmodule Screens.V2.CandidateGenerator.Widgets.Alerts do
           alert: alert,
           screen: config,
           location_context: location_context,
-          # routes_at_stop: routes_at_stop,
-          # stop_sequences: stop_sequences,
           now: now
         }
       end)
@@ -50,10 +40,6 @@ defmodule Screens.V2.CandidateGenerator.Widgets.Alerts do
       :error -> []
     end
   end
-
-  # # The route types we care about for alerts at this screen
-  # defp get_route_type_filter(app_id) when app_id in [BusEink, BusShelter], do: [:bus]
-  # defp get_route_type_filter(GlEink), do: [:light_rail]
 
   @doc """
   Filters out alerts whose effects we are not interested in, as well as those that do not inform at least one of:

--- a/lib/screens/v2/candidate_generator/widgets/alerts.ex
+++ b/lib/screens/v2/candidate_generator/widgets/alerts.ex
@@ -22,7 +22,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.Alerts do
         fetch_location_context_fn \\ &Stop.fetch_location_context/3
       )
       when app in @alert_supporting_screen_types do
-    with location_context <- fetch_location_context_fn.(app, stop_id, now),
+    with {:ok, location_context} <- fetch_location_context_fn.(app, stop_id, now),
          reachable_stop_ids =
            local_and_downstream_stop_ids(location_context.stop_sequences, stop_id),
          {:ok, alerts} <-

--- a/lib/screens/v2/candidate_generator/widgets/alerts.ex
+++ b/lib/screens/v2/candidate_generator/widgets/alerts.ex
@@ -4,6 +4,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.Alerts do
   alias Screens.Alerts.Alert
   alias Screens.Config.Screen
   alias Screens.Config.V2.{Alerts, BusEink, BusShelter, GlEink}
+  alias Screens.Routes.Route
   alias Screens.Stops.Stop
   alias Screens.Util
   alias Screens.V2.WidgetInstance.Alert, as: AlertWidget
@@ -25,13 +26,14 @@ defmodule Screens.V2.CandidateGenerator.Widgets.Alerts do
     with {:ok, location_context} <- fetch_location_context_fn.(app, stop_id, now),
          reachable_stop_ids =
            local_and_downstream_stop_ids(location_context.stop_sequences, stop_id),
+         route_ids <- Route.route_ids(location_context.routes),
          {:ok, alerts} <-
            fetch_alerts_by_stop_and_route_fn.(
              reachable_stop_ids,
-             location_context.route_ids_at_stop
+             route_ids
            ) do
       alerts
-      |> filter_alerts(reachable_stop_ids, location_context.route_ids_at_stop, now)
+      |> filter_alerts(reachable_stop_ids, route_ids, now)
       |> Enum.map(fn alert ->
         %AlertWidget{
           alert: alert,

--- a/lib/screens/v2/candidate_generator/widgets/elevator_closures.ex
+++ b/lib/screens/v2/candidate_generator/widgets/elevator_closures.ex
@@ -16,7 +16,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ElevatorClosures do
         now \\ DateTime.utc_now(),
         fetch_location_context_fn \\ &Stop.fetch_location_context/3
       ) do
-    with  location_context <- fetch_location_context_fn.(PreFare, parent_station_id, now),
+    with location_context <- fetch_location_context_fn.(PreFare, parent_station_id, now),
          {:ok, parent_station_map} <- Stop.fetch_parent_station_name_map(),
          {:ok, elevator_closures, facility_id_to_name} <- fetch_elevator_closures() do
       icon_map = get_icon_map(elevator_closures, parent_station_id)

--- a/lib/screens/v2/candidate_generator/widgets/elevator_closures.ex
+++ b/lib/screens/v2/candidate_generator/widgets/elevator_closures.ex
@@ -23,7 +23,6 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ElevatorClosures do
 
       [
         %ElevatorStatusWidget{
-          # TODO: put anything else into location context?
           alerts: elevator_closures,
           location_context: location_context,
           facility_id_to_name: facility_id_to_name,

--- a/lib/screens/v2/candidate_generator/widgets/elevator_closures.ex
+++ b/lib/screens/v2/candidate_generator/widgets/elevator_closures.ex
@@ -4,8 +4,6 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ElevatorClosures do
   alias Screens.Alerts.Alert
   alias Screens.Config.Screen
   alias Screens.Config.V2.{ElevatorStatus, PreFare}
-  alias Screens.RoutePatterns.RoutePattern
-  alias Screens.Routes.Route
   alias Screens.Stops.Stop
   alias Screens.V2.WidgetInstance.ElevatorStatus, as: ElevatorStatusWidget
 
@@ -15,25 +13,29 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ElevatorClosures do
             elevator_status: %ElevatorStatus{parent_station_id: parent_station_id}
           }
         } = config,
-        now
+        now \\ DateTime.utc_now(),
+        fetch_location_context_fn \\ &Stop.fetch_location_context/3
       ) do
-    with {:ok, routes_at_stop} <-
-           Route.fetch_routes_by_stop(parent_station_id, now, [:light_rail, :subway]),
-         route_ids_at_stop = Enum.map(routes_at_stop, & &1.route_id),
-         {:ok, stop_sequences} <-
-           RoutePattern.fetch_parent_station_sequences_through_stop(
-             parent_station_id,
-             route_ids_at_stop
-           ),
+    with  location_context <- fetch_location_context_fn.(PreFare, parent_station_id, now),
+        #  {:ok, routes_at_stop} <-
+        #    Route.fetch_routes_by_stop(parent_station_id, now, [:light_rail, :subway]),
+        # route_ids_at_stop = Enum.map(routes_at_stop, & &1.route_id),
+        #  {:ok, stop_sequences} <-
+        #    RoutePattern.fetch_parent_station_sequences_through_stop(
+        #      parent_station_id,
+        #      route_ids_at_stop
+        #    ),
          {:ok, parent_station_map} <- Stop.fetch_parent_station_name_map(),
          {:ok, elevator_closures, facility_id_to_name} <- fetch_elevator_closures() do
       icon_map = get_icon_map(elevator_closures, parent_station_id)
 
+      # IO.inspect(elevator_closures, label: "elevator closures")
       [
         %ElevatorStatusWidget{
           alerts: elevator_closures,
+          location_context: location_context,
           facility_id_to_name: facility_id_to_name,
-          stop_sequences: stop_sequences,
+          # stop_sequences: stop_sequences,
           screen: config,
           now: now,
           station_id_to_name: parent_station_map,

--- a/lib/screens/v2/candidate_generator/widgets/elevator_closures.ex
+++ b/lib/screens/v2/candidate_generator/widgets/elevator_closures.ex
@@ -17,25 +17,16 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ElevatorClosures do
         fetch_location_context_fn \\ &Stop.fetch_location_context/3
       ) do
     with  location_context <- fetch_location_context_fn.(PreFare, parent_station_id, now),
-        #  {:ok, routes_at_stop} <-
-        #    Route.fetch_routes_by_stop(parent_station_id, now, [:light_rail, :subway]),
-        # route_ids_at_stop = Enum.map(routes_at_stop, & &1.route_id),
-        #  {:ok, stop_sequences} <-
-        #    RoutePattern.fetch_parent_station_sequences_through_stop(
-        #      parent_station_id,
-        #      route_ids_at_stop
-        #    ),
          {:ok, parent_station_map} <- Stop.fetch_parent_station_name_map(),
          {:ok, elevator_closures, facility_id_to_name} <- fetch_elevator_closures() do
       icon_map = get_icon_map(elevator_closures, parent_station_id)
 
-      # IO.inspect(elevator_closures, label: "elevator closures")
       [
         %ElevatorStatusWidget{
+          # TODO: put anything else into location context?
           alerts: elevator_closures,
           location_context: location_context,
           facility_id_to_name: facility_id_to_name,
-          # stop_sequences: stop_sequences,
           screen: config,
           now: now,
           station_id_to_name: parent_station_map,

--- a/lib/screens/v2/candidate_generator/widgets/elevator_closures.ex
+++ b/lib/screens/v2/candidate_generator/widgets/elevator_closures.ex
@@ -16,7 +16,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ElevatorClosures do
         now \\ DateTime.utc_now(),
         fetch_location_context_fn \\ &Stop.fetch_location_context/3
       ) do
-    with location_context <- fetch_location_context_fn.(PreFare, parent_station_id, now),
+    with {:ok, location_context} <- fetch_location_context_fn.(PreFare, parent_station_id, now),
          {:ok, parent_station_map} <- Stop.fetch_parent_station_name_map(),
          {:ok, elevator_closures, facility_id_to_name} <- fetch_elevator_closures() do
       icon_map = get_icon_map(elevator_closures, parent_station_id)

--- a/lib/screens/v2/candidate_generator/widgets/reconstructed_alert.ex
+++ b/lib/screens/v2/candidate_generator/widgets/reconstructed_alert.ex
@@ -37,7 +37,6 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlert do
           alert: alert,
           now: now,
           location_context: location_context,
-          # TODO: these two items look like location stuff? Should they be?
           informed_stations_string: get_stations(alert, fetch_stop_name_fn),
           is_terminal_station: is_terminal?(stop_id, location_context.stop_sequences)
         }

--- a/lib/screens/v2/candidate_generator/widgets/reconstructed_alert.ex
+++ b/lib/screens/v2/candidate_generator/widgets/reconstructed_alert.ex
@@ -26,35 +26,23 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlert do
         fetch_stop_name_fn \\ &Stop.fetch_stop_name/1,
         fetch_location_context_fn \\ &Stop.fetch_location_context/3
       ) do
-    # Filtering by subway and light_rail types
     with location_context <- fetch_location_context_fn.(PreFare, stop_id, now),
-        #  {:ok, routes_at_stop} <- fetch_routes_by_stop_fn.(stop_id, now, [:light_rail, :subway]),
-        #  route_ids_at_stop =
-        #    routes_at_stop
-        #    |> Enum.map(& &1.route_id)
-        #    # We shouldn't handle Mattapan outages at this time
-        #    |> Enum.reject(fn id -> id === "Mattapan" end),
+        # TODO: make sure we're handling Mattapan outages correctly even without the "reject"
          {:ok, alerts} <- fetch_alerts_fn.(route_ids: location_context.route_ids_at_stop) do
-        #  {:ok, stop_sequences} <-
-        #    fetch_stop_sequences_by_stop_fn.(stop_id, route_ids_at_stop) do
+
       alerts
-      # |> IO.inspect(label: "alerts")
       |> Enum.filter(&relevant?(&1, config, location_context, now))
-      # |> IO.inspect(label: "filtered alerts")
       |> Enum.map(fn alert ->
         %ReconstructedAlert{
           screen: config,
           alert: alert,
           now: now,
           location_context: location_context,
-          # stop_sequences: stop_sequences,
-          # routes_at_stop: routes_at_stop,
-          # TODO: these two items look like location stuff. Check em
+          # TODO: these two items look like location stuff? Should they be?
           informed_stations_string: get_stations(alert, fetch_stop_name_fn),
           is_terminal_station: is_terminal?(stop_id, location_context.stop_sequences)
         }
       end)
-      # |> IO.inspect(label: "recon alert widgets")
     else
       :error -> []
     end
@@ -66,7 +54,6 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlert do
          %LocationContext{} = location_context,
          now
        ) do
-        # IO.inspect(location_context, label: "location")
     reconstructed_alert = %ReconstructedAlert{
       screen: config,
       alert: alert,
@@ -84,8 +71,6 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlert do
   end
 
   defp relevant_location?(reconstructed_alert) do
-    IO.inspect(reconstructed_alert, label: "reconstructed alert")
-    IO.inspect(BaseAlert.location(reconstructed_alert), label: "output of location")
     case BaseAlert.location(reconstructed_alert) do
       location when location in [:downstream, :upstream] ->
         true

--- a/lib/screens/v2/candidate_generator/widgets/reconstructed_alert.ex
+++ b/lib/screens/v2/candidate_generator/widgets/reconstructed_alert.ex
@@ -27,7 +27,6 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlert do
         fetch_location_context_fn \\ &Stop.fetch_location_context/3
       ) do
     with {:ok, location_context} <- fetch_location_context_fn.(PreFare, stop_id, now),
-         # TODO: make sure we're handling Mattapan outages correctly even without the "reject"
          {:ok, alerts} <- fetch_alerts_fn.(route_ids: location_context.route_ids_at_stop) do
       alerts
       |> Enum.filter(&relevant?(&1, config, location_context, now))

--- a/lib/screens/v2/candidate_generator/widgets/reconstructed_alert.ex
+++ b/lib/screens/v2/candidate_generator/widgets/reconstructed_alert.ex
@@ -9,7 +9,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlert do
   alias Screens.Routes.Route
   alias Screens.Stops.Stop
   alias Screens.Util
-  alias Screens.V2.WidgetInstance.Common.BaseAlert
+  alias Screens.V2.LocalizedAlert
   alias Screens.V2.WidgetInstance.ReconstructedAlert
 
   @relevant_effects ~w[shuttle suspension station_closure delay]a
@@ -70,7 +70,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlert do
   end
 
   defp relevant_location?(reconstructed_alert) do
-    case BaseAlert.location(reconstructed_alert) do
+    case LocalizedAlert.location(reconstructed_alert) do
       location when location in [:downstream, :upstream] ->
         true
 
@@ -118,7 +118,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlert do
            location_context: %{home_stop: stop_id, stop_sequences: stop_sequences}
          } = t
        ) do
-    informed_entities = BaseAlert.informed_entities(t)
+    informed_entities = Alert.informed_entities(t)
 
     direction_id =
       informed_entities
@@ -156,7 +156,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlert do
   defp get_stations(alert, fetch_stop_name_fn) do
     stop_ids =
       %ReconstructedAlert{alert: alert}
-      |> BaseAlert.informed_entities()
+      |> Alert.informed_entities()
       |> Enum.flat_map(fn %{stop: stop_id} ->
         case stop_id do
           nil -> []

--- a/lib/screens/v2/candidate_generator/widgets/reconstructed_alert.ex
+++ b/lib/screens/v2/candidate_generator/widgets/reconstructed_alert.ex
@@ -27,9 +27,8 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlert do
         fetch_location_context_fn \\ &Stop.fetch_location_context/3
       ) do
     with location_context <- fetch_location_context_fn.(PreFare, stop_id, now),
-        # TODO: make sure we're handling Mattapan outages correctly even without the "reject"
+         # TODO: make sure we're handling Mattapan outages correctly even without the "reject"
          {:ok, alerts} <- fetch_alerts_fn.(route_ids: location_context.route_ids_at_stop) do
-
       alerts
       |> Enum.filter(&relevant?(&1, config, location_context, now))
       |> Enum.map(fn alert ->

--- a/lib/screens/v2/candidate_generator/widgets/reconstructed_alert.ex
+++ b/lib/screens/v2/candidate_generator/widgets/reconstructed_alert.ex
@@ -6,6 +6,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlert do
   alias Screens.Config.V2.Header.CurrentStopId
   alias Screens.Config.V2.PreFare
   alias Screens.LocationContext
+  alias Screens.Routes.Route
   alias Screens.Stops.Stop
   alias Screens.Util
   alias Screens.V2.WidgetInstance.Common.BaseAlert
@@ -27,7 +28,8 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlert do
         fetch_location_context_fn \\ &Stop.fetch_location_context/3
       ) do
     with {:ok, location_context} <- fetch_location_context_fn.(PreFare, stop_id, now),
-         {:ok, alerts} <- fetch_alerts_fn.(route_ids: location_context.route_ids_at_stop) do
+         route_ids <- Route.route_ids(location_context.routes),
+         {:ok, alerts} <- fetch_alerts_fn.(route_ids: route_ids) do
       alerts
       |> Enum.filter(&relevant?(&1, config, location_context, now))
       |> Enum.map(fn alert ->

--- a/lib/screens/v2/candidate_generator/widgets/reconstructed_alert.ex
+++ b/lib/screens/v2/candidate_generator/widgets/reconstructed_alert.ex
@@ -26,7 +26,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlert do
         fetch_stop_name_fn \\ &Stop.fetch_stop_name/1,
         fetch_location_context_fn \\ &Stop.fetch_location_context/3
       ) do
-    with location_context <- fetch_location_context_fn.(PreFare, stop_id, now),
+    with {:ok, location_context} <- fetch_location_context_fn.(PreFare, stop_id, now),
          # TODO: make sure we're handling Mattapan outages correctly even without the "reject"
          {:ok, alerts} <- fetch_alerts_fn.(route_ids: location_context.route_ids_at_stop) do
       alerts

--- a/lib/screens/v2/localized_alert.ex
+++ b/lib/screens/v2/localized_alert.ex
@@ -17,7 +17,7 @@ defmodule Screens.V2.LocalizedAlert do
           | DupAlert.t()
           | ReconstructedAlert.t()
           | ElevatorStatus.t()
-          | %{alert: Alert.t(), location_context: LocationContext.t(), screen?: Screen.t()}
+          | %{optional(:screen) => Screen.t(), alert: Alert.t(), location_context: LocationContext.t()}
 
   @type stop_id :: String.t()
 

--- a/lib/screens/v2/localized_alert.ex
+++ b/lib/screens/v2/localized_alert.ex
@@ -281,6 +281,7 @@ defmodule Screens.V2.LocalizedAlert do
 
         # For a systemwide alert (affecting all bus or all subway/light rail)
         # entity has route type, but no stop or route
+        # credo:disable-for-next-line
         # TODO bug: currently breaks for pre-fare, dups (because they are multimodal, and alerts UI lumps
         # together subway and light rail)
         %{route_type: route_type_id, stop: nil, route: nil}, uninformed ->

--- a/lib/screens/v2/localized_alert.ex
+++ b/lib/screens/v2/localized_alert.ex
@@ -12,7 +12,8 @@ defmodule Screens.V2.LocalizedAlert do
   alias Screens.V2.WidgetInstance.Alert, as: AlertWidget
   alias Screens.V2.WidgetInstance.{DupAlert, ElevatorStatus, ReconstructedAlert}
 
-  @type t :: AlertWidget.t()
+  @type t ::
+          AlertWidget.t()
           | DupAlert.t()
           | ReconstructedAlert.t()
           | ElevatorStatus.t()
@@ -40,7 +41,9 @@ defmodule Screens.V2.LocalizedAlert do
   stop IDs in its informed entities.
   """
   @spec get_headsign_from_informed_entities(t()) :: headsign
-  def get_headsign_from_informed_entities(%{screen: %Screen{app_id: app_id}, location_context: location_context} = t)
+  def get_headsign_from_informed_entities(
+        %{screen: %Screen{app_id: app_id}, location_context: location_context} = t
+      )
       when app_id in [:dup_v2, :pre_fare_v2] do
     with headsign_matchers when is_map(headsign_matchers) <- headsign_matchers(t) do
       informed_stop_ids = MapSet.new(Alert.informed_entities(t), & &1.stop)

--- a/lib/screens/v2/localized_alert.ex
+++ b/lib/screens/v2/localized_alert.ex
@@ -17,7 +17,11 @@ defmodule Screens.V2.LocalizedAlert do
           | DupAlert.t()
           | ReconstructedAlert.t()
           | ElevatorStatus.t()
-          | %{optional(:screen) => Screen.t(), alert: Alert.t(), location_context: LocationContext.t()}
+          | %{
+              optional(:screen) => Screen.t(),
+              alert: Alert.t(),
+              location_context: LocationContext.t()
+            }
 
   @type stop_id :: String.t()
 

--- a/lib/screens/v2/location_context.ex
+++ b/lib/screens/v2/location_context.ex
@@ -8,8 +8,8 @@ defmodule Screens.LocationContext do
   @enforce_keys [:home_stop]
   defstruct home_stop: "",
             stop_sequences: [],
-            upstream_stops: %MapSet{},
-            downstream_stops: %MapSet{},
+            upstream_stops: MapSet.new(),
+            downstream_stops: MapSet.new(),
             routes: [],
             route_ids_at_stop: [],
             alert_route_types: []

--- a/lib/screens/v2/location_context.ex
+++ b/lib/screens/v2/location_context.ex
@@ -11,7 +11,6 @@ defmodule Screens.LocationContext do
             upstream_stops: MapSet.new(),
             downstream_stops: MapSet.new(),
             routes: [],
-            route_ids_at_stop: [],
             alert_route_types: []
 
   @type t :: %__MODULE__{
@@ -20,7 +19,6 @@ defmodule Screens.LocationContext do
           upstream_stops: MapSet.t(Stop.id()),
           downstream_stops: MapSet.t(Stop.id()),
           routes: list(%{route_id: Route.id(), active?: boolean()}),
-          route_ids_at_stop: list(Route.id()),
           alert_route_types: list(RouteType.t())
         }
 end

--- a/lib/screens/v2/location_context.ex
+++ b/lib/screens/v2/location_context.ex
@@ -1,0 +1,25 @@
+defmodule Screens.LocationContext do
+  @moduledoc false
+
+  alias Screens.Routes.Route
+  alias Screens.RouteType
+  alias Screens.Stops.Stop
+
+  defstruct home_stop: "",
+            stop_sequences: [],
+            upstream_stops: nil,
+            downstream_stops: nil,
+            routes: [],
+            route_ids_at_stop: [],
+            alert_route_types: []
+
+  @type t :: %__MODULE__{
+          home_stop: Stop.id(),
+          stop_sequences: list(list(Stop.id())),
+          upstream_stops: MapSet.t(Stop.id()),
+          downstream_stops: MapSet.t(Stop.id()),
+          routes: list(%{route_id: Route.id(), active?: boolean()}),
+          route_ids_at_stop: list(Route.id()),
+          alert_route_types: list(RouteType.t())
+        }
+end

--- a/lib/screens/v2/location_context.ex
+++ b/lib/screens/v2/location_context.ex
@@ -5,10 +5,11 @@ defmodule Screens.LocationContext do
   alias Screens.RouteType
   alias Screens.Stops.Stop
 
+  @enforce_keys [:home_stop]
   defstruct home_stop: "",
             stop_sequences: [],
-            upstream_stops: nil,
-            downstream_stops: nil,
+            upstream_stops: %MapSet{},
+            downstream_stops: %MapSet{},
             routes: [],
             route_ids_at_stop: [],
             alert_route_types: []

--- a/lib/screens/v2/widget_instance/alert.ex
+++ b/lib/screens/v2/widget_instance/alert.ex
@@ -3,7 +3,7 @@ defmodule Screens.V2.WidgetInstance.Alert do
 
   alias Screens.Alerts.Alert
   alias Screens.Config.Screen
-  alias Screens.LocationContext  
+  alias Screens.LocationContext
   alias Screens.V2.WidgetInstance
   alias Screens.V2.WidgetInstance.Common.BaseAlert
   alias Screens.V2.WidgetInstance.ReconstructedAlert
@@ -101,13 +101,14 @@ defmodule Screens.V2.WidgetInstance.Alert do
   end
 
   defp serialize_route_pills(%__MODULE__{screen: %Screen{app_id: app_id}} = t) do
-    routes = if app_id === :gl_eink_v2 do
-      # Get route pills for alert, including that on connecting GL branches
-      BaseAlert.informed_subway_routes(t)
-    else
-      # Get route pills for an alert, but only the routes that are at this stop
-      BaseAlert.informed_routes_at_home_stop(t)
-    end
+    routes =
+      if app_id === :gl_eink_v2 do
+        # Get route pills for alert, including that on connecting GL branches
+        BaseAlert.informed_subway_routes(t)
+      else
+        # Get route pills for an alert, but only the routes that are at this stop
+        BaseAlert.informed_routes_at_home_stop(t)
+      end
 
     if length(routes) <= 3 do
       routes

--- a/lib/screens/v2/widget_instance/alert.ex
+++ b/lib/screens/v2/widget_instance/alert.ex
@@ -201,7 +201,7 @@ defmodule Screens.V2.WidgetInstance.Alert do
   def valid_candidate?(%__MODULE__{screen: %Screen{app_id: screen_type}} = t)
       when screen_type in [:bus_shelter_v2, :bus_eink_v2] do
     priority(t) != :no_render and
-    LocalizedAlert.location(t) in [:inside, :boundary_upstream, :boundary_downstream]
+      LocalizedAlert.location(t) in [:inside, :boundary_upstream, :boundary_downstream]
   end
 
   # Any subway alert that is not filtered out in the candidate_generator is valid and should appear on screens›.

--- a/lib/screens/v2/widget_instance/alert.ex
+++ b/lib/screens/v2/widget_instance/alert.ex
@@ -4,8 +4,8 @@ defmodule Screens.V2.WidgetInstance.Alert do
   alias Screens.Alerts.Alert
   alias Screens.Config.Screen
   alias Screens.LocationContext
-  alias Screens.V2.WidgetInstance
   alias Screens.V2.LocalizedAlert
+  alias Screens.V2.WidgetInstance  
   alias Screens.V2.WidgetInstance.Serializer.RoutePill
 
   defstruct screen: nil,

--- a/lib/screens/v2/widget_instance/alert.ex
+++ b/lib/screens/v2/widget_instance/alert.ex
@@ -5,7 +5,7 @@ defmodule Screens.V2.WidgetInstance.Alert do
   alias Screens.Config.Screen
   alias Screens.LocationContext
   alias Screens.V2.LocalizedAlert
-  alias Screens.V2.WidgetInstance  
+  alias Screens.V2.WidgetInstance
   alias Screens.V2.WidgetInstance.Serializer.RoutePill
 
   defstruct screen: nil,

--- a/lib/screens/v2/widget_instance/alert.ex
+++ b/lib/screens/v2/widget_instance/alert.ex
@@ -22,8 +22,6 @@ defmodule Screens.V2.WidgetInstance.Alert do
           screen: Screen.t(),
           alert: Alert.t(),
           location_context: LocationContext.t(),
-          # stop_sequences: list(list(stop_id())),
-          # routes_at_stop: list(%{route_id: route_id(), active?: boolean()}),
           now: DateTime.t()
         }
 
@@ -33,7 +31,6 @@ defmodule Screens.V2.WidgetInstance.Alert do
 
   @automated_override_priority [1, 2]
 
-  # TODO: not sure if there's anything to be done here
   # Keep these in descending order of priority--highest priority (lowest integer value) first
   @relevant_effects ~w[shuttle stop_closure suspension station_closure detour stop_moved snow_route elevator_closure]a
 
@@ -103,7 +100,6 @@ defmodule Screens.V2.WidgetInstance.Alert do
     }
   end
 
-  # Only runs for THIS widget (bus shelter, e-ink. not prefare / dup)
   defp serialize_route_pills(%__MODULE__{screen: %Screen{app_id: app_id}} = t) do
     routes = if app_id === :gl_eink_v2 do
       # Get route pills for alert, including that on connecting GL branches
@@ -298,22 +294,6 @@ defmodule Screens.V2.WidgetInstance.Alert do
     def audio_valid_candidate?(instance), do: Alert.audio_valid_candidate?(instance)
     def audio_view(instance), do: Alert.audio_view(instance)
   end
-
-  # defimpl Screens.V2.SingleAlertWidget do
-  #   alias Screens.V2.WidgetInstance.Alert
-
-  #   def alert(instance), do: instance.alert
-
-  #   def screen(instance), do: instance.screen
-
-  #   def home_stop_id(instance), do: instance.screen.app_params.alerts.stop_id
-
-  #   def routes_at_stop(instance), do: instance.routes_at_stop
-
-  #   def stop_sequences(instance), do: instance.stop_sequences
-
-  #   def headsign_matchers(_instance), do: nil
-  # end
 
   defimpl Screens.V2.AlertsWidget do
     alias Screens.V2.WidgetInstance.Alert

--- a/lib/screens/v2/widget_instance/alert.ex
+++ b/lib/screens/v2/widget_instance/alert.ex
@@ -5,7 +5,7 @@ defmodule Screens.V2.WidgetInstance.Alert do
   alias Screens.Config.Screen
   alias Screens.LocationContext
   alias Screens.V2.WidgetInstance
-  alias Screens.V2.WidgetInstance.Common.BaseAlert
+  alias Screens.V2.LocalizedAlert
   alias Screens.V2.WidgetInstance.Serializer.RoutePill
 
   defstruct screen: nil,
@@ -88,7 +88,7 @@ defmodule Screens.V2.WidgetInstance.Alert do
 
   @spec serialize(t()) :: map()
   def serialize(t) do
-    e = BaseAlert.effect(t)
+    e = Alert.effect(t)
 
     %{
       route_pills: serialize_route_pills(t),
@@ -103,10 +103,10 @@ defmodule Screens.V2.WidgetInstance.Alert do
     routes =
       if app_id === :gl_eink_v2 do
         # Get route pills for alert, including that on connecting GL branches
-        BaseAlert.informed_subway_routes(t)
+        LocalizedAlert.informed_subway_routes(t)
       else
         # Get route pills for an alert, but only the routes that are at this stop
-        BaseAlert.informed_routes_at_home_stop(t)
+        LocalizedAlert.informed_routes_at_home_stop(t)
       end
 
     if length(routes) <= 3 do
@@ -151,13 +151,13 @@ defmodule Screens.V2.WidgetInstance.Alert do
 
   def takeover_alert?(%__MODULE__{screen: %Screen{app_id: bus_app_id}} = t)
       when bus_app_id in [:bus_shelter_v2, :bus_eink_v2] do
-    BaseAlert.effect(t) in [:stop_closure, :stop_moved, :suspension, :detour] and
-      BaseAlert.informs_all_active_routes_at_home_stop?(t)
+    Alert.effect(t) in [:stop_closure, :stop_moved, :suspension, :detour] and
+      LocalizedAlert.informs_all_active_routes_at_home_stop?(t)
   end
 
   def takeover_alert?(%__MODULE__{screen: %Screen{app_id: :gl_eink_v2}} = t) do
-    BaseAlert.effect(t) in [:station_closure, :suspension, :shuttle] and
-      BaseAlert.location(t) in [:inside, :boundary_upstream, :boundary_downstream]
+    Alert.effect(t) in [:station_closure, :suspension, :shuttle] and
+      LocalizedAlert.location(t) in [:inside, :boundary_upstream, :boundary_downstream]
   end
 
   defp takeover_slot_names(%__MODULE__{screen: %Screen{app_id: :bus_shelter_v2}}) do
@@ -194,14 +194,14 @@ defmodule Screens.V2.WidgetInstance.Alert do
       )
       when screen_type in [:bus_shelter_v2, :bus_eink_v2] do
     priority(t) != :no_render and
-      BaseAlert.location(t) in [:inside, :boundary_downstream]
+      LocalizedAlert.location(t) in [:inside, :boundary_downstream]
   end
 
   # For all other bus alert effects, all stops in the `informed_entities` are directly affected by the alert and would be useful for riders to see.
   def valid_candidate?(%__MODULE__{screen: %Screen{app_id: screen_type}} = t)
       when screen_type in [:bus_shelter_v2, :bus_eink_v2] do
     priority(t) != :no_render and
-      BaseAlert.location(t) in [:inside, :boundary_upstream, :boundary_downstream]
+    LocalizedAlert.location(t) in [:inside, :boundary_upstream, :boundary_downstream]
   end
 
   # Any subway alert that is not filtered out in the candidate_generator is valid and should appear on screens›.
@@ -227,7 +227,7 @@ defmodule Screens.V2.WidgetInstance.Alert do
 
   @spec tiebreaker_location(t()) :: pos_integer() | WidgetInstance.no_render()
   def tiebreaker_location(%__MODULE__{} = t) do
-    case BaseAlert.location(t) do
+    case LocalizedAlert.location(t) do
       :inside -> 1
       :boundary_upstream -> 2
       :boundary_downstream -> 2
@@ -251,7 +251,7 @@ defmodule Screens.V2.WidgetInstance.Alert do
 
   @spec tiebreaker_effect(t()) :: pos_integer() | WidgetInstance.no_render()
   def tiebreaker_effect(%__MODULE__{} = t) do
-    Keyword.get(@effect_priorities, BaseAlert.effect(t), :no_render)
+    Keyword.get(@effect_priorities, Alert.effect(t), :no_render)
   end
 
   @spec seconds_from_onset(t()) :: integer()

--- a/lib/screens/v2/widget_instance/alert.ex
+++ b/lib/screens/v2/widget_instance/alert.ex
@@ -3,10 +3,7 @@ defmodule Screens.V2.WidgetInstance.Alert do
 
   alias Screens.Alerts.Alert
   alias Screens.Config.Screen
-  alias Screens.Config.V2.{Alerts, BusEink, BusShelter, GlEink, PreFare}
-  alias Screens.Config.V2.Header.CurrentStopId
-  alias Screens.RouteType
-  alias Screens.Util
+  alias Screens.LocationContext  
   alias Screens.V2.WidgetInstance
   alias Screens.V2.WidgetInstance.Common.BaseAlert
   alias Screens.V2.WidgetInstance.ReconstructedAlert
@@ -14,8 +11,7 @@ defmodule Screens.V2.WidgetInstance.Alert do
 
   defstruct screen: nil,
             alert: nil,
-            stop_sequences: nil,
-            routes_at_stop: nil,
+            location_context: nil,
             now: nil
 
   @type stop_id :: String.t()
@@ -25,8 +21,9 @@ defmodule Screens.V2.WidgetInstance.Alert do
   @type t :: %__MODULE__{
           screen: Screen.t(),
           alert: Alert.t(),
-          stop_sequences: list(list(stop_id())),
-          routes_at_stop: list(%{route_id: route_id(), active?: boolean()}),
+          location_context: LocationContext.t(),
+          # stop_sequences: list(list(stop_id())),
+          # routes_at_stop: list(%{route_id: route_id(), active?: boolean()}),
           now: DateTime.t()
         }
 
@@ -36,8 +33,9 @@ defmodule Screens.V2.WidgetInstance.Alert do
 
   @automated_override_priority [1, 2]
 
+  # TODO: not sure if there's anything to be done here
   # Keep these in descending order of priority--highest priority (lowest integer value) first
-  @relevant_effects ~w[shuttle stop_closure suspension station_closure detour stop_move stop_moved snow_route elevator_closure]a
+  @relevant_effects ~w[shuttle stop_closure suspension station_closure detour stop_moved snow_route elevator_closure]a
 
   @effect_priorities Enum.with_index(@relevant_effects, 1)
 
@@ -69,7 +67,7 @@ defmodule Screens.V2.WidgetInstance.Alert do
                   Enum.map(@relevant_effects, fn
                     bus when bus in ~w[shuttle detour]a -> :bus
                     major when major in ~w[stop_closure suspension station_closure]a -> :x
-                    minor when minor in ~w[stop_move stop_moved elevator_closure]a -> :warning
+                    minor when minor in ~w[stop_moved elevator_closure]a -> :warning
                     :snow_route -> :snowflake
                   end)
                 )
@@ -105,12 +103,18 @@ defmodule Screens.V2.WidgetInstance.Alert do
     }
   end
 
-  defp serialize_route_pills(t) do
-    routes = informed_routes(t)
+  # Only runs for THIS widget (bus shelter, e-ink. not prefare / dup)
+  defp serialize_route_pills(%__MODULE__{screen: %Screen{app_id: app_id}} = t) do
+    routes = if app_id === :gl_eink_v2 do
+      # Get route pills for alert, including that on connecting GL branches
+      BaseAlert.informed_subway_routes(t)
+    else
+      # Get route pills for an alert, but only the routes that are at this stop
+      BaseAlert.informed_routes_at_home_stop(t)
+    end
 
-    if MapSet.size(routes) <= 3 do
+    if length(routes) <= 3 do
       routes
-      |> Enum.to_list()
       |> Enum.sort_by(fn route_id ->
         case Integer.parse(route_id) do
           # Bus route (including SL_, CT_)
@@ -119,10 +123,11 @@ defmodule Screens.V2.WidgetInstance.Alert do
           _ -> route_id
         end
       end)
-      |> Enum.map(&RoutePill.serialize_route_for_alert(&1, MapSet.size(routes) == 1))
+      |> Enum.map(&RoutePill.serialize_route_for_alert(&1, length(routes) == 1))
     else
-      t
-      |> route_type()
+      t.location_context.alert_route_types
+      # For bus shelter / e-ink, there's only 1 list item
+      |> List.first()
       |> RoutePill.serialize_route_type_for_alert()
       |> List.wrap()
     end
@@ -150,8 +155,8 @@ defmodule Screens.V2.WidgetInstance.Alert do
 
   def takeover_alert?(%__MODULE__{screen: %Screen{app_id: bus_app_id}} = t)
       when bus_app_id in [:bus_shelter_v2, :bus_eink_v2] do
-    effect(t) in [:stop_closure, :stop_move, :stop_moved, :suspension, :detour] and
-      informs_all_active_routes_at_home_stop?(t)
+    effect(t) in [:stop_closure, :stop_moved, :suspension, :detour] and
+      BaseAlert.informs_all_active_routes_at_home_stop?(t)
   end
 
   def takeover_alert?(%__MODULE__{screen: %Screen{app_id: :gl_eink_v2}} = t) do
@@ -164,7 +169,7 @@ defmodule Screens.V2.WidgetInstance.Alert do
       ) do
     effect(t) in [:station_closure, :suspension, :shuttle] and
       BaseAlert.location(t, is_terminal_station) == :inside and
-      informs_all_active_routes_at_home_stop?(t)
+      BaseAlert.informs_all_active_routes_at_home_stop?(t)
   end
 
   defp takeover_slot_names(%__MODULE__{screen: %Screen{app_id: :bus_shelter_v2}}) do
@@ -216,96 +221,8 @@ defmodule Screens.V2.WidgetInstance.Alert do
     priority(t) != :no_render
   end
 
-  @spec seconds_from_onset(t()) :: integer()
-  def seconds_from_onset(%__MODULE__{alert: %Alert{active_period: [{start, _} | _]}, now: now})
-      when not is_nil(start) do
-    DateTime.diff(now, start, :second)
-  end
-
-  @spec seconds_to_next_active_period(t()) :: integer() | :infinity
-  def seconds_to_next_active_period(%__MODULE__{
-        alert: %Alert{active_period: active_periods},
-        now: now
-      })
-      when not is_nil(active_periods) do
-    next_active_period =
-      Enum.find(active_periods, fn {start, _} ->
-        not is_nil(start) and DateTime.compare(now, start) in [:lt, :eq]
-      end)
-
-    case next_active_period do
-      nil -> :infinity
-      {start, _} -> DateTime.diff(start, now, :second)
-    end
-  end
-
-  def seconds_to_next_active_period(_t), do: :infinity
-
-  @spec home_stop_id(t()) :: String.t()
-  def home_stop_id(%{
-        screen: %Screen{app_params: %app{alerts: %Alerts{stop_id: stop_id}}}
-      })
-      when app in [BusShelter, GlEink, BusEink] do
-    stop_id
-  end
-
-  def home_stop_id(%{
-        screen: %Screen{
-          app_params: %app{reconstructed_alert_widget: %CurrentStopId{stop_id: stop_id}}
-        }
-      })
-      when app in [PreFare] do
-    stop_id
-  end
-
-  @spec informed_entities(t()) :: list(Alert.informed_entity())
-  def informed_entities(%{alert: %Alert{informed_entities: informed_entities}}) do
-    informed_entities
-  end
-
-  @spec upstream_stop_id_set(t()) :: MapSet.t(stop_id())
-  def upstream_stop_id_set(%{} = t) do
-    home_stop_id = home_stop_id(t)
-
-    t.stop_sequences
-    |> Enum.flat_map(fn stop_sequence -> Util.slice_before(stop_sequence, home_stop_id) end)
-    |> MapSet.new()
-  end
-
-  @spec downstream_stop_id_set(t()) :: MapSet.t(stop_id())
-  def downstream_stop_id_set(%{} = t) do
-    home_stop_id = home_stop_id(t)
-
-    t.stop_sequences
-    |> Enum.flat_map(fn stop_sequence -> Util.slice_after(stop_sequence, home_stop_id) end)
-    |> MapSet.new()
-  end
-
   @spec effect(t() | ReconstructedAlert.t()) :: Alert.effect()
   def effect(%{alert: %Alert{effect: effect}}), do: effect
-
-  def all_routes_at_stop(%{routes_at_stop: routes}) do
-    MapSet.new(routes, & &1.route_id)
-  end
-
-  def active_routes_at_stop(%{routes_at_stop: routes}) do
-    routes
-    |> Enum.filter(& &1.active?)
-    |> MapSet.new(& &1.route_id)
-  end
-
-  def route_type(%__MODULE__{screen: %Screen{app_id: :bus_shelter_v2}}), do: :bus
-  def route_type(%__MODULE__{screen: %Screen{app_id: :bus_eink_v2}}), do: :bus
-  def route_type(%__MODULE__{screen: %Screen{app_id: :gl_eink_v2}}), do: :light_rail
-
-  def route_type(%{
-        screen: %Screen{app_id: :pre_fare_v2},
-        routes_at_stop: routes_at_stop
-      }) do
-    routes_at_stop
-    |> Enum.map(& &1.type)
-    |> Enum.dedup()
-  end
 
   # Time units in seconds
   @hour 60 * 60
@@ -352,88 +269,10 @@ defmodule Screens.V2.WidgetInstance.Alert do
     Keyword.get(@effect_priorities, effect(t), :no_render)
   end
 
-  defp informs_all_active_routes_at_home_stop?(t) do
-    MapSet.subset?(active_routes_at_stop(t), BaseAlert.informed_routes_at_home_stop(t))
-  end
-
-  # For GL, we want to list all affected branches for the alert and not just the branch serving the home stop.
-  # This allows us to show a pill for each branch in the informed_entities of the alert (or GL pill if all branches are affected).
-  defp informed_routes(%__MODULE__{screen: %Screen{app_id: :gl_eink_v2}} = t) do
-    t
-    |> informed_entities()
-    |> Enum.filter(fn
-      %{route: "Green" <> _} -> true
-      _ -> false
-    end)
-    |> Enum.map(fn %{route: route} -> route end)
-    |> Enum.into(MapSet.new())
-    |> Enum.reduce_while(MapSet.new(), fn
-      route, acc ->
-        if MapSet.size(acc) == 2 do
-          {:halt, MapSet.new(["Green"])}
-        else
-          {:cont, MapSet.put(acc, route)}
-        end
-    end)
-  end
-
-  # Takes all_routes_at_stop and removes any route that is not affected by the alert.
-  # Remaining routes show as pills on the alert component.
-  defp informed_routes(t) do
-    rt = route_type(t)
-    home_stop = home_stop_id(t)
-    downstream_stop_set = downstream_stop_id_set(t)
-    route_set = all_routes_at_stop(t)
-
-    # allows us to pattern match against the empty set
-    empty_set = MapSet.new()
-
-    uninformed_routes =
-      Enum.reduce_while(informed_entities(t), route_set, fn
-        _ie, ^empty_set ->
-          {:halt, empty_set}
-
-        %{route_type: nil, stop: nil, route: nil}, uninformed ->
-          {:cont, uninformed}
-
-        %{route_type: route_type_id, stop: nil, route: nil}, uninformed ->
-          # Route type might be a single atom or list of atoms
-          cond do
-            is_list(rt) and RouteType.from_id(route_type_id) in rt ->
-              {:halt, empty_set}
-
-            RouteType.from_id(route_type_id) == rt ->
-              {:halt, empty_set}
-
-            true ->
-              {:cont, uninformed}
-          end
-
-        %{stop: ^home_stop, route: nil}, _uninformed ->
-          {:halt, empty_set}
-
-        # We can't handle this case properly until the struct is updated to record which routes serve which stops.
-        # %{stop: stop, route: nil}, uninformed when stop in downstream_stops ->
-        #   {:cont, MapSet.difference(uninformed, routes_by_stop[stop])}
-
-        %{stop: ^home_stop, route: route}, uninformed ->
-          {:cont, MapSet.delete(uninformed, route)}
-
-        %{stop: stop, route: route}, uninformed when is_binary(stop) ->
-          if stop in downstream_stop_set do
-            {:cont, MapSet.delete(uninformed, route)}
-          else
-            {:cont, uninformed}
-          end
-
-        %{stop: nil, route: route}, uninformed ->
-          {:cont, MapSet.delete(uninformed, route)}
-
-        _ie, uninformed ->
-          {:cont, uninformed}
-      end)
-
-    MapSet.difference(route_set, uninformed_routes)
+  @spec seconds_from_onset(t()) :: integer()
+  def seconds_from_onset(%__MODULE__{alert: %Alert{active_period: [{start, _} | _]}, now: now})
+      when not is_nil(start) do
+    DateTime.diff(now, start, :second)
   end
 
   def audio_serialize(_instance), do: %{}
@@ -460,21 +299,21 @@ defmodule Screens.V2.WidgetInstance.Alert do
     def audio_view(instance), do: Alert.audio_view(instance)
   end
 
-  defimpl Screens.V2.SingleAlertWidget do
-    alias Screens.V2.WidgetInstance.Alert
+  # defimpl Screens.V2.SingleAlertWidget do
+  #   alias Screens.V2.WidgetInstance.Alert
 
-    def alert(instance), do: instance.alert
+  #   def alert(instance), do: instance.alert
 
-    def screen(instance), do: instance.screen
+  #   def screen(instance), do: instance.screen
 
-    def home_stop_id(instance), do: instance.screen.app_params.alerts.stop_id
+  #   def home_stop_id(instance), do: instance.screen.app_params.alerts.stop_id
 
-    def routes_at_stop(instance), do: instance.routes_at_stop
+  #   def routes_at_stop(instance), do: instance.routes_at_stop
 
-    def stop_sequences(instance), do: instance.stop_sequences
+  #   def stop_sequences(instance), do: instance.stop_sequences
 
-    def headsign_matchers(_instance), do: nil
-  end
+  #   def headsign_matchers(_instance), do: nil
+  # end
 
   defimpl Screens.V2.AlertsWidget do
     alias Screens.V2.WidgetInstance.Alert

--- a/lib/screens/v2/widget_instance/common/base_alert.ex
+++ b/lib/screens/v2/widget_instance/common/base_alert.ex
@@ -44,7 +44,7 @@ defmodule Screens.V2.WidgetInstance.Common.BaseAlert do
   - the home stop is not on the boundary of the alert's affected region.
   - the widget does not have a map of headsign matchers (`SingleAlertWidget.headsign_matchers(t)` returns nil)
   """
-  @spec get_headsign_from_informed_entities(t()) :: headsign | nil
+  @spec get_headsign_from_informed_entities(t()) :: headsign
   def get_headsign_from_informed_entities(%{screen: %Screen{app_id: app_id}} = t)
       when app_id in [:dup_v2, :pre_fare_v2] do
     with headsign_matchers when is_map(headsign_matchers) <- headsign_matchers(t) do

--- a/lib/screens/v2/widget_instance/common/base_alert.ex
+++ b/lib/screens/v2/widget_instance/common/base_alert.ex
@@ -223,7 +223,6 @@ defmodule Screens.V2.WidgetInstance.Common.BaseAlert do
   # Different screens may consolidate the GL branch alerts
   @spec consolidate_gl(list(String.t()), atom()) :: list(String.t())
   # GL E-ink consolidates the GL branches to Green Line if there are > 2 branches
-  # We want to list all affected branches for the alert, not just the one serving the home stop
   defp consolidate_gl(affected_routes, :gl_eink_v2) do
     green_routes =
       Enum.filter(affected_routes, fn

--- a/lib/screens/v2/widget_instance/common/base_alert.ex
+++ b/lib/screens/v2/widget_instance/common/base_alert.ex
@@ -251,8 +251,8 @@ defmodule Screens.V2.WidgetInstance.Common.BaseAlert do
   @spec informed_routes_at_home_stop(t()) :: MapSet.t(Route.id())
   def informed_routes_at_home_stop(t) do
     rts = t.location_context.alert_route_types
-    home_stop = t.location_context.stop_id
-    route_set = t.location_context.routes
+    home_stop = t.location_context.home_stop
+    route_set = MapSet.new(t.location_context.route_ids_at_stop)
 
     # allows us to pattern match against the empty set
     empty_set = MapSet.new()

--- a/lib/screens/v2/widget_instance/dup_alert.ex
+++ b/lib/screens/v2/widget_instance/dup_alert.ex
@@ -288,22 +288,6 @@ defmodule Screens.V2.WidgetInstance.DupAlert do
     def audio_view(instance), do: DupAlert.audio_view(instance)
   end
 
-  # defimpl Screens.V2.SingleAlertWidget do
-  #   def alert(instance), do: instance.alert
-
-  #   def screen(instance), do: instance.screen
-
-  #   def home_stop_id(instance), do: instance.screen.app_params.alerts.stop_id
-
-  #   def routes_at_stop(instance), do: instance.subway_routes_at_stop
-
-  #   def stop_sequences(instance), do: instance.stop_sequences
-
-  #   def headsign_matchers(_instance) do
-  #     Application.get_env(:screens, :dup_alert_headsign_matchers)
-  #   end
-  # end
-
   defimpl Screens.V2.AlertsWidget do
     alias Screens.V2.WidgetInstance.DupAlert
 

--- a/lib/screens/v2/widget_instance/dup_alert.ex
+++ b/lib/screens/v2/widget_instance/dup_alert.ex
@@ -5,6 +5,7 @@ defmodule Screens.V2.WidgetInstance.DupAlert do
 
   alias Screens.Alerts.Alert
   alias Screens.Config.Screen
+  alias Screens.LocationContext
   alias Screens.V2.WidgetInstance.Common.BaseAlert
   alias Screens.V2.WidgetInstance.DupAlert.Serialize
 
@@ -13,8 +14,7 @@ defmodule Screens.V2.WidgetInstance.DupAlert do
   @enforce_keys [
     :screen,
     :alert,
-    :stop_sequences,
-    :subway_routes_at_stop,
+    :location_context,
     :primary_section_count,
     :rotation_index,
     :stop_name
@@ -24,8 +24,7 @@ defmodule Screens.V2.WidgetInstance.DupAlert do
   @type t :: %__MODULE__{
           screen: Screen.t(),
           alert: Alert.t(),
-          stop_sequences: list(list(stop_id)),
-          subway_routes_at_stop: list(%{route_id: route_id, active?: boolean}),
+          location_context: LocationContext.t(),
           primary_section_count: pos_integer(),
           rotation_index: rotation_index,
           stop_name: String.t()
@@ -289,21 +288,21 @@ defmodule Screens.V2.WidgetInstance.DupAlert do
     def audio_view(instance), do: DupAlert.audio_view(instance)
   end
 
-  defimpl Screens.V2.SingleAlertWidget do
-    def alert(instance), do: instance.alert
+  # defimpl Screens.V2.SingleAlertWidget do
+  #   def alert(instance), do: instance.alert
 
-    def screen(instance), do: instance.screen
+  #   def screen(instance), do: instance.screen
 
-    def home_stop_id(instance), do: instance.screen.app_params.alerts.stop_id
+  #   def home_stop_id(instance), do: instance.screen.app_params.alerts.stop_id
 
-    def routes_at_stop(instance), do: instance.subway_routes_at_stop
+  #   def routes_at_stop(instance), do: instance.subway_routes_at_stop
 
-    def stop_sequences(instance), do: instance.stop_sequences
+  #   def stop_sequences(instance), do: instance.stop_sequences
 
-    def headsign_matchers(_instance) do
-      Application.get_env(:screens, :dup_alert_headsign_matchers)
-    end
-  end
+  #   def headsign_matchers(_instance) do
+  #     Application.get_env(:screens, :dup_alert_headsign_matchers)
+  #   end
+  # end
 
   defimpl Screens.V2.AlertsWidget do
     alias Screens.V2.WidgetInstance.DupAlert

--- a/lib/screens/v2/widget_instance/dup_alert.ex
+++ b/lib/screens/v2/widget_instance/dup_alert.ex
@@ -6,7 +6,7 @@ defmodule Screens.V2.WidgetInstance.DupAlert do
   alias Screens.Alerts.Alert
   alias Screens.Config.Screen
   alias Screens.LocationContext
-  alias Screens.V2.WidgetInstance.Common.BaseAlert
+  alias Screens.V2.LocalizedAlert
   alias Screens.V2.WidgetInstance.DupAlert.Serialize
 
   require Logger
@@ -156,7 +156,7 @@ defmodule Screens.V2.WidgetInstance.DupAlert do
   defp get_layout_parameters(t) do
     %{
       effect: t.alert.effect,
-      location: BaseAlert.location(t),
+      location: LocalizedAlert.location(t),
       affected_line_count: length(get_affected_lines(t)),
       primary_section_count: t.primary_section_count
     }
@@ -239,7 +239,7 @@ defmodule Screens.V2.WidgetInstance.DupAlert do
 
   def get_affected_lines(t) do
     t
-    |> BaseAlert.informed_routes_at_home_stop()
+    |> LocalizedAlert.informed_routes_at_home_stop()
     |> routes_to_lines()
   end
 

--- a/lib/screens/v2/widget_instance/dup_alert/serialize.ex
+++ b/lib/screens/v2/widget_instance/dup_alert/serialize.ex
@@ -5,7 +5,7 @@ defmodule Screens.V2.WidgetInstance.DupAlert.Serialize do
 
   alias Screens.Alerts.Alert
   alias Screens.Config.V2.FreeTextLine
-  alias Screens.V2.WidgetInstance.Common.BaseAlert
+  alias Screens.V2.LocalizedAlert
   alias Screens.V2.WidgetInstance.DupAlert
 
   @type full_screen_alert_map :: %{
@@ -95,7 +95,7 @@ defmodule Screens.V2.WidgetInstance.DupAlert.Serialize do
   defp partial_alert_free_text(t) do
     affected_lines = get_affected_lines_as_strings(t)
 
-    case {affected_lines, t.alert.effect, BaseAlert.location(t)} do
+    case {affected_lines, t.alert.effect, LocalizedAlert.location(t)} do
       {[line], :delay, _} ->
         [bold(line), "delays"]
 
@@ -128,7 +128,7 @@ defmodule Screens.V2.WidgetInstance.DupAlert.Serialize do
       [line_pill] ->
         no_trains = [bold("No"), line_pill, bold("trains")]
 
-        if BaseAlert.location(t) in [:boundary_upstream, :boundary_downstream] do
+        if LocalizedAlert.location(t) in [:boundary_upstream, :boundary_downstream] do
           headsign = get_headsign(t)
 
           no_trains ++ [bold("to #{headsign}")]
@@ -163,7 +163,7 @@ defmodule Screens.V2.WidgetInstance.DupAlert.Serialize do
   end
 
   defp get_headsign(t) do
-    headsign = BaseAlert.get_headsign_from_informed_entities(t)
+    headsign = LocalizedAlert.get_headsign_from_informed_entities(t)
 
     case headsign do
       {:adj, hs} -> hs

--- a/lib/screens/v2/widget_instance/dup_alert/serialize.ex
+++ b/lib/screens/v2/widget_instance/dup_alert/serialize.ex
@@ -165,12 +165,6 @@ defmodule Screens.V2.WidgetInstance.DupAlert.Serialize do
   defp get_headsign(t) do
     headsign = BaseAlert.get_headsign_from_informed_entities(t)
 
-    if is_nil(headsign) do
-      raise(
-        "[DUP v2 no headsign] Could not determine headsign for DUP alert alert_id=#{t.alert.id}"
-      )
-    end
-
     case headsign do
       {:adj, hs} -> hs
       hs -> hs

--- a/lib/screens/v2/widget_instance/elevator_status.ex
+++ b/lib/screens/v2/widget_instance/elevator_status.ex
@@ -18,8 +18,6 @@ defmodule Screens.V2.WidgetInstance.ElevatorStatus do
 
     defstruct station: nil
 
-    # TODO: just curious, do the separate `alert_ids` definitions lead to double-counting
-    # of how many times an elevator closure appears on a pre-fare?
     defimpl Screens.V2.AlertsWidget do
       def alert_ids(page) do
         Enum.map(page.station.elevator_closures, & &1.alert_id)

--- a/lib/screens/v2/widget_instance/elevator_status.ex
+++ b/lib/screens/v2/widget_instance/elevator_status.ex
@@ -81,7 +81,7 @@ defmodule Screens.V2.WidgetInstance.ElevatorStatus do
   alias Screens.Config.V2.{ElevatorStatus, PreFare}
   alias Screens.LocationContext
   alias Screens.V2.AlertsWidget
-  alias Screens.V2.WidgetInstance.Common.BaseAlert
+  alias Screens.V2.LocalizedAlert
 
   defstruct screen: nil,
             now: nil,
@@ -158,7 +158,7 @@ defmodule Screens.V2.WidgetInstance.ElevatorStatus do
     |> Enum.filter(&active_at_home_station?(&1, t))
   end
 
-  # The definition of this "elsewhere" is different than the output of BaseAlert.Location.
+  # The definition of this "elsewhere" is different than the output of LocalizedAlert.location.
   # This elsewhere means "anywhere but here"
   defp get_active_elsewhere(
          %__MODULE__{
@@ -222,7 +222,7 @@ defmodule Screens.V2.WidgetInstance.ElevatorStatus do
          %__MODULE__{location_context: location_context, now: now}
        ) do
     active = Alert.happening_now?(alert, now)
-    alert_location = BaseAlert.location(%{alert: alert, location_context: location_context})
+    alert_location = LocalizedAlert.location(%{alert: alert, location_context: location_context})
     active and (alert_location === :upstream or alert_location === :downstream)
   end
 

--- a/lib/screens/v2/widget_instance/elevator_status.ex
+++ b/lib/screens/v2/widget_instance/elevator_status.ex
@@ -18,8 +18,8 @@ defmodule Screens.V2.WidgetInstance.ElevatorStatus do
 
     defstruct station: nil
 
-    # Do the separate `alert_ids` definitions lead to double-counting of how many times
-    # an elevator closure appears on a pre-fare?
+    # TODO: just curious, do the separate `alert_ids` definitions lead to double-counting
+    # of how many times an elevator closure appears on a pre-fare?
     defimpl Screens.V2.AlertsWidget do
       def alert_ids(page) do
         Enum.map(page.station.elevator_closures, & &1.alert_id)

--- a/lib/screens/v2/widget_instance/elevator_status.ex
+++ b/lib/screens/v2/widget_instance/elevator_status.ex
@@ -190,27 +190,32 @@ defmodule Screens.V2.WidgetInstance.ElevatorStatus do
   end
 
   @spec alert_is_relevant?(Alert.t(), t(), atom()) :: boolean()
-  defp alert_is_relevant?(%Alert{effect: :elevator_closure, informed_entities: entities} = alert,
-      %__MODULE__{location_context: location_context, now: now},
-      option
-    ) do
-
+  defp alert_is_relevant?(
+         %Alert{effect: :elevator_closure, informed_entities: entities} = alert,
+         %__MODULE__{location_context: location_context, now: now},
+         option
+       ) do
     active = Alert.happening_now?(alert, now)
     here = Enum.any?(entities, fn e -> e.stop == location_context.home_stop end)
 
-    case option do 
-      :upcoming -> not active and here
-      :here -> active and here
-      :downstream -> 
+    case option do
+      :upcoming ->
+        not active and here
+
+      :here ->
+        active and here
+
+      :downstream ->
         alert_location = BaseAlert.location(%{alert: alert, location_context: location_context})
-        active and alert_location === :upstream or alert_location === :downstream
+        (active and alert_location === :upstream) or (alert_location === :downstream)
+
       :elsewhere ->
-        active and entities
-            |> get_stations_from_entities()
-            |> Enum.any?(fn station -> station != location_context.home_stop end)
+        active and
+          entities
+          |> get_stations_from_entities()
+          |> Enum.any?(fn station -> station != location_context.home_stop end)
     end
   end
-
 
   defp sort_elsewhere(e1, _e2, %__MODULE__{location_context: %{stop_sequences: stop_sequences}}) do
     stations = get_stations_from_entities(e1)

--- a/lib/screens/v2/widget_instance/reconstructed_alert.ex
+++ b/lib/screens/v2/widget_instance/reconstructed_alert.ex
@@ -15,8 +15,6 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
             alert: nil,
             now: nil,
             location_context: nil,
-            # stop_sequences: nil,
-            # routes_at_stop: nil,
             informed_stations_string: nil,
             is_terminal_station: false
 
@@ -29,8 +27,6 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
           alert: Alert.t(),
           now: DateTime.t(),
           location_context: LocationContext.t(),
-          # stop_sequences: list(list(stop_id())),
-          # routes_at_stop: list(%{route_id: route_id(), active?: boolean()}),
           informed_stations_string: String.t(),
           is_terminal_station: boolean()
         }
@@ -503,7 +499,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
          %__MODULE__{alert: %Alert{effect: :shuttle, cause: cause, header: header}} = t
        ) do
     informed_entities = BaseAlert.informed_entities(t)
-  
+
     affected_routes = BaseAlert.informed_subway_routes(t)
 
     if length(affected_routes) > 1 do
@@ -665,24 +661,6 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
     def audio_valid_candidate?(t), do: ReconstructedAlert.temporarily_override_alert(t)
     def audio_view(_instance), do: ScreensWeb.V2.Audio.ReconstructedAlertView
   end
-
-  # defimpl Screens.V2.SingleAlertWidget do
-  #   alias Screens.V2.WidgetInstance.ReconstructedAlert
-
-  #   def alert(instance), do: instance.alert
-
-  #   def screen(instance), do: instance.screen
-
-  #   def home_stop_id(instance), do: instance.screen.app_params.reconstructed_alert_widget.stop_id
-
-  #   def routes_at_stop(instance), do: instance.routes_at_stop
-
-  #   def stop_sequences(instance), do: instance.stop_sequences
-
-  #   def headsign_matchers(_instance) do
-  #     Application.get_env(:screens, :prefare_alert_headsign_matchers)
-  #   end
-  # end
 
   defimpl Screens.V2.AlertsWidget do
     def alert_ids(t), do: ReconstructedAlert.alert_ids(t)

--- a/lib/screens/v2/widget_instance/reconstructed_alert.ex
+++ b/lib/screens/v2/widget_instance/reconstructed_alert.ex
@@ -6,7 +6,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
   alias Screens.Config.V2.FreeTextLine
   alias Screens.LocationContext
   alias Screens.Stops.Stop
-  alias Screens.V2.WidgetInstance.Common.BaseAlert
+  alias Screens.V2.LocalizedAlert
   alias Screens.V2.WidgetInstance.ReconstructedAlert
   alias Screens.V2.WidgetInstance.Serializer.RoutePill
 
@@ -44,7 +44,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
 
   # Using hd/1 because we know that only single line stations use this function.
   defp get_destination(t, location) do
-    informed_entities = BaseAlert.informed_entities(t)
+    informed_entities = Alert.informed_entities(t)
 
     {direction_id, route_id} =
       informed_entities
@@ -56,7 +56,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
       # When the alert is non-directional but the station is at the boundary:
       # direction_id will be nil, but we still want to show the alert impacts one direction only
       is_nil(direction_id) and location == :boundary ->
-        BaseAlert.get_headsign_from_informed_entities(t)
+        LocalizedAlert.get_headsign_from_informed_entities(t)
 
       # When the alert is non-directional and the station is outside the alert range
       is_nil(direction_id) ->
@@ -84,9 +84,9 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
   def takeover_alert?(
         %{screen: %Screen{app_id: :pre_fare_v2}, is_terminal_station: is_terminal_station} = t
       ) do
-    BaseAlert.effect(t) in [:station_closure, :suspension, :shuttle] and
-      BaseAlert.location(t, is_terminal_station) == :inside and
-      BaseAlert.informs_all_active_routes_at_home_stop?(t)
+    Alert.effect(t) in [:station_closure, :suspension, :shuttle] and
+      LocalizedAlert.location(t, is_terminal_station) == :inside and
+      LocalizedAlert.informs_all_active_routes_at_home_stop?(t)
   end
 
   defp serialize_takeover_alert(
@@ -94,8 +94,8 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
            alert: %Alert{effect: :suspension, cause: cause}
          } = t
        ) do
-    informed_entities = BaseAlert.informed_entities(t)
-    affected_routes = BaseAlert.informed_subway_routes(t)
+    informed_entities = Alert.informed_entities(t)
+    affected_routes = LocalizedAlert.informed_subway_routes(t)
     cause_text = cause |> Alert.get_cause_string() |> String.capitalize()
 
     location_text = get_endpoints(informed_entities, hd(affected_routes))
@@ -133,8 +133,8 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
            alert: %Alert{effect: :shuttle, cause: cause}
          } = t
        ) do
-    informed_entities = BaseAlert.informed_entities(t)
-    affected_routes = BaseAlert.informed_subway_routes(t)
+    informed_entities = Alert.informed_entities(t)
+    affected_routes = LocalizedAlert.informed_subway_routes(t)
     cause_text = cause |> Alert.get_cause_string() |> String.capitalize()
 
     location_text = get_endpoints(informed_entities, hd(affected_routes))
@@ -170,7 +170,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
   defp serialize_takeover_alert(
          %__MODULE__{alert: %Alert{effect: :station_closure, cause: cause}} = t
        ) do
-    affected_routes = BaseAlert.informed_subway_routes(t)
+    affected_routes = LocalizedAlert.informed_subway_routes(t)
     cause_text = cause |> Alert.get_cause_string() |> String.capitalize()
 
     %{
@@ -192,7 +192,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
            }
          } = t
        ) do
-    affected_routes = BaseAlert.informed_subway_routes(t)
+    affected_routes = LocalizedAlert.informed_subway_routes(t)
     cause_text = Alert.get_cause_string(cause)
 
     %{
@@ -207,7 +207,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
   end
 
   defp serialize_inside_flex_alert(%__MODULE__{alert: %Alert{effect: :shuttle, cause: cause}} = t) do
-    affected_routes = BaseAlert.informed_subway_routes(t)
+    affected_routes = LocalizedAlert.informed_subway_routes(t)
     cause_text = Alert.get_cause_string(cause)
 
     %{
@@ -226,7 +226,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
            alert: %Alert{effect: :station_closure, cause: cause}
          } = t
        ) do
-    affected_routes = BaseAlert.informed_subway_routes(t)
+    affected_routes = LocalizedAlert.informed_subway_routes(t)
     cause_text = Alert.get_cause_string(cause)
 
     line =
@@ -252,7 +252,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
          } = t
        )
        when severity > 3 and severity < 7 do
-    affected_routes = BaseAlert.informed_subway_routes(t)
+    affected_routes = LocalizedAlert.informed_subway_routes(t)
 
     %{
       issue: header,
@@ -271,7 +271,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
          } = t
        )
        when severity >= 7 do
-    affected_routes = BaseAlert.informed_subway_routes(t)
+    affected_routes = LocalizedAlert.informed_subway_routes(t)
     cause_text = Alert.get_cause_string(cause)
     {delay_description, delay_minutes} = Alert.interpret_severity(severity)
     destination = get_destination(t, :inside)
@@ -315,7 +315,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
            alert: %Alert{effect: :suspension, cause: cause, header: header}
          } = t
        ) do
-    affected_routes = BaseAlert.informed_subway_routes(t)
+    affected_routes = LocalizedAlert.informed_subway_routes(t)
 
     if length(affected_routes) > 1 do
       %{
@@ -355,7 +355,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
            alert: %Alert{effect: :shuttle, cause: cause, header: header}
          } = t
        ) do
-    affected_routes = BaseAlert.informed_subway_routes(t)
+    affected_routes = LocalizedAlert.informed_subway_routes(t)
 
     if length(affected_routes) > 1 do
       %{
@@ -398,7 +398,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
          } = t
        )
        when severity > 3 and severity < 7 do
-    affected_routes = BaseAlert.informed_subway_routes(t)
+    affected_routes = LocalizedAlert.informed_subway_routes(t)
 
     %{
       issue: header,
@@ -417,7 +417,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
          } = t
        )
        when severity >= 7 do
-    affected_routes = BaseAlert.informed_subway_routes(t)
+    affected_routes = LocalizedAlert.informed_subway_routes(t)
 
     if length(affected_routes) > 1 do
       %{
@@ -464,9 +464,9 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
   defp serialize_outside_alert(
          %__MODULE__{alert: %Alert{effect: :suspension, cause: cause, header: header}} = t
        ) do
-    informed_entities = BaseAlert.informed_entities(t)
+    informed_entities = Alert.informed_entities(t)
 
-    affected_routes = BaseAlert.informed_subway_routes(t)
+    affected_routes = LocalizedAlert.informed_subway_routes(t)
 
     if length(affected_routes) > 1 do
       %{
@@ -505,9 +505,9 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
   defp serialize_outside_alert(
          %__MODULE__{alert: %Alert{effect: :shuttle, cause: cause, header: header}} = t
        ) do
-    informed_entities = BaseAlert.informed_entities(t)
+    informed_entities = Alert.informed_entities(t)
 
-    affected_routes = BaseAlert.informed_subway_routes(t)
+    affected_routes = LocalizedAlert.informed_subway_routes(t)
 
     if length(affected_routes) > 1 do
       %{
@@ -549,7 +549,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
            informed_stations_string: informed_stations_string
          } = t
        ) do
-    affected_routes = BaseAlert.informed_subway_routes(t)
+    affected_routes = LocalizedAlert.informed_subway_routes(t)
 
     cause_text = Alert.get_cause_string(cause)
 
@@ -565,7 +565,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
   end
 
   defp serialize_outside_alert(%__MODULE__{alert: %Alert{effect: :delay, header: header}} = t) do
-    affected_routes = BaseAlert.informed_subway_routes(t)
+    affected_routes = LocalizedAlert.informed_subway_routes(t)
 
     %{
       issue: header,
@@ -611,7 +611,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
   end
 
   def serialize(%__MODULE__{is_terminal_station: is_terminal_station} = t) do
-    case BaseAlert.location(t, is_terminal_station) do
+    case LocalizedAlert.location(t, is_terminal_station) do
       :inside ->
         t |> serialize_inside_alert() |> Map.put(:region, :inside)
 

--- a/lib/screens/v2/widget_instance/subway_status.ex
+++ b/lib/screens/v2/widget_instance/subway_status.ex
@@ -153,8 +153,8 @@ defmodule Screens.V2.WidgetInstance.SubwayStatus do
     %{full: direction, abbrev: direction}
   end
 
-  # TODO: get_endpoints is a common function
-  # could also be consolidated?
+  # credo:disable-for-next-line
+  # TODO: get_endpoints is a common function; could be consolidated
   defp get_endpoints(informed_entities, route_id) do
     case Stop.get_stop_sequence(informed_entities, route_id) do
       nil ->

--- a/lib/screens/v2/widget_instance/subway_status.ex
+++ b/lib/screens/v2/widget_instance/subway_status.ex
@@ -153,6 +153,8 @@ defmodule Screens.V2.WidgetInstance.SubwayStatus do
     %{full: direction, abbrev: direction}
   end
 
+  # TODO: get_endpoints is a common function
+  # could also be consolidated?
   defp get_endpoints(informed_entities, route_id) do
     case Stop.get_stop_sequence(informed_entities, route_id) do
       nil ->

--- a/test/screens/v2/localized_alert_test.exs
+++ b/test/screens/v2/localized_alert_test.exs
@@ -5,7 +5,7 @@ defmodule Screens.V2.LocalizedAlertTest do
   alias Screens.Config.Screen
   alias Screens.Config.V2.BusShelter
   alias Screens.RouteType
-    alias Screens.V2.LocalizedAlert, as: LocalizedAlert
+  alias Screens.V2.LocalizedAlert, as: LocalizedAlert
   alias Screens.V2.WidgetInstance.Alert, as: AlertWidget
 
   setup :setup_base

--- a/test/screens/v2/localized_alert_test.exs
+++ b/test/screens/v2/localized_alert_test.exs
@@ -1,12 +1,12 @@
-defmodule Screens.V2.WidgetInstance.Common.BaseAlertTest do
+defmodule Screens.V2.LocalizedAlertTest do
   use ExUnit.Case, async: true
 
   alias Screens.Alerts.Alert
   alias Screens.Config.Screen
   alias Screens.Config.V2.BusShelter
   alias Screens.RouteType
+    alias Screens.V2.LocalizedAlert, as: LocalizedAlert
   alias Screens.V2.WidgetInstance.Alert, as: AlertWidget
-  alias Screens.V2.WidgetInstance.Common.BaseAlert, as: BaseAlertWidget
 
   setup :setup_base
 
@@ -106,20 +106,20 @@ defmodule Screens.V2.WidgetInstance.Common.BaseAlertTest do
     test "handles empty informed entities", %{widget: widget} do
       widget = put_informed_entities(widget, [])
 
-      assert :elsewhere == BaseAlertWidget.location(widget)
+      assert :elsewhere == LocalizedAlert.location(widget)
     end
 
     test "handles all-nil informed entities", %{widget: widget} do
       widget = put_informed_entities(widget, [ie()])
 
-      assert :elsewhere == BaseAlertWidget.location(widget)
+      assert :elsewhere == LocalizedAlert.location(widget)
     end
 
     test "returns :elsewhere if an alert's informed entities only apply to routes not serving this stop",
          %{widget: widget} do
       widget = put_informed_entities(widget, [ie(route: "x"), ie(route: "y")])
 
-      assert :elsewhere == BaseAlertWidget.location(widget)
+      assert :elsewhere == LocalizedAlert.location(widget)
     end
 
     test "returns :inside if any of an alert's informed entities is %{route_type: <route type of this screen>}",
@@ -133,7 +133,7 @@ defmodule Screens.V2.WidgetInstance.Common.BaseAlertTest do
           ie()
         ])
 
-      assert :inside == BaseAlertWidget.location(widget)
+      assert :inside == LocalizedAlert.location(widget)
     end
 
     test "ignores route type if paired with any other specifier", %{widget: widget} do
@@ -144,13 +144,13 @@ defmodule Screens.V2.WidgetInstance.Common.BaseAlertTest do
           ie(stop: "1", route: "x", route_type: RouteType.to_id(:bus))
         ])
 
-      assert :upstream == BaseAlertWidget.location(widget)
+      assert :upstream == LocalizedAlert.location(widget)
     end
 
     test "ignores route type if it doesn't match this screen's route type", %{widget: widget} do
       widget = put_informed_entities(widget, [ie(route_type: RouteType.to_id(:light_rail))])
 
-      assert :elsewhere == BaseAlertWidget.location(widget)
+      assert :elsewhere == LocalizedAlert.location(widget)
     end
 
     test "returns :inside if any of an alert's informed entities is %{route: <route that serves this stop>}",
@@ -162,17 +162,17 @@ defmodule Screens.V2.WidgetInstance.Common.BaseAlertTest do
           ie(stop: "20", route: "a")
         ])
 
-      assert :inside == BaseAlertWidget.location(widget)
+      assert :inside == LocalizedAlert.location(widget)
     end
 
     test "treats active and inactive (not running on the current day) routes the same", %{
       widget: widget
     } do
       widget = put_informed_entities(widget, [ie(route: "a")])
-      assert :inside == BaseAlertWidget.location(widget)
+      assert :inside == LocalizedAlert.location(widget)
 
       widget = put_informed_entities(widget, [ie(route: "b")])
-      assert :inside == BaseAlertWidget.location(widget)
+      assert :inside == LocalizedAlert.location(widget)
     end
 
     test "ignores route if it doesn't serve this stop", %{widget: widget} do
@@ -182,7 +182,7 @@ defmodule Screens.V2.WidgetInstance.Common.BaseAlertTest do
           ie(route: "x")
         ])
 
-      assert :upstream == BaseAlertWidget.location(widget)
+      assert :upstream == LocalizedAlert.location(widget)
     end
 
     test "returns :upstream for an alert that only affects upstream stops", %{widget: widget} do
@@ -192,7 +192,7 @@ defmodule Screens.V2.WidgetInstance.Common.BaseAlertTest do
           ie(stop: "20", route: "a")
         ])
 
-      assert :upstream == BaseAlertWidget.location(widget)
+      assert :upstream == LocalizedAlert.location(widget)
     end
 
     test "returns :boundary_upstream for an alert that affects upstream stops and this stop", %{
@@ -205,7 +205,7 @@ defmodule Screens.V2.WidgetInstance.Common.BaseAlertTest do
           ie(stop: "20", route: "a")
         ])
 
-      assert :boundary_upstream == BaseAlertWidget.location(widget)
+      assert :boundary_upstream == LocalizedAlert.location(widget)
     end
 
     test "returns :inside for an alert that only affects this stop", %{widget: widget} do
@@ -216,7 +216,7 @@ defmodule Screens.V2.WidgetInstance.Common.BaseAlertTest do
           ie(stop: "5", route: "a")
         ])
 
-      assert :inside == BaseAlertWidget.location(widget)
+      assert :inside == LocalizedAlert.location(widget)
     end
 
     test "returns :inside for an alert that affects upstream stops, downstream stops, and this stop",
@@ -228,7 +228,7 @@ defmodule Screens.V2.WidgetInstance.Common.BaseAlertTest do
           ie(stop: "6")
         ])
 
-      assert :inside == BaseAlertWidget.location(widget)
+      assert :inside == LocalizedAlert.location(widget)
     end
 
     test "returns :boundary_downstream for an alert that affects downstream stops and this stop",
@@ -242,7 +242,7 @@ defmodule Screens.V2.WidgetInstance.Common.BaseAlertTest do
           ie(stop: "90", route: "a")
         ])
 
-      assert :boundary_downstream == BaseAlertWidget.location(widget)
+      assert :boundary_downstream == LocalizedAlert.location(widget)
     end
 
     test "returns :downstream for an alert that only affects downstream stops", %{widget: widget} do
@@ -252,7 +252,7 @@ defmodule Screens.V2.WidgetInstance.Common.BaseAlertTest do
           ie(stop: "90", route: "a")
         ])
 
-      assert :downstream == BaseAlertWidget.location(widget)
+      assert :downstream == LocalizedAlert.location(widget)
     end
 
     test "returns :downstream for an alert that affects upstream and downstream stops, but not this stop",
@@ -263,7 +263,7 @@ defmodule Screens.V2.WidgetInstance.Common.BaseAlertTest do
           ie(stop: "6")
         ])
 
-      assert :downstream == BaseAlertWidget.location(widget)
+      assert :downstream == LocalizedAlert.location(widget)
     end
   end
 


### PR DESCRIPTION
Replaces https://github.com/mbta/screens/pull/1737. Added fetch_location_context to all alert CGs, refactored WidgetInstances to use that context and interact with BaseAlert. 

I marked some ideas for future work with TODO, which I know breaks credo. My question there is, should that work be done now, or can it wait for the future? If it can wait, I'll have credo ignore the line. (I don't think it's a problem to keep TODOs in code as a reminder for future work, but I still want to keep the credo check so it helps catch TODOs we did NOT want to intentionally leave there.)

Tests are in a separate PR: https://github.com/mbta/screens/pull/1743

Needs:
- [x] testing of Mattapan outages on different screens
- [x] decide which todos we should keep and which should be ditched.
- [x] check on [that bug](https://github.com/mbta/screens/pull/1710#discussion_r1175724871) Jon noticed in the OG PR (@jzimbel-mbta please advise)
