### PR TITLE
tweak: Crowding level translation

### DIFF
--- a/lib/screens/ol_crowding/logger.ex
+++ b/lib/screens/ol_crowding/logger.ex
@@ -44,7 +44,7 @@ defmodule Screens.OlCrowding.LogCrowdingInfo do
       Enum.map_join(
         prediction.vehicle.carriages,
         ",",
-        &Util.translate_carriage_occupancy_status(&1.occupancy_status)
+        &Util.translate_carriage_occupancy_status(&1.occupancy_status, &1.occupancy_percentage)
       )
 
     cond do

--- a/lib/screens/ol_crowding/logger.ex
+++ b/lib/screens/ol_crowding/logger.ex
@@ -44,7 +44,7 @@ defmodule Screens.OlCrowding.LogCrowdingInfo do
       Enum.map_join(
         prediction.vehicle.carriages,
         ",",
-        &Util.translate_carriage_occupancy_status(&1.occupancy_status, &1.occupancy_percentage)
+        &Util.translate_carriage_occupancy_status/1
       )
 
     cond do

--- a/lib/screens/util.ex
+++ b/lib/screens/util.ex
@@ -210,14 +210,21 @@ defmodule Screens.Util do
     Date.add(get_service_date_today(now), 1)
   end
 
-  def translate_carriage_occupancy_status(:no_data_available), do: :no_data
-  def translate_carriage_occupancy_status(:many_seats_available), do: :not_crowded
-  def translate_carriage_occupancy_status(:few_seats_available), do: :not_crowded
-  def translate_carriage_occupancy_status(:standing_room_only), do: :some_crowding
-  def translate_carriage_occupancy_status(:crushed_standing_room_only), do: :crowded
-  def translate_carriage_occupancy_status(:full), do: :crowded
-  def translate_carriage_occupancy_status(:not_accepting_passengers), do: :closed
-  def translate_carriage_occupancy_status(_), do: nil
+  def translate_carriage_occupancy_status(:no_data_available, _), do: :no_data
+  def translate_carriage_occupancy_status(:not_accepting_passengers, _), do: :closed
+
+  def translate_carriage_occupancy_status(_, occupancy_percentage)
+      when occupancy_percentage <= 12,
+      do: :not_crowded
+
+  def translate_carriage_occupancy_status(_, occupancy_percentage)
+      when occupancy_percentage <= 40,
+      do: :some_crowding
+
+  def translate_carriage_occupancy_status(_, occupancy_percentage) when occupancy_percentage > 40,
+    do: :crowded
+
+  def translate_carriage_occupancy_status(_, _), do: nil
 
   @doc """
     Adds a timeout to a function. Mainly used for child processes of a Task.Supervisor

--- a/lib/screens/util.ex
+++ b/lib/screens/util.ex
@@ -2,6 +2,7 @@ defmodule Screens.Util do
   @moduledoc false
 
   alias Screens.Config.State
+  alias Screens.Vehicles.Carriage
 
   def format_time(t) do
     t |> DateTime.truncate(:second) |> DateTime.to_iso8601()
@@ -210,21 +211,25 @@ defmodule Screens.Util do
     Date.add(get_service_date_today(now), 1)
   end
 
-  def translate_carriage_occupancy_status(:no_data_available, _), do: :no_data
-  def translate_carriage_occupancy_status(:not_accepting_passengers, _), do: :closed
+  def translate_carriage_occupancy_status(%Carriage{occupancy_status: :no_data_available}),
+    do: :no_data
 
-  def translate_carriage_occupancy_status(_, occupancy_percentage)
+  def translate_carriage_occupancy_status(%Carriage{occupancy_status: :not_accepting_passengers}),
+    do: :closed
+
+  def translate_carriage_occupancy_status(%Carriage{occupancy_percentage: occupancy_percentage})
       when occupancy_percentage <= 12,
       do: :not_crowded
 
-  def translate_carriage_occupancy_status(_, occupancy_percentage)
+  def translate_carriage_occupancy_status(%Carriage{occupancy_percentage: occupancy_percentage})
       when occupancy_percentage <= 40,
       do: :some_crowding
 
-  def translate_carriage_occupancy_status(_, occupancy_percentage) when occupancy_percentage > 40,
-    do: :crowded
+  def translate_carriage_occupancy_status(%Carriage{occupancy_percentage: occupancy_percentage})
+      when occupancy_percentage > 40,
+      do: :crowded
 
-  def translate_carriage_occupancy_status(_, _), do: nil
+  def translate_carriage_occupancy_status(_), do: nil
 
   @doc """
     Adds a timeout to a function. Mainly used for child processes of a Task.Supervisor

