### PR TITLE
tweak: Suppress automated alerts on pre-fares & DUPs, for October RL maintenance diversion

### DIFF
--- a/lib/screens/v2/widget_instance/dup_alert.ex
+++ b/lib/screens/v2/widget_instance/dup_alert.ex
@@ -85,7 +85,12 @@ defmodule Screens.V2.WidgetInstance.DupAlert do
 
   @spec valid_candidate?(t()) :: boolean()
   def valid_candidate?(%__MODULE__{} = t) do
-    alert_layout(t) != :no_render
+    # Suppress alerts 519314 and 529291, at all stations served by the Red Line.
+    suppressed =
+      t.alert.id in ["519314", "529291"] and
+        Enum.any?(t.location_context.routes, &(&1[:route_id] == "Red"))
+
+    not suppressed and alert_layout(t) != :no_render
   end
 
   # Inputs/output are stored as a table for readability.

--- a/lib/screens/v2/widget_instance/reconstructed_alert.ex
+++ b/lib/screens/v2/widget_instance/reconstructed_alert.ex
@@ -652,12 +652,12 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
   def alert_ids(%__MODULE__{} = t), do: [t.alert.id]
 
   def valid_candidate?(%__MODULE__{} = t) do
-    # Suppress alert 519312 at Porter and Charles/MGH
-    t.alert.id != "519312" or
-      t.screen.app_params.reconstructed_alert_widget.stop_id not in [
-        "place-portr",
-        "place-chmnl"
-      ]
+    # Suppress alerts 519314 and 529291, at all stations served by the Red Line.
+    suppressed =
+      t.alert.id in ["519314", "529291"] and
+        Enum.any?(t.location_context.routes, &(&1[:route_id] == "Red"))
+
+    not suppressed
   end
 
   defimpl Screens.V2.WidgetInstance do


### PR DESCRIPTION
**Asana task**: ad hoc?

The two alerts are "two sides of the same coin"—one informs southbound trips and the other northbound, because using a single alert for both directions caused problems for JFK countdown clocks.

- [ ] Tests added?
