### PR TITLE
[bug] OFM tags use underscore instead of hyphen

### DIFF
--- a/assets/src/components/v2/triptych/README.md
+++ b/assets/src/components/v2/triptych/README.md
@@ -62,7 +62,7 @@ Once you've created the client app package, you'll need to send it to Outfront f
 Ask a Screens team member for the email of our contact at Outfront.
 In your message, be sure to specify:
 - a player name (or "Liveboard name"), and
-- a triptych pane (or `Array_configuration`--value should be of the form "Triple-(Left|Middle|Right)")
+- a triptych pane (or `Array_configuration`--value should be of the form "Triple_(Left|Middle|Right)")
 that they should set on the test screen.
 
 ## Debugging

--- a/assets/src/util/outfront.tsx
+++ b/assets/src/util/outfront.tsx
@@ -126,11 +126,11 @@ const arrayConfigurationToTriptychPane = (
   arrayConfiguration: string | null
 ): TriptychPane | null => {
   switch (arrayConfiguration) {
-    case "Triple-Left":
+    case "Triple_Left":
       return "left";
-    case "Triple-Middle":
+    case "Triple_Middle":
       return "middle";
-    case "Triple-Right":
+    case "Triple_Right":
       return "right";
     default:
       return null;
@@ -138,7 +138,7 @@ const arrayConfigurationToTriptychPane = (
 };
 
 const triptychPaneToArrayConfiguration = (pane: TriptychPane): string => {
-  return `Triple-${pane[0].toUpperCase().concat(pane.slice(1))}`;
+  return `Triple_${pane[0].toUpperCase().concat(pane.slice(1))}`;
 };
 
 interface OFMWindow extends Window {


### PR DESCRIPTION
Ah! OFM tags are in the form `Triple_Left` instead of with a hyphen.