--- a/lib/screens/v2/candidate_generator/widgets/train_crowding.ex
+++ b/lib/screens/v2/candidate_generator/widgets/train_crowding.ex
@@ -127,7 +127,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.TrainCrowding do
       Enum.map_join(
         prediction.vehicle.carriages,
         ",",
-        &Util.translate_carriage_occupancy_status(&1.occupancy_status)
+        &Util.translate_carriage_occupancy_status(&1.occupancy_status, &1.occupancy_percentage)
       )
 
     Logger.info(

--- a/lib/screens/v2/candidate_generator/widgets/train_crowding.ex
+++ b/lib/screens/v2/candidate_generator/widgets/train_crowding.ex
@@ -127,7 +127,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.TrainCrowding do
       Enum.map_join(
         prediction.vehicle.carriages,
         ",",
-        &Util.translate_carriage_occupancy_status(&1.occupancy_status, &1.occupancy_percentage)
+        &Util.translate_carriage_occupancy_status/1
       )
 
     Logger.info(

--- a/lib/screens/v2/widget_instance/train_crowding.ex
+++ b/lib/screens/v2/widget_instance/train_crowding.ex
@@ -59,7 +59,11 @@ defmodule Screens.V2.WidgetInstance.TrainCrowding do
   defp serialize_carriages(nil), do: nil
 
   defp serialize_carriages(carriages),
-    do: Enum.map(carriages, &Util.translate_carriage_occupancy_status(&1.occupancy_status))
+    do:
+      Enum.map(
+        carriages,
+        &Util.translate_carriage_occupancy_status(&1.occupancy_status, &1.occupancy_percentage)
+      )
 
   def priority(_instance), do: [1]
 

--- a/lib/screens/v2/widget_instance/train_crowding.ex
+++ b/lib/screens/v2/widget_instance/train_crowding.ex
@@ -62,7 +62,7 @@ defmodule Screens.V2.WidgetInstance.TrainCrowding do
     do:
       Enum.map(
         carriages,
-        &Util.translate_carriage_occupancy_status(&1.occupancy_status, &1.occupancy_percentage)
+        &Util.translate_carriage_occupancy_status/1
       )
 
   def priority(_instance), do: [1]

--- a/lib/screens/vehicles/carriage.ex
+++ b/lib/screens/vehicles/carriage.ex
@@ -2,7 +2,8 @@ defmodule Screens.Vehicles.Carriage do
   @moduledoc false
 
   defstruct car_number: nil,
-            occupancy_status: nil
+            occupancy_status: nil,
+            occupancy_percentage: nil
 
   @type occupancy_status ::
           :many_seats_available
@@ -16,6 +17,7 @@ defmodule Screens.Vehicles.Carriage do
 
   @type t :: %__MODULE__{
           car_number: String.t(),
-          occupancy_status: occupancy_status | nil
+          occupancy_status: occupancy_status | nil,
+          occupancy_percentage: integer()
         }
 end

--- a/lib/screens/vehicles/parser.ex
+++ b/lib/screens/vehicles/parser.ex
@@ -51,11 +51,13 @@ defmodule Screens.Vehicles.Parser do
 
   defp parse_car_crowding(%{
          "label" => car_number,
-         "occupancy_status" => occupancy_status
+         "occupancy_status" => occupancy_status,
+         "occupancy_percentage" => occupancy_percentage
        }),
        do: %Screens.Vehicles.Carriage{
          car_number: car_number,
-         occupancy_status: parse_occupancy_status(occupancy_status)
+         occupancy_status: parse_occupancy_status(occupancy_status),
+         occupancy_percentage: occupancy_percentage
        }
 
   defp trip_id_from_trip_data(%{"data" => %{"id" => trip_id}}), do: trip_id

--- a/test/screens/v2/widget_instance/train_crowding_test.exs
+++ b/test/screens/v2/widget_instance/train_crowding_test.exs
@@ -34,12 +34,32 @@ defmodule Screens.V2.WidgetInstance.TrainCrowdingTest do
             stop_id: "10001",
             current_status: :incoming_at,
             carriages: [
-              %Carriage{car_number: "1", occupancy_status: :crushed_standing_room_only},
-              %Carriage{car_number: "2", occupancy_status: :few_seats_available},
-              %Carriage{car_number: "3", occupancy_status: :standing_room_only},
-              %Carriage{car_number: "4", occupancy_status: :many_seats_available},
-              %Carriage{car_number: "5", occupancy_status: :full},
-              %Carriage{car_number: "6", occupancy_status: :not_accepting_passengers}
+              %Carriage{
+                car_number: "1",
+                occupancy_status: :crushed_standing_room_only,
+                occupancy_percentage: 45
+              },
+              %Carriage{
+                car_number: "2",
+                occupancy_status: :few_seats_available,
+                occupancy_percentage: 5
+              },
+              %Carriage{
+                car_number: "3",
+                occupancy_status: :standing_room_only,
+                occupancy_percentage: 20
+              },
+              %Carriage{
+                car_number: "4",
+                occupancy_status: :many_seats_available,
+                occupancy_percentage: 5
+              },
+              %Carriage{car_number: "5", occupancy_status: :full, occupancy_percentage: 45},
+              %Carriage{
+                car_number: "6",
+                occupancy_status: :not_accepting_passengers,
+                occupancy_percentage: -1
+              }
             ]
           })
       })
