### PR TITLE
Allow DUPs departures logic to handle multiple parent_stop_ids

### DIFF
--- a/lib/screens/v2/candidate_generator/dup/departures.ex
+++ b/lib/screens/v2/candidate_generator/dup/departures.ex
@@ -375,13 +375,14 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
     headsign in MapSet.new(branch_terminals)
   end
 
-  defp interpret_entities(entities, [parent_stop_id]) do
+  defp interpret_entities(entities, parent_stop_ids) do
     informed_stop_ids = Enum.into(entities, MapSet.new(), & &1.stop)
+    parent_stop_id = List.first(parent_stop_ids)
 
     {region, headsign} =
       :screens
       |> Application.get_env(:dup_alert_headsign_matchers)
-      |> Map.get(parent_stop_id)
+      |> Map.get(parent_stop_id, [])
       |> Enum.find_value({:inside, nil}, fn
         %{
           informed: informed,


### PR DESCRIPTION
**Asana task**: [🐞 DUP: SL5 suspension at Tufts breaks screen](https://app.asana.com/0/1185117109217432/1204542345952187/f)

Description

The logic was breaking due to the `interpret_entities/2` function not being able pattern match against cases where `parent_stop_ids` was a list of more than one stop_ids. It looks like we only interpret the entities when we're determining whether or not to show headways, and we only have headway configs defined for parent stop ids which are only relevant for subway (as far as I can tell). Therefore, I think we should be able to just take the first item in the list and default to `{:inside, nil}` for the case when `parent_stop_ids` has a length > 1.
