### PR TITLE
feat: Add admin config columns (thus far) for triptych app

### DIFF
--- a/assets/src/apps/admin.tsx
+++ b/assets/src/apps/admin.tsx
@@ -23,6 +23,7 @@ import {
   BusShelterV2ScreensTable,
   PreFareV2ScreensTable,
   DupV2ScreensTable,
+  TriptychV2ScreensTable
 } from "Components/admin/admin_tables";
 import ImageManager from "Components/admin/admin_image_manager";
 import Devops from "Components/admin/devops";
@@ -76,6 +77,9 @@ const App = (): JSX.Element => {
         </Route>
         <Route exact path="/pre-fare-v2-screens">
           <PreFareV2ScreensTable />
+        </Route>
+        <Route exact path="/triptych-v2-screens">
+          <TriptychV2ScreensTable />
         </Route>
         <Route exact path="/json-editor">
           <AdminForm />

--- a/assets/src/components/admin/admin_navbar.tsx
+++ b/assets/src/components/admin/admin_navbar.tsx
@@ -49,6 +49,9 @@ const AdminNavbar = (): JSX.Element => {
       <Link to="/pre-fare-v2-screens">
         <button>Pre-Fare V2 Screens Table</button>
       </Link>
+      <Link to="/triptych-v2-screens">
+        <button>Triptych V2 Screens Table</button>
+      </Link>
       <Link to="/json-editor">
         <button>JSON Editor</button>
       </Link>

--- a/assets/src/components/admin/admin_tables.tsx
+++ b/assets/src/components/admin/admin_tables.tsx
@@ -687,6 +687,24 @@ const shuttleBusInfoColumn = {
   FormCell: FormTextarea,
 };
 
+const trainCrowdingColumn = {
+  Header: "Train Crowding",
+  accessor: buildAppParamAccessor("train_crowding"),
+  mutator: buildAppParamMutator("train_crowding"),
+  Cell: EditableTextarea,
+  disableFilters: true,
+  FormCell: FormTextarea,
+};
+
+const localEvergreenSetsColumn = {
+  Header: "Local Evergreen Content Sets",
+  accessor: buildAppParamAccessor("local_evergreen_sets"),
+  mutator: buildAppParamMutator("local_evergreen_sets"),
+  Cell: EditableTextarea,
+  disableFilters: true,
+  FormCell: FormTextarea,
+};
+
 const PreFareV2ScreensTable = (): JSX.Element => {
   const dataFilter = ({ app_id }) => {
     return app_id === "pre_fare_v2";
@@ -762,7 +780,15 @@ const TriptychV2ScreensTable = (): JSX.Element => {
     return app_id === "triptych_v2";
   };
 
-  return <AdminTable columns={[...v2Columns]} dataFilter={dataFilter} />;
+  return (
+    <AdminTable
+      columns={[
+        trainCrowdingColumn,
+        localEvergreenSetsColumn,
+      ]}
+      dataFilter={dataFilter}
+    />
+  );
 };
 
 export {


### PR DESCRIPTION
**Asana task**: [Triptych: Add to admin tool](https://app.asana.com/0/1185117109217413/1205259332301425/f)

This just adds the usual textarea columns for the two config fields we have so far in the triptych app: train crowding and local evergreen sets.

(`local_evergreen_sets` will replace `evergreen_content` in the config definitions soon, in Hannah's PR)

A column for configuring the "version+player name displayer" will be added in the PR that adds that feature.

- [ ] Tests added?
