### PR TITLE
In LocationContext, tag stop sequences by their routes

### DIFF
--- a/lib/screens/v2/location_context.ex
+++ b/lib/screens/v2/location_context.ex
@@ -1,13 +1,14 @@
 defmodule Screens.LocationContext do
   @moduledoc false
 
+  alias Screens.RoutePatterns.RoutePattern
   alias Screens.Routes.Route
   alias Screens.RouteType
   alias Screens.Stops.Stop
 
   @enforce_keys [:home_stop]
   defstruct home_stop: "",
-            stop_sequences: [],
+            tagged_stop_sequences: %{},
             upstream_stops: MapSet.new(),
             downstream_stops: MapSet.new(),
             routes: [],
@@ -15,10 +16,29 @@ defmodule Screens.LocationContext do
 
   @type t :: %__MODULE__{
           home_stop: Stop.id(),
-          stop_sequences: list(list(Stop.id())),
+          # Stop sequences through this stop, keyed under their associated routes
+          tagged_stop_sequences: %{Route.id() => list(list(Stop.id()))},
           upstream_stops: MapSet.t(Stop.id()),
           downstream_stops: MapSet.t(Stop.id()),
           routes: list(%{route_id: Route.id(), active?: boolean()}),
           alert_route_types: list(RouteType.t())
         }
+
+  @doc """
+  Returns IDs of routes that serve this location.
+  """
+  @spec route_ids(t()) :: list(Route.id())
+  def route_ids(%__MODULE__{} = t) do
+    Route.route_ids(t.routes)
+  end
+
+  @doc """
+  Returns the stop sequences of routes that serve this location.
+  Sequences follow the order of direction_id=0 for their respective routes.
+  Generally, this means they go from north/east -> south/west.
+  """
+  @spec stop_sequences(t()) :: list(list(Stop.id()))
+  def stop_sequences(%__MODULE__{} = t) do
+    RoutePattern.untag_stop_sequences(t.tagged_stop_sequences)
+  end
 end

--- a/lib/screens/v2/widget_instance/elevator_status.ex
+++ b/lib/screens/v2/widget_instance/elevator_status.ex
@@ -224,11 +224,12 @@ defmodule Screens.V2.WidgetInstance.ElevatorStatus do
     active and (alert_location === :upstream or alert_location === :downstream)
   end
 
-  defp sort_elsewhere(e1, _e2, %__MODULE__{location_context: %{stop_sequences: stop_sequences}}) do
+  defp sort_elsewhere(e1, _e2, %__MODULE__{location_context: location_context}) do
     stations = get_stations_from_entities(e1)
 
     flat_stop_sequences =
-      stop_sequences
+      location_context
+      |> LocationContext.stop_sequences()
       |> List.flatten()
 
     # NOTE: fix this, stop sequences never contain parent station IDs

--- a/test/screens/route_patterns/route_pattern_test.exs
+++ b/test/screens/route_patterns/route_pattern_test.exs
@@ -3,7 +3,7 @@ defmodule Screens.RoutePatterns.RoutePatternTest do
 
   import Screens.RoutePatterns.RoutePattern
 
-  describe "fetch_stop_sequences_through_stop/2" do
+  describe "fetch_tagged_stop_sequences_through_stop/2" do
     test "returns {:ok, sequences} if fetch function returns {:ok, data}" do
       stop_id = "1265"
 
@@ -18,13 +18,22 @@ defmodule Screens.RoutePatterns.RoutePatternTest do
           %{
             "type" => "trip",
             "relationships" => %{
-              "stops" => %{"data" => [%{"id" => "1"}, %{"id" => "2"}, %{"id" => "3"}]}
+              "stops" => %{"data" => [%{"id" => "1"}, %{"id" => "2"}, %{"id" => "3"}]},
+              "route" => %{"data" => %{"id" => "route1"}}
             }
           },
           %{
             "type" => "trip",
             "relationships" => %{
-              "stops" => %{"data" => [%{"id" => "5"}, %{"id" => "6"}, %{"id" => "7"}]}
+              "stops" => %{"data" => [%{"id" => "3"}, %{"id" => "2"}, %{"id" => "1"}]},
+              "route" => %{"data" => %{"id" => "route1"}}
+            }
+          },
+          %{
+            "type" => "trip",
+            "relationships" => %{
+              "stops" => %{"data" => [%{"id" => "5"}, %{"id" => "6"}, %{"id" => "7"}]},
+              "route" => %{"data" => %{"id" => "route2"}}
             }
           }
         ]
