### PR TITLE
polish: Last minute misc fixes

### DIFF
--- a/assets/css/v2/lcd_common_styles/subway_status.scss
+++ b/assets/css/v2/lcd_common_styles/subway_status.scss
@@ -47,13 +47,16 @@
 
   .subway-status_status--contracted.subway-status_status--one-alert {
     // 114px
-    height: $status-top-padding + $pill-height + $contracted-status-with-one-alert-bottom-padding;
+    height: $status-top-padding + $pill-height +
+      $contracted-status-with-one-alert-bottom-padding;
   }
 
   .subway-status_status--contracted.subway-status_status--two-alerts:not(.subway-status_status--has-second-pill) {
     // 193px
     // Second alert still gets the height of a pill, despite not having one visible
-    height: $status-top-padding + (2 * $pill-height) + $intra-alert-margin-without-second-pill + $contracted-status-with-two-alerts-bottom-padding;
+    height: $status-top-padding + (2 * $pill-height) +
+      $intra-alert-margin-without-second-pill +
+      $contracted-status-with-two-alerts-bottom-padding;
   }
 
   // &--contracted.subway-status_status--two-alerts.subway-status_status--has-second-pill {}
@@ -144,7 +147,8 @@
     }
   }
 
-  .subway-status_status--contracted .subway-status_alert_text-container.subway-status_alert_text-container--hide-overflow {
+  .subway-status_status--contracted
+    .subway-status_alert_text-container.subway-status_alert_text-container--hide-overflow {
     height: $pill-height;
   }
 

--- a/assets/css/v2/lcd_common_styles/subway_status.scss
+++ b/assets/css/v2/lcd_common_styles/subway_status.scss
@@ -134,6 +134,14 @@
     width: fit-content;
     max-width: 830px;
     margin-left: 24px;
+
+    &--2-branches {
+      max-width: 671px;
+    }
+
+    &--3-branches {
+      max-width: 605px;
+    }
   }
 
   .subway-status_status--contracted .subway-status_alert_text-container.subway-status_alert_text-container--hide-overflow {

--- a/assets/src/components/v2/subway_status/lcd_subway_status.tsx
+++ b/assets/src/components/v2/subway_status/lcd_subway_status.tsx
@@ -204,12 +204,19 @@ const BasicAlert = forwardRef<HTMLDivElement, BasicAlertProps>(
     }
 
     let textContainerClassName = "subway-status_alert_text-container";
+    const textContainerModifiers = [];
     if (hideOverflow) {
-      textContainerClassName = classWithModifier(
-        textContainerClassName,
-        "hide-overflow"
-      );
+      textContainerModifiers.push("hide-overflow");
     }
+
+    if (routePill?.branches) {
+      textContainerModifiers.push(`${routePill.branches.length}-branches`);
+    }
+
+    textContainerClassName = classWithModifiers(
+      textContainerClassName,
+      textContainerModifiers
+    );
 
     let statusTextClassName = "subway-status_alert_status-text";
     if (status === NORMAL_STATUS) {

--- a/assets/src/components/v2/subway_status/lcd_subway_status.tsx
+++ b/assets/src/components/v2/subway_status/lcd_subway_status.tsx
@@ -111,10 +111,14 @@ interface AlertWithID extends Alert {
  *
  * When the text wraps to a second line it's more than that, which is all we care about to detect overflows.
  */
-const CONTRACTED_ALERT_MAX_HEIGHT = 80;
+const CONTRACTED_ALERT_MAX_HEIGHT = 82;
 const EXTENDED_ALERT_MAX_HEIGHT = 120;
 
-const CONTRACTED_ALERT_FITTING_STEPS = [FittingStep.PerAlertEffect, FittingStep.Abbrev, FittingStep.FullSize];
+const CONTRACTED_ALERT_FITTING_STEPS = [
+  FittingStep.PerAlertEffect,
+  FittingStep.Abbrev,
+  FittingStep.FullSize,
+];
 const EXTENDED_ALERT_FITTING_STEPS = [FittingStep.Abbrev, FittingStep.FullSize];
 
 const ALERTS_URL = "mbta.com/alerts";
@@ -127,7 +131,12 @@ const ContractedAlert: ComponentType<AlertWithID> = ({
   id,
 }) => {
   const { ref, abbrev, truncateStatus, replaceLocationWithUrl, isDone } =
-    useSubwayStatusTextResizer(CONTRACTED_ALERT_MAX_HEIGHT, CONTRACTED_ALERT_FITTING_STEPS, id, status);
+    useSubwayStatusTextResizer(
+      CONTRACTED_ALERT_MAX_HEIGHT,
+      CONTRACTED_ALERT_FITTING_STEPS,
+      id,
+      status
+    );
 
   let locationText: string | null;
   if (replaceLocationWithUrl) {
@@ -141,7 +150,9 @@ const ContractedAlert: ComponentType<AlertWithID> = ({
   if (truncateStatus) {
     const effect = firstWord(status);
     status =
-      effect === "Bypassing" ? `Bypassing ${stationCount} ${stationCount === 1 ? "stop" : "stops"}` : effect;
+      effect === "Bypassing"
+        ? `Bypassing ${stationCount} ${stationCount === 1 ? "stop" : "stops"}`
+        : effect;
   }
 
   return (
@@ -161,8 +172,12 @@ const ExtendedAlert: ComponentType<AlertWithID> = ({
   location,
   id,
 }) => {
-  const { ref, abbrev, isDone } =
-    useSubwayStatusTextResizer(EXTENDED_ALERT_MAX_HEIGHT, EXTENDED_ALERT_FITTING_STEPS, id, status);
+  const { ref, abbrev, isDone } = useSubwayStatusTextResizer(
+    EXTENDED_ALERT_MAX_HEIGHT,
+    EXTENDED_ALERT_FITTING_STEPS,
+    id,
+    status
+  );
 
   let locationText: string | null;
   if (isAlertLocationMap(location)) {

--- a/lib/screens/v2/widget_instance/subway_status.ex
+++ b/lib/screens/v2/widget_instance/subway_status.ex
@@ -596,12 +596,10 @@ defmodule Screens.V2.WidgetInstance.SubwayStatus do
     case branch_alerts do
       # One branch alert, no trunk alerts
       [alert] ->
-        route_id = List.first(route_ids, "Green")
-
         serialized_alert =
           Map.merge(
             %{route_pill: serialize_gl_pill_with_branches(route_ids)},
-            serialize_alert(alert, route_id)
+            serialize_green_line_branch_alert(alert, route_ids)
           )
 
         if total_alert_count < 3 and gl_alert_count == 1 do

--- a/lib/screens/v2/widget_instance/subway_status.ex
+++ b/lib/screens/v2/widget_instance/subway_status.ex
@@ -729,9 +729,7 @@ defmodule Screens.V2.WidgetInstance.SubwayStatus do
     max(total_affected_routes, total_alerts)
   end
 
-  defp get_total_affected_routes_for_alert(%Alert{informed_entities: informed_entities} = alert) do
-    gl_stop_sets = Enum.map(Stop.get_gl_stop_sequences(), &MapSet.new/1)
-
+  defp get_total_affected_routes_for_alert(%Alert{informed_entities: informed_entities}) do
     # Get all unique routes in informed_entities
     affected_routes =
       informed_entities
@@ -741,16 +739,11 @@ defmodule Screens.V2.WidgetInstance.SubwayStatus do
       end)
       |> Enum.uniq()
 
-    # If an alert affects the GL trunk, we need to treat it like it affects a single route.
-    # Otherwise, our count will be too high or low and will throw off extended vs. contracted logic.
+    # If an alert affects 1+ GL branches, count it as one route.
     affected_routes =
-      if alert_affects_gl_trunk_or_whole_line?(alert, gl_stop_sets) do
-        affected_routes
-        |> Enum.reject(fn route -> String.starts_with?(route, "Green") end)
-        |> Enum.concat(["Green"])
-      else
-        affected_routes
-      end
+      affected_routes
+      |> Enum.reject(fn route -> String.starts_with?(route, "Green") end)
+      |> Enum.concat(["Green"])
 
     length(affected_routes)
   end


### PR DESCRIPTION
**Asana task**: [GL multi-branch station closures omit stops](https://www.notion.so/mbta-downtown-crossing/GL-multi-branch-station-closures-omit-stops-867ac83ee89b4feaa9c1d80386e3d1e6?pvs=4) and ad-hoc

3 big things:
1. Fixed `max-width` so that it adjusts as more branch pills are added.
2. Alert count logic was still a little off. If an alert affects GL at all, count it as 1 alert. No need to only consolidate when all branches are affected.
3. Changed a GL serializer function so that we show the full list of multi-branch station closures.

- [ ] Tests added?
