### PR TITLE
Add a new log fn for unrecognized triptych player name

### DIFF
--- a/lib/screens/log_screen_data.ex
+++ b/lib/screens/log_screen_data.ex
@@ -59,6 +59,10 @@ defmodule Screens.LogScreenData do
     log_message("[screen frontend error]", data)
   end
 
+  def log_unrecognized_triptych_player(player_name) do
+    log_message("[unrecognized triptych player name]", %{player_name: player_name})
+  end
+
   def log_api_response(response, screen_id, last_refresh, is_screen, screen_side \\ nil)
 
   def log_api_response(


### PR DESCRIPTION
**Asana task**: ad hoc?

This just adds and uses a `log_unrecognized_triptych_player` function. The rest of the changes are from my adding an alias + the formatter adjusting indentation.

- [ ] Tests added?
