### PR TITLE
polish: E-Ink Subway Status text resizing rowHeight

### DIFF
--- a/assets/css/v2/eink/subway_status.scss
+++ b/assets/css/v2/eink/subway_status.scss
@@ -65,6 +65,7 @@
 
   .subway-status_alert_route-pill-container {
     display: inline-block;
+    margin-right: 16px;
 
     .branch-icon {
       display: inline-block;
@@ -81,7 +82,6 @@
     display: inline-block;
     vertical-align: top;
     font-family: Inter, sans-serif;
-    max-width: 1024px;
     margin-left: 24px;
     font-weight: 800;
     line-height: 65px;

--- a/assets/src/components/v2/subway_status/eink_subway_status.tsx
+++ b/assets/src/components/v2/subway_status/eink_subway_status.tsx
@@ -98,7 +98,11 @@ interface AlertRowProps extends Alert {
 }
 
 const ALERTS_URL = "mbta.com/alerts";
-const ALERT_FITTING_STEPS = [FittingStep.PerAlertEffect, FittingStep.Abbrev, FittingStep.FullSize];
+const ALERT_FITTING_STEPS = [
+  FittingStep.PerAlertEffect,
+  FittingStep.Abbrev,
+  FittingStep.FullSize,
+];
 
 const AlertRow: ComponentType<AlertRowProps> = ({
   route_pill: routePill,
@@ -109,7 +113,7 @@ const AlertRow: ComponentType<AlertRowProps> = ({
   showInlineBranches,
 }) => {
   // row height is a little taller when there is an inline GL branch pill
-  const rowHeight = showInlineBranches ? 70 : 60;
+  const rowHeight = showInlineBranches ? 70 : 65;
   const { ref, abbrev, truncateStatus, replaceLocationWithUrl } =
     useSubwayStatusTextResizer(rowHeight, ALERT_FITTING_STEPS, id, status);
 
@@ -125,7 +129,9 @@ const AlertRow: ComponentType<AlertRowProps> = ({
   if (truncateStatus) {
     const effect = firstWord(status);
     status =
-      effect === "Bypassing" ? `Bypassing ${stationCount} ${stationCount === 1 ? "stop" : "stops"}` : effect;
+      effect === "Bypassing"
+        ? `Bypassing ${stationCount} ${stationCount === 1 ? "stop" : "stops"}`
+        : effect;
   }
 
   return (


### PR DESCRIPTION
**Notion tasks**: [Bypassed station unnecessarily summarized](https://www.notion.so/mbta-downtown-crossing/Bypassed-station-unnecessarily-summarized-5885f654f43e43adb4f33f37c48967dc?pvs=4)
[Suspension bounds unnecessarily omitted](https://www.notion.so/mbta-downtown-crossing/Suspension-bounds-unnecessarily-omitted-927085aa49ab444c9d05b84bfbb38cbd?pvs=4)
[Unnecessary abbreviation on e-Ink](https://www.notion.so/mbta-downtown-crossing/Unnecessary-abbreviation-on-e-Ink-1ba31ff6786d4c5c91c00b189d06550b?pvs=4)
[Delays missing duration](https://www.notion.so/mbta-downtown-crossing/Delays-missing-duration-86f2035c055a4d6ab633b103cf4a00e3?pvs=4)

The `rowHeight` for E-Ink text resizing was a little too small. Increasing it keeps some statuses from being unnecessarily summarized.

- [ ] Tests added?
