### PR TITLE
tweak: Include triptych player name in data request logs

### DIFF
--- a/lib/screens/log_screen_data.ex
+++ b/lib/screens/log_screen_data.ex
@@ -17,14 +17,17 @@ defmodule Screens.LogScreenData do
         screen_id,
         last_refresh,
         is_screen,
-        requestor,
-        screen_side \\ nil,
-        rotation_index \\ nil,
-        triptych_pane \\ nil,
-        triptych_player_name \\ nil,
-        ofm_app_package_version \\ nil
+        params
       ) do
+    requestor = params["requestor"]
+
     if is_screen or not is_nil(requestor) do
+      screen_side = params["screen_side"]
+      rotation_index = params["rotation_index"]
+      triptych_pane = params["pane"]
+      triptych_player_name = params["player_name"]
+      ofm_app_package_version = params["version"]
+
       data =
         %{
           screen_id: screen_id,

--- a/lib/screens/log_screen_data.ex
+++ b/lib/screens/log_screen_data.ex
@@ -21,6 +21,7 @@ defmodule Screens.LogScreenData do
         screen_side \\ nil,
         rotation_index \\ nil,
         triptych_pane \\ nil,
+        triptych_player_name \\ nil,
         ofm_app_package_version \\ nil
       ) do
     if is_screen or not is_nil(requestor) do
@@ -34,6 +35,7 @@ defmodule Screens.LogScreenData do
         |> insert_requestor(requestor)
         |> insert_dup_rotation_index(rotation_index)
         |> insert_triptych_pane(triptych_pane)
+        |> insert_triptych_player_name(triptych_player_name)
         |> insert_version(ofm_app_package_version)
 
       log_message("[screen data request]", data)
@@ -155,6 +157,11 @@ defmodule Screens.LogScreenData do
 
   defp insert_triptych_pane(data, triptych_pane),
     do: Map.put(data, :triptych_pane, triptych_pane)
+
+  defp insert_triptych_player_name(data, nil), do: data
+
+  defp insert_triptych_player_name(data, triptych_player_name),
+    do: Map.put(data, :triptych_player_name, triptych_player_name)
 
   defp insert_version(data, nil), do: data
   defp insert_version(data, version), do: Map.put(data, :ofm_app_package_version, version)

--- a/lib/screens_web/controllers/screen_api_controller.ex
+++ b/lib/screens_web/controllers/screen_api_controller.ex
@@ -34,7 +34,7 @@ defmodule ScreensWeb.ScreenApiController do
         screen_id,
         last_refresh,
         is_screen,
-        params["requestor"]
+        params
       )
 
     if nonexistent_screen?(screen_id) do
@@ -60,9 +60,7 @@ defmodule ScreensWeb.ScreenApiController do
         screen_id,
         nil,
         is_screen,
-        params["requestor"],
-        nil,
-        rotation_index
+        params
       )
 
     if nonexistent_screen?(screen_id) do

--- a/lib/screens_web/controllers/v2/screen_api_controller.ex
+++ b/lib/screens_web/controllers/v2/screen_api_controller.ex
@@ -24,6 +24,7 @@ defmodule ScreensWeb.V2.ScreenApiController do
     screen_side = params["screen_side"]
     rotation_index = params["rotation_index"]
     triptych_pane = params["pane"]
+    triptych_player_name = params["player_name"]
     ofm_app_package_version = params["version"]
 
     LogScreenData.log_data_request(
@@ -34,6 +35,7 @@ defmodule ScreensWeb.V2.ScreenApiController do
       screen_side,
       rotation_index,
       triptych_pane,
+      triptych_player_name,
       ofm_app_package_version
     )
 

--- a/lib/screens_web/controllers/v2/screen_api_controller.ex
+++ b/lib/screens_web/controllers/v2/screen_api_controller.ex
@@ -22,21 +22,13 @@ defmodule ScreensWeb.V2.ScreenApiController do
   def show(conn, %{"id" => screen_id, "last_refresh" => last_refresh} = params) do
     is_screen = ScreensWeb.UserAgent.is_screen_conn?(conn, screen_id)
     screen_side = params["screen_side"]
-    rotation_index = params["rotation_index"]
     triptych_pane = params["pane"]
-    triptych_player_name = params["player_name"]
-    ofm_app_package_version = params["version"]
 
     LogScreenData.log_data_request(
       screen_id,
       last_refresh,
       is_screen,
-      params["requestor"],
-      screen_side,
-      rotation_index,
-      triptych_pane,
-      triptych_player_name,
-      ofm_app_package_version
+      params
     )
 
     cond do
@@ -117,8 +109,7 @@ defmodule ScreensWeb.V2.ScreenApiController do
       screen_id,
       last_refresh,
       false,
-      params["requestor"],
-      params["screen_side"]
+      params
     )
 
     cond do


### PR DESCRIPTION
**Asana task**: ad hoc

This will help us match up logs with real screens, and make sure that the placement of each player matches up with what OFM's station maps said.

- [ ] Tests added?
