### PR TITLE
polish: Total alert logic

### DIFF
--- a/lib/screens/v2/widget_instance/subway_status.ex
+++ b/lib/screens/v2/widget_instance/subway_status.ex
@@ -709,7 +709,7 @@ defmodule Screens.V2.WidgetInstance.SubwayStatus do
   def get_total_alerts(alerts) do
     total_affected_routes =
       alerts
-      |> Enum.uniq()
+      |> Enum.uniq_by(& &1.id)
       |> Enum.map(&get_total_affected_routes_for_alert/1)
       |> Enum.sum()
 


### PR DESCRIPTION
**Asana task**: ad-hoc

I found another edge case 😄 If you have 1 branch alert and 1 multi-line alert that affects GL trunk, it was not being counted as 3 alerts. This was causing the non-GL route to show as `extended` because all GL alerts were counted as affecting a single route. Now, the logic looks at all unique affected routes and recognizes that trunk and branch alerts need to be counted separately. 

- [ ] Tests added?
