### PR TITLE
polish: Omit informational delays

### DIFF
--- a/lib/screens/v2/candidate_generator/widgets/subway_status.ex
+++ b/lib/screens/v2/candidate_generator/widgets/subway_status.ex
@@ -21,6 +21,10 @@ defmodule Screens.V2.CandidateGenerator.Widgets.SubwayStatus do
     relevant_effect?(alert) and Alert.happening_now?(alert, now)
   end
 
+  # Omit up to 10 minute delays.
+  defp relevant_effect?(%Alert{effect: :delay, severity: severity}) when severity > 3,
+    do: true
+
   defp relevant_effect?(%Alert{effect: effect}),
-    do: effect in [:suspension, :shuttle, :delay, :station_closure]
+    do: effect in [:suspension, :shuttle, :station_closure]
 end


### PR DESCRIPTION
**Notion task**: [Omit informational delays](https://www.notion.so/mbta-downtown-crossing/Omit-informational-delays-eb8be2aaf68d483bb41788bfaf382160?pvs=4)

Delays <= 10 minutes are now filtered out.

- [ ] Tests added?