@@ -32,10 +41,10 @@ defmodule Screens.RoutePatterns.RoutePatternTest do
 
       get_json_fn = fn _, ^params -> {:ok, data} end
 
-      expected_stop_sequences = [~w[1 2 3], ~w[5 6 7]]
+      expected_stop_sequences = %{"route1" => [~w[1 2 3], ~w[3 2 1]], "route2" => [~w[5 6 7]]}
 
       assert {:ok, expected_stop_sequences} ==
-               fetch_stop_sequences_through_stop(stop_id, [], get_json_fn)
+               fetch_tagged_stop_sequences_through_stop(stop_id, [], get_json_fn)
     end
 
     test "returns :error if fetch function returns :error" do
@@ -43,7 +52,7 @@ defmodule Screens.RoutePatterns.RoutePatternTest do
 
       get_json_fn = fn _, _ -> :error end
 
-      assert :error == fetch_stop_sequences_through_stop(stop_id, [], get_json_fn)
+      assert :error == fetch_tagged_stop_sequences_through_stop(stop_id, [], get_json_fn)
     end
 
     test "returns filtered list if route_filters is provided" do
@@ -70,10 +79,10 @@ defmodule Screens.RoutePatterns.RoutePatternTest do
 
       get_json_fn = fn _, ^params -> {:ok, data} end
 
-      expected_stop_sequences = [~w[5 6 7]]
+      expected_stop_sequences = %{"Orange" => [~w[5 6 7]]}
 
       assert {:ok, expected_stop_sequences} ==
-               fetch_stop_sequences_through_stop(stop_id, route_filters, get_json_fn)
+               fetch_tagged_stop_sequences_through_stop(stop_id, route_filters, get_json_fn)
     end
   end
 end

--- a/test/screens/v2/candidate_generator/widgets/alerts_test.exs
+++ b/test/screens/v2/candidate_generator/widgets/alerts_test.exs
@@ -7,6 +7,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.AlertsTest do
   alias Screens.Config.Screen
   alias Screens.Config.V2.{Alerts, BusShelter, Solari}
   alias Screens.LocationContext
+  alias Screens.RoutePatterns.RoutePattern
   alias Screens.Stops.Stop
   alias Screens.V2.WidgetInstance.Alert, as: AlertWidget
 
@@ -35,12 +36,14 @@ defmodule Screens.V2.CandidateGenerator.Widgets.AlertsTest do
         %{route_id: "44", active?: true}
       ]
 
