### PR TITLE
polish: Alert count logic

### DIFF
--- a/lib/screens/v2/widget_instance/subway_status.ex
+++ b/lib/screens/v2/widget_instance/subway_status.ex
@@ -135,36 +135,42 @@ defmodule Screens.V2.WidgetInstance.SubwayStatus do
   end
 
   def serialize_one_row_for_all_routes(grouped_alerts) do
+    total_alert_count = get_total_alerts(grouped_alerts)
+
     %{
-      blue: serialize_single_alert_row_for_route(grouped_alerts, "Blue"),
-      orange: serialize_single_alert_row_for_route(grouped_alerts, "Orange"),
-      red: serialize_single_alert_row_for_route(grouped_alerts, "Red"),
-      green: serialize_green_line(grouped_alerts)
+      blue: serialize_single_alert_row_for_route(grouped_alerts, "Blue", total_alert_count),
+      orange: serialize_single_alert_row_for_route(grouped_alerts, "Orange", total_alert_count),
+      red: serialize_single_alert_row_for_route(grouped_alerts, "Red", total_alert_count),
+      green: serialize_green_line(grouped_alerts, total_alert_count)
     }
   end
 
   # At most 1 alert on any route
   def serialize_routes_zero_or_one_alert(grouped_alerts) do
+    total_alert_count = get_total_alerts(grouped_alerts)
+
     %{
-      blue: serialize_single_alert_row_for_route(grouped_alerts, "Blue"),
-      orange: serialize_single_alert_row_for_route(grouped_alerts, "Orange"),
-      red: serialize_single_alert_row_for_route(grouped_alerts, "Red"),
-      green: serialize_green_line(grouped_alerts)
+      blue: serialize_single_alert_row_for_route(grouped_alerts, "Blue", total_alert_count),
+      orange: serialize_single_alert_row_for_route(grouped_alerts, "Orange", total_alert_count),
+      red: serialize_single_alert_row_for_route(grouped_alerts, "Red", total_alert_count),
+      green: serialize_green_line(grouped_alerts, total_alert_count)
     }
   end
 
   # More than 1 alert on any one route
   def serialize_routes_multiple_alerts(grouped_alerts, multi_alert_routes) do
     multi_alert_route_ids = Enum.map(multi_alert_routes, &elem(&1, 0))
+    total_alert_count = get_total_alerts(grouped_alerts)
 
     cond do
       "Green" in multi_alert_route_ids ->
         # Collapse all non-GL routes and display as many GL alerts as possible.
         %{
-          blue: serialize_single_alert_row_for_route(grouped_alerts, "Blue"),
-          orange: serialize_single_alert_row_for_route(grouped_alerts, "Orange"),
-          red: serialize_single_alert_row_for_route(grouped_alerts, "Red"),
-          green: serialize_green_line(grouped_alerts)
+          blue: serialize_single_alert_row_for_route(grouped_alerts, "Blue", total_alert_count),
+          orange:
+            serialize_single_alert_row_for_route(grouped_alerts, "Orange", total_alert_count),
+          red: serialize_single_alert_row_for_route(grouped_alerts, "Red", total_alert_count),
+          green: serialize_green_line(grouped_alerts, total_alert_count)
         }
 
       length(multi_alert_route_ids) == 1 ->
@@ -178,7 +184,7 @@ defmodule Screens.V2.WidgetInstance.SubwayStatus do
             blue: serialize_multiple_alert_rows_for_route(grouped_alerts, "Blue"),
             orange: serialize_multiple_alert_rows_for_route(grouped_alerts, "Orange"),
             red: serialize_multiple_alert_rows_for_route(grouped_alerts, "Red"),
-            green: serialize_green_line(grouped_alerts)
+            green: serialize_green_line(grouped_alerts, total_alert_count)
           }
         else
           serialize_one_row_for_all_routes(grouped_alerts)
@@ -216,7 +222,7 @@ defmodule Screens.V2.WidgetInstance.SubwayStatus do
   end
 
   # Only executed when route displays one status.
