### PR TITLE
[hotfix] Turn off blue bikes (process is failing)

### DIFF
--- a/lib/screens/application.ex
+++ b/lib/screens/application.ex
@@ -22,7 +22,8 @@ defmodule Screens.Application do
       :hackney_pool.child_spec(:blue_bikes_pool, []),
       :hackney_pool.child_spec(:api_v3_pool, max_connections: 100),
       {Screens.Stops.StationsWithRoutesAgent, %{}},
-      {Screens.BlueBikes.State, name: Screens.BlueBikes.State},
+      # Turning this off because it's not in use, and the process is failing
+      # {Screens.BlueBikes.State, name: Screens.BlueBikes.State},
       # Task supervisor for ScreensByAlert async updates
       # This supervisor is only used in deployment envs, but it's harmless to start it anyway in local dev.
       {Task.Supervisor, name: Screens.ScreensByAlert.Memcache.TaskSupervisor},


### PR DESCRIPTION
Adhoc: Erlang VM is crashing, and I'm seeing a lot of Sentry errors related to this. Hopefully this will resolve the crashing.
