### PR TITLE
feat: Fullstory initialization

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -4407,6 +4407,19 @@
       "integrity": "sha512-ws57AidsDvREKrZKYffXddNkyaF14iHNHm8VQnZH6t99E8gczjNN0GpvcGny0imC80yQ0tHz1xVUKk/KFQSUyA==",
       "dev": true
     },
+    "@fullstory/browser": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@fullstory/browser/-/browser-1.7.1.tgz",
+      "integrity": "sha512-IBPisG+xRyTHHX8XkZJkQRbP2hVYNMZUYW8R3YiB582dl/VZImkFN+LopIAfPqB97FAZgUTofi7flkrHT4Qmtg==",
+      "requires": {
+        "@fullstory/snippet": "1.3.1"
+      }
+    },
+    "@fullstory/snippet": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@fullstory/snippet/-/snippet-1.3.1.tgz",
+      "integrity": "sha512-NgrBWGHH5i8zejlRFSyJNhovkNqHAXsWKrcXIWaABrgESwbkdGETjOU7BD7d1ZeT0X+QXL/2yr/1y4xnWfVkwQ=="
+    },
     "@gar/promisify": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.2.tgz",

--- a/assets/package.json
+++ b/assets/package.json
@@ -12,6 +12,7 @@
     "check": "npm run lint:check && npm run format:check"
   },
   "dependencies": {
+    "@fullstory/browser": "^1.7.1",
     "core-js": "^3.15.2",
     "lodash": "^4.17.21",
     "moment": "^2.29.1",

--- a/assets/src/apps/solari.tsx
+++ b/assets/src/apps/solari.tsx
@@ -1,6 +1,9 @@
 import initSentry from "Util/sentry";
 initSentry("solari");
 
+import initFullstory from "Util/fullstory";
+initFullstory();
+
 declare function require(name: string): string;
 // tslint:disable-next-line
 require("../../css/solari.scss");
@@ -54,6 +57,6 @@ const handleWatchdogMessage = (ev: MessageEvent) => {
   if (ev.data.type === "watchdog") {
     (ev?.source as Window)?.postMessage(ev.data, "*");
   }
-}
+};
 
 ReactDOM.render(<App />, document.getElementById("app"));

--- a/assets/src/apps/v2/bus_eink.tsx
+++ b/assets/src/apps/v2/bus_eink.tsx
@@ -1,6 +1,9 @@
 import initSentry from "Util/sentry";
 initSentry("bus_eink_v2");
 
+import initFullstory from "Util/fullstory";
+initFullstory();
+
 declare function require(name: string): string;
 // tslint:disable-next-line
 require("../../../css/bus_eink_v2.scss");

--- a/assets/src/apps/v2/bus_shelter.tsx
+++ b/assets/src/apps/v2/bus_shelter.tsx
@@ -1,6 +1,9 @@
 import initSentry from "Util/sentry";
 initSentry("bus_shelter");
 
+import initFullstory from "Util/fullstory";
+initFullstory();
+
 declare function require(name: string): string;
 // tslint:disable-next-line
 require("../../../css/bus_shelter_v2.scss");

--- a/assets/src/apps/v2/dup.tsx
+++ b/assets/src/apps/v2/dup.tsx
@@ -1,6 +1,9 @@
 import initSentry from "Util/sentry";
 initSentry("dup_v2");
 
+import initFullstory from "Util/fullstory";
+initFullstory();
+
 declare function require(name: string): string;
 // tslint:disable-next-line
 require("../../../css/dup_v2.scss");

--- a/assets/src/apps/v2/gl_eink.tsx
+++ b/assets/src/apps/v2/gl_eink.tsx
@@ -1,6 +1,9 @@
 import initSentry from "Util/sentry";
 initSentry("gl_eink_v2");
 
+import initFullstory from "Util/fullstory";
+initFullstory();
+
 declare function require(name: string): string;
 // tslint:disable-next-line
 require("../../../css/gl_eink_v2.scss");

--- a/assets/src/apps/v2/pre_fare.tsx
+++ b/assets/src/apps/v2/pre_fare.tsx
@@ -1,6 +1,9 @@
 import initSentry from "Util/sentry";
 initSentry("pre_fare");
 
