### PR TITLE
tweak: Adjust routes/endpoints to accept error logs from OFM clients

### DIFF
--- a/lib/screens_web/controllers/v2/screen_api_controller.ex
+++ b/lib/screens_web/controllers/v2/screen_api_controller.ex
@@ -7,7 +7,8 @@ defmodule ScreensWeb.V2.ScreenApiController do
   alias Screens.V2.ScreenData
 
   plug(:check_config)
-  plug Corsica, [origins: "*"] when action in [:show_dup, :show_triptych]
+
+  plug Corsica, [origins: "*"] when action in [:show_dup, :show_triptych, :log_frontend_error]
 
   defp check_config(conn, _) do
     if State.ok?() do
@@ -127,13 +128,34 @@ defmodule ScreensWeb.V2.ScreenApiController do
     end
   end
 
-  def log_frontend_error(conn, %{
-        "id" => screen_id,
-        "errorMessage" => error_message,
-        "stacktrace" => stack_trace
-      }) do
-    LogScreenData.log_frontend_error(screen_id, error_message, stack_trace)
+  def log_frontend_error(conn, params) do
+    # Some basic defensive measures since this endpoint is very permissive.
+    # We make sure each param is a string and trim them to reasonable lengths, in case they're huge.
+    id = params["id"]
+    true = is_binary(id)
+    id = String.slice(id, 0..99)
+
+    error_message = params["errorMessage"]
+    true = is_binary(error_message)
+    error_message = String.slice(error_message, 0..499)
+
+    stacktrace = params["stacktrace"]
+    true = is_binary(stacktrace)
+    stacktrace = String.slice(stacktrace, 0..999)
+
+    LogScreenData.log_frontend_error(id, error_message, stacktrace)
     json(conn, %{success: true})
+  end
+
+  def log_frontend_error_preflight(conn, _) do
+    # https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request
+    # When coming from an OFM client package, the client asks permission
+    # to make this cross-origin POST request and we need to tell it that that's ok.
+    Corsica.send_preflight_resp(conn,
+      origins: "*",
+      allow_methods: ["POST"],
+      allow_headers: ["content-type"]
+    )
   end
 
   defp nonexistent_screen?(screen_id) do

--- a/lib/screens_web/router.ex
+++ b/lib/screens_web/router.ex
@@ -88,7 +88,13 @@ defmodule ScreensWeb.Router do
       get "/:id/simulation", ScreenApiController, :simulation
       get "/:id/dup", ScreenApiController, :show_dup
       get "/:player_name/triptych", ScreenApiController, :show_triptych
+    end
+
+    scope "/api/logging" do
+      pipe_through [:redirect_prod_http, :api]
+
       post "/log_frontend_error", ScreenApiController, :log_frontend_error
+      options "/log_frontend_error", ScreenApiController, :log_frontend_error_preflight
     end
 
     scope "/audio" do


### PR DESCRIPTION
**Asana task**: ad hoc / triptych app troubleshooting

Changes:
- Add `/log_frontend_error` to endpoints reachable by OFM clients
- Add some basic defensive logic to it since it's more permissive now, and accepts data from clients
- Add a function to handle the "preflight" OPTIONS requests that clients fire before sending their POST requests—another part of the CORS protocol

Tested manually with a client package that POSTs to this endpoint.

- [ ] Tests added?
