### PR TITLE
Cm/ol crowding accuracy logging

### DIFF
--- a/lib/screens/application.ex
+++ b/lib/screens/application.ex
@@ -33,7 +33,8 @@ defmodule Screens.Application do
       # Task supervisor for ScreensByAlert self-refresh jobs
       {Task.Supervisor, name: Screens.ScreensByAlert.SelfRefreshRunner.TaskSupervisor},
       # ScreensByAlert self-refresh job runner
-      {Screens.ScreensByAlert.SelfRefreshRunner, name: Screens.ScreensByAlert.SelfRefreshRunner}
+      {Screens.ScreensByAlert.SelfRefreshRunner, name: Screens.ScreensByAlert.SelfRefreshRunner},
+      Screens.OlCrowding.DynamicSupervisor
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html

--- a/lib/screens/ol_crowding/logger.ex
+++ b/lib/screens/ol_crowding/logger.ex
@@ -1,0 +1,62 @@
+defmodule Screens.OlCrowding.Logger do
+  @moduledoc false
+
+  require Logger
+  use GenServer
+
+  alias Screens.Predictions.Prediction
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts)
+  end
+
+  @impl true
+  def init(state) do
+    schedule_run()
+
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_info(
+        :run,
+        %{
+          prediction: prediction,
+          logging_options: %{
+            is_real_screen: true,
+            screen_id: screen_id,
+            triptych_pane: triptych_pane
+          },
+          train_crowding_config: train_crowding_config,
+          fetch_predictions_fn: fetch_predictions_fn,
+          fetch_parent_stop_id_fn: fetch_parent_stop_id_fn,
+          fetch_params: fetch_params
+        } = state
+      ) do
+    schedule_run()
+
+    {:ok, predictions} = fetch_predictions_fn.(fetch_params)
+    next_train_prediction = List.first(predictions)
+    crowding_levels = Enum.map_join(prediction.vehicle.carriages, ",", & &1.occupancy_status)
+
+    if Prediction.vehicle_status(next_train_prediction) != :stopped_at and
+         next_train_prediction |> Prediction.stop_for_vehicle() |> fetch_parent_stop_id_fn.() ==
+           train_crowding_config.station_id do
+      Logger.info(
+        "[train_crowding car_crowding_accuracy_info] screen_id=#{screen_id} triptych_pane=#{triptych_pane} trip_id=#{prediction.trip.id} car_crowding_levels=#{crowding_levels}"
+      )
+
+      {:noreply, state}
+    else
+      Logger.info(
+        "[train_crowding car_crowding_accuracy_info] screen_id=#{screen_id} triptych_pane=#{triptych_pane} trip_id=#{prediction.trip.id} car_crowding_levels=#{crowding_levels}"
+      )
+
+      {:stop, :shutdown, state}
+    end
+  end
+
+  defp schedule_run do
+    Process.send_after(self(), :run, 5000)
+  end
+end

--- a/lib/screens/ol_crowding/supervisor.ex
+++ b/lib/screens/ol_crowding/supervisor.ex
@@ -1,0 +1,50 @@
+defmodule Screens.OlCrowding.DynamicSupervisor do
+  @moduledoc false
+
+  use DynamicSupervisor
+  alias Screens.OlCrowding.Logger
+
+  def start_link(init_arg) do
+    DynamicSupervisor.start_link(__MODULE__, init_arg, name: __MODULE__)
+  end
+
+  @impl true
+  def init(_init_arg) do
+    DynamicSupervisor.init(strategy: :one_for_one)
+  end
+
+  def start_logger(
+        prediction,
+        %{
+          is_real_screen: true,
+          screen_id: screen_id,
+          triptych_pane: triptych_pane
+        },
+        train_crowding_config,
+        fetch_predictions_fn,
+        fetch_parent_stop_id_fn,
+        fetch_params
+      ) do
+    spec = %{
+      id: Logger,
+      start:
+        {Logger, :start_link,
+         [
+           %{
+             prediction: prediction,
+             logging_options: %{
+               is_real_screen: true,
+               screen_id: screen_id,
+               triptych_pane: triptych_pane
+             },
+             train_crowding_config: train_crowding_config,
+             fetch_predictions_fn: fetch_predictions_fn,
+             fetch_parent_stop_id_fn: fetch_parent_stop_id_fn,
+             fetch_params: fetch_params
+           }
+         ]}
+    }
+
+    DynamicSupervisor.start_child(__MODULE__, spec)
+  end
+end

--- a/lib/screens/v2/widget_instance/train_crowding.ex
+++ b/lib/screens/v2/widget_instance/train_crowding.ex
@@ -56,17 +56,7 @@ defmodule Screens.V2.WidgetInstance.TrainCrowding do
   end
 
   defp serialize_carriages(nil), do: nil
-
-  defp serialize_carriages(carriages),
-    do: Enum.map(carriages, fn car -> serialize_occupancy_status(car.occupancy_status) end)
-
-  defp serialize_occupancy_status(:no_data_available), do: :no_data
-  defp serialize_occupancy_status(:many_seats_available), do: :not_crowded
-  defp serialize_occupancy_status(:few_seats_available), do: :not_crowded
-  defp serialize_occupancy_status(:standing_room_only), do: :some_crowding
-  defp serialize_occupancy_status(:crushed_standing_room_only), do: :crowded
-  defp serialize_occupancy_status(:full), do: :crowded
-  defp serialize_occupancy_status(:not_accepting_passengers), do: :closed
+  defp serialize_carriages(carriages), do: Enum.map(carriages, fn car -> car.occupancy_status end)
 
   def priority(_instance), do: [1]
 

