### PR TITLE
fix(subway status): Use smaller font-size for contracted alert location text

### DIFF
--- a/assets/css/v2/lcd_common_styles/subway_status.scss
+++ b/assets/css/v2/lcd_common_styles/subway_status.scss
@@ -171,18 +171,19 @@
   span.subway-status_alert_location-text {
     // common styles for location text
     font-weight: 500;
-    font-size: 32px;
   }
 
   .subway-status_status--contracted span.subway-status_alert_location-text {
     // contracted-specific styles for location text
     margin-left: 16px;
     line-height: $pill-height;
+    font-size: 27px;
   }
 
   .subway-status_status--extended span.subway-status_alert_location-text {
     // extended-specific styles for location text
     line-height: 48px;
+    font-size: 32px;
   }
 
   .branch-icon {


### PR DESCRIPTION
**QA task**: [Incorrect type size used for location](https://www.notion.so/mbta-downtown-crossing/Incorrect-type-size-used-for-location-e75cf20a6a08493a8e09df1ee0250fb6?pvs=4)

When the location shares a line with the status, it has a font-size of 27px, not 32px.

- [ ] Tests added?