@@ -70,12 +90,32 @@ defmodule Screens.V2.WidgetInstance.TrainCrowdingTest do
     test "serializes data, last crowding level (no_data)", %{widget: widget} do
       widget =
         put_crowding_levels(widget, [
-          %Carriage{car_number: "1", occupancy_status: :no_data_available},
-          %Carriage{car_number: "2", occupancy_status: :no_data_available},
-          %Carriage{car_number: "3", occupancy_status: :standing_room_only},
-          %Carriage{car_number: "4", occupancy_status: :many_seats_available},
-          %Carriage{car_number: "5", occupancy_status: :full},
-          %Carriage{car_number: "6", occupancy_status: :not_accepting_passengers}
+          %Carriage{
+            car_number: "1",
+            occupancy_status: :no_data_available,
+            occupancy_percentage: -1
+          },
+          %Carriage{
+            car_number: "2",
+            occupancy_status: :no_data_available,
+            occupancy_percentage: -1
+          },
+          %Carriage{
+            car_number: "3",
+            occupancy_status: :standing_room_only,
+            occupancy_percentage: 25
+          },
+          %Carriage{
+            car_number: "4",
+            occupancy_status: :many_seats_available,
+            occupancy_percentage: 5
+          },
+          %Carriage{car_number: "5", occupancy_status: :full, occupancy_percentage: 45},
+          %Carriage{
+            car_number: "6",
+            occupancy_status: :not_accepting_passengers,
+            occupancy_percentage: -1
+          }
         ])
 
       expected = %{


### PR DESCRIPTION
**Asana task**: [OL Crowding: Crowding Level Adjustments](https://app.asana.com/0/1185117109217413/1205660768175007/f)

Updated crowding level translation to use `occupancy_percentage` when there is data. 

- [ ] Tests added?
