### PR TITLE
tweak: Exclude triptychs from self-refresh job; Move unrelated logic out of Screens.Config.State

### DIFF
--- a/lib/screens/config/screen.ex
+++ b/lib/screens/config/screen.ex
@@ -5,6 +5,7 @@ defmodule Screens.Config.Screen do
 
   alias Screens.Config.{Bus, Dup, Gl, Solari, V2}
   alias Screens.Util
+  alias Screens.V2.ScreenData.Parameters
 
   @type app_id ::
           :bus_eink
@@ -120,6 +121,14 @@ defmodule Screens.Config.Screen do
     screen_config.app_id
     |> Atom.to_string()
     |> String.ends_with?(@v2_app_id_suffix)
+  end
+
+  @doc """
+  Returns true if this screen can show any widget that implements `Screens.V2.AlertsWidget`.
+  """
+  @spec shows_alerts?(t()) :: boolean()
+  def shows_alerts?(screen_config) do
+    Parameters.shows_alerts?(screen_config)
   end
 
   for vendor <- ~w[gds mercury solari c3ms outfront]a do

--- a/lib/screens/config/state.ex
+++ b/lib/screens/config/state.ex
@@ -174,18 +174,17 @@ defmodule Screens.Config.State do
     {:reply, app_params, state}
   end
 
-  def handle_call({:screen_ids, filter_fn}, _from, %__MODULE__{config: config} = state)
-      when is_function(filter_fn, 1) do
+  def handle_call({:screen_ids, nil}, _from, %__MODULE__{config: config} = state) do
+    {:reply, Map.keys(config.screens), state}
+  end
+
+  def handle_call({:screen_ids, filter_fn}, _from, %__MODULE__{config: config} = state) do
     ids =
       config.screens
       |> Enum.filter(filter_fn)
       |> Enum.map(fn {screen_id, _screen_config} -> screen_id end)
 
     {:reply, ids, state}
-  end
-
-  def handle_call({:screen_ids, _}, _from, %__MODULE__{config: config} = state) do
-    {:reply, Map.keys(config.screens), state}
   end
 
   def handle_call({:mode_disabled?, mode}, _from, %__MODULE__{config: config} = state) do

--- a/lib/screens/config/state.ex
+++ b/lib/screens/config/state.ex
@@ -54,18 +54,23 @@ defmodule Screens.Config.State do
     GenServer.call(pid, {:app_params, screen_id})
   end
 
+  @doc """
+  Returns a list of all screen IDs, or those that satisfy a filter.
+
+  You may optionally supply a filter function, which will be used to filter the results.
+  The filter function will be passed a tuple of {screen_id, screen_config} and should return true if that screen ID should be included in the results.
+  """
+  def screen_ids(filter_fn \\ nil, pid \\ __MODULE__)
+      when is_nil(filter_fn) or is_function(filter_fn, 1) do
+    GenServer.call(pid, {:screen_ids, filter_fn})
+  end
+
   def screens(pid \\ __MODULE__) do
     GenServer.call(pid, :screens)
   end
 
   def config(pid \\ __MODULE__) do
     GenServer.call(pid, :config)
-  end
-
-  @spec v2_screens_visible_to_screenplay(GenServer.server()) ::
-          list(screen_id :: String.t()) | :error
-  def v2_screens_visible_to_screenplay(pid \\ __MODULE__) do
-    GenServer.call(pid, :v2_screens_visible_to_screenplay)
   end
 
   def mode_disabled?(pid \\ __MODULE__, mode) do
@@ -169,20 +174,24 @@ defmodule Screens.Config.State do
     {:reply, app_params, state}
   end
 
+  def handle_call({:screen_ids, filter_fn}, _from, %__MODULE__{config: config} = state)
+      when is_function(filter_fn, 1) do
+    ids =
+      config.screens
+      |> Enum.filter(filter_fn)
+      |> Enum.map(fn {screen_id, _screen_config} -> screen_id end)
+
+    {:reply, ids, state}
+  end
+
+  def handle_call({:screen_ids, _}, _from, %__MODULE__{config: config} = state) do
+    {:reply, Map.keys(config.screens), state}
+  end
+
   def handle_call({:mode_disabled?, mode}, _from, %__MODULE__{config: config} = state) do
     %Devops{disabled_modes: disabled_modes} = config.devops
 
     {:reply, Enum.member?(disabled_modes, mode), state}
-  end
-
-  def handle_call(:v2_screens_visible_to_screenplay, _from, %__MODULE__{config: config} = state) do
-    screen_ids =
-      config.screens
-      |> Stream.reject(fn {_screen_id, screen_config} -> screen_config.hidden_from_screenplay end)
-      |> Stream.filter(fn {_screen_id, screen_config} -> Screen.v2_screen?(screen_config) end)
-      |> Enum.map(fn {screen_id, _screen_config} -> screen_id end)
-
-    {:reply, screen_ids, state}
   end
 
   # If we're in an error state, all queries on the state get an :error response

