### PR TITLE
polish: branch vs trunk logic

### DIFF
--- a/lib/screens/stops/stop.ex
+++ b/lib/screens/stops/stop.ex
@@ -409,6 +409,10 @@ defmodule Screens.Stops.Stop do
     @route_stop_sequences
   end
 
+  def get_gl_stop_sequences do
+    Enum.map(@green_line_branches, &get_route_stop_sequence/1)
+  end
+
   defp sequence_match?(stop_sequence, informed_entities) do
     ie_stops =
       informed_entities
@@ -425,7 +429,7 @@ defmodule Screens.Stops.Stop do
   end
 
   def gl_trunk_stops do
-    @route_stop_sequences |> Map.get("Green") |> hd() |> Enum.map(&elem(&1, 0)) |> MapSet.new()
+    @green_line_trunk_stops
   end
 
   def stop_id_to_name(route_id) do

--- a/lib/screens/v2/widget_instance/subway_status.ex
+++ b/lib/screens/v2/widget_instance/subway_status.ex
@@ -485,8 +485,8 @@ defmodule Screens.V2.WidgetInstance.SubwayStatus do
       end)
       |> Enum.uniq()
 
-    Enum.count(gl_stop_sequences, fn stop_sequence ->
-      alert_stops != [] and Enum.all?(alert_stops, &(&1 in stop_sequence))
+    alert_stops != [] and Enum.count(gl_stop_sequences, fn stop_sequence ->
+      Enum.all?(alert_stops, &(&1 in stop_sequence))
     end) > 1
   end
 

--- a/lib/screens/v2/widget_instance/subway_status.ex
+++ b/lib/screens/v2/widget_instance/subway_status.ex
@@ -475,7 +475,7 @@ defmodule Screens.V2.WidgetInstance.SubwayStatus do
     end)
   end
 
-  #
+  # If the affected stops are fully contained in more than one branch, the alert affects the trunk
   defp alert_affects_gl_trunk?(%Alert{informed_entities: informed_entities}, gl_stop_sets) do
     alert_stops =
       informed_entities

--- a/lib/screens/v2/widget_instance/subway_status.ex
+++ b/lib/screens/v2/widget_instance/subway_status.ex
@@ -476,7 +476,7 @@ defmodule Screens.V2.WidgetInstance.SubwayStatus do
   end
 
   #
-  defp alert_affects_gl_trunk?(%Alert{informed_entities: informed_entities}, gl_stop_sequences) do
+  defp alert_affects_gl_trunk?(%Alert{informed_entities: informed_entities}, gl_stop_sets) do
     alert_stops =
       informed_entities
       |> Enum.filter(fn
@@ -487,7 +487,7 @@ defmodule Screens.V2.WidgetInstance.SubwayStatus do
       |> MapSet.new()
 
     if MapSet.size(alert_stops) > 0 do
-      Enum.count(gl_stop_sequences, &MapSet.subset?(alert_stops, &1)) > 1
+      Enum.count(gl_stop_sets, &MapSet.subset?(alert_stops, &1)) > 1
     else
       false
     end

--- a/lib/screens/v2/widget_instance/subway_status.ex
+++ b/lib/screens/v2/widget_instance/subway_status.ex
@@ -483,6 +483,7 @@ defmodule Screens.V2.WidgetInstance.SubwayStatus do
         %{stop: nil} -> false
         ie -> String.starts_with?(ie.stop, "place-") and String.starts_with?(ie.route, "Green-")
       end)
+      |> Enum.map(& &1.stop)
       |> Enum.uniq()
 
     alert_stops != [] and

--- a/lib/screens/v2/widget_instance/subway_status.ex
+++ b/lib/screens/v2/widget_instance/subway_status.ex
@@ -484,12 +484,13 @@ defmodule Screens.V2.WidgetInstance.SubwayStatus do
         ie -> String.starts_with?(ie.stop, "place-") and String.starts_with?(ie.route, "Green-")
       end)
       |> Enum.map(& &1.stop)
-      |> Enum.uniq()
+      |> MapSet.new()
 
-    alert_stops != [] and
-      Enum.count(gl_stop_sequences, fn stop_sequence ->
-        Enum.all?(alert_stops, &(&1 in stop_sequence))
-      end) > 1
+    if MapSet.size(alert_stops) > 0 do
+      Enum.count(gl_stop_sequences, &MapSet.subset?(alert_stops, &1)) > 1
+    else
+      false
+    end
   end
 
   defp alert_affects_gl_trunk_or_whole_line?(alert, gl_stop_sets) do

--- a/test/screens/v2/widget_instance/subway_status_test.exs
+++ b/test/screens/v2/widget_instance/subway_status_test.exs
@@ -544,7 +544,7 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
           %Alert{
             effect: :station_closure,
             informed_entities: [
-              %{route: "Green-D", stop: "place-woodl"},
+              %{route: "Green-D", stop: "place-gover"},
               %{route: "Green-D", stop: "place-river"}
             ]
           }
