### PR TITLE
polish: GL Trunk Endpoint Logic

### DIFF
--- a/lib/screens/stops/stop.ex
+++ b/lib/screens/stops/stop.ex
@@ -237,6 +237,8 @@ defmodule Screens.Stops.Stop do
     "Green" => [@green_line_trunk_stops]
   }
 
+  @green_line_branches ["Green-B", "Green-C", "Green-D", "Green-E"]
+
   # --- These functions involve the API ---
 
   def fetch_parent_station_name_map(get_json_fn \\ &V3Api.get_json/2) do
@@ -384,6 +386,12 @@ defmodule Screens.Stops.Stop do
   @doc """
   Finds a stop sequence which contains all stations in informed_entities.
   """
+  def get_stop_sequence(informed_entities, "Green") do
+    Enum.find_value(@green_line_branches, fn branch ->
+      get_stop_sequence(informed_entities, branch)
+    end)
+  end
+
   def get_stop_sequence(informed_entities, route_id) do
     stop_sequences = Map.get(@route_stop_sequences, route_id)
     Enum.find(stop_sequences, &sequence_match?(&1, informed_entities))

--- a/test/screens/v2/widget_instance/subway_status_test.exs
+++ b/test/screens/v2/widget_instance/subway_status_test.exs
@@ -1371,6 +1371,53 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
 
       assert expected == WidgetInstance.serialize(instance)
     end
+
+    test "finds correct endpoints if shuttle starts on trunk" do
+      instance = %SubwayStatus{
+        subway_alerts: [
+          %Alert{
+            effect: :shuttle,
+            informed_entities: [
+              %{direction_id: nil, route: "Green-C", route_type: 0, stop: "place-kencl"},
+              %{direction_id: nil, route: "Green-C", route_type: 0, stop: "place-smary"},
+              %{direction_id: nil, route: "Green-C", route_type: 0, stop: "place-hwsst"},
+              %{direction_id: nil, route: "Green-C", route_type: 0, stop: "place-kntst"}
+            ]
+          }
+        ]
+      }
+
+      expected = %{
+        blue: %{
+          alerts: [
+            %{route_pill: %{color: :blue, text: "BL", type: :text}, status: "Normal Service"}
+          ],
+          type: :contracted
+        },
+        green: %{
+          type: :extended,
+          alert: %{
+            location: %{abbrev: "Kenmore to Kent St", full: "Kenmore to Kent Street"},
+            route_pill: %{color: :green, text: "GL", type: :text},
+            status: "Shuttle Bus"
+          }
+        },
+        orange: %{
+          alerts: [
+            %{route_pill: %{color: :orange, text: "OL", type: :text}, status: "Normal Service"}
+          ],
+          type: :contracted
+        },
+        red: %{
+          alerts: [
+            %{route_pill: %{color: :red, text: "RL", type: :text}, status: "Normal Service"}
+          ],
+          type: :contracted
+        }
+      }
+
+      assert expected == WidgetInstance.serialize(instance)
+    end
   end
 
   describe "slot_names/1" do


### PR DESCRIPTION
**Notion task**: [Shuttle / extended / part of route](https://www.notion.so/mbta-downtown-crossing/Shuttle-extended-part-of-route-ba411313c5ce4f719f77b4f0d2a8b825?pvs=4)

When a branch alert starts on the trunk, the endpoint logic had a hard time figuring out what branch to look up for stop sequences. I added a `Green` function that just goes through each branch until it finds the correct range of stop sequences. 

- [ ] Tests added?
