### PR TITLE
bugfix: Fix DUP playername logic. Use `getDeviceInfo`

### DIFF
--- a/assets/src/apps/v2/dup.tsx
+++ b/assets/src/apps/v2/dup.tsx
@@ -123,7 +123,7 @@ const responseMapper: ResponseMapper = (apiResponse) => {
 };
 
 const App = (): JSX.Element => {
-  let playerName;
+  let playerName = null;
   if (isDup()) {
     playerName = useOutfrontPlayerName();
   }

--- a/assets/src/apps/v2/dup.tsx
+++ b/assets/src/apps/v2/dup.tsx
@@ -123,13 +123,44 @@ const responseMapper: ResponseMapper = (apiResponse) => {
 };
 
 const App = (): JSX.Element => {
+  const dEl = document.createElement("div");
+  dEl.id = "debug";
+  document.body.appendChild(dEl);
+  // save the original console.log function
+  const old_logger = console.log;
+  // grab html element for adding console.log output
+  const html_logger = document.getElementById("debug");
+  // replace console.log function with our own function
+  console.log = function (...msgs) {
+    // first call old logger for console output
+    old_logger.call(this, arguments);
+
+    // convert object args to strings and join them together
+    const text = msgs
+      .map((msg) => {
+        if (typeof msg == "object") {
+          return JSON && JSON.stringify ? JSON.stringify(msg) : msg;
+        } else {
+          return msg;
+        }
+      })
+      .join(" ");
+
+    // add the log to the html element.
+    html_logger.innerHTML += "<div>" + text + "<div>";
+  };
+
   let playerName = null;
   if (isDup()) {
     playerName = useOutfrontPlayerName();
   }
 
+  // playerName = "BRW-DUP-004"
+
   if (playerName !== null) {
+    console.log("player name is: ", playerName)
     const id = `DUP-${playerName.trim()}`;
+    console.log("id is ", id)
     return (
       <MappingContext.Provider value={TYPE_TO_COMPONENT}>
         <ResponseMapperContext.Provider value={responseMapper}>

--- a/assets/src/apps/v2/dup.tsx
+++ b/assets/src/apps/v2/dup.tsx
@@ -123,44 +123,13 @@ const responseMapper: ResponseMapper = (apiResponse) => {
 };
 
 const App = (): JSX.Element => {
-  const dEl = document.createElement("div");
-  dEl.id = "debug";
-  document.body.appendChild(dEl);
-  // save the original console.log function
-  const old_logger = console.log;
-  // grab html element for adding console.log output
-  const html_logger = document.getElementById("debug");
-  // replace console.log function with our own function
-  console.log = function (...msgs) {
-    // first call old logger for console output
-    old_logger.call(this, arguments);
-
-    // convert object args to strings and join them together
-    const text = msgs
-      .map((msg) => {
-        if (typeof msg == "object") {
-          return JSON && JSON.stringify ? JSON.stringify(msg) : msg;
-        } else {
-          return msg;
-        }
-      })
-      .join(" ");
-
-    // add the log to the html element.
-    html_logger.innerHTML += "<div>" + text + "<div>";
-  };
-
   let playerName = null;
   if (isDup()) {
     playerName = useOutfrontPlayerName();
   }
 
-  // playerName = "BRW-DUP-004"
-
   if (playerName !== null) {
-    console.log("player name is: ", playerName)
     const id = `DUP-${playerName.trim()}`;
-    console.log("id is ", id)
     return (
       <MappingContext.Provider value={TYPE_TO_COMPONENT}>
         <ResponseMapperContext.Provider value={responseMapper}>

--- a/assets/src/apps/v2/dup.tsx
+++ b/assets/src/apps/v2/dup.tsx
@@ -38,6 +38,7 @@ import PageLoadNoData from "Components/v2/dup/page_load_no_data";
 import NoData from "Components/v2/dup/no_data";
 import OvernightDepartures from "Components/v2/dup/overnight_departures";
 import useOutfrontPlayerName from "Hooks/use_outfront_player_name";
+import { isDup } from "Util/util";
 
 const TYPE_TO_COMPONENT = {
   screen_normal: NormalScreen,
@@ -122,7 +123,11 @@ const responseMapper: ResponseMapper = (apiResponse) => {
 };
 
 const App = (): JSX.Element => {
-  const playerName = useOutfrontPlayerName();
+  // TODO: add requestor conditional so this doesn't execute for Screenplay
+  let playerName;
+  if (isDup()) {
+    playerName = useOutfrontPlayerName();
+  }
 
   if (playerName !== null) {
     const id = `DUP-${playerName.trim()}`;

--- a/assets/src/apps/v2/dup.tsx
+++ b/assets/src/apps/v2/dup.tsx
@@ -123,7 +123,6 @@ const responseMapper: ResponseMapper = (apiResponse) => {
 };
 
 const App = (): JSX.Element => {
-  // TODO: add requestor conditional so this doesn't execute for Screenplay
   let playerName;
   if (isDup()) {
     playerName = useOutfrontPlayerName();

--- a/assets/src/components/v2/dup/README.md
+++ b/assets/src/components/v2/dup/README.md
@@ -2,7 +2,7 @@
 
 - Ensure [Corsica](https://hexdocs.pm/corsica/Corsica.html) is used on the server to allow CORS requests (ideally limited to just the DUP-relevant routes). It should already be configured at [this line](/lib/screens_web/controllers/v2/screen_api_controller.ex#L9) in the API controller--if it is, you don't need to do anything for this step.
 - Double check that any behavior specific to the DUP screen environment happens inside of an `isDup()` check. This includes:
-  - `buildApiPath` in use_api_response.tsx should return a full URL for the API path: prefix `apiPath` string with "https://screens.mbta.com".
+  - `apiPath` in use_api_response.tsx should return a full URL for the API path: prefix `apiPath` string with "https://screens.mbta.com".
   - `imagePath` in util.tsx should return relative paths (no leading `/`).
 - Create priv/static/dup-app.html if it doesn’t already exist. Copy paste the following contents in:
 

--- a/assets/src/components/v2/dup/version.tsx
+++ b/assets/src/components/v2/dup/version.tsx
@@ -1,1 +1,1 @@
-export const DUP_VERSION = "23.6.21.1";
+export const DUP_VERSION = "23.7.12.1";

--- a/assets/src/components/v2/dup/version.tsx
+++ b/assets/src/components/v2/dup/version.tsx
@@ -1,1 +1,1 @@
-export const DUP_VERSION = "23.7.25.1";
+export const DUP_VERSION = "23.7.25.2";

--- a/assets/src/components/v2/dup/version.tsx
+++ b/assets/src/components/v2/dup/version.tsx
@@ -1,1 +1,1 @@
-export const DUP_VERSION = "23.7.12.1";
+export const DUP_VERSION = "23.7.20.1";

--- a/assets/src/components/v2/dup/version.tsx
+++ b/assets/src/components/v2/dup/version.tsx
@@ -1,1 +1,1 @@
-export const DUP_VERSION = "23.7.21.1";
+export const DUP_VERSION = "23.7.21.2";

--- a/assets/src/components/v2/dup/version.tsx
+++ b/assets/src/components/v2/dup/version.tsx
@@ -1,1 +1,1 @@
-export const DUP_VERSION = "23.7.21.2";
+export const DUP_VERSION = "23.7.25.1";

--- a/assets/src/components/v2/dup/version.tsx
+++ b/assets/src/components/v2/dup/version.tsx
@@ -1,1 +1,1 @@
-export const DUP_VERSION = "23.7.20.1";
+export const DUP_VERSION = "23.7.21.1";

--- a/assets/src/components/v2/screen_page.tsx
+++ b/assets/src/components/v2/screen_page.tsx
@@ -8,6 +8,7 @@ interface Props {
 
 const ScreenPage = ({ id }: Props) => {
   const screenId = id ?? (useParams() as { id: string }).id;
+  console.log("screenId: ", screenId)
   return <ScreenContainer id={screenId} />;
 };
 

--- a/assets/src/components/v2/screen_page.tsx
+++ b/assets/src/components/v2/screen_page.tsx
@@ -8,7 +8,6 @@ interface Props {
 
 const ScreenPage = ({ id }: Props) => {
   const screenId = id ?? (useParams() as { id: string }).id;
-  console.log("screenId: ", screenId)
   return <ScreenContainer id={screenId} />;
 };
 

--- a/assets/src/hooks/use_outfront_player_name.tsx
+++ b/assets/src/hooks/use_outfront_player_name.tsx
@@ -4,29 +4,20 @@ const useOutfrontPlayerName = () => {
   const [playerName, setPlayerName] = useState("");
 
   useEffect(() => {
-    console.log("Running the useEffect hook")
     if (parent?.parent?.mraid ?? false) {
-      console.log("  Within the condition: parent?.parent?.mraid == true")
       const mraid = parent.parent.mraid;
       try {
-        console.log("   Within the try. Attempting to getDeviceInfo and parse the result")
         const deviceInfo = mraid.getDeviceInfo();
-        console.log("   result of getDeviceInfo: ", deviceInfo)
         const info = JSON.parse(deviceInfo);
-        console.log("   result of JSON.parse: ", info)
         setPlayerName(info.deviceName)
       } catch (err) {
-        console.log("Error: ", err)
         setPlayerName("noMraid");
       }
     }
     // Will rerun if MRAID changes
   }, [parent?.parent?.mraid]);
   
-  if (playerName.length > 0) { 
-    console.log("useOutfrontPlayerName hook has finished. Returning current state of playerName: ", playerName)
-  }
-  return playerName;
+  return playerName !== "" ? playerName : null;
 };
 
 export default useOutfrontPlayerName;

--- a/assets/src/hooks/use_outfront_player_name.tsx
+++ b/assets/src/hooks/use_outfront_player_name.tsx
@@ -4,16 +4,24 @@ const useOutfrontPlayerName = () => {
   const [playerName, setPlayerName] = useState("");
 
   useEffect(() => {
+    console.log("Running the useEffect hook")
     if (parent?.parent?.mraid ?? false) {
+      console.log("  Within the condition: parent?.parent?.mraid == true")
       try {
+        console.log("   Within the try. Attempting to getDeviceInfo and parse the result")
         const info = JSON.parse(mraid.getDeviceInfo());
+        console.log("   result of getDeviceInfo: ", mraid.getDeviceInfo())
+        console.log("   result of JSON.parse: ", info)
         setPlayerName(info.deviceName)
       } catch (err) {
+        console.log("   Within the catch. Setting deviceName to `noMraid`")
         setPlayerName("noMraid");
       }
     }
+    // Will rerun if MRAID changes
   }, [parent?.parent?.mraid]);
   
+  if (playerName) console.log("useOutfrontPlayerName hook has finished. Returning current state of playerName: ", playerName)
   return playerName;
 };
 

--- a/assets/src/hooks/use_outfront_player_name.tsx
+++ b/assets/src/hooks/use_outfront_player_name.tsx
@@ -15,7 +15,7 @@ const useOutfrontPlayerName = () => {
         console.log("   result of JSON.parse: ", info)
         setPlayerName(info.deviceName)
       } catch (err) {
-        console.log("   Within the catch. Setting deviceName to `noMraid`")
+        console.log("Error: ", err)
         setPlayerName("noMraid");
       }
     }

--- a/assets/src/hooks/use_outfront_player_name.tsx
+++ b/assets/src/hooks/use_outfront_player_name.tsx
@@ -9,8 +9,9 @@ const useOutfrontPlayerName = () => {
       console.log("  Within the condition: parent?.parent?.mraid == true")
       try {
         console.log("   Within the try. Attempting to getDeviceInfo and parse the result")
-        const info = JSON.parse(mraid.getDeviceInfo());
-        console.log("   result of getDeviceInfo: ", mraid.getDeviceInfo())
+        const deviceInfo = mraid.getDeviceInfo();
+        console.log("   result of getDeviceInfo: ", deviceInfo)
+        const info = JSON.parse(deviceInfo);
         console.log("   result of JSON.parse: ", info)
         setPlayerName(info.deviceName)
       } catch (err) {
@@ -21,7 +22,9 @@ const useOutfrontPlayerName = () => {
     // Will rerun if MRAID changes
   }, [parent?.parent?.mraid]);
   
-  if (playerName) console.log("useOutfrontPlayerName hook has finished. Returning current state of playerName: ", playerName)
+  if (playerName.length > 0) { 
+    console.log("useOutfrontPlayerName hook has finished. Returning current state of playerName: ", playerName)
+  }
   return playerName;
 };
 

--- a/assets/src/hooks/use_outfront_player_name.tsx
+++ b/assets/src/hooks/use_outfront_player_name.tsx
@@ -7,6 +7,7 @@ const useOutfrontPlayerName = () => {
     console.log("Running the useEffect hook")
     if (parent?.parent?.mraid ?? false) {
       console.log("  Within the condition: parent?.parent?.mraid == true")
+      const mraid = parent.parent.mraid;
       try {
         console.log("   Within the try. Attempting to getDeviceInfo and parse the result")
         const deviceInfo = mraid.getDeviceInfo();

--- a/assets/src/hooks/use_outfront_player_name.tsx
+++ b/assets/src/hooks/use_outfront_player_name.tsx
@@ -1,39 +1,20 @@
 import { useEffect, useState } from "react";
 
-const useOutfrontTags = () => {
-  const [tags, setTags] = useState(null);
-
-  let mraid;
-
-  try {
-    mraid = parent?.parent?.mraid;
-  } catch (_) {}
-
-  if (mraid) {
-    useEffect(() => {
-      if (parent?.parent?.mraid ?? false) {
-        try {
-          const rawTags = parent.parent.mraid.getTags();
-          setTags(JSON.parse(rawTags).tags);
-        } catch (err) {
-          setTags(null);
-        }
-      }
-    }, [parent?.parent?.mraid]);
-  }
-
-  return tags;
-};
-
 const useOutfrontPlayerName = () => {
-  const tags = useOutfrontTags();
-  if (tags !== null) {
-    const playerName =
-      tags.find(({ name }) => name === "player_name")?.value?.[0] ?? null;
-    return playerName;
-  } else {
-    return null;
-  }
+  const [playerName, setPlayerName] = useState(null);
+
+  useEffect(() => {
+    if (parent?.parent?.mraid ?? false) {
+      try {
+        const info = JSON.parse(mraid.getDeviceInfo());
+        setPlayerName(info.deviceName)
+      } catch (err) {
+        setPlayerName(null);
+      }
+    }
+  }, [parent?.parent?.mraid]);
+  
+  return playerName;
 };
 
 export default useOutfrontPlayerName;

--- a/assets/src/hooks/use_outfront_player_name.tsx
+++ b/assets/src/hooks/use_outfront_player_name.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 
 const useOutfrontPlayerName = () => {
-  const [playerName, setPlayerName] = useState(null);
+  const [playerName, setPlayerName] = useState("");
 
   useEffect(() => {
     if (parent?.parent?.mraid ?? false) {
@@ -9,7 +9,7 @@ const useOutfrontPlayerName = () => {
         const info = JSON.parse(mraid.getDeviceInfo());
         setPlayerName(info.deviceName)
       } catch (err) {
-        setPlayerName(null);
+        setPlayerName("noMraid");
       }
     }
   }, [parent?.parent?.mraid]);


### PR DESCRIPTION
The original logic assumed player_name was passed with tags, but it actually should be accessed with a different function `getDeviceInfo`.