### PR TITLE
fix: Handle unrecognized screen IDs in `screen_name_for_id`

### DIFF
--- a/lib/screens/log_screen_data.ex
+++ b/lib/screens/log_screen_data.ex
@@ -128,8 +128,10 @@ defmodule Screens.LogScreenData do
   end
 
   defp screen_name_for_id(screen_id) do
-    %Screen{name: name} = State.screen(screen_id)
-    name
+    case State.screen(screen_id) do
+      %Screen{name: name} -> name
+      nil -> "UNKNOWN_SCREEN"
+    end
   end
 
   defp insert_screen_side(data, nil), do: data


### PR DESCRIPTION
**Asana task**: ad hoc

Little fix for an issue I noticed while poking around. This change lets the server properly log data requests from unrecognized screens, and send back 404s.

- [ ] Tests added?
