### PR TITLE
polish: environment name positioning

### DIFF
--- a/assets/css/v2/bus_shelter/normal_header.scss
+++ b/assets/css/v2/bus_shelter/normal_header.scss
@@ -56,7 +56,7 @@
 
 .normal-header__environment {
   @include font--text--75bold;
-  position: relative;
+  position: absolute;
   padding-left: 40px;
   padding-top: 10px;
   font-size: 36px;

--- a/assets/css/v2/eink/normal_header.scss
+++ b/assets/css/v2/eink/normal_header.scss
@@ -98,7 +98,7 @@
 .normal-header__environment {
   font-family: Helvetica, sans-serif;
   font-weight: 700;
-  position: relative;
+  position: absolute;
   padding-left: 40px;
   padding-top: 10px;
   font-size: 36px;

--- a/assets/css/v2/pre_fare/normal_header.scss
+++ b/assets/css/v2/pre_fare/normal_header.scss
@@ -62,7 +62,7 @@
 
 .normal-header__environment {
   @include font--text--75bold;
-  position: relative;
+  position: absolute;
   font-size: 36px;
   color: #ffffff;
   letter-spacing: 0;


### PR DESCRIPTION
**Asana task**: ad-hoc

Changed positioning to `absolute` so it does not push down the stop name in the header.

- [ ] Tests added?
