### PR TITLE
Suppress one of the RL Surge alerts for SubwayStatus.

### DIFF
--- a/lib/screens/v2/candidate_generator/widgets/subway_status.ex
+++ b/lib/screens/v2/candidate_generator/widgets/subway_status.ex
@@ -18,7 +18,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.SubwayStatus do
   end
 
   def relevant?(alert, now) do
-    relevant_effect?(alert) and Alert.happening_now?(alert, now)
+    relevant_effect?(alert) and Alert.happening_now?(alert, now) and not suppressed?(alert)
   end
 
   # Omit up to 10 minute delays.
@@ -26,4 +26,6 @@ defmodule Screens.V2.CandidateGenerator.Widgets.SubwayStatus do
 
   defp relevant_effect?(%Alert{effect: effect}),
     do: effect in [:suspension, :shuttle, :station_closure]
+
+  defp suppressed?(alert), do: alert.id == "529291"
 end


### PR DESCRIPTION
**Asana task**: ad-hoc

Due to an AlertsUI bug, two directional alerts were created instead of a single alert. The two alerts look identical in SubwayStatus so OIOs are [requesting](https://mbta.slack.com/archives/CAEMN4QAX/p1697711805061549) a suppression for one of them.

- [ ] Tests added?
