### PR TITLE
fix: DUP V2 rotation_index logging

### DIFF
--- a/assets/src/hooks/v2/use_api_response.tsx
+++ b/assets/src/hooks/v2/use_api_response.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useState } from "react";
 import { getDataset, getDatasetValue } from "Util/dataset";
 import { getScreenSide, isDup, isRealScreen } from "Util/util";
 import * as SentryLogger from "Util/sentry";
+import { ROTATION_INDEX } from "Components/v2/dup/rotation_index";
 
 const MINUTE_IN_MS = 60_000;
 
@@ -163,7 +164,7 @@ const useBaseApiResponse = ({
   let apiPath = `/v2/api/screen/${id}${routePart}?last_refresh=${lastRefresh}${isRealScreenParam}${screenSideParam}${requestorParam}`;
 
   if (isDup()) {
-    apiPath = "https://screens.mbta.com" + apiPath;
+    apiPath = `https://screens.mbta.com${apiPath}&rotation_index=${ROTATION_INDEX}`;
   }
 
   if (screenIdsWithOffsetMap) {

--- a/lib/screens_web/controllers/v2/screen_api_controller.ex
+++ b/lib/screens_web/controllers/v2/screen_api_controller.ex
@@ -21,13 +21,15 @@ defmodule ScreensWeb.V2.ScreenApiController do
   def show(conn, %{"id" => screen_id, "last_refresh" => last_refresh} = params) do
     is_screen = ScreensWeb.UserAgent.is_screen_conn?(conn, screen_id)
     screen_side = params["screen_side"]
+    rotation_index = params["rotation_index"]
 
     Screens.LogScreenData.log_data_request(
       screen_id,
       last_refresh,
       is_screen,
       params["requestor"],
-      screen_side
+      screen_side,
+      rotation_index
     )
 
     cond do


### PR DESCRIPTION
**Asana task**: [[DUP v2] Log page numbers](https://app.asana.com/0/1185117109217413/1204606315677357/f)

In the v2 migration, we accidentally removed `page_number` from DUP logs. This PR adds it back.

- [ ] Tests added?
