### PR TITLE
tweak: E-Ink Subway Status backend

### DIFF
--- a/test/screens/v2/widget_instance/subway_status_test.exs
+++ b/test/screens/v2/widget_instance/subway_status_test.exs
@@ -1104,6 +1104,94 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
       assert expected == WidgetInstance.serialize(instance)
     end
 
+    test "handles 2 alerts on GL branches and 2 alerts on non-GL route on e-Ink" do
+      instance = %SubwayStatus{
+        screen: struct(Screen, app_id: :bus_eink_v2),
+        subway_alerts: [
+          %Alert{
+            effect: :delay,
+            severity: 9,
+            informed_entities: [
+              %{route: "Green-C", stop: nil}
+            ]
+          },
+          %Alert{
+            effect: :delay,
+            severity: 5,
+            informed_entities: [
+              %{route: "Green-B", stop: nil, direction_id: 0}
+            ]
+          },
+          %Alert{
+            effect: :station_closure,
+            informed_entities: [
+              %{route: "Orange", stop: "place-ogmnl"}
+            ]
+          },
+          %Alert{
+            effect: :delay,
+            severity: 5,
+            informed_entities: [
+              %{route: "Orange", stop: nil}
+            ]
+          }
+        ]
+      }
+
+      expected = %{
+        blue: %{
+          type: :contracted,
+          alerts: [
+            %{
+              route_pill: %{type: :text, text: "BL", color: :blue},
+              status: "Normal Service"
+            }
+          ]
+        },
+        orange: %{
+          type: :contracted,
+          alerts: [
+            %{
+              location: %{abbrev: "Oak Grove", full: "Oak Grove"},
+              route_pill: %{color: :orange, text: "OL", type: :text},
+              status: "Bypassing"
+            },
+            %{
+              location: nil,
+              route_pill: %{color: :orange, text: "OL", type: :text},
+              status: "Delays up to 20 minutes"
+            }
+          ]
+        },
+        red: %{
+          type: :contracted,
+          alerts: [
+            %{
+              route_pill: %{type: :text, text: "RL", color: :red},
+              status: "Normal Service"
+            }
+          ]
+        },
+        green: %{
+          type: :contracted,
+          alerts: [
+            %{
+              route_pill: %{type: :text, text: "GL", color: :green, branches: [:b]},
+              status: "Delays up to 20 minutes",
+              location: %{abbrev: "Westbound", full: "Westbound"}
+            },
+            %{
+              route_pill: %{type: :text, text: "GL", color: :green, branches: [:c]},
+              status: "Delays over 60 minutes",
+              location: nil
+            }
+          ]
+        }
+      }
+
+      assert expected == WidgetInstance.serialize(instance)
+    end
+
     test "uses 'Entire line' location text for whole-line shuttles" do
       instance = %SubwayStatus{
         subway_alerts: [


### PR DESCRIPTION
**Asana task**: ad-hoc

E-Ink data needs to be a tad different than LCD. Each route is able to show up to two alerts at all times. Any time an `:extended` alert would be shown, we show a header instead. This means we need to only condense alerts for a route if there are 3+ alerts instead of 2+ alerts. 

- [x] Tests added?
