### PR TITLE
Added window property for js capture in iframes.

### DIFF
--- a/assets/src/components/v2/simulation_screen_page.tsx
+++ b/assets/src/components/v2/simulation_screen_page.tsx
@@ -1,8 +1,14 @@
 import React from "react";
 import { useParams } from "react-router-dom";
 import SimulationScreenContainer from "./simulation_screen_container";
+import { getDatasetValue } from "Util/dataset";
 
-const SimulationScreenPage = ({opts = {}}) => {
+const SimulationScreenPage = ({ opts = {} }) => {
+  const environmentName = getDatasetValue("environmentName");
+  if (environmentName !== "screens-prod") {
+    window["_fs_run_in_iframe"] = true;
+  }
+
   const { id } = useParams() as { id: string };
   return <SimulationScreenContainer id={id} opts={opts} />;
 };


### PR DESCRIPTION
**Asana task**: [Configure Fullstory to capture iframes](https://app.asana.com/0/1185117109217413/1204351329872461/f)

Added this to Screenplay, but misread the docs saying it also needs to be in the app showing in the `iframe`. This is only set in prod on simulation pages, so live screens won't have it.

- [ ] Tests added?