--- a/lib/screens/vehicles/parser.ex
+++ b/lib/screens/vehicles/parser.ex
@@ -55,7 +55,7 @@ defmodule Screens.Vehicles.Parser do
        }),
        do: %Screens.Vehicles.Carriage{
          car_number: car_number,
-         occupancy_status: parse_occupancy_status(occupancy_status)
+         occupancy_status: parse_carriage_occupancy_status(occupancy_status)
        }
 
   defp trip_id_from_trip_data(%{"data" => %{"id" => trip_id}}), do: trip_id
@@ -77,4 +77,13 @@ defmodule Screens.Vehicles.Parser do
   defp parse_occupancy_status("NO_DATA_AVAILABLE"), do: :no_data_available
   defp parse_occupancy_status("NOT_ACCEPTING_PASSENGERS"), do: :not_accepting_passengers
   defp parse_occupancy_status(_), do: nil
+
+  defp parse_carriage_occupancy_status("NO_DATA_AVAILABLE"), do: :no_data
+  defp parse_carriage_occupancy_status("MANY_SEATS_AVAILABLE"), do: :not_crowded
+  defp parse_carriage_occupancy_status("FEW_SEATS_AVAILABLE"), do: :not_crowded
+  defp parse_carriage_occupancy_status("STANDING_ROOM_ONLY"), do: :some_crowding
+  defp parse_carriage_occupancy_status("CRUSHED_STANDING_ROOM_ONLY"), do: :crowded
+  defp parse_carriage_occupancy_status("FULL"), do: :crowded
+  defp parse_carriage_occupancy_status("NOT_ACCEPTING_PASSENGERS"), do: :closed
+  defp parse_carriage_occupancy_status(_), do: nil
 end

--- a/test/screens/v2/widget_instance/train_crowding_test.exs
+++ b/test/screens/v2/widget_instance/train_crowding_test.exs
@@ -34,12 +34,12 @@ defmodule Screens.V2.WidgetInstance.TrainCrowdingTest do
             stop_id: "10001",
             current_status: :incoming_at,
             carriages: [
-              %Carriage{car_number: "1", occupancy_status: :crushed_standing_room_only},
-              %Carriage{car_number: "2", occupancy_status: :few_seats_available},
-              %Carriage{car_number: "3", occupancy_status: :standing_room_only},
-              %Carriage{car_number: "4", occupancy_status: :many_seats_available},
-              %Carriage{car_number: "5", occupancy_status: :full},
-              %Carriage{car_number: "6", occupancy_status: :not_accepting_passengers}
+              %Carriage{car_number: "1", occupancy_status: :crowded},
+              %Carriage{car_number: "2", occupancy_status: :not_crowded},
+              %Carriage{car_number: "3", occupancy_status: :some_crowding},
+              %Carriage{car_number: "4", occupancy_status: :not_crowded},
+              %Carriage{car_number: "5", occupancy_status: :crowded},
+              %Carriage{car_number: "6", occupancy_status: :closed}
             ]
           })
       })
@@ -70,12 +70,12 @@ defmodule Screens.V2.WidgetInstance.TrainCrowdingTest do
     test "serializes data, last crowding level (no_data)", %{widget: widget} do
       widget =
         put_crowding_levels(widget, [
-          %Carriage{car_number: "1", occupancy_status: :no_data_available},
-          %Carriage{car_number: "2", occupancy_status: :no_data_available},
-          %Carriage{car_number: "3", occupancy_status: :standing_room_only},
-          %Carriage{car_number: "4", occupancy_status: :many_seats_available},
-          %Carriage{car_number: "5", occupancy_status: :full},
-          %Carriage{car_number: "6", occupancy_status: :not_accepting_passengers}
+          %Carriage{car_number: "1", occupancy_status: :no_data},
+          %Carriage{car_number: "2", occupancy_status: :no_data},
+          %Carriage{car_number: "3", occupancy_status: :some_crowding},
+          %Carriage{car_number: "4", occupancy_status: :not_crowded},
+          %Carriage{car_number: "5", occupancy_status: :crowded},
+          %Carriage{car_number: "6", occupancy_status: :closed}
         ])
 
       expected = %{


### PR DESCRIPTION
**Asana task**: [title](url)

During the heuristics discussion, we realized we aren't able to capture crowding widget accuracy while the widget is on screen. In this PR, I added a `DynamicSupervisor` that is able to spin up background processes that log crowding data every 5 seconds until the train is stopped at the current station. With these logs, we will be able to compare the existing logs (`[train_crowding car_crowding_info]`) with the added logs (`[train_crowding car_crowding_accuracy_info]`). If the `car_crowding_levels` change at all, we know that we were not able to give accurate crowding data to riders before the train arrived.

I did make one change to the widget logic. I moved the crowding class translations up to the vehicle parser. This allows us to see if a crowding class change results in a color change on screen.

- [ ] Tests added?
