### PR TITLE
Changed track_number to only display for CR.

### DIFF
--- a/lib/screens/v2/widget_instance/serializer/route_pill.ex
+++ b/lib/screens/v2/widget_instance/serializer/route_pill.ex
@@ -65,7 +65,7 @@ defmodule Screens.V2.WidgetInstance.Serializer.RoutePill do
   def serialize_for_departure(route_id, route_name, route_type, track_number) do
     route =
       cond do
-        not is_nil(track_number) ->
+        route_type == :rail and not is_nil(track_number) ->
           %{type: :text, text: "TR#{track_number}"}
 
         route_type == :rail ->


### PR DESCRIPTION
**Asana task**: [Fix track numbers](https://app.asana.com/0/1185117109217413/1204606306810793/f)

This changes the route pill display logic to only show track numbers for commuter rail routes, which fixes an issue where some subway routes were inadvertently showing track numbers.