### PR TITLE
fix: Updated DUP package README

### DIFF
--- a/assets/src/components/v2/dup/README.md
+++ b/assets/src/components/v2/dup/README.md
@@ -32,7 +32,7 @@
 - Set the version string in assets/src/components/v2/dup/version.tsx to `current_year.current_month.current_day.1`.
 - In assets/webpack.config.js, change `publicPath` in the font config to have value `'fonts/'`.
 - **Only if you are packaging for local testing**
-  - replace `const station = useOutfrontStation();` in assets/src/apps/v2/dup.tsx with `const station = "Broadway";` (or any other station name from one of the DUP screen IDs (`DUP-${name}-V2`)). This data is provided by Outfront's "wrapper" app that runs on the real DUP screens, but we need to set it ourselves during testing. Think of it as a sort of frontend environment variable.
+  - replace `const playerName = useOutfrontPlayerName();` in assets/src/apps/v2/dup.tsx with `const playerName = "BRW-DUP-005";` (or any other player name from one of the DUP screen IDs (`DUP-${playerName}`)). This data is provided by Outfront's "wrapper" app that runs on the real DUP screens, but we need to set it ourselves during testing. Think of it as a sort of frontend environment variable.
   - replace `apiPath = "https://screens.mbta.com" + apiPath;` in assets/src/hooks/v2/use_api_response.tsx with `apiPath = "http://localhost:4000" + apiPath;`.
 - `cd` to priv/static and run the following:
   ```sh


### PR DESCRIPTION
**Asana task**: ad-hoc

The instructions needed to be tweaked a bit now that we no longer reference stations in DUP screen IDs.

- [ ] Tests added?