-  def serialize_single_alert_row_for_route(grouped_alerts, route_id) do
+  def serialize_single_alert_row_for_route(grouped_alerts, route_id, total_alert_count) do
     alerts = Map.get(grouped_alerts, route_id)
 
     data =
@@ -231,7 +237,7 @@ defmodule Screens.V2.WidgetInstance.SubwayStatus do
           serialize_alert_summary(length(alerts), serialize_route_pill(route_id))
       end
 
-    if get_total_alerts(grouped_alerts) in 1..2 and data.status != "Normal Service" do
+    if total_alert_count in 1..2 and data.status != "Normal Service" do
       %{
         type: :extended,
         alert: data
@@ -466,16 +472,16 @@ defmodule Screens.V2.WidgetInstance.SubwayStatus do
       alert_whole_line_stops == @green_line_branches
   end
 
-  def serialize_green_line(grouped_alerts) do
+  def serialize_green_line(grouped_alerts, total_alert_count) do
     green_line_alerts =
       @green_line_branches
       |> Enum.flat_map(fn route -> Map.get(grouped_alerts, route, []) end)
       |> Enum.uniq()
 
-    alert_count = length(green_line_alerts)
+    gl_alert_count = length(green_line_alerts)
 
-    if alert_count == 0 do
-      serialize_single_alert_row_for_route(grouped_alerts, "Green")
+    if gl_alert_count == 0 do
+      serialize_single_alert_row_for_route(grouped_alerts, "Green", total_alert_count)
     else
       {trunk_alerts, branch_alerts} =
         Enum.split_with(green_line_alerts, &alert_affects_gl_trunk_or_whole_line?/1)
@@ -485,8 +491,11 @@ defmodule Screens.V2.WidgetInstance.SubwayStatus do
         {[], branch_alerts} ->
           %{type: :contracted, alerts: serialize_green_line_branch_alerts(branch_alerts, false)}
 
-        {[trunk_alert], []} ->
+        {[trunk_alert], []} when total_alert_count < 3 ->
           %{type: :extended, alert: serialize_trunk_alert(trunk_alert)}
+
+        {[trunk_alert], []} ->
+          %{type: :contracted, alerts: [serialize_trunk_alert(trunk_alert)]}
 
         # If there is a single alert on the GL trunk, show it in its own row.
         # Show branch alert/summary on another row.
@@ -511,7 +520,7 @@ defmodule Screens.V2.WidgetInstance.SubwayStatus do
         {_, _} ->
           %{
             type: :contracted,
-            alerts: [serialize_alert_summary(alert_count, serialize_route_pill("Green"))]
+            alerts: [serialize_alert_summary(gl_alert_count, serialize_route_pill("Green"))]
           }
       end
     end
@@ -533,15 +542,19 @@ defmodule Screens.V2.WidgetInstance.SubwayStatus do
   end
 
   defp serialize_green_line_branch_alerts(branch_alerts, has_trunk_alert) do
-    route_ids = Enum.flat_map(branch_alerts, &alert_routes/1)
+    route_ids =
+      branch_alerts
+      |> Enum.flat_map(&alert_routes/1)
+      |> Enum.filter(&String.starts_with?(&1, "Green"))
+
     alert_count = length(branch_alerts)
 
     case {branch_alerts, has_trunk_alert} do
       # Show the branch alert in a row under the trunk alert.
-      {[alert], true} ->
+      {[branch_alert], true} ->
         Map.merge(
-          %{route_pill: serialize_gl_pill_with_branches(alert_routes(alert))},
-          serialize_green_line_branch_alert(alert, alert_routes(alert))
+          %{route_pill: serialize_gl_pill_with_branches(alert_routes(branch_alert))},
+          serialize_green_line_branch_alert(branch_alert, route_ids)
         )
 
       # Always consolidate 2+ branch alerts if there is a trunk alert

--- a/lib/screens/v2/widget_instance/subway_status.ex
+++ b/lib/screens/v2/widget_instance/subway_status.ex
@@ -488,6 +488,10 @@ defmodule Screens.V2.WidgetInstance.SubwayStatus do
 
       case {trunk_alerts, branch_alerts} do
         # If there are no alerts for the GL trunk, serialize any alerts on the branches
+        {[], [_] = branch_alerts} when total_alert_count < 3 and gl_alert_count == 1 ->
+          [branch_alert] = serialize_green_line_branch_alerts(branch_alerts, false)
+          %{type: :extended, alert: branch_alert}
+
         {[], branch_alerts} ->
           %{type: :contracted, alerts: serialize_green_line_branch_alerts(branch_alerts, false)}
 

--- a/lib/screens/v2/widget_instance/subway_status.ex
+++ b/lib/screens/v2/widget_instance/subway_status.ex
@@ -625,13 +625,28 @@ defmodule Screens.V2.WidgetInstance.SubwayStatus do
     end
   end
 
+  # If there is a single alert affecting multiple routes, we need to count that as multiple alerts.
+  # To get around that case, we can return either the total routes or total alerts, whichever is greater.
+  # This will allow us to better determine if :extended or :contracted is needed.
   defp get_total_alerts(grouped_alerts) do
-    grouped_alerts
-    |> Enum.flat_map(&elem(&1, 1))
-    |> Enum.uniq_by(fn
-      "Green-" <> _ -> "Green"
-      route_id -> route_id
-    end)
-    |> length()
+    total_affected_routes =
+      grouped_alerts
+      |> Map.keys()
+      |> Enum.uniq_by(fn
+        "Green-" <> _ -> "Green"
+        route_id -> route_id
+      end)
+      |> length()
+
+    total_alerts =
+      grouped_alerts
+      |> Enum.flat_map(&elem(&1, 1))
+      |> Enum.uniq_by(fn
+        "Green-" <> _ -> "Green"
+        route_id -> route_id
+      end)
+      |> length()
+
+    max(total_affected_routes, total_alerts)
   end
 end

--- a/test/screens/v2/widget_instance/subway_status_test.exs
+++ b/test/screens/v2/widget_instance/subway_status_test.exs
@@ -1114,6 +1114,139 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
       assert expected == WidgetInstance.serialize(instance)
     end
 
+    test "handles 1 alert on GL trunk and 2 alerts on non-GL route" do
+      instance = %SubwayStatus{
+        subway_alerts: [
+          %Alert{
+            effect: :delay,
+            severity: 5,
+            informed_entities: [
+              %{route: "Green-D", stop: "place-gover"},
+              %{route: "Green-D", stop: "place-pktrm"},
+              %{route: "Green-D", stop: "place-boyls"}
+            ]
+          },
+          %Alert{
+            effect: :station_closure,
+            informed_entities: [
+              %{route: "Orange", stop: "place-ogmnl"}
+            ]
+          },
+          %Alert{
+            effect: :suspension,
+            informed_entities: [
+              %{route: "Blue", stop: "place-bmmnl"}
+            ]
+          }
+        ]
+      }
+
+      expected = %{
+        blue: %{
+          alerts: [
+            %{
+              route_pill: %{color: :blue, text: "BL", type: :text},
+              status: "Suspension",
+              location: %{abbrev: "Beachmont", full: "Beachmont"}
+            }
+          ],
+          type: :contracted
+        },
+        orange: %{
+          type: :contracted,
+          alerts: [
+            %{
+              location: %{abbrev: "Oak Grove", full: "Oak Grove"},
+              route_pill: %{color: :orange, text: "OL", type: :text},
+              station_count: 1,
+              status: "Bypassing"
+            }
+          ]
+        },
+        red: %{
+          type: :contracted,
+          alerts: [
+            %{
+              route_pill: %{type: :text, text: "RL", color: :red},
+              status: "Normal Service"
+            }
+          ]
+        },
+        green: %{
+          type: :contracted,
+          alerts: [
+            %{
+              location: %{abbrev: "Gov't Ctr to Boylston", full: "Government Center to Boylston"},
+              route_pill: %{color: :green, text: "GL", type: :text},
+              status: "Delays up to 20 minutes"
+            }
+          ]
+        }
+      }
+
+      assert expected == WidgetInstance.serialize(instance)
+    end
+
+    test "handles 1 alert on GL branch and 1 alert on non-GL route" do
+      instance = %SubwayStatus{
+        subway_alerts: [
+          %Alert{
+            effect: :delay,
+            severity: 9,
+            informed_entities: [
+              %{route: "Green-C", stop: nil}
+            ]
+          },
+          %Alert{
+            effect: :station_closure,
+            informed_entities: [
+              %{route: "Orange", stop: "place-ogmnl"}
+            ]
+          }
+        ]
+      }
+
+      expected = %{
+        blue: %{
+          type: :contracted,
+          alerts: [
+            %{
+              route_pill: %{type: :text, text: "BL", color: :blue},
+              status: "Normal Service"
+            }
+          ]
+        },
+        orange: %{
+          type: :extended,
+          alert: %{
+            route_pill: %{type: :text, text: "OL", color: :orange},
+            status: "Bypassing",
+            location: %{abbrev: "Oak Grove", full: "Oak Grove"},
+            station_count: 1
+          }
+        },
+        red: %{
+          type: :contracted,
+          alerts: [
+            %{
+              route_pill: %{type: :text, text: "RL", color: :red},
+              status: "Normal Service"
+            }
+          ]
+        },
+        green: %{
+          type: :extended,
+          alert: %{
+            route_pill: %{type: :text, text: "GL", color: :green, branches: [:c]},
+            status: "Delays over 60 minutes",
+            location: nil
+          }
+        }
+      }
+
+      assert expected == WidgetInstance.serialize(instance)
+    end
+
     test "handles 1 alert affecting 3 routes" do
       instance = %SubwayStatus{
         subway_alerts: [

--- a/test/screens/v2/widget_instance/subway_status_test.exs
+++ b/test/screens/v2/widget_instance/subway_status_test.exs
@@ -1114,6 +1114,66 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
       assert expected == WidgetInstance.serialize(instance)
     end
 
+    test "handles 1 alert affecting 3 routes" do
+      instance = %SubwayStatus{
+        subway_alerts: [
+          %Alert{
+            effect: :delay,
+            severity: 9,
+            informed_entities: [
+              %{route: "Green-C", stop: nil},
+              %{route: "Blue", stop: nil},
+              %{route: "Orange", stop: nil}
+            ]
+          }
+        ]
+      }
+
+      expected = %{
+        blue: %{
+          type: :contracted,
+          alerts: [
+            %{
+              route_pill: %{type: :text, text: "BL", color: :blue},
+              status: "Delays over 60 minutes",
+              location: nil
+            }
+          ]
+        },
+        orange: %{
+          type: :contracted,
+          alerts: [
+            %{
+              route_pill: %{type: :text, text: "OL", color: :orange},
+              status: "Delays over 60 minutes",
+              location: nil
+            }
+          ]
+        },
+        red: %{
+          type: :contracted,
+          alerts: [
+            %{
+              route_pill: %{type: :text, text: "RL", color: :red},
+              status: "Normal Service"
+            }
+          ]
+        },
+        green: %{
+          type: :contracted,
+          alerts: [
+            %{
+              route_pill: %{type: :text, text: "GL", color: :green, branches: [:c]},
+              status: "Delays over 60 minutes",
+              location: nil
+            }
+          ]
+        }
+      }
+
+      assert expected == WidgetInstance.serialize(instance)
+    end
+
     test "uses 'Entire line' location text for whole-line shuttles" do
       instance = %SubwayStatus{
         subway_alerts: [


### PR DESCRIPTION
**Notion tasks**: [Multiple rows show up expanded](https://www.notion.so/mbta-downtown-crossing/Multiple-rows-show-up-expanded-e54526b1088b4074bb06d12b10f8be12?pvs=4)
[Incorrect station name appears](https://www.notion.so/mbta-downtown-crossing/Incorrect-station-name-appears-20c2bc0377ff495fb16b089b768d0139?pvs=4)

Total alert count logic was off when there was an alert that affected multiple routes. The function now looks at total affected routes and total unique alert IDs and returns the max of the two counts. This allows `:extended` vs `:contracted` logic to pick the correct type.

- [x] Tests added?