-      stop_sequences = [
-        ~w[11531 1265 1266],
-        ~w[1262 11531 1265 1266 10413],
-        ~w[1265 1266 10413 11413 17411],
-        ~w[1260 1262 11531 1265]
-      ]
+      tagged_stop_sequences = %{
+        "A" => [~w[11531 1265 1266]],
+        "B" => [~w[1262 11531 1265 1266 10413]],
+        "C" => [~w[1265 1266 10413 11413 17411]],
+        "D" => [~w[1260 1262 11531 1265]]
+      }
+
+      stop_sequences = RoutePattern.untag_stop_sequences(tagged_stop_sequences)
 
       alerts = [
         %Alert{
@@ -66,7 +69,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.AlertsTest do
 
       location_context = %LocationContext{
         home_stop: stop_id,
-        stop_sequences: stop_sequences,
+        tagged_stop_sequences: tagged_stop_sequences,
         upstream_stops: Stop.upstream_stop_id_set(stop_id, stop_sequences),
         downstream_stops: Stop.downstream_stop_id_set(stop_id, stop_sequences),
         routes: routes_at_stop,

--- a/test/screens/v2/candidate_generator/widgets/reconstructed_alert_test.exs
+++ b/test/screens/v2/candidate_generator/widgets/reconstructed_alert_test.exs
@@ -8,6 +8,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlertTest do
   alias Screens.Config.V2.Header.CurrentStopId
   alias Screens.Config.V2.{PreFare, Solari}
   alias Screens.LocationContext
+  alias Screens.RoutePatterns.RoutePattern
   alias Screens.Stops.Stop
   alias Screens.V2.WidgetInstance.ReconstructedAlert, as: ReconstructedAlertWidget
 
@@ -89,9 +90,11 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlertTest do
         }
       ]
 
-      stop_sequences = [
-        ["place-ogmnl", "place-mlmnl", "place-welln", "place-astao"]
-      ]
+      tagged_stop_sequences = %{
+        "A" => [["place-ogmnl", "place-mlmnl", "place-welln", "place-astao"]]
+      }
+
+      stop_sequences = RoutePattern.untag_stop_sequences(tagged_stop_sequences)
 
       fetch_stop_name_fn = fn
         "place-ogmnl" -> "Oak Grove"
@@ -102,7 +105,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlertTest do
 
       location_context = %LocationContext{
         home_stop: stop_id,
-        stop_sequences: stop_sequences,
+        tagged_stop_sequences: tagged_stop_sequences,
         upstream_stops: Stop.upstream_stop_id_set(stop_id, stop_sequences),
         downstream_stops: Stop.downstream_stop_id_set(stop_id, stop_sequences),
         routes: routes_at_stop,

--- a/test/screens/v2/widget_instance/alert_test.exs
+++ b/test/screens/v2/widget_instance/alert_test.exs
@@ -5,6 +5,7 @@ defmodule Screens.V2.WidgetInstance.AlertTest do
   alias Screens.Config.Screen
   alias Screens.Config.V2.{BusEink, BusShelter, GlEink}
   alias Screens.LocationContext
+  alias Screens.RoutePatterns.RoutePattern
   alias Screens.Stops.Stop
   alias Screens.V2.AlertsWidget
   alias Screens.V2.WidgetInstance.Alert, as: AlertWidget
@@ -18,7 +19,7 @@ defmodule Screens.V2.WidgetInstance.AlertTest do
         screen: %Screen{app_params: nil, vendor: nil, device_id: nil, name: nil, app_id: nil},
         location_context: %LocationContext{
           home_stop: nil,
-          stop_sequences: nil,
+          tagged_stop_sequences: nil,
           upstream_stops: nil,
           downstream_stops: nil,
           routes: nil,
@@ -47,12 +48,14 @@ defmodule Screens.V2.WidgetInstance.AlertTest do
     %{widget | alert: %{widget.alert | informed_entities: ies}}
   end
 
-  defp put_stop_sequences(widget, sequences) do
+  defp put_tagged_stop_sequences(widget, tagged_sequences) do
+    sequences = RoutePattern.untag_stop_sequences(tagged_sequences)
+
     %{
       widget
       | location_context: %{
           widget.location_context
-          | stop_sequences: sequences,
+          | tagged_stop_sequences: tagged_sequences,
             upstream_stops:
               Stop.upstream_stop_id_set(widget.location_context.home_stop, sequences),
             downstream_stops:
@@ -93,16 +96,20 @@ defmodule Screens.V2.WidgetInstance.AlertTest do
     %{widget: put_home_stop(widget, BusShelter, home_stop)}
   end
 
-  defp setup_stop_sequences(%{widget: widget}) do
-    stop_sequences = [
-      ~w[0 1 2 3 4  5 6 7 8 9],
-      ~w[10 20 30 4 5 7],
-      ~w[           5 6 90],
-      ~w[200 40     5],
-      ~w[111 222 333]
-    ]
+  defp setup_tagged_stop_sequences(%{widget: widget}) do
+    tagged_stop_sequences = %{
+      "A" => [
+        ~w[0 1 2 3 4  5 6 7 8 9],
+        ~w[10 20 30 4 5 7]
+      ],
+      "B" => [
+        ~w[           5 6 90],
+        ~w[200 40     5],
+        ~w[111 222 333]
+      ]
+    }
 
-    %{widget: put_stop_sequences(widget, stop_sequences)}
+    %{widget: put_tagged_stop_sequences(widget, tagged_stop_sequences)}
   end
 
   defp setup_routes(%{widget: widget}) do
@@ -118,7 +125,7 @@ defmodule Screens.V2.WidgetInstance.AlertTest do
   defp setup_location_context(%{widget: widget}) do
     %{widget: widget}
     |> setup_home_stop()
-    |> setup_stop_sequences()
+    |> setup_tagged_stop_sequences()
     |> setup_routes()
   end
 

--- a/test/screens/v2/widget_instance/dup_special_case_alert_test.exs
+++ b/test/screens/v2/widget_instance/dup_special_case_alert_test.exs
@@ -4,6 +4,7 @@ defmodule Screens.V2.WidgetInstance.DupSpecialCaseAlertTest do
   alias Screens.Config.Screen
   alias Screens.Config.V2.{Alerts, Departures, Dup, FreeTextLine}
   alias Screens.LocationContext
+  alias Screens.RoutePatterns.RoutePattern
   alias Screens.Stops.Stop
   alias Screens.V2.CandidateGenerator.Dup.Alerts, as: DupAlerts
   alias Screens.V2.WidgetInstance.DupSpecialCaseAlert
@@ -66,101 +67,114 @@ defmodule Screens.V2.WidgetInstance.DupSpecialCaseAlertTest do
     ]
   end
 
-  defp stop_sequences("place-kencl") do
-    [
-      [
-        "place-unsqu",
-        "place-lech",
-        "place-spmnl",
-        "place-north",
-        "place-haecl",
-        "place-gover",
-        "place-pktrm",
-        "place-boyls",
-        "place-armnl",
-        "place-coecl",
-        "place-hymnl",
-        "place-kencl",
-        "place-fenwy",
-        "place-longw",
-        "place-bvmnl",
-        "place-brkhl",
-        "place-bcnfd",
-        "place-rsmnl",
-        "place-chhil",
-        "place-newto",
-        "place-newtn",
-        "place-eliot",
-        "place-waban",
-        "place-woodl",
-        "place-river"
+  defp tagged_stop_sequences("place-kencl") do
+    %{
+      "Green-B" => [
+        [
+          "place-gover",
+          "place-pktrm",
+          "place-boyls",
+          "place-armnl",
+          "place-coecl",
+          "place-hymnl",
+          "place-kencl",
+          "place-bland",
+          "place-buest",
+          "place-bucen",
+          "place-amory",
+          "place-babck",
+          "place-brico",
+          "place-harvd",
+          "place-grigg",
+          "place-alsgr",
+          "place-wrnst",
+          "place-wascm",
+          "place-sthld",
+          "place-chswk",
+          "place-chill",
+          "place-sougr",
+          "place-lake"
+        ]
       ],
-      [
-        "place-gover",
-        "place-pktrm",
-        "place-boyls",
-        "place-armnl",
-        "place-coecl",
-        "place-hymnl",
-        "place-kencl",
-        "place-bland",
-        "place-buest",
-        "place-bucen",
-        "place-amory",
-        "place-babck",
-        "place-brico",
-        "place-harvd",
-        "place-grigg",
-        "place-alsgr",
-        "place-wrnst",
-        "place-wascm",
-        "place-sthld",
-        "place-chswk",
-        "place-chill",
-        "place-sougr",
-        "place-lake"
+      "Green-C" => [
+        [
+          "place-gover",
+          "place-pktrm",
+          "place-boyls",
+          "place-armnl",
+          "place-coecl",
+          "place-hymnl",
+          "place-kencl",
+          "place-smary",
+          "place-hwsst",
+          "place-kntst",
+          "place-stpul",
+          "place-cool",
+          "place-sumav",
+          "place-bndhl",
+          "place-fbkst",
+          "place-bcnwa",
+          "place-tapst",
+          "place-denrd",
+          "place-engav",
+          "place-clmnl"
+        ]
       ],
-      [
-        "place-gover",
-        "place-pktrm",
-        "place-boyls",
-        "place-armnl",
-        "place-coecl",
-        "place-hymnl",
-        "place-kencl",
-        "place-smary",
-        "place-hwsst",
-        "place-kntst",
-        "place-stpul",
-        "place-cool",
-        "place-sumav",
-        "place-bndhl",
-        "place-fbkst",
-        "place-bcnwa",
-        "place-tapst",
-        "place-denrd",
-        "place-engav",
-        "place-clmnl"
+      "Green-D" => [
+        [
+          "place-unsqu",
+          "place-lech",
+          "place-spmnl",
+          "place-north",
+          "place-haecl",
+          "place-gover",
+          "place-pktrm",
+          "place-boyls",
+          "place-armnl",
+          "place-coecl",
+          "place-hymnl",
+          "place-kencl",
+          "place-fenwy",
+          "place-longw",
+          "place-bvmnl",
+          "place-brkhl",
+          "place-bcnfd",
+          "place-rsmnl",
+          "place-chhil",
+          "place-newto",
+          "place-newtn",
+          "place-eliot",
+          "place-waban",
+          "place-woodl",
+          "place-river"
+        ]
       ]
-    ]
+    }
   end
 
-  defp stop_sequences("place-wtcst") do
-    [
-      [
-        "place-sstat",
-        "place-crtst",
-        "place-wtcst",
-        "place-conrd",
-        "place-aport",
-        "place-estav",
-        "place-boxdt",
-        "place-belsq",
-        "place-chels"
+  defp tagged_stop_sequences("place-wtcst") do
+    %{
+      # SL1
+      "741" => [["place-sstat", "place-crtst", "place-wtcst", "place-conrd", "17091"]],
+      # SL2
+      "742" => [
+        ["place-sstat", "place-crtst", "place-wtcst", "place-conrd", "247", "30249", "30250"]
       ],
-      ["place-sstat", "place-crtst", "place-wtcst", "place-conrd", "247", "30249", "30250"],
-      ["place-sstat", "place-crtst", "place-wtcst", "place-conrd", "17091"]
-    ]
+      # SL3
+      "743" => [
+        [
+          "place-sstat",
+          "place-crtst",
+          "place-wtcst",
+          "place-conrd",
+          "place-aport",
+          "place-estav",
+          "place-boxdt",
+          "place-belsq",
+          "place-chels"
+        ]
+      ]
+    }
   end
 
   describe "dup alert_instances/6 > serialize/1" do
@@ -900,12 +914,15 @@ defmodule Screens.V2.WidgetInstance.DupSpecialCaseAlertTest do
         wtc_alerts: wtc_alerts,
         fetch_location_context_fn: fn
           _, stop_id, _ ->
+            tagged_stop_sequences = tagged_stop_sequences(stop_id)
+            stop_sequences = RoutePattern.untag_stop_sequences(tagged_stop_sequences)
+
             {:ok,
              %LocationContext{
                home_stop: stop_id,
-               stop_sequences: stop_sequences(stop_id),
-               upstream_stops: Stop.upstream_stop_id_set(stop_id, stop_sequences(stop_id)),
-               downstream_stops: Stop.downstream_stop_id_set(stop_id, stop_sequences(stop_id)),
+               tagged_stop_sequences: tagged_stop_sequences,
+               upstream_stops: Stop.upstream_stop_id_set(stop_id, stop_sequences),
+               downstream_stops: Stop.downstream_stop_id_set(stop_id, stop_sequences),
                routes: routes(stop_id),
                alert_route_types: Stop.get_route_type_filter(Dup, stop_id)
              }}

--- a/test/screens/v2/widget_instance/elevator_status_test.exs
+++ b/test/screens/v2/widget_instance/elevator_status_test.exs
@@ -6,6 +6,7 @@ defmodule Screens.V2.WidgetInstance.ElevatorStatusTest do
   alias Screens.Config.Screen
   alias Screens.Config.V2.{ElevatorStatus, PreFare}
   alias Screens.LocationContext
+  alias Screens.RoutePatterns.RoutePattern
   alias Screens.Stops.Stop
 
   # Convenience function to build an elevator alert
@@ -57,10 +58,14 @@ defmodule Screens.V2.WidgetInstance.ElevatorStatusTest do
       "place-qux" => "Qux Station"
     }
 
-    stop_sequences = [
-      ["place-foo", "place-bar"],
-      ["place-foo", "place-bar"]
-    ]
+    tagged_stop_sequences = %{
+      "A" => [
+        ["place-foo", "place-bar"],
+        ["place-foo", "place-bar"]
+      ]
+    }
+
+    stop_sequences = RoutePattern.untag_stop_sequences(tagged_stop_sequences)
 
     station_id_to_icons = %{
       "place-foo" => [:red],
@@ -71,7 +76,7 @@ defmodule Screens.V2.WidgetInstance.ElevatorStatusTest do
 
     location_context = %LocationContext{
       home_stop: home_station_id,
-      stop_sequences: stop_sequences,
+      tagged_stop_sequences: tagged_stop_sequences,
       upstream_stops: Stop.upstream_stop_id_set(home_station_id, stop_sequences),
       downstream_stops: Stop.downstream_stop_id_set(home_station_id, stop_sequences),
       routes: [],

--- a/test/screens/v2/widget_instance/reconstructed_alert_property_test.exs
+++ b/test/screens/v2/widget_instance/reconstructed_alert_property_test.exs
@@ -14,6 +14,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertPropertyTest do
   alias Screens.Config.V2.{PreFare}
   alias Screens.Config.V2.Header.CurrentStopId
   alias Screens.LocationContext
+  alias Screens.RoutePatterns.RoutePattern
   alias Screens.Stops.Stop
   alias Screens.Util
   alias Screens.V2.CandidateGenerator
@@ -1139,8 +1140,10 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertPropertyTest do
           }
         end)
 
-      station_sequences =
-        Enum.map(route_ids_at_stop, fn id -> Stop.get_route_stop_sequence(id) end)
+      tagged_station_sequences =
+        Map.new(route_ids_at_stop, fn id -> {id, [Stop.get_route_stop_sequence(id)]} end)
+
+      station_sequences = RoutePattern.untag_stop_sequences(tagged_station_sequences)
 
       fetch_alerts_fn = fn _ -> {:ok, [alert]} end
       fetch_stop_name_fn = fn _ -> "Test" end
@@ -1149,7 +1152,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertPropertyTest do
         {:ok,
          %LocationContext{
            home_stop: stop_id,
-           stop_sequences: station_sequences,
+           tagged_stop_sequences: tagged_station_sequences,
            upstream_stops: Stop.upstream_stop_id_set(stop_id, station_sequences),
            downstream_stops: Stop.downstream_stop_id_set(stop_id, station_sequences),
            routes: routes_at_stop,

--- a/test/screens/v2/widget_instance/reconstructed_alert_test.exs
+++ b/test/screens/v2/widget_instance/reconstructed_alert_test.exs
@@ -6,6 +6,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
   alias Screens.Config.V2.{PreFare}
   alias Screens.Config.V2.Header.CurrentStopId
   alias Screens.LocationContext
+  alias Screens.RoutePatterns.RoutePattern
   alias Screens.Stops.Stop
   alias Screens.V2.AlertsWidget
   alias Screens.V2.CandidateGenerator
@@ -22,7 +23,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
         screen: %Screen{app_params: nil, vendor: nil, device_id: nil, name: nil, app_id: nil},
         location_context: %LocationContext{
           home_stop: nil,
-          stop_sequences: nil,
+          tagged_stop_sequences: nil,
           upstream_stops: nil,
           downstream_stops: nil,
           routes: nil,
@@ -51,12 +52,14 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
     %{widget | alert: %{widget.alert | informed_entities: ies}}
   end
 
-  defp put_stop_sequences(widget, sequences) do
+  defp put_tagged_stop_sequences(widget, tagged_sequences) do
+    sequences = RoutePattern.untag_stop_sequences(tagged_sequences)
+
     %{
       widget
       | location_context: %{
           widget.location_context
-          | stop_sequences: sequences,
+          | tagged_stop_sequences: tagged_sequences,
             upstream_stops:
               Stop.upstream_stop_id_set(widget.location_context.home_stop, sequences),
             downstream_stops:
@@ -123,26 +126,30 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
   defp setup_transfer_station(%{widget: widget}) do
     home_stop = "place-dwnxg"
 
-    stop_sequences = [
-      [
-        "place-ogmnl",
-        "place-haecl",
-        "place-dwnxg",
-        "place-forhl"
+    tagged_stop_sequences = %{
+      "Orange" => [
+        [
+          "place-ogmnl",
+          "place-haecl",
+          "place-dwnxg",
+          "place-forhl"
+        ]
       ],
-      [
-        "place-alfcl",
-        "place-pktrm",
-        "place-dwnxg",
-        "place-asmnl"
-      ],
-      [
-        "place-alfcl",
-        "place-dwnxg",
-        "place-sstat",
-        "place-brntn"
+      "Red" => [
+        [
+          "place-alfcl",
+          "place-pktrm",
+          "place-dwnxg",
+          "place-asmnl"
+        ],
+        [
+          "place-alfcl",
+          "place-dwnxg",
+          "place-sstat",
+          "place-brntn"
+        ]
       ]
-    ]
+    }
 
     routes = [
       %{
@@ -166,7 +173,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
     widget =
       widget
       |> put_home_stop(PreFare, home_stop)
-      |> put_stop_sequences(stop_sequences)
+      |> put_tagged_stop_sequences(tagged_stop_sequences)
       |> put_informed_stations_string("Downtown Crossing")
       |> put_routes_at_stop(routes)
 
@@ -176,14 +183,16 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
   defp setup_single_line_station(%{widget: widget}) do
     home_stop = "place-mlmnl"
 
-    stop_sequences = [
-      [
-        "place-ogmnl",
-        "place-mlmnl",
-        "place-welln",
-        "place-astao"
+    tagged_stop_sequences = %{
+      "Orange" => [
+        [
+          "place-ogmnl",
+          "place-mlmnl",
+          "place-welln",
+          "place-astao"
+        ]
       ]
-    ]
+    }
 
     routes = [
       %{
@@ -199,7 +208,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
     widget =
       widget
       |> put_home_stop(PreFare, home_stop)
-      |> put_stop_sequences(stop_sequences)
+      |> put_tagged_stop_sequences(tagged_stop_sequences)
       |> put_informed_stations_string("Malden Center")
       |> put_routes_at_stop(routes)
 
@@ -213,29 +222,33 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
     %{widget: put_home_stop(widget, PreFare, home_stop)}
   end
 
-  defp setup_stop_sequences(%{widget: widget}) do
-    stop_sequences = [
-      [
-        "place-ogmnl",
-        "place-dwnxg",
-        "place-chncl",
-        "place-forhl"
+  defp setup_tagged_stop_sequences(%{widget: widget}) do
+    tagged_stop_sequences = %{
+      "Orange" => [
+        [
+          "place-ogmnl",
+          "place-dwnxg",
+          "place-chncl",
+          "place-forhl"
+        ]
       ],
-      [
-        "place-asmnl",
-        "place-dwnxg",
-        "place-pktrm",
-        "place-alfcl"
-      ],
-      [
-        "place-alfcl",
-        "place-dwnxg",
-        "place-sstat",
-        "place-brntn"
+      "Red" => [
+        [
+          "place-asmnl",
+          "place-dwnxg",
+          "place-pktrm",
+          "place-alfcl"
+        ],
+        [
+          "place-alfcl",
+          "place-dwnxg",
+          "place-sstat",
+          "place-brntn"
+        ]
       ]
-    ]
+    }
 
-    %{widget: put_stop_sequences(widget, stop_sequences)}
+    %{widget: put_tagged_stop_sequences(widget, tagged_stop_sequences)}
   end
 
   defp setup_informed_entities_string(%{widget: widget}) do
@@ -245,7 +258,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
   defp setup_location_context(%{widget: widget}) do
     %{widget: widget}
     |> setup_home_stop()
-    |> setup_stop_sequences()
+    |> setup_tagged_stop_sequences()
     |> setup_routes()
   end
 
@@ -371,14 +384,16 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
         |> put_home_stop(PreFare, "place-forhl")
         |> put_informed_entities([ie(stop: "place-chncl"), ie(stop: "place-forhl")])
         |> put_effect(:suspension)
-        |> put_stop_sequences([
-          [
-            "place-ogmnl",
-            "place-dwnxg",
-            "place-chncl",
-            "place-forhl"
+        |> put_tagged_stop_sequences(%{
+          "Orange" => [
+            [
+              "place-ogmnl",
+              "place-dwnxg",
+              "place-chncl",
+              "place-forhl"
+            ]
           ]
-        ])
+        })
         |> put_is_terminal_station(true)
         |> put_is_full_screen(true)
 
@@ -393,14 +408,16 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
         |> put_home_stop(PreFare, "place-forhl")
         |> put_informed_entities([ie(stop: "place-chncl"), ie(stop: "place-forhl")])
         |> put_effect(:shuttle)
-        |> put_stop_sequences([
-          [
-            "place-ogmnl",
-            "place-dwnxg",
-            "place-chncl",
-            "place-forhl"
+        |> put_tagged_stop_sequences(%{
+          "Orange" => [
+            [
+              "place-ogmnl",
+              "place-dwnxg",
+              "place-chncl",
+              "place-forhl"
+            ]
           ]
-        ])
+        })
         |> put_is_terminal_station(true)
         |> put_is_full_screen(true)
 
@@ -438,14 +455,16 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
         |> put_home_stop(PreFare, "place-forhl")
         |> put_informed_entities([ie(stop: "place-chncl"), ie(stop: "place-forhl")])
         |> put_effect(:severe_delay)
-        |> put_stop_sequences([
-          [
-            "place-ogmnl",
-            "place-dwnxg",
-            "place-chncl",
-            "place-forhl"
+        |> put_tagged_stop_sequences(%{
+          "Orange" => [
+            [
+              "place-ogmnl",
+              "place-dwnxg",
+              "place-chncl",
+              "place-forhl"
+            ]
           ]
-        ])
+        })
         |> put_is_terminal_station(true)
 
       assert [3] == WidgetInstance.priority(widget)
@@ -1305,14 +1324,16 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
           ie(stop: "place-spmnl", route: "Green-E", route_type: 0)
         ])
         |> put_cause(:unknown)
-        |> put_stop_sequences([
-          [
-            "place-smpmnl",
-            "place-north",
-            "place-haecl",
-            "place-gover"
+        |> put_tagged_stop_sequences(%{
+          "Green-E" => [
+            [
+              "place-symcl",
+              "place-north",
+              "place-haecl",
+              "place-gover"
+            ]
           ]
-        ])
+        })
         |> put_routes_at_stop([
           %{
             route_id: "Green-D",
@@ -1617,7 +1638,8 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
       ]
 
       now = ~U[2022-06-24 12:00:00Z]
-      station_sequences = [Stop.get_route_stop_sequence("Orange")]
+      tagged_station_sequences = %{"Orange" => [Stop.get_route_stop_sequence("Orange")]}
+      station_sequences = RoutePattern.untag_stop_sequences(tagged_station_sequences)
 
       fetch_alerts_fn = fn _ -> {:ok, alerts} end
       fetch_stop_name_fn = fn _ -> "Wellington" end
@@ -1626,7 +1648,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
         {:ok,
          %LocationContext{
            home_stop: stop_id,
-           stop_sequences: station_sequences,
+           tagged_stop_sequences: tagged_station_sequences,
            upstream_stops: Stop.upstream_stop_id_set(stop_id, station_sequences),
            downstream_stops: Stop.downstream_stop_id_set(stop_id, station_sequences),
            routes: routes_at_stop,
@@ -2001,7 +2023,8 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
       ]
 
       now = ~U[2022-06-24 12:00:00Z]
-      station_sequences = [Stop.get_route_stop_sequence("Green")]
+      tagged_station_sequences = %{"Green" => [Stop.get_route_stop_sequence("Green")]}
+      station_sequences = RoutePattern.untag_stop_sequences(tagged_station_sequences)
 
       fetch_alerts_fn = fn _ -> {:ok, alerts} end
       fetch_stop_name_fn = fn _ -> "Government Center" end
@@ -2010,7 +2033,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
         {:ok,
          %LocationContext{
            home_stop: stop_id,
-           stop_sequences: station_sequences,
+           tagged_stop_sequences: tagged_station_sequences,
            upstream_stops: Stop.upstream_stop_id_set(stop_id, station_sequences),
            downstream_stops: Stop.downstream_stop_id_set(stop_id, station_sequences),
            routes: routes_at_stop,


### PR DESCRIPTION
**Asana task**: ad hoc

This stores some extra data in the `LocationContext` struct, which is useful for disruption diagrams for now, and maybe other things in the future.

Code expecting the original, untagged list of stop sequences can now get it by calling `LocationContext.stop_sequences(location_context)` if it's already inside the struct, or `RoutePattern.untag_stop_sequences(tagged_stop_sequences)` if handling the tagged sequence map directly.

- [x] Tests added? <sup>(None added, but many updated)</sup>