+import initFullstory from "Util/fullstory";
+initFullstory();
+
 declare function require(name: string): string;
 // tslint:disable-next-line
 require("../../../css/pre_fare_v2.scss");

--- a/assets/src/components/v2/simulation_screen_page.tsx
+++ b/assets/src/components/v2/simulation_screen_page.tsx
@@ -1,14 +1,8 @@
 import React from "react";
 import { useParams } from "react-router-dom";
 import SimulationScreenContainer from "./simulation_screen_container";
-import { getDatasetValue } from "Util/dataset";
 
 const SimulationScreenPage = ({ opts = {} }) => {
-  const environmentName = getDatasetValue("environmentName");
-  if (environmentName === "screens-prod") {
-    window["_fs_run_in_iframe"] = true;
-  }
-
   const { id } = useParams() as { id: string };
   return <SimulationScreenContainer id={id} opts={opts} />;
 };

--- a/assets/src/util/fullstory.tsx
+++ b/assets/src/util/fullstory.tsx
@@ -7,10 +7,13 @@ import { isRealScreen } from "./util";
  * a real production screen AND the URL does not contain the disable_sentry param.
  */
 const initFullstory = () => {
-  const fullstoryOrgId = getDatasetValue("fullstoryOrgId");
+  const screenplayFullstoryOrgId = getDatasetValue("screenplayFullstoryOrgId");
 
-  if (fullstoryOrgId && !isRealScreen()) {
-    FullStory.init({ orgId: fullstoryOrgId, recordCrossDomainIFrames: true });
+  if (screenplayFullstoryOrgId && !isRealScreen()) {
+    FullStory.init({
+      orgId: screenplayFullstoryOrgId,
+      recordCrossDomainIFrames: true,
+    });
   }
 };
 

--- a/assets/src/util/fullstory.tsx
+++ b/assets/src/util/fullstory.tsx
@@ -3,8 +3,8 @@ import * as FullStory from "@fullstory/browser";
 import { isRealScreen } from "./util";
 
 /**
- * Initializes Sentry if the DSN is defined AND this client is running on
- * a real production screen AND the URL does not contain the disable_sentry param.
+ * Initializes Fullstory if the org ID is defined
+ * AND this client is running on a production screen simulation.
  */
 const initFullstory = () => {
   const screenplayFullstoryOrgId = getDatasetValue("screenplayFullstoryOrgId");

--- a/assets/src/util/fullstory.tsx
+++ b/assets/src/util/fullstory.tsx
@@ -1,0 +1,17 @@
+import { getDatasetValue } from "Util/dataset";
+import * as FullStory from "@fullstory/browser";
+import { isRealScreen } from "./util";
+
+/**
+ * Initializes Sentry if the DSN is defined AND this client is running on
+ * a real production screen AND the URL does not contain the disable_sentry param.
+ */
+const initFullstory = () => {
+  const fullstoryOrgId = getDatasetValue("fullstoryOrgId");
+
+  if (fullstoryOrgId && !isRealScreen()) {
+    FullStory.init({ orgId: fullstoryOrgId, recordCrossDomainIFrames: true });
+  }
+};
+
+export default initFullstory;

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -53,7 +53,7 @@ config :screens,
   environment_name: eb_env_name,
   signs_ui_s3_bucket: signs_ui_s3_bucket,
   sentry_frontend_dsn: System.get_env("SENTRY_DSN"),
-  fullstory_org_id: System.get_env("FULLSTORY_ORG_ID")
+  screenplay_fullstory_org_id: System.get_env("SCREENPLAY_FULLSTORY_ORG_ID")
 
 config :sentry,
   dsn: System.get_env("SENTRY_DSN"),

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -52,7 +52,8 @@ config :screens,
   api_v3_key: api_v3_key,
   environment_name: eb_env_name,
   signs_ui_s3_bucket: signs_ui_s3_bucket,
-  sentry_frontend_dsn: System.get_env("SENTRY_DSN")
+  sentry_frontend_dsn: System.get_env("SENTRY_DSN"),
+  fullstory_org_id: System.get_env("FULLSTORY_ORG_ID")
 
 config :sentry,
   dsn: System.get_env("SENTRY_DSN"),

--- a/lib/screens_web/controllers/v2/screen_controller.ex
+++ b/lib/screens_web/controllers/v2/screen_controller.ex
@@ -108,8 +108,9 @@ defmodule ScreensWeb.V2.ScreenController do
   end
 
   def simulation(conn, params) do
-    conn = assign(conn, :fullstory_org_id, Application.get_env(:screenplay, :fullstory_org_id))
-    index(conn, params)
+    conn
+    |> assign(:fullstory_org_id, Application.get_env(:screenplay, :fullstory_org_id))
+    |> index(params)
   end
 
   defp render_not_found(conn) do

--- a/lib/screens_web/controllers/v2/screen_controller.ex
+++ b/lib/screens_web/controllers/v2/screen_controller.ex
@@ -109,7 +109,10 @@ defmodule ScreensWeb.V2.ScreenController do
 
   def simulation(conn, params) do
     conn
-    |> assign(:fullstory_org_id, Application.get_env(:screenplay, :fullstory_org_id))
+    |> assign(
+      :screenplay_fullstory_org_id,
+      Application.get_env(:screens, :screenplay_fullstory_org_id)
+    )
     |> index(params)
   end
 

--- a/lib/screens_web/controllers/v2/screen_controller.ex
+++ b/lib/screens_web/controllers/v2/screen_controller.ex
@@ -107,6 +107,11 @@ defmodule ScreensWeb.V2.ScreenController do
     render_not_found(conn)
   end
 
+  def simulation(conn, params) do
+    conn = assign(conn, :fullstory_org_id, Application.get_env(:screenplay, :fullstory_org_id))
+    index(conn, params)
+  end
+
   defp render_not_found(conn) do
     conn
     |> assign(:app_id, @default_app_id)

--- a/lib/screens_web/router.ex
+++ b/lib/screens_web/router.ex
@@ -78,7 +78,7 @@ defmodule ScreensWeb.Router do
       pipe_through [:redirect_prod_http, :browser]
 
       get "/:id", ScreenController, :index
-      get "/:id/simulation", ScreenController, :index
+      get "/:id/simulation", ScreenController, :simulation
     end
 
     scope "/api/screen" do

--- a/lib/screens_web/templates/v2/screen/index.html.eex
+++ b/lib/screens_web/templates/v2/screen/index.html.eex
@@ -16,8 +16,8 @@
   <%= if not is_nil(@rotation_index) do %>
     data-rotation-index="<%= @rotation_index %>"
   <% end %>
-  <%= if assigns[:fullstory_org_id] do %>
-    data-fullstory-org-id="<%= assigns[:fullstory_org_id] %>"
+  <%= if assigns[:screenplay_fullstory_org_id] do %>
+    data-screenplay-fullstory-org-id="<%= assigns[:screenplay_fullstory_org_id] %>"
   <% end %>
   data-requestor="<%= @requestor %>"
   data-disable-sentry="<%= @disable_sentry %>"

--- a/lib/screens_web/templates/v2/screen/index.html.eex
+++ b/lib/screens_web/templates/v2/screen/index.html.eex
@@ -16,6 +16,9 @@
   <%= if not is_nil(@rotation_index) do %>
     data-rotation-index="<%= @rotation_index %>"
   <% end %>
+  <%= if assigns[:fullstory_org_id] do %>
+    data-fullstory-org-id="<%= assigns[:fullstory_org_id] %>"
+  <% end %>
   data-requestor="<%= @requestor %>"
   data-disable-sentry="<%= @disable_sentry %>"
 ></div>


### PR DESCRIPTION
**Asana task**: [Configure Fullstory to capture iframes](https://app.asana.com/0/1185117109217413/1204351329872461/f)

I believe I misunderstood the docs. Fullstory needs to be initialized in the iframe source domain with the new window attribute. The attribute doesn't do anything on it's own. In order to make sure it is not initialized on live screens, I only add the org ID to `conn.assigns` from the `simulation` endpoint and prevent the frontend from attempting the init on real screens. 

This [PR](https://github.com/mbta/devops/pull/951) must be merged before this one.

- [ ] Tests added?
