### PR TITLE
tweak: v2 DUP screen IDs

### DIFF
--- a/assets/src/apps/v2/dup.tsx
+++ b/assets/src/apps/v2/dup.tsx
@@ -37,7 +37,7 @@ import {
 import PageLoadNoData from "Components/v2/dup/page_load_no_data";
 import NoData from "Components/v2/dup/no_data";
 import OvernightDepartures from "Components/v2/dup/overnight_departures";
-import useOutfrontStation from "Hooks/use_outfront_station";
+import useOutfrontPlayerName from "Hooks/use_outfront_player_name";
 
 const TYPE_TO_COMPONENT = {
   screen_normal: NormalScreen,
@@ -122,10 +122,10 @@ const responseMapper: ResponseMapper = (apiResponse) => {
 };
 
 const App = (): JSX.Element => {
-  const station = useOutfrontStation();
+  const playerName = useOutfrontPlayerName();
 
-  if (station !== null) {
-    const id = `DUP-${station.replace(/\s/g, "")}-V2`;
+  if (playerName !== null) {
+    const id = `DUP-${playerName.trim()}`;
     return (
       <MappingContext.Provider value={TYPE_TO_COMPONENT}>
         <ResponseMapperContext.Provider value={responseMapper}>

--- a/assets/src/components/v2/dup/normal_header.tsx
+++ b/assets/src/components/v2/dup/normal_header.tsx
@@ -21,11 +21,11 @@ const NormalHeader = ({
 }: NormalHeaderProps) => {
   const playerName = useOutfrontPlayerName();
   let version = DUP_VERSION;
-  if (code) {
-    version = `${version}; Maintenance code: ${code}`;
-  }
   if (playerName) {
     version = `${version}-${playerName}`;
+  }
+  if (code) {
+    version = `${version}; Maintenance code: ${code}`;
   }
 
   return (

--- a/assets/src/components/v2/dup/normal_header.tsx
+++ b/assets/src/components/v2/dup/normal_header.tsx
@@ -2,6 +2,7 @@ import React from "react";
 
 import DefaultNormalHeader, { Icon } from "Components/v2/normal_header";
 import { DUP_VERSION } from "Components/v2/dup/version";
+import useOutfrontPlayerName from "Hooks/use_outfront_player_name";
 
 interface NormalHeaderProps {
   text: string;
@@ -18,9 +19,11 @@ const NormalHeader = ({
   accentPattern,
   code,
 }: NormalHeaderProps) => {
+  const playerName = useOutfrontPlayerName();
+
   return (
     <DefaultNormalHeader
-      icon={color === 'yellow' ? Icon.logo_negative : Icon.logo}
+      icon={color === "yellow" ? Icon.logo_negative : Icon.logo}
       text={text}
       time={time}
       // Currently, we don't use different codes that populating this would be useful...
@@ -30,6 +33,7 @@ const NormalHeader = ({
       showTo={false}
       classModifiers={color}
       accentPattern={accentPattern}
+      playerName={playerName}
     />
   );
 };

--- a/assets/src/components/v2/dup/normal_header.tsx
+++ b/assets/src/components/v2/dup/normal_header.tsx
@@ -20,6 +20,13 @@ const NormalHeader = ({
   code,
 }: NormalHeaderProps) => {
   const playerName = useOutfrontPlayerName();
+  let version = DUP_VERSION;
+  if (code) {
+    version = `${version}; Maintenance code: ${code}`;
+  }
+  if (playerName) {
+    version = `${version}-${playerName}`;
+  }
 
   return (
     <DefaultNormalHeader
@@ -28,12 +35,11 @@ const NormalHeader = ({
       time={time}
       // Currently, we don't use different codes that populating this would be useful...
       // But this was a feature available in v1, so just set it up here.
-      version={DUP_VERSION + (code ? "; Maintenance code: " + code : "")}
+      version={version}
       maxHeight={208}
       showTo={false}
       classModifiers={color}
       accentPattern={accentPattern}
-      playerName={playerName}
     />
   );
 };

--- a/assets/src/components/v2/normal_header.tsx
+++ b/assets/src/components/v2/normal_header.tsx
@@ -123,15 +123,12 @@ const NormalHeaderUpdated = () => {
 
 interface NormalHeaderVersionProps {
   version: string;
-  playerName?: string;
 }
 
 const NormalHeaderVersion: ComponentType<NormalHeaderVersionProps> = ({
   version,
-  playerName,
 }) => {
-  const text = version + (playerName ? `-${playerName}` : "");
-  return <div className="normal-header-version">{text}</div>;
+  return <div className="normal-header-version">{version}</div>;
 };
 
 const NormalHeaderAccent = ({
@@ -158,7 +155,6 @@ interface Props {
   fullName?: boolean;
   classModifiers?: string;
   accentPattern?: string;
-  playerName?: string;
 }
 
 const NormalHeader: ComponentType<Props> = ({
@@ -172,7 +168,6 @@ const NormalHeader: ComponentType<Props> = ({
   fullName = false,
   classModifiers,
   accentPattern,
-  playerName,
 }) => {
   const { ref: headerRef, size: headerSize } = useTextResizer({
     sizes: Object.keys(TitleSize),
@@ -190,9 +185,7 @@ const NormalHeader: ComponentType<Props> = ({
         fullName={fullName}
       />
       {time && <NormalHeaderTime time={time} />}
-      {version && (
-        <NormalHeaderVersion version={version} playerName={playerName} />
-      )}
+      {version && <NormalHeaderVersion version={version} />}
       {showUpdated && <NormalHeaderUpdated />}
       {accentPattern && (
         <NormalHeaderAccent accentPatternFile={accentPattern} />

--- a/assets/src/components/v2/normal_header.tsx
+++ b/assets/src/components/v2/normal_header.tsx
@@ -15,7 +15,7 @@ enum Icon {
   green_d = "green_d",
   green_e = "green_e",
   logo = "logo",
-  logo_negative = "logo_negative"
+  logo_negative = "logo_negative",
 }
 
 enum TitleSize {
@@ -29,7 +29,7 @@ const ICON_TO_SRC: Record<Icon, string> = {
   green_d: "GL-D.svg",
   green_e: "GL-E.svg",
   logo: "logo-white.svg",
-  logo_negative: "logo-black.svg"
+  logo_negative: "logo-black.svg",
 };
 
 const abbreviateText = (text: string) => {
@@ -123,12 +123,15 @@ const NormalHeaderUpdated = () => {
 
 interface NormalHeaderVersionProps {
   version: string;
+  playerName?: string;
 }
 
 const NormalHeaderVersion: ComponentType<NormalHeaderVersionProps> = ({
   version,
+  playerName,
 }) => {
-  return <div className="normal-header-version">{version}</div>;
+  const text = version + (playerName ? `-${playerName}` : "");
+  return <div className="normal-header-version">{text}</div>;
 };
 
 const NormalHeaderAccent = ({
@@ -155,6 +158,7 @@ interface Props {
   fullName?: boolean;
   classModifiers?: string;
   accentPattern?: string;
+  playerName?: string;
 }
 
 const NormalHeader: ComponentType<Props> = ({
@@ -168,6 +172,7 @@ const NormalHeader: ComponentType<Props> = ({
   fullName = false,
   classModifiers,
   accentPattern,
+  playerName,
 }) => {
   const { ref: headerRef, size: headerSize } = useTextResizer({
     sizes: Object.keys(TitleSize),
@@ -185,7 +190,9 @@ const NormalHeader: ComponentType<Props> = ({
         fullName={fullName}
       />
       {time && <NormalHeaderTime time={time} />}
-      {version && <NormalHeaderVersion version={version} />}
+      {version && (
+        <NormalHeaderVersion version={version} playerName={playerName} />
+      )}
       {showUpdated && <NormalHeaderUpdated />}
       {accentPattern && (
         <NormalHeaderAccent accentPatternFile={accentPattern} />

--- a/assets/src/hooks/use_outfront_player_name.tsx
+++ b/assets/src/hooks/use_outfront_player_name.tsx
@@ -1,0 +1,39 @@
+import { useEffect, useState } from "react";
+
+const useOutfrontTags = () => {
+  const [tags, setTags] = useState(null);
+
+  let mraid;
+
+  try {
+    mraid = parent?.parent?.mraid;
+  } catch (_) {}
+
+  if (mraid) {
+    useEffect(() => {
+      if (parent?.parent?.mraid ?? false) {
+        try {
+          const rawTags = parent.parent.mraid.getTags();
+          setTags(JSON.parse(rawTags).tags);
+        } catch (err) {
+          setTags(null);
+        }
+      }
+    }, [parent?.parent?.mraid]);
+  }
+
+  return tags;
+};
+
+const useOutfrontPlayerName = () => {
+  const tags = useOutfrontTags();
+  if (tags !== null) {
+    const playerName =
+      tags.find(({ name }) => name === "player_name")?.value?.[0] ?? null;
+    return playerName;
+  } else {
+    return null;
+  }
+};
+
+export default useOutfrontPlayerName;


### PR DESCRIPTION
**Asana task**: [Modify DUP app to use unique screen IDs](https://app.asana.com/0/1185117109217413/1204742012101948/f)

Decided to keep the old hook just so I didn't have to worry about v1 for now. None of those are live anyway. When we tear down the v1 app, we can remove the hook then.

I also created a script for replacing the v2 DUP screens in the config. Would that be useful to check in? I don't foresee needing it again after the first time we use it.

- [ ] Tests added?