--- a/lib/screens/screens_by_alert/self_refresh_runner.ex
+++ b/lib/screens/screens_by_alert/self_refresh_runner.ex
@@ -4,6 +4,7 @@ defmodule Screens.ScreensByAlert.SelfRefreshRunner do
   screen data, and simulates data requests for any that it finds.
   """
 
+  alias Screens.Config.Screen
   alias Screens.ScreensByAlert
 
   # (Not a real module--just a name assigned to the Task.Supervisor process that supervises each simulated data request run)
@@ -44,7 +45,7 @@ defmodule Screens.ScreensByAlert.SelfRefreshRunner do
     now = System.system_time(:second)
 
     {screen_ids_to_refresh, overflow} =
-      Screens.Config.State.v2_screens_visible_to_screenplay()
+      watched_screen_ids()
       # get a mapping from each ID to its last updated time
       |> ScreensByAlert.get_screens_last_updated()
       # filter to outdated IDs
@@ -75,6 +76,24 @@ defmodule Screens.ScreensByAlert.SelfRefreshRunner do
     end)
 
     {:noreply, state}
+  end
+
+  defp watched_screen_ids do
+    Screens.Config.State.screen_ids(fn {_screen_id, screen_config} ->
+      valid_for_self_refresh?(screen_config)
+    end)
+  end
+
+  # A screen is valid for self-refresh if all of these are true:
+  # - It's a v2 screen (i.e., it shows widgets)
+  # - It's not hidden from Screenplay
+  # - It's a screen type that can show alerts in some capacity
+  defp valid_for_self_refresh?(screen_config) do
+    is_v2 = Screen.v2_screen?(screen_config)
+    is_visible_to_screenplay = not screen_config.hidden_from_screenplay
+    shows_alerts = Screen.shows_alerts?(screen_config)
+
+    is_v2 and is_visible_to_screenplay and shows_alerts
   end
 
   defp schedule_run do

--- a/lib/screens/v2/screen_data/parameters.ex
+++ b/lib/screens/v2/screen_data/parameters.ex
@@ -38,14 +38,8 @@ defmodule Screens.V2.ScreenData.Parameters do
     triptych_v2: 0
   }
 
-  # This list should contain IDs of all apps that can show any widget that implements `Screens.V2.AlertsWidget`.
-  @apps_that_show_alerts [
-    :bus_eink_v2,
-    :bus_shelter_v2,
-    :gl_eink_v2,
-    :pre_fare_v2,
-    :dup_v2
-  ]
+  # This list should contain IDs of any apps that __do not__ show any widget that implements `Screens.V2.AlertsWidget`.
+  @apps_that_do_not_show_alerts [:triptych_v2]
 
   @spec get_candidate_generator(Screens.Config.Screen.t() | atom()) :: candidate_generator()
   def get_candidate_generator(%Screens.Config.Screen{app_id: app_id}) do
@@ -83,7 +77,7 @@ defmodule Screens.V2.ScreenData.Parameters do
   end
 
   def shows_alerts?(app_id) do
-    app_id in @apps_that_show_alerts
+    app_id not in @apps_that_do_not_show_alerts
   end
 
   @spec get_audio_interval_offset_seconds(Screens.Config.Screen.t()) :: pos_integer()

--- a/lib/screens/v2/screen_data/parameters.ex
+++ b/lib/screens/v2/screen_data/parameters.ex
@@ -38,6 +38,15 @@ defmodule Screens.V2.ScreenData.Parameters do
     triptych_v2: 0
   }
 
+  # This list should contain IDs of all apps that can show any widget that implements `Screens.V2.AlertsWidget`.
+  @apps_that_show_alerts [
+    :bus_eink_v2,
+    :bus_shelter_v2,
+    :gl_eink_v2,
+    :pre_fare_v2,
+    :dup_v2
+  ]
+
   @spec get_candidate_generator(Screens.Config.Screen.t() | atom()) :: candidate_generator()
   def get_candidate_generator(%Screens.Config.Screen{app_id: app_id}) do
     get_candidate_generator(app_id)
@@ -63,6 +72,18 @@ defmodule Screens.V2.ScreenData.Parameters do
 
   def get_audio_readout_interval(app_id) do
     Map.get(@app_id_to_audio_readout_interval, app_id)
+  end
+
+  @doc """
+  Returns true for screen types that can show any widget that implements `Screens.V2.AlertsWidget`.
+  """
+  @spec shows_alerts?(Screens.Config.Screen.t() | atom()) :: boolean()
+  def shows_alerts?(%Screens.Config.Screen{app_id: app_id}) do
+    shows_alerts?(app_id)
+  end
+
+  def shows_alerts?(app_id) do
+    app_id in @apps_that_show_alerts
   end
 
   @spec get_audio_interval_offset_seconds(Screens.Config.Screen.t()) :: pos_integer()


### PR DESCRIPTION
**Asana task**: ad hoc

In preparation for triptychs appearing in Screenplay, this prevents the screens-by-alert self refresh job from wasting effort on triptychs since they never show alerts and are likely to load less frequently than the cache TTL.

👉 I tried to put the list of non-alert-showing screen types in a high visibility spot, since we'll need to keep it manually updated. (I couldn't think of a simple programmatic way to determine whether a given screen can show alert widgets.)
I'm very open to suggestions on this, though. Either a way to make the list even more visible, or a way to automatically determine this screen type trait.

- [ ] Tests added?
