### PR TITLE
fix: Tweak config so vscode can consistently resolve aliased import paths

### DIFF
--- a/assets/tsconfig.json
+++ b/assets/tsconfig.json
@@ -45,10 +45,10 @@
     "moduleResolution": "node" /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */,
     "baseUrl": "./src",                       /* Base directory to resolve non-absolute module names. */
     "paths": {
-      "Components": ["/components"],
-      "Hooks": ["/hooks"],
-      "Util": ["/util"],
-      "Constants": ["/constants"]
+      "Components/*": ["components/*"],
+      "Hooks/*": ["hooks/*"],
+      "Util/*": ["util/*"],
+      "Constants/*": ["constants/*"]
     },                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                       /* List of folders to include type definitions from. */


### PR DESCRIPTION
**Asana task**: ad hoc

This stops vscode from incorrectly, and inconsistently, flagging various aliased imports as duplicate-imports, and other confusing behavior.

This fix is purely "cosmetic"—the webpack config to resolve aliases was already correct so the code was being compiled/bundled correctly; this just fixes the TS counterpart so that our editors don't raise false alarms all over the place.

- [ ] Tests added?
