### PR TITLE
fix: Update typing for SingleAlertWidget.routes_at_stop

### DIFF
--- a/lib/screens/v2/single_alert_widget.ex
+++ b/lib/screens/v2/single_alert_widget.ex
@@ -10,6 +10,7 @@ defprotocol Screens.V2.SingleAlertWidget do
 
   alias Screens.Alerts.Alert
   alias Screens.Config.Screen
+  alias Screens.RouteType
 
   @type alert_id :: String.t()
   @type stop_id :: String.t()
@@ -38,7 +39,8 @@ defprotocol Screens.V2.SingleAlertWidget do
   @doc """
   Gets the list of routes that serve this widget's home stop.
   """
-  @spec routes_at_stop(t()) :: list(%{route_id: route_id(), active?: boolean()})
+  @spec routes_at_stop(t()) ::
+          list(%{route_id: route_id(), active?: boolean(), type: RouteType.t()})
   def routes_at_stop(widget)
 
   @doc """


### PR DESCRIPTION
**Asana task**: ad hoc

The typing for `routes_at_stop` had it returning lists of `%{route_id:, active?:}`, but we actually have more keys in the list's maps, including `type`. This means the seeming error at [this line](https://github.com/mbta/screens/blob/master/lib/screens/v2/widget_instance/common/base_alert.ex#L114) was only due to inaccurate typing.

- [ ] Tests added?
