### PR TITLE
fix: Prevent Error Boundary on packaged DUPs

### DIFF
--- a/assets/src/components/v2/screen_container.tsx
+++ b/assets/src/components/v2/screen_container.tsx
@@ -4,6 +4,7 @@ import React, {
   ComponentType,
   useState,
   useEffect,
+  Fragment,
 } from "react";
 import useApiResponse, {
   ApiResponse,
@@ -92,12 +93,13 @@ const ScreenLayout: ComponentType<ScreenLayoutProps> = ({
   showBlink,
 }) => {
   const responseMapper = useContext(ResponseMapperContext);
+  const ErrorBoundaryOrFragment = isDup() ? Fragment : WidgetTreeErrorBoundary;
 
   return (
     <div className="screen-container">
-      <WidgetTreeErrorBoundary>
+      <ErrorBoundaryOrFragment>
         {apiResponse && <Widget data={responseMapper(apiResponse)} />}
-      </WidgetTreeErrorBoundary>
+      </ErrorBoundaryOrFragment>
       {showBlink && <div className="screen-container-blink" />}
     </div>
   );


### PR DESCRIPTION
**Asana task**: ad-hoc

While working on another task, I noticed that the new error boundary does not play nicely with packaged DUPs. Because Outfront is constantly reloading these pages, I think it's ok to just remove it from DUPs. Open to alternatives though.

- [ ] Tests added?