@@ -583,15 +583,18 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
           type: :contracted,
           alerts: [
             %{
-              route_pill: %{type: :text, text: "GL", color: :green},
-              status: "Suspension",
-              location: %{abbrev: "Gov't Ctr to Boylston", full: "Government Center to Boylston"}
+              location: %{
+                abbrev: "Gov't Ctr and Riverside",
+                full: "Government Center and Riverside"
+              },
+              route_pill: %{color: :green, text: "GL", type: :text},
+              station_count: 2,
+              status: "Bypassing"
             },
             %{
-              route_pill: %{type: :text, text: "GL", color: :green, branches: [:d]},
-              status: "Bypassing",
-              location: %{abbrev: "Woodland and Riverside", full: "Woodland and Riverside"},
-              station_count: 2
+              location: %{abbrev: "Gov't Ctr to Boylston", full: "Government Center to Boylston"},
+              route_pill: %{branches: [:c], color: :green, text: "GL", type: :text},
+              status: "Suspension"
             }
           ]
         }
@@ -621,7 +624,10 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
           %Alert{
             effect: :station_closure,
             informed_entities: [
-              %{route: "Green-E", stop: "place-symcl"},
+              %{route: "Green-B", stop: "place-gover"},
+              %{route: "Green-C", stop: "place-gover"},
+              %{route: "Green-D", stop: "place-gover"},
+              %{route: "Green-E", stop: "place-gover"},
               %{route: "Green-E", stop: "place-nuniv"}
             ]
           }
@@ -660,12 +666,16 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
           type: :contracted,
           alerts: [
             %{
-              route_pill: %{type: :text, text: "GL", color: :green},
-              status: "Suspension",
-              location: %{abbrev: "Gov't Ctr to Boylston", full: "Government Center to Boylston"}
+              location: %{
+                abbrev: "Gov't Ctr and Northeast'n",
+                full: "Government Center and Northeastern University"
+              },
+              route_pill: %{color: :green, text: "GL", type: :text},
+              status: "Bypassing",
+              station_count: 2
             },
             %{
-              route_pill: %{type: :text, text: "GL", color: :green, branches: [:b, :e]},
+              route_pill: %{type: :text, text: "GL", color: :green, branches: [:b, :c]},
               status: "2 current alerts",
               location: "mbta.com/alerts"
             }
@@ -691,9 +701,10 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
             effect: :delay,
             severity: 5,
             informed_entities: [
-              %{route: "Green-E", stop: "place-lech"},
-              %{route: "Green-E", stop: "place-spmnl"},
-              %{route: "Green-E", stop: "place-north"}
+              %{route: "Green-B", stop: nil},
+              %{route: "Green-C", stop: nil},
+              %{route: "Green-D", stop: nil},
+              %{route: "Green-E", stop: nil}
             ]
           }
         ]
@@ -731,14 +742,14 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
           type: :contracted,
           alerts: [
             %{
-              location: %{abbrev: "Gov't Ctr to Boylston", full: "Government Center to Boylston"},
-              route_pill: %{color: :green, text: "GL", type: :text},
-              status: "Suspension"
-            },
-            %{
-              location: %{abbrev: "Lechmere to North Sta", full: "Lechmere to North Station"},
+              location: nil,
               route_pill: %{color: :green, text: "GL", type: :text},
               status: "Delays up to 20 minutes"
+            },
+            %{
+              location: %{abbrev: "Gov't Ctr to Boylston", full: "Government Center to Boylston"},
+              route_pill: %{color: :green, text: "GL", type: :text, branches: [:c]},
+              status: "Suspension"
             }
           ]
         }
@@ -975,15 +986,16 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
             effect: :delay,
             severity: 5,
             informed_entities: [
-              %{route: "Green-D", stop: "place-gover"},
-              %{route: "Green-D", stop: "place-pktrm"},
-              %{route: "Green-D", stop: "place-boyls"}
+              %{route: "Green-B", stop: nil},
+              %{route: "Green-C", stop: nil},
+              %{route: "Green-D", stop: nil},
+              %{route: "Green-E", stop: nil}
             ]
           },
           %Alert{
             effect: :station_closure,
             informed_entities: [
-              %{route: "Green-D", stop: "place-unsqu"}
+              %{route: "Green-D", stop: "place-kencl"}
             ]
           }
         ]
