### PR TITLE
tweak(triptych): Do not render slots outside the viewport when using the 3-slot split layout

### DIFF
--- a/assets/src/components/v2/triptych/triptych_three_pane.tsx
+++ b/assets/src/components/v2/triptych/triptych_three_pane.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import Widget, { WidgetData } from "Components/v2/widget";
+import { TriptychPane, getTriptychPane } from "Util/outfront";
 
 interface Props {
   left_pane: WidgetData;
@@ -8,21 +9,26 @@ interface Props {
   right_pane: WidgetData;
 }
 
+const isInViewport = (pane: TriptychPane | null, slotPosition: TriptychPane) =>
+  pane == null || pane == slotPosition;
+
 const TriptychThreePane: React.ComponentType<Props> = ({
   left_pane: leftPane,
   middle_pane: middlePane,
   right_pane: rightPane,
 }) => {
+  const pane = getTriptychPane();
+
   return (
     <>
       <div className="left-pane">
-        <Widget data={leftPane} />
+        {isInViewport(pane, "left") && <Widget data={leftPane} />}
       </div>
       <div className="middle-pane">
-        <Widget data={middlePane} />
+        {isInViewport(pane, "middle") && <Widget data={middlePane} />}
       </div>
       <div className="right-pane">
-        <Widget data={rightPane} />
+        {isInViewport(pane, "right") && <Widget data={rightPane} />}
       </div>
     </>
   );


### PR DESCRIPTION
**Asana task**: ad hoc

Panes besides the displayed one now only render the identifiers, just in case something has gone really wrong and we're seeing those for some reason. (Plus, they aren't expensive to render)

Screenshot 👇 notice that the `.left-pane` and `.right-pane` elements have no children since they are outside the viewport.
<img width="1680" alt="image" src="https://github.com/mbta/screens/assets/63608771/c0d102c5-6caf-4ca7-b140-c01048e0a28e">

- [ ] Tests added?
