### PR TITLE
polish: E-Ink Subway Status margin

### DIFF
--- a/assets/css/v2/eink/subway_status.scss
+++ b/assets/css/v2/eink/subway_status.scss
@@ -82,7 +82,6 @@
     vertical-align: top;
     font-family: Inter, sans-serif;
     max-width: 1024px;
-    margin-left: 24px;
     font-weight: 800;
     line-height: 65px;
     font-size: 56px;


### PR DESCRIPTION
**Notion task**: [e-Ink text is misaligned](https://www.notion.so/mbta-downtown-crossing/e-Ink-text-is-misaligned-222864ebfe74471d9684f846e9004443?pvs=4)

Fixed left margin on e-ink Subway Status.

- [ ] Tests added?