@@ -1118,12 +1130,10 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
       instance = %SubwayStatus{
         subway_alerts: [
           %Alert{
-            effect: :delay,
-            severity: 5,
+            effect: :station_closure,
             informed_entities: [
-              %{route: "Green-D", stop: "place-gover"},
-              %{route: "Green-D", stop: "place-pktrm"},
-              %{route: "Green-D", stop: "place-boyls"}
+              %{route: "Green-D", stop: "place-lech"},
+              %{route: "Green-E", stop: "place-lech"}
             ]
           },
           %Alert{
@@ -1176,9 +1186,10 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
           type: :contracted,
           alerts: [
             %{
-              location: %{abbrev: "Gov't Ctr to Boylston", full: "Government Center to Boylston"},
+              location: %{abbrev: "Lechmere", full: "Lechmere"},
               route_pill: %{color: :green, text: "GL", type: :text},
-              status: "Delays up to 20 minutes"
+              status: "Bypassing",
+              station_count: 1
             }
           ]
         }
@@ -1513,7 +1524,7 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
           type: :extended,
           alert: %{
             location: %{abbrev: "Kenmore to Kent St", full: "Kenmore to Kent Street"},
-            route_pill: %{color: :green, text: "GL", type: :text},
+            route_pill: %{color: :green, text: "GL", type: :text, branches: [:c]},
             status: "Shuttle Bus"
           }
         },

--- a/test/screens/v2/widget_instance/subway_status_test.exs
+++ b/test/screens/v2/widget_instance/subway_status_test.exs
@@ -622,13 +622,13 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
             ]
           },
           %Alert{
-            effect: :station_closure,
+            effect: :delay,
+            severity: 6,
             informed_entities: [
-              %{route: "Green-B", stop: "place-gover"},
-              %{route: "Green-C", stop: "place-gover"},
-              %{route: "Green-D", stop: "place-gover"},
-              %{route: "Green-E", stop: "place-gover"},
-              %{route: "Green-E", stop: "place-nuniv"}
+              %{route: "Green-B", stop: nil},
+              %{route: "Green-C", stop: nil},
+              %{route: "Green-D", stop: nil},
+              %{route: "Green-E", stop: nil}
             ]
           }
         ]
@@ -666,13 +666,9 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
           type: :contracted,
           alerts: [
             %{
-              location: %{
-                abbrev: "Gov't Ctr and Northeast'n",
-                full: "Government Center and Northeastern University"
-              },
+              location: nil,
               route_pill: %{color: :green, text: "GL", type: :text},
-              status: "Bypassing",
-              station_count: 2
+              status: "Delays up to 25 minutes"
             },
             %{
               route_pill: %{type: :text, text: "GL", color: :green, branches: [:b, :c]},

--- a/test/screens/v2/widget_instance/subway_status_test.exs
+++ b/test/screens/v2/widget_instance/subway_status_test.exs
@@ -536,9 +536,9 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
           %Alert{
             effect: :suspension,
             informed_entities: [
-              %{route: "Green-C", stop: "place-gover"},
-              %{route: "Green-C", stop: "place-pktrm"},
-              %{route: "Green-C", stop: "place-boyls"}
+              %{route: "Green-C", stop: "place-hwsst"},
+              %{route: "Green-C", stop: "place-kntst"},
+              %{route: "Green-C", stop: "place-stpul"}
             ]
           },
           %Alert{
@@ -592,7 +592,10 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
               status: "Bypassing"
             },
             %{
-              location: %{abbrev: "Gov't Ctr to Boylston", full: "Government Center to Boylston"},
+              location: %{
+                abbrev: "Hawes St to St. Paul St",
+                full: "Hawes Street to Saint Paul Street"
+              },
               route_pill: %{branches: [:c], color: :green, text: "GL", type: :text},
               status: "Suspension"
             }
@@ -609,9 +612,9 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
           %Alert{
             effect: :suspension,
             informed_entities: [
-              %{route: "Green-C", stop: "place-gover"},
-              %{route: "Green-C", stop: "place-pktrm"},
-              %{route: "Green-C", stop: "place-boyls"}
+              %{route: "Green-C", stop: "place-hwsst"},
+              %{route: "Green-C", stop: "place-kntst"},
+              %{route: "Green-C", stop: "place-stpul"}
             ]
           },
           %Alert{
@@ -689,8 +692,7 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
             effect: :suspension,
             informed_entities: [
               %{route: "Green-C", stop: "place-gover"},
-              %{route: "Green-C", stop: "place-pktrm"},
-              %{route: "Green-C", stop: "place-boyls"}
+              %{route: "Green-C", stop: "place-pktrm"}
             ]
           },
           %Alert{
@@ -743,8 +745,11 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
               status: "Delays up to 20 minutes"
             },
             %{
-              location: %{abbrev: "Gov't Ctr to Boylston", full: "Government Center to Boylston"},
-              route_pill: %{color: :green, text: "GL", type: :text, branches: [:c]},
+              location: %{
+                abbrev: "Gov't Ctr to Park St",
+                full: "Government Center to Park Street"
+              },
+              route_pill: %{color: :green, text: "GL", type: :text},
               status: "Suspension"
             }
           ]


### PR DESCRIPTION
**Notion task**: [Fix GL branch vs trunk alert](https://www.notion.so/mbta-downtown-crossing/Fix-GL-branch-vs-trunk-alert-d5a287156e734f3d960580ade8591a38?pvs=4)

Our previous branch vs trunk logic was causing some confusion when a branch alert included a stop on the trunk (i.e. GL-C shuttle starting at Kenmore). In summary, the new logic is:

A station closure is a trunk alert if any closed station is on the trunk. Shuttles and suspensions are trunk if the list of affected stops fits in more than one branch. A delay with no stop range is a trunk alert if it affects all branches. Otherwise, it uses the same logic as shuttles and suspensions.

- [ ] Tests added?
