### PR TITLE
LCD subway status text-fitting fixes

### DIFF
--- a/assets/css/v2/lcd_common_styles/subway_status.scss
+++ b/assets/css/v2/lcd_common_styles/subway_status.scss
@@ -101,6 +101,14 @@
     }
   }
 
+  // Prevents text-container from wrapping to a second line below the pill
+  // if it's too long.
+  .subway-status_alert-sizer--hide-overflow {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: clip;
+  }
+
   .subway-status_alert_route-pill-container {
     display: inline-block;
     // If the row has no pill, we still keep this element as a pill-sized
@@ -121,6 +129,8 @@
     height: $pill-height;
   }
 
+  // Prevents location text from wrapping to a second line below the status
+  // if it's too long.
   .subway-status_alert_text-container.subway-status_alert_text-container--hide-overflow {
     overflow: hidden;
     white-space: nowrap;

--- a/assets/css/v2/lcd_common_styles/subway_status.scss
+++ b/assets/css/v2/lcd_common_styles/subway_status.scss
@@ -138,6 +138,7 @@
     // extended-specific styles for status text
     display: block;
     height: 68px;
+    margin-bottom: 4px;
   }
 
   span.subway-status_alert_status-text.subway-status_alert_status-text--normal-service {
@@ -160,9 +161,6 @@
 
   .subway-status_status--extended span.subway-status_alert_location-text {
     // extended-specific styles for location text
-    display: block;
-    margin-top: 4px;
-    height: 48px;
     line-height: 48px;
   }
 

--- a/assets/src/components/v2/subway_status/eink_subway_status.tsx
+++ b/assets/src/components/v2/subway_status/eink_subway_status.tsx
@@ -17,6 +17,7 @@ import {
   isExtended,
   isGLMultiPill,
   useSubwayStatusTextResizer,
+  FittingStep,
 } from "./subway_status_common";
 
 ////////////////
@@ -97,6 +98,7 @@ interface AlertRowProps extends Alert {
 }
 
 const ALERTS_URL = "mbta.com/alerts";
+const ALERT_FITTING_STEPS = [FittingStep.PerAlertEffect, FittingStep.Abbrev, FittingStep.FullSize];
 
 const AlertRow: ComponentType<AlertRowProps> = ({
   route_pill: routePill,
@@ -109,7 +111,7 @@ const AlertRow: ComponentType<AlertRowProps> = ({
   // row height is a little taller when there is an inline GL branch pill
   const rowHeight = showInlineBranches ? 70 : 60;
   const { ref, abbrev, truncateStatus, replaceLocationWithUrl } =
-    useSubwayStatusTextResizer(rowHeight, id, status);
+    useSubwayStatusTextResizer(rowHeight, ALERT_FITTING_STEPS, id, status);
 
   let locationText: string | null;
   if (replaceLocationWithUrl) {

--- a/assets/src/components/v2/subway_status/lcd_subway_status.tsx
+++ b/assets/src/components/v2/subway_status/lcd_subway_status.tsx
@@ -112,9 +112,9 @@ interface AlertWithID extends Alert {
  * When the text wraps to a second line it's more than that, which is all we care about to detect overflows.
  */
 const CONTRACTED_ALERT_MAX_HEIGHT = 80;
-const CONTRACTED_ALERT_FITTING_STEPS = [FittingStep.PerAlertEffect, FittingStep.Abbrev, FittingStep.FullSize];
-
 const EXTENDED_ALERT_MAX_HEIGHT = 120;
+
+const CONTRACTED_ALERT_FITTING_STEPS = [FittingStep.PerAlertEffect, FittingStep.Abbrev, FittingStep.FullSize];
 const EXTENDED_ALERT_FITTING_STEPS = [FittingStep.Abbrev, FittingStep.FullSize];
 
 const ALERTS_URL = "mbta.com/alerts";

--- a/assets/src/components/v2/subway_status/lcd_subway_status.tsx
+++ b/assets/src/components/v2/subway_status/lcd_subway_status.tsx
@@ -23,6 +23,7 @@ import {
   isExtended,
   isGLMultiPill,
   useSubwayStatusTextResizer,
+  FittingStep,
 } from "./subway_status_common";
 
 ////////////////
@@ -94,7 +95,7 @@ const ExtendedStatus: ComponentType<ExtendedStatusProps> = ({
 }) => {
   return (
     <div className={classWithModifier("subway-status_status", "extended")}>
-      <ExtendedAlert {...alert} />
+      <ExtendedAlert {...alert} id={getAlertID(alert, "extended")} />
       {showRule && <div className="subway-status_status_rule" />}
     </div>
   );
@@ -105,19 +106,16 @@ interface AlertWithID extends Alert {
   id: string;
 }
 
-// Ordered from "smallest" to "largest"
-enum FittingStep {
-  PerAlertEffect,
-  Abbrev,
-  FullSize,
-}
-
 /**
- * Max pixel height of a ContractedAlert's "subway-status_alert-sizer" div element when content doesn't wrap.
+ * Max pixel height of each alert type's "subway-status_alert-sizer" div element when content doesn't wrap.
  *
  * When the text wraps to a second line it's more than that, which is all we care about to detect overflows.
  */
 const CONTRACTED_ALERT_MAX_HEIGHT = 80;
+const CONTRACTED_ALERT_FITTING_STEPS = [FittingStep.PerAlertEffect, FittingStep.Abbrev, FittingStep.FullSize];
+
+const EXTENDED_ALERT_MAX_HEIGHT = 120;
+const EXTENDED_ALERT_FITTING_STEPS = [FittingStep.Abbrev, FittingStep.FullSize];
 
 const ALERTS_URL = "mbta.com/alerts";
 
@@ -128,8 +126,8 @@ const ContractedAlert: ComponentType<AlertWithID> = ({
   station_count: stationCount,
   id,
 }) => {
-  const { ref, abbrev, truncateStatus, replaceLocationWithUrl, fittingStep } =
-    useSubwayStatusTextResizer(CONTRACTED_ALERT_MAX_HEIGHT, id, status);
+  const { ref, abbrev, truncateStatus, replaceLocationWithUrl, isDone } =
+    useSubwayStatusTextResizer(CONTRACTED_ALERT_MAX_HEIGHT, CONTRACTED_ALERT_FITTING_STEPS, id, status);
 
   let locationText: string | null;
   if (replaceLocationWithUrl) {
@@ -146,29 +144,29 @@ const ContractedAlert: ComponentType<AlertWithID> = ({
       effect === "Bypassing" ? `Bypassing ${stationCount} stops` : effect;
   }
 
-  // If we're on the last attempt to fit text in the row and it still overflows,
-  // we prevent it from wrapping or pushing other content out of place.
-  const hideOverflow = fittingStep === FittingStep.PerAlertEffect;
-
   return (
     <BasicAlert
       routePill={routePill}
       status={status}
       location={locationText}
-      hideOverflow={hideOverflow}
+      hideOverflow={isDone}
       ref={ref}
     />
   );
 };
 
-const ExtendedAlert: ComponentType<Alert> = ({
+const ExtendedAlert: ComponentType<AlertWithID> = ({
   route_pill: routePill,
   status,
   location,
+  id,
 }) => {
+  const { ref, abbrev, isDone } =
+    useSubwayStatusTextResizer(EXTENDED_ALERT_MAX_HEIGHT, EXTENDED_ALERT_FITTING_STEPS, id, status);
+
   let locationText: string | null;
   if (isAlertLocationMap(location)) {
-    locationText = location.full;
+    locationText = abbrev ? location.abbrev : location.full;
   } else {
     locationText = location;
   }
@@ -178,7 +176,8 @@ const ExtendedAlert: ComponentType<Alert> = ({
       routePill={routePill}
       status={status}
       location={locationText}
-      hideOverflow
+      hideOverflow={isDone}
+      ref={ref}
     />
   );
 };

--- a/assets/src/components/v2/subway_status/lcd_subway_status.tsx
+++ b/assets/src/components/v2/subway_status/lcd_subway_status.tsx
@@ -198,6 +198,11 @@ const BasicAlert = forwardRef<HTMLDivElement, BasicAlertProps>(
       routePill ? "has-pill" : "no-pill"
     );
 
+    let sizerClassName = "subway-status_alert-sizer";
+    if (hideOverflow) {
+      sizerClassName = classWithModifier(sizerClassName, "hide-overflow");
+    }
+
     let textContainerClassName = "subway-status_alert_text-container";
     if (hideOverflow) {
       textContainerClassName = classWithModifier(
@@ -216,7 +221,7 @@ const BasicAlert = forwardRef<HTMLDivElement, BasicAlertProps>(
 
     return (
       <div className={containerClassName}>
-        <div className="subway-status_alert-sizer" ref={ref}>
+        <div className={sizerClassName} ref={ref}>
           <div className="subway-status_alert_route-pill-container">
             {routePill && <SubwayStatusRoutePill routePill={routePill} />}
           </div>

--- a/assets/src/components/v2/subway_status/subway_status_common.tsx
+++ b/assets/src/components/v2/subway_status/subway_status_common.tsx
@@ -145,8 +145,8 @@ enum FittingStep {
   FullSize,
 }
 
-export const useSubwayStatusTextResizer = (rowHeight, id, status) => {
-  const { ref, size: fittingStep } = useTextResizer({
+export const useSubwayStatusTextResizer = (rowHeight: number, id: string, status: string) => {
+  const { ref, size: fittingStep, isDone } = useTextResizer({
     sizes: [
       FittingStep.PerAlertEffect,
       FittingStep.Abbrev,
@@ -182,5 +182,5 @@ export const useSubwayStatusTextResizer = (rowHeight, id, status) => {
       }
   }
 
-  return { ref, abbrev, truncateStatus, replaceLocationWithUrl, fittingStep };
+  return { ref, abbrev, truncateStatus, replaceLocationWithUrl, fittingStep, isDone };
 };

--- a/assets/src/components/v2/subway_status/subway_status_common.tsx
+++ b/assets/src/components/v2/subway_status/subway_status_common.tsx
@@ -120,15 +120,13 @@ const clearLocationForAllGLBranchesAlert = (
 export const getAlertID = (
   alert: Alert,
   statusType: Section["type"],
-  index: number
+  index: number = 0
 ): string => {
   const location = isAlertLocationMap(alert.location)
     ? `${alert.location.abbrev}-${alert.location.full}`
     : alert.location;
 
-  const routePill = `${alert?.route_pill?.color ?? ""}-${
-    alert?.route_pill?.branches?.join("") ?? ""
-  }`;
+  const routePill = `${alert?.route_pill?.color ?? ""}-${alert?.route_pill?.branches?.join("") ?? ""}`;
 
   return `${statusType}-${index}-${location}-${routePill}`;
 };
@@ -139,19 +137,15 @@ export const isContractedWith1Alert = (
   isContracted(section) && section.alerts.length === 1;
 
 // Ordered from "smallest" to "largest"
-enum FittingStep {
-  PerAlertEffect,
-  Abbrev,
-  FullSize,
+export enum FittingStep {
+  PerAlertEffect = "PerAlertEffect",
+  Abbrev = "Abbrev",
+  FullSize = "FullSize",
 }
 
-export const useSubwayStatusTextResizer = (rowHeight: number, id: string, status: string) => {
+export const useSubwayStatusTextResizer = (rowHeight: number, steps: FittingStep[], id: string, status: string) => {
   const { ref, size: fittingStep, isDone } = useTextResizer({
-    sizes: [
-      FittingStep.PerAlertEffect,
-      FittingStep.Abbrev,
-      FittingStep.FullSize,
-    ],
+    sizes: steps,
     maxHeight: rowHeight,
     resetDependencies: [id],
   });

--- a/lib/screens/v2/widget_instance/subway_status.ex
+++ b/lib/screens/v2/widget_instance/subway_status.ex
@@ -33,6 +33,7 @@ defmodule Screens.V2.WidgetInstance.SubwayStatus do
 
   @type alert :: %{
           optional(:route_pill) => route_pill(),
+          optional(:station_count) => integer(),
           status: String.t(),
           location: String.t() | location_map() | nil
         }


### PR DESCRIPTION
**QA task**: [Station closure / extended / three stops](https://www.notion.so/mbta-downtown-crossing/Station-closure-extended-three-stops-4c21e366f22a45ed99b52c867d392cda?pvs=4)

This fixes a few remaining issues with automatic text-fitting on the new subway status widget:
- (After fixing a subtle bug with it) Use the `isDone` value returned by `useTextResizer` / `useSubwayStatusTextResizer` to set overflow-hiding styles appropriately, instead of trying to infer when the resizing is done.
- Add text-fitting to extended alert location text, because we need it in certain very rare scenarios.
- (Not flagged in QA, but a known bug) In contracted alerts, prevent the status+location from wrapping below the pill icon in cases where the text is still too long after all resizing attempts.

[Delays / extended / whole route](https://www.notion.so/mbta-downtown-crossing/Delays-extended-whole-route-6bb469f525174f678fdc83d5d53cab55?pvs=4) is a somewhat related item flagged during QA, but this behavior was actually following the designs. Pending a response from Paul H, I might add a tweak for that to this PR.

- [ ] Tests added?
