### PR TITLE
Cm/adjust diagram size positioning

### DIFF
--- a/assets/css/v2/pre_fare/prefare_single_screen_alert.scss
+++ b/assets/css/v2/pre_fare/prefare_single_screen_alert.scss
@@ -37,8 +37,15 @@
   .alert-card__body {
     min-height: 0;
     flex-grow: 1;
-    padding: 120px 56px 32px 56px;
+    padding: 120px 56px 0 56px;
     box-sizing: border-box;
+
+    .alert-card__content-block {
+      height: 100%;
+      display: flex;
+      flex-flow: column;
+      align-items: flex-start;
+    }
   }
 
   .alert-card__issue,
@@ -141,6 +148,13 @@
   }
   .alert-card__footer__datetime {
     font-weight: 600;
+  }
+
+  .disruption-diagram-container {
+    flex: 1 1 0;
+    &:not(:first-child) {
+      margin-bottom: 32px;
+    }
   }
 }
 

--- a/assets/css/v2/pre_fare/prefare_single_screen_alert.scss
+++ b/assets/css/v2/pre_fare/prefare_single_screen_alert.scss
@@ -152,7 +152,6 @@
 
   .disruption-diagram-container {
     flex: 1;
-    margin-bottom: 32px;
   }
 }
 

--- a/assets/css/v2/pre_fare/prefare_single_screen_alert.scss
+++ b/assets/css/v2/pre_fare/prefare_single_screen_alert.scss
@@ -152,9 +152,7 @@
 
   .disruption-diagram-container {
     flex: 1 1 0;
-    &:not(:first-child) {
-      margin-bottom: 32px;
-    }
+    margin-bottom: 32px;
   }
 }
 

--- a/assets/css/v2/pre_fare/prefare_single_screen_alert.scss
+++ b/assets/css/v2/pre_fare/prefare_single_screen_alert.scss
@@ -151,7 +151,7 @@
   }
 
   .disruption-diagram-container {
-    flex: 1 1 0;
+    flex: 1;
     margin-bottom: 32px;
   }
 }

--- a/assets/css/v2/pre_fare/reconstructed_alert.scss
+++ b/assets/css/v2/pre_fare/reconstructed_alert.scss
@@ -177,7 +177,7 @@ $alert-card-footer-height: 80px;
   /* Alert contents */
   .alert-card {
     width: 1016px;
-    height: $takeover-card-height;
+    height: 100%;
     border-radius: 4px;
     background-color: #e5e4e1;
     color: #171f26;
@@ -191,7 +191,15 @@ $alert-card-footer-height: 80px;
       font-size: 200px;
       font-weight: 800;
 
+      .container {
+        height: 100%;
+        display: flex;
+        flex-flow: column;
+        align-items: flex-start;
+      }
+
       &__icon {
+        flex-shrink: 0;
         height: 300px;
         margin-bottom: 48px;
         padding-top: 112px;
@@ -243,6 +251,12 @@ $alert-card-footer-height: 80px;
       &__isa-icon {
         height: 61px;
         padding-right: 33px;
+      }
+
+      .disruption-diagram-container {
+        flex: 1 1 0;
+        margin-top: 32px;
+        margin-bottom: 32px;
       }
     }
 

--- a/assets/css/v2/pre_fare/reconstructed_alert.scss
+++ b/assets/css/v2/pre_fare/reconstructed_alert.scss
@@ -254,7 +254,7 @@ $alert-card-footer-height: 80px;
       }
 
       .disruption-diagram-container {
-        flex: 1 1 0;
+        flex: 1;
         margin-bottom: 32px;
       }
     }

--- a/assets/css/v2/pre_fare/reconstructed_alert.scss
+++ b/assets/css/v2/pre_fare/reconstructed_alert.scss
@@ -255,7 +255,6 @@ $alert-card-footer-height: 80px;
 
       .disruption-diagram-container {
         flex: 1 1 0;
-        margin-top: 32px;
         margin-bottom: 32px;
       }
     }

--- a/assets/css/v2/pre_fare/reconstructed_alert.scss
+++ b/assets/css/v2/pre_fare/reconstructed_alert.scss
@@ -255,7 +255,6 @@ $alert-card-footer-height: 80px;
 
       .disruption-diagram-container {
         flex: 1;
-        margin-bottom: 32px;
       }
     }
 

--- a/assets/src/components/v2/disruption_diagram/disruption_diagram.tsx
+++ b/assets/src/components/v2/disruption_diagram/disruption_diagram.tsx
@@ -110,7 +110,9 @@ const CurrentStopIconRedLine: ComponentType<IconProps> = ({ x }) => {
   return (
     <>
       <path
-        transform={`translate(${x - (iconWidth + strokeWidth) / 2})`}
+        transform={`translate(${x - (iconWidth + strokeWidth) / 2} ${
+          -(iconWidth - strokeWidth) / 3
+        })`}
         d="M32.6512 3.92661C30.0824 1.3578 25.9176 1.3578 23.3488 3.92661L3.92661 23.3488C1.3578 25.9176 1.3578 30.0824 3.92661 32.6512L23.3488 52.0734C25.9176 54.6422 30.0824 54.6422 32.6512 52.0734L52.0734 32.6512C54.6422 30.0824 54.6422 25.9176 52.0734 23.3488L32.6512 3.92661Z"
         className="middle-slot__background--red"
         stroke="#E6E4E1"
@@ -118,7 +120,9 @@ const CurrentStopIconRedLine: ComponentType<IconProps> = ({ x }) => {
         strokeLinejoin="round"
       />
       <path
-        transform={`translate(${x - (iconWidth + strokeWidth) / 2})`}
+        transform={`translate(${x - (iconWidth + strokeWidth) / 2} ${
+          -(iconWidth - strokeWidth) / 3
+        })`}
         fillRule="evenodd"
         clipRule="evenodd"
         d="M15.4855 29.219C14.7045 28.438 14.7045 27.1717 15.4855 26.3906L26.3906 15.4855C27.1717 14.7045 28.438 14.7045 29.219 15.4855L40.1242 26.3906C40.9052 27.1717 40.9052 28.438 40.1241 29.219L29.219 40.1242C28.438 40.9052 27.1717 40.9052 26.3906 40.1241L15.4855 29.219Z"
@@ -177,7 +181,7 @@ const CurrentStopIconEndpoint: ComponentType<IconProps> = ({ x }) => {
 
   return (
     <path
-      transform={`translate(${x - iconWidth / 2} -8)`}
+      transform={`translate(${x - iconWidth / 2} ${-iconWidth / 3})`}
       d="M3.13388 28.7629C1.74155 30.1552 1.74155 32.4126 3.13388 33.8049L28.2253 58.8964C29.6176 60.2887 31.8751 60.2887 33.2674 58.8964L58.3588 33.8049C59.7511 32.4126 59.7511 30.1552 58.3588 28.7629L33.2674 3.67141C31.8751 2.27909 29.6176 2.27909 28.2253 3.67141L3.13388 28.7629Z"
       fill="#EE2E24"
       stroke="#E6E4E1"

--- a/assets/src/components/v2/disruption_diagram/disruption_diagram.tsx
+++ b/assets/src/components/v2/disruption_diagram/disruption_diagram.tsx
@@ -777,7 +777,7 @@ const DisruptionDiagram: ComponentType<DisruptionDiagramData> = (props) => {
 
     const height = dimensions?.height;
 
-    if (height) {
+    if (isDone && height) {
       setLineMapHeight(height);
     }
   }, [isDone]);
@@ -785,7 +785,6 @@ const DisruptionDiagram: ComponentType<DisruptionDiagramData> = (props) => {
   return (
     <svg
       height="100%"
-      overflow="visible"
       viewBox={`0 0 904 ${svgHeight}`}
       id="whole-svg"
       visibility={isDone ? "visible" : "hidden"}

--- a/assets/src/components/v2/disruption_diagram/disruption_diagram.tsx
+++ b/assets/src/components/v2/disruption_diagram/disruption_diagram.tsx
@@ -5,6 +5,7 @@ const MAX_WIDTH = 904;
 const SLOT_WIDTH = 24;
 const LINE_HEIGHT = 24;
 const EMPHASIS_HEIGHT = 80;
+const EMPHASIS_PADDING_TOP = 8;
 // L can vary based on arrow vs diamond (current stop). Would be nice if this was
 // programmatic, but this works for now
 const L = 17;
@@ -790,7 +791,7 @@ const DisruptionDiagram: ComponentType<DisruptionDiagramData> = (props) => {
       <g
         id="line-map"
         transform={`translate(${SLOT_WIDTH / 2}, ${
-          lineMapHeight - 8 * scaleFactor
+          lineMapHeight - EMPHASIS_PADDING_TOP * scaleFactor - 16
         }) scale(${scaleFactor})`}
       >
         <EffectBackgroundComponent
@@ -832,7 +833,7 @@ const DisruptionDiagram: ComponentType<DisruptionDiagramData> = (props) => {
         <g
           id="alert-emphasis"
           transform={`translate(${SLOT_WIDTH / 2}, ${
-            lineMapHeight + EMPHASIS_HEIGHT - 8 * scaleFactor
+            lineMapHeight + EMPHASIS_HEIGHT - EMPHASIS_PADDING_TOP * scaleFactor
           })`}
         >
           <AlertEmphasisComponent

--- a/assets/src/components/v2/disruption_diagram/disruption_diagram.tsx
+++ b/assets/src/components/v2/disruption_diagram/disruption_diagram.tsx
@@ -767,7 +767,7 @@ const DisruptionDiagram: ComponentType<DisruptionDiagramData> = (props) => {
 
       setIsDone(true);
     }
-  }, [svgHeight]);
+  });
 
   // Get the finalized height of the line map after scaling and abbreviations
   useEffect(() => {

--- a/assets/src/components/v2/disruption_diagram/disruption_diagram.tsx
+++ b/assets/src/components/v2/disruption_diagram/disruption_diagram.tsx
@@ -751,14 +751,14 @@ const DisruptionDiagram: ComponentType<DisruptionDiagramData> = (props) => {
     const height = dimensions?.height;
     const width = dimensions?.width;
 
-    if (!isDoneScaling && width && height) {
+    if (!isDoneScaling && width) {
       // Scale diagram up or down so width is 904px
       setScaleFactor(904 / width);
       setIsDoneScaling(true);
-    } else if (!isDone && isDoneScaling && height) {
+    } else if (!isDone && isDoneScaling) {
       // If the height of the line map + emphasis (if present) is still too tall,
       // abbreviate station names.
-      if (height + (hasEmphasis ? EMPHASIS_HEIGHT : 0) > svgHeight) {
+      if (height && height + (hasEmphasis ? EMPHASIS_HEIGHT : 0) > svgHeight) {
         setDoAbbreviate(true);
       }
 
@@ -785,10 +785,10 @@ const DisruptionDiagram: ComponentType<DisruptionDiagramData> = (props) => {
       overflow="visible"
       viewBox={`0 0 904 ${svgHeight}`}
       id="whole-svg"
+      visibility={isDone ? "visible" : "hidden"}
     >
       <g
         id="line-map"
-        visibility={isDone ? "visible" : "hidden"}
         transform={`translate(${SLOT_WIDTH / 2}, ${
           lineMapHeight - 8 * scaleFactor
         }) scale(${scaleFactor})`}

--- a/assets/src/components/v2/disruption_diagram/disruption_diagram.tsx
+++ b/assets/src/components/v2/disruption_diagram/disruption_diagram.tsx
@@ -549,7 +549,9 @@ const MiddleSlotComponent: ComponentType<MiddleSlotComponentProps> = ({
           className={classWithModifier(`label-${labelTextClass}`, textModifier)}
           transform={`translate(${x} -32) rotate(-45)`}
         >
-          {abbreviate ? label.abbrev : label.full}
+          {abbreviate || label.full === "Massachusetts Avenue"
+            ? label.abbrev
+            : label.full}
         </text>
       )}
     </>

--- a/assets/src/components/v2/disruption_diagram/disruption_diagram.tsx
+++ b/assets/src/components/v2/disruption_diagram/disruption_diagram.tsx
@@ -110,7 +110,7 @@ const CurrentStopIconRedLine: ComponentType<IconProps> = ({ x }) => {
   return (
     <>
       <path
-        transform={`translate(${x - (iconWidth + strokeWidth) / 2} -4)`}
+        transform={`translate(${x - (iconWidth + strokeWidth) / 2})`}
         d="M32.6512 3.92661C30.0824 1.3578 25.9176 1.3578 23.3488 3.92661L3.92661 23.3488C1.3578 25.9176 1.3578 30.0824 3.92661 32.6512L23.3488 52.0734C25.9176 54.6422 30.0824 54.6422 32.6512 52.0734L52.0734 32.6512C54.6422 30.0824 54.6422 25.9176 52.0734 23.3488L32.6512 3.92661Z"
         className="middle-slot__background--red"
         stroke="#E6E4E1"
@@ -118,7 +118,7 @@ const CurrentStopIconRedLine: ComponentType<IconProps> = ({ x }) => {
         strokeLinejoin="round"
       />
       <path
-        transform={`translate(${x - (iconWidth + strokeWidth) / 2} -4)`}
+        transform={`translate(${x - (iconWidth + strokeWidth) / 2})`}
         fillRule="evenodd"
         clipRule="evenodd"
         d="M15.4855 29.219C14.7045 28.438 14.7045 27.1717 15.4855 26.3906L26.3906 15.4855C27.1717 14.7045 28.438 14.7045 29.219 15.4855L40.1242 26.3906C40.9052 27.1717 40.9052 28.438 40.1241 29.219L29.219 40.1242C28.438 40.9052 27.1717 40.9052 26.3906 40.1241L15.4855 29.219Z"
@@ -136,7 +136,9 @@ const CurrentStopIcon: ComponentType<IconProps> = ({ x }) => {
   return (
     <>
       <path
-        transform={`translate(${x - (iconWidth + strokeWidth) / 2} -4)`}
+        transform={`translate(${x - (iconWidth + strokeWidth) / 2} ${
+          -(iconWidth - strokeWidth) / 3
+        })`}
         d="M3.15665 25.2076C1.61445 26.7498 1.61445 29.2502 3.15665 30.7924L25.2076 52.8434C26.7498 54.3856 29.2502 54.3856 30.7924 52.8434L52.8434 30.7924C54.3856 29.2502 54.3856 26.7498 52.8434 25.2076L30.7924 3.15668C29.2502 1.61448 26.7498 1.61448 25.2076 3.15668L3.15665 25.2076Z"
         fill="#EE2E24"
         stroke="#E6E4E1"
@@ -152,7 +154,7 @@ const CurrentStopIconEndpointRedLine: ComponentType<IconProps> = ({ x }) => {
   return (
     <>
       <path
-        transform={`translate(${x - iconWidth / 2} -8)`}
+        transform={`translate(${x - iconWidth / 2} ${-iconWidth / 3})`}
         d="M39.4605 4.26181C36.4447 1.24606 31.5553 1.24606 28.5395 4.26181L4.26181 28.5395C1.24606 31.5553 1.24606 36.4447 4.26181 39.4605L28.5395 63.7382C31.5553 66.7539 36.4447 66.7539 39.4605 63.7382L63.7382 39.4605C66.7539 36.4447 66.7539 31.5553 63.7382 28.5395L39.4605 4.26181Z"
         fill="#EE2E24"
         stroke="#E6E4E1"
@@ -160,7 +162,7 @@ const CurrentStopIconEndpointRedLine: ComponentType<IconProps> = ({ x }) => {
         strokeLinejoin="round"
       />
       <path
-        transform={`translate(${x - iconWidth / 2} -8)`}
+        transform={`translate(${x - iconWidth / 2} ${-iconWidth / 3})`}
         fillRule="evenodd"
         clipRule="evenodd"
         d="M18.0032 35.1702C17.2222 34.3892 17.2222 33.1229 18.0032 32.3418L32.3417 18.0033C33.1228 17.2223 34.3891 17.2223 35.1702 18.0033L49.5086 32.3418C50.2897 33.1229 50.2897 34.3892 49.5086 35.1702L35.1702 49.5087C34.3891 50.2898 33.1228 50.2898 32.3417 49.5087L18.0032 35.1702Z"
@@ -189,9 +191,9 @@ const SuspensionStopIcon: ComponentType<IconProps> = ({ x }) => {
 
   return (
     <>
-      <rect x={x - iconWidth / 4} y="16" width="18" height="16" fill="white" />
+      <rect x={x - iconWidth / 4} width="18" height="16" fill="white" />
       <path
-        transform={`translate(${x - iconWidth / 2} 9)`}
+        transform={`translate(${x - iconWidth / 2} ${-iconWidth})`}
         fillRule="evenodd"
         clipRule="evenodd"
         d="M8.93886 0C8.76494 0 8.5985 0.0707868 8.47786 0.196069L0.178995 8.81412C0.0641567 8.93338 0 9.09249 0 9.25805V21.0682C0 21.238 0.0674284 21.4008 0.187452 21.5208L8.47922 29.8125C8.59924 29.9326 8.76202 30 8.93176 30H21.0611C21.2351 30 21.4015 29.9292 21.5221 29.8039L29.821 21.1859C29.9358 21.0666 30 20.9075 30 20.7419V8.93176C30 8.76202 29.9326 8.59924 29.8125 8.47922L21.5208 0.187452C21.4008 0.0674284 21.238 0 21.0682 0H8.93886ZM7.5935 10.0066C7.34658 10.2576 7.34866 10.6608 7.59816 10.9091L11.957 15.248L7.59623 19.6793C7.34824 19.9313 7.35156 20.3366 7.60365 20.5845L9.73397 22.6794C9.98593 22.9272 10.391 22.9239 10.6389 22.672L15 18.2404L19.3611 22.672C19.609 22.9239 20.0141 22.9272 20.266 22.6794L22.3964 20.5845C22.6484 20.3366 22.6518 19.9313 22.4038 19.6793L18.043 15.248L22.4018 10.9091C22.6513 10.6608 22.6534 10.2576 22.4065 10.0066L20.2613 7.82685C20.0124 7.5739 19.6052 7.5718 19.3537 7.82217L15 12.1559L10.6463 7.82217C10.3948 7.5718 9.98758 7.5739 9.73865 7.82685L7.5935 10.0066Z"
@@ -208,7 +210,9 @@ const StationClosureStopIcon: ComponentType<IconProps> = ({ x, className }) => {
   return (
     <path
       className={className}
-      transform={`translate(${x - (iconWidth + strokeWidth) / 2} -2)`}
+      transform={`translate(${x - (iconWidth + strokeWidth) / 2} ${
+        -iconWidth / 4
+      })`}
       d="M22.6628 27.0001L23.9119 25.7308L22.6498 24.4744L17.0202 18.8706L18.8677 16.9933L24.4828 22.5826L25.7463 23.8404L27.0099 22.5826L32.625 16.9933L34.4725 18.8706L28.8429 24.4744L27.5807 25.7308L28.8298 27.0001L34.4649 32.7261L32.6588 34.5021L27.0229 28.7751L25.7463 27.4779L24.4698 28.7751L18.8338 34.5021L17.0278 32.7261L22.6628 27.0001ZM35.0884 18.2575L35.0876 18.2583L35.0884 18.2575ZM19.4568 35.1147L19.456 35.114L19.4568 35.1147ZM3.22013 15.2827L4.51025 16.5251L3.22013 15.2827C2.73421 15.7873 2.46274 16.4606 2.46274 17.1611V34.0832C2.46274 34.8014 2.74805 35.4902 3.25592 35.9981L15.1366 47.8788L16.4031 46.6124L15.1367 47.8788C15.6445 48.3867 16.3333 48.672 17.0515 48.672H34.4309C35.1669 48.672 35.8711 48.3725 36.3816 47.8424L48.2725 35.4941C48.7585 34.9895 49.0299 34.3162 49.0299 33.6157V16.6936C49.0299 15.9754 48.7446 15.2866 48.2368 14.7788L46.9703 16.0452L48.2367 14.7787L36.356 2.898C35.8481 2.39014 35.1593 2.10483 34.4411 2.10483H17.0617C16.3258 2.10483 15.6215 2.40435 15.111 2.93447L3.22013 15.2827Z"
       fill="#171F26"
       stroke="#E6E4E1"
@@ -218,13 +222,13 @@ const StationClosureStopIcon: ComponentType<IconProps> = ({ x, className }) => {
 };
 
 const ShuttleStopIcon: ComponentType<IconProps> = ({ x }) => (
-  <circle cx={x} cy="24" r="10" fill="white" stroke="#171F26" strokeWidth="4" />
+  <circle cx={x} cy="12" r="10" fill="white" stroke="#171F26" strokeWidth="4" />
 );
 
 const StopIcon: ComponentType<IconProps> = ({ x, className }) => (
   <circle
     cx={x}
-    cy="24"
+    cy="12"
     r="10"
     fill="white"
     className={className}
@@ -235,7 +239,7 @@ const StopIcon: ComponentType<IconProps> = ({ x, className }) => (
 const StopIconEndpoint: ComponentType<IconProps> = ({ x, className }) => (
   <circle
     cx={x}
-    cy="24"
+    cy="12"
     r="20"
     fill="white"
     className={className}
@@ -245,7 +249,7 @@ const StopIconEndpoint: ComponentType<IconProps> = ({ x, className }) => (
 
 const ArrowEndpoint: ComponentType<IconProps> = ({ x, className }) => (
   <path
-    transform={`translate(${x} 12)`}
+    transform={`translate(${x})`}
     width={204}
     d="M0 24V0H59.446C59.8085 0 60.1642 0.0985159 60.475 0.285014L77.1417 10.285C78.4364 11.0618 78.4364 12.9382 77.1417 13.715L60.475 23.715C60.1642 23.9015 59.8085 24 59.446 24H0Z"
     className={className}
@@ -258,7 +262,7 @@ const getEndpointLabel = (labelID: string, x: number, isArrow: boolean) => {
     return (
       <text
         className="label--endpoint"
-        transform={`translate(${x} -5) rotate(-45)`}
+        transform={`translate(${x} -32) rotate(-45)`}
       >
         {isArrow && <tspan className="label">to </tspan>}
         {labelParts[0]}
@@ -269,14 +273,14 @@ const getEndpointLabel = (labelID: string, x: number, isArrow: boolean) => {
       <>
         <text
           className="label--endpoint"
-          transform={`translate(${x} -5) rotate(-45)`}
+          transform={`translate(${x} -32) rotate(-45)`}
         >
           {isArrow && <tspan className="label">to </tspan>}
           {labelParts[0]}
         </text>
         <text
           className="label--endpoint"
-          transform={`translate(${x + 45} -5) rotate(-45)`}
+          transform={`translate(${x + 45} -32) rotate(-45)`}
         >
           {labelParts[1]}
         </text>
@@ -310,7 +314,6 @@ const FirstSlotComponent: ComponentType<FirstSlotComponentProps> = ({
     icon = (
       <path
         className={classWithModifier("end-slot__arrow", line)}
-        transform="translate(0 12)"
         d="M35 0V24L19.554 24C19.1915 24 18.8358 23.9015 18.525 23.715L1.85831 13.715C0.563633 12.9382 0.563633 11.0618 1.85831 10.285L18.525 0.285015C18.8358 0.0985165 19.1915 0 19.554 0L35 0Z"
         fill={line}
       />
@@ -357,7 +360,6 @@ const FirstSlotComponent: ComponentType<FirstSlotComponentProps> = ({
         height={LINE_HEIGHT}
         fill={line}
         x={L + SLOT_WIDTH / 2}
-        y="12"
       />
     );
   } else {
@@ -468,7 +470,6 @@ const MiddleSlotComponent: ComponentType<MiddleSlotComponentProps> = ({
         width={SLOT_WIDTH + spaceBetween}
         height={LINE_HEIGHT}
         x={x}
-        y="12"
       />
     );
   }
@@ -533,7 +534,7 @@ const MiddleSlotComponent: ComponentType<MiddleSlotComponentProps> = ({
       {label === "…" ? (
         <text
           className={classWithModifier(`label-${labelTextClass}`, textModifier)}
-          transform={`translate(${x - 12} ${-5})`}
+          transform={`translate(${x - 12} -32)`}
         >
           {" "}
           {label}{" "}
@@ -541,7 +542,7 @@ const MiddleSlotComponent: ComponentType<MiddleSlotComponentProps> = ({
       ) : (
         <text
           className={classWithModifier(`label-${labelTextClass}`, textModifier)}
-          transform={`translate(${x} ${-5}) rotate(-45)`}
+          transform={`translate(${x} -32) rotate(-45)`}
         >
           {abbreviate ? label.abbrev : label.full}
         </text>
@@ -575,9 +576,9 @@ const EffectBackgroundComponent: ComponentType<
     background = (
       <line
         x1={x1 + dashXunit}
-        y1="24"
+        y1="12"
         x2={x2}
-        y2="24"
+        y2="12"
         strokeWidth={16}
         stroke="black"
         strokeDasharray={`${dash} ${gap}`}
@@ -585,13 +586,7 @@ const EffectBackgroundComponent: ComponentType<
     );
   } else if (effect === "suspension") {
     background = (
-      <rect
-        width={x2 - x1 + SLOT_WIDTH}
-        height="16"
-        x={x1}
-        y="16"
-        fill="#AEAEAE"
-      />
+      <rect width={x2 - x1 + SLOT_WIDTH} height="16" x={x1} fill="#AEAEAE" />
     );
   } else {
     background = <></>;
@@ -628,14 +623,9 @@ const AlertEmphasisComponent: ComponentType<AlertEmphasisComponentProps> = ({
   if (effect === "shuttle") {
     icon = (
       <>
-        <circle
-          cx={middleOfLine}
-          cy="16"
-          r={widthOfBackground}
-          fill="#171F26"
-        />
+        <circle cx={middleOfLine} cy="8" r={widthOfBackground} fill="#171F26" />
         <path
-          transform={`translate(${middleOfLine - widthOfBackground} -24)`}
+          transform={`translate(${middleOfLine - widthOfBackground} -32)`}
           fillRule="evenodd"
           clipRule="evenodd"
           d="M60.8695 37.5334L58.842 21.6673C58.327 18.8044 56.513 17.6872 53.8141 16.5156C49.3915 14.9398 44.7285 14.0896 40.017 14C35.2983 14.0906 30.628 14.9408 26.1974 16.5156C23.532 17.6651 21.7178 18.8039 21.1691 21.6668L19.1309 37.5334V59.4837H22.709V63.3065C22.7138 64.8769 24.0275 66.1487 25.6492 66.153C27.2708 66.1484 28.5841 64.8765 28.5889 63.3062V59.4834H51.5189V63.3062C51.5111 64.3282 52.0697 65.2758 52.9824 65.789C53.8951 66.3022 55.0219 66.3022 55.9346 65.789C56.8473 65.2758 57.4059 64.3282 57.3982 63.3062V59.4834H60.87L60.8695 37.5334ZM31.429 18.0156H48.6755C49.4054 18.0156 49.997 18.5886 49.997 19.2954C49.997 20.0022 49.4054 20.5751 48.6755 20.5751H31.429C30.6991 20.5751 30.1074 20.0022 30.1074 19.2954C30.1074 18.5886 30.6991 18.0156 31.429 18.0156ZM24.5181 24.5431L22.839 37.069C22.8167 37.2128 22.8167 37.359 22.839 37.5028C22.8175 37.9344 22.9743 38.3566 23.2748 38.676C23.5752 38.9955 23.9947 39.186 24.4404 39.2055H55.7192C56.1641 39.2101 56.5924 39.0417 56.9081 38.7379C57.2237 38.4341 57.4002 38.0204 57.3982 37.5895V37.5028C57.4207 37.359 57.4207 37.2128 57.3982 37.069L55.7192 24.5431C55.5841 23.7547 54.8758 23.1793 54.0506 23.1876H26.1971C25.3697 23.179 24.6582 23.7534 24.5181 24.5431ZM25.6476 52.6951C23.9189 52.6982 22.515 51.3436 22.5117 49.6696C22.5085 47.9956 23.9072 46.636 25.6358 46.6328C27.3645 46.6296 28.7686 47.984 28.772 49.658C28.7741 50.4621 28.446 51.2341 27.86 51.8038C27.2739 52.3735 26.478 52.6941 25.6476 52.6951ZM54.4601 46.6328C52.733 46.6339 51.3332 47.9895 51.332 49.662C51.3309 51.3345 52.7289 52.6918 54.4555 52.6951C55.2881 52.6973 56.0872 52.3781 56.6759 51.808C57.2647 51.238 57.5945 50.4642 57.5923 49.658C57.5889 47.9855 56.1872 46.6317 54.4601 46.6328Z"
@@ -646,15 +636,9 @@ const AlertEmphasisComponent: ComponentType<AlertEmphasisComponentProps> = ({
   } else if (effect === "suspension") {
     icon = (
       <>
-        <rect
-          x={middleOfLine - 35}
-          y="-6"
-          width={60}
-          height={45}
-          fill="white"
-        />
+        <rect x={middleOfLine - 35} width={60} height={45} fill="white" />
         <path
-          transform={`translate(${middleOfLine - widthOfBackground} -24)`}
+          transform={`translate(${middleOfLine - widthOfBackground})`}
           fillRule="evenodd"
           clipRule="evenodd"
           d="M23.837 0C23.3732 0 22.9293 0.188765 22.6076 0.522852L0.47732 23.5043C0.171085 23.8223 0 24.2467 0 24.6881V56.182C0 56.6346 0.179809 57.0687 0.499871 57.3888L22.6112 79.5001C22.9313 79.8202 23.3654 80 23.818 80H56.163C56.6268 80 57.0707 79.8112 57.3924 79.4771L79.5227 56.4957C79.8289 56.1777 80 55.7534 80 55.3119V23.818C80 23.3654 79.8202 22.9313 79.5001 22.6112L57.3888 0.499871C57.0687 0.179809 56.6346 0 56.182 0H23.837ZM20.2493 26.6844C19.5909 27.3535 19.5964 28.4288 20.2618 29.091L31.8854 40.6614L20.2566 52.478C19.5953 53.15 19.6042 54.2309 20.2764 54.892L25.9573 60.4784C26.6291 61.1391 27.7094 61.1303 28.3703 60.4586L40 48.6411L51.6297 60.4586C52.2906 61.1303 53.3708 61.1391 54.0427 60.4784L59.7236 54.892C60.3958 54.2309 60.4047 53.15 59.7434 52.478L48.1146 40.6614L59.7383 29.091C60.4036 28.4288 60.4091 27.3535 59.7507 26.6844L54.0303 20.8716C53.3665 20.1971 52.2805 20.1915 51.6098 20.8591L40 32.4157L28.3902 20.8591C27.7195 20.1915 26.6335 20.1971 25.9697 20.8716L20.2493 26.6844Z"
@@ -753,7 +737,6 @@ const DisruptionDiagram: ComponentType<DisruptionDiagramData> = (props) => {
 
   const [isDone, setIsDone] = useState(false);
   const [isDoneScaling, setIsDoneScaling] = useState(false);
-  const [lineMapHeight, setLineMapHeight] = useState(0);
 
   useEffect(() => {
     const dimensions = document
@@ -768,27 +751,27 @@ const DisruptionDiagram: ComponentType<DisruptionDiagramData> = (props) => {
       setScaleFactor(904 / width);
       setIsDoneScaling(true);
     } else if (!isDone && isDoneScaling && height) {
-      if (height > svgHeight) {
+      if (height + EMPHASIS_HEIGHT > svgHeight) {
         setDoAbbreviate(true);
       }
-      setLineMapHeight(height);
 
       setIsDone(true);
     }
-  });
-
-  const tranlatedY = Math.max(lineMapHeight, svgHeight);
+  }, [svgHeight]);
 
   return (
-    <svg width={904} height="100%" id="whole-svg">
+    <svg
+      height="100%"
+      overflow="visible"
+      viewBox={`0 0 904 ${svgHeight}`}
+      id="whole-svg"
+    >
       <g
         id="line-map"
-        transform={`translate(${SLOT_WIDTH / 2}, ${
-          hasEmphasis
-            ? tranlatedY - EMPHASIS_HEIGHT * 2.25
-            : tranlatedY - EMPHASIS_HEIGHT * 0.75
-        }) scale(${scaleFactor})`}
         visibility={isDone ? "visible" : "hidden"}
+        transform={`translate(${SLOT_WIDTH / 2}, ${
+          svgHeight - EMPHASIS_HEIGHT * 2
+        }) scale(${scaleFactor})`}
       >
         <EffectBackgroundComponent
           effectRegionSlotIndexRange={
@@ -827,8 +810,9 @@ const DisruptionDiagram: ComponentType<DisruptionDiagramData> = (props) => {
       </g>
       {hasEmphasis && (
         <g
+          id="alert-emphasis"
           transform={`translate(${SLOT_WIDTH / 2}, ${
-            tranlatedY - EMPHASIS_HEIGHT * 0.75
+            svgHeight - EMPHASIS_HEIGHT / 1.5
           })`}
         >
           <AlertEmphasisComponent

--- a/assets/src/components/v2/pre_fare_single_screen_alert.tsx
+++ b/assets/src/components/v2/pre_fare_single_screen_alert.tsx
@@ -1,5 +1,5 @@
 import useTextResizer from "Hooks/v2/use_text_resizer";
-import React from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { getHexColor, STRING_TO_SVG } from "Util/svg_utils";
 import DisruptionDiagram, {
   DisruptionDiagramData,
@@ -28,11 +28,11 @@ interface PreFareSingleScreenAlertProps {
 }
 
 interface EnrichedRoute {
-  route_id: string,
-  svg_name: string
+  route_id: string;
+  svg_name: string;
 }
 
-// For the standard layout, issue font can be medium or large. 
+// For the standard layout, issue font can be medium or large.
 // If remedy is "Seek alternate route", font size is static. Otherwise, it uses the same font size as
 // the issue.
 const standardLayout = (
@@ -79,8 +79,8 @@ const multiLineLayout = (
   unaffected_routes: EnrichedRoute[],
   disruptionDiagram?: DisruptionDiagramData
 ) => {
-  const AffectedLinePill = STRING_TO_SVG[routes[0].svg_name]
-  const affectedLineColor = getHexColor(getRouteColor(routes[0].route_id))
+  const AffectedLinePill = STRING_TO_SVG[routes[0].svg_name];
+  const affectedLineColor = getHexColor(getRouteColor(routes[0].route_id));
 
   return (
     <div className="alert-card__content-block">
@@ -89,17 +89,25 @@ const multiLineLayout = (
         <div className="alert-card__content-block__text--large">
           <AffectedLinePill
             className="alert-card__content-block__route-pill"
-            color={affectedLineColor} />
+            color={affectedLineColor}
+          />
           <span>trains are skipping this station</span>
         </div>
       </div>
       <div className="alert-card__issue">
         <InfoIcon className="alert-card__icon" />
         <div className="alert-card__content-block__text--large">
-          {unaffected_routes.map(route => {
-            const UnaffectedLinePill = STRING_TO_SVG[route.svg_name]
-            const unaffectedLineColor = getHexColor(getRouteColor(route.route_id))
-            return <UnaffectedLinePill className="alert-card__content-block__route-pill" color={unaffectedLineColor} />
+          {unaffected_routes.map((route) => {
+            const UnaffectedLinePill = STRING_TO_SVG[route.svg_name];
+            const unaffectedLineColor = getHexColor(
+              getRouteColor(route.route_id)
+            );
+            return (
+              <UnaffectedLinePill
+                className="alert-card__content-block__route-pill"
+                color={unaffectedLineColor}
+              />
+            );
           })}
           <span>trains stop as usual</span>
         </div>
@@ -235,10 +243,29 @@ const remedySection = (
 );
 
 const mapSection = (disruptionDiagram?: DisruptionDiagramData) => {
+  const [diagramHeight, setDiagramHeight] = useState(0);
+  const ref = useRef(null);
+
+  useEffect(() => {
+    if (!ref.current) return;
+    const resizeObserver = new ResizeObserver(() => {
+      // Do what you want to do when the size of the element changes
+      setDiagramHeight(ref.current.clientHeight);
+    });
+    resizeObserver.observe(ref.current);
+    return () => resizeObserver.disconnect(); // clean up
+  });
+
   return (
-    <div style={{ height: 408, width: 904 }}>
-      {disruptionDiagram && <DisruptionDiagram {...disruptionDiagram} />}
-    </div>
+    disruptionDiagram && (
+      <div
+        id="disruption-diagram-container"
+        className="disruption-diagram-container"
+        ref={ref}
+      >
+        <DisruptionDiagram {...disruptionDiagram} svgHeight={diagramHeight} />
+      </div>
+    )
   );
 };
 
@@ -331,41 +358,43 @@ const PreFareSingleScreenAlert: React.ComponentType<
 };
 
 const getRouteColor = (route_id: string) => {
-  switch(route_id.substring(0, 3)) {
+  switch (route_id.substring(0, 3)) {
     case "Red":
-      return "red"
+      return "red";
     case "Ora":
-      return "orange"
+      return "orange";
     case "Blu":
-      return "blue"
+      return "blue";
     case "Gre":
-      return "green"
+      return "green";
     default:
-      return "yellow"
+      return "yellow";
   }
 };
 
 // If only one route color is represented ("gl-union" and "gl-riverside" are the same route color)
 // use that, otherwise "yellow"
 const getAlertColor = (routes: EnrichedRoute[]) => {
-  const colors = routes.map(r => getRouteColor(r.route_id))
-  const uniqueColors = new Set(colors).size
-  return uniqueColors == 1 ? colors[0] : "yellow"
-}
+  const colors = routes.map((r) => getRouteColor(r.route_id));
+  const uniqueColors = new Set(colors).size;
+  return uniqueColors == 1 ? colors[0] : "yellow";
+};
 
-const PreFareAlertBanner: React.ComponentType<{routes: EnrichedRoute[]}> = ({
-  routes
+const PreFareAlertBanner: React.ComponentType<{ routes: EnrichedRoute[] }> = ({
+  routes,
 }) => {
   let banner;
 
   if (
     routes.length === 1 &&
-    ["rl", "ol", "bl", "gl", "gl-b", "gl-c", "gl-d", "gl-e"].includes(routes[0].svg_name)
+    ["rl", "ol", "bl", "gl", "gl-b", "gl-c", "gl-d", "gl-e"].includes(
+      routes[0].svg_name
+    )
   ) {
     // One destination, short text
-    const route = routes[0]
-    const LinePill = STRING_TO_SVG[route.svg_name]
-    const color = getRouteColor(route.route_id)
+    const route = routes[0];
+    const LinePill = STRING_TO_SVG[route.svg_name];
+    const color = getRouteColor(route.route_id);
 
     banner = (
       <div className={classWithModifiers("alert-banner", ["small", color])}>
@@ -379,9 +408,9 @@ const PreFareAlertBanner: React.ComponentType<{routes: EnrichedRoute[]}> = ({
     );
   } else if (routes.length === 1) {
     // One destination, long text
-    const route = routes[0]
-    const LinePill = STRING_TO_SVG[route.svg_name]
-    const color = getRouteColor(route.route_id)
+    const route = routes[0];
+    const LinePill = STRING_TO_SVG[route.svg_name];
+    const color = getRouteColor(route.route_id);
 
     banner = (
       <div
@@ -414,7 +443,7 @@ const PreFareAlertBanner: React.ComponentType<{routes: EnrichedRoute[]}> = ({
           riders to
         </span>
         {routes.map((route) => {
-          const LinePill = STRING_TO_SVG[route.svg_name]
+          const LinePill = STRING_TO_SVG[route.svg_name];
           return (
             <LinePill
               className="alert-banner__route-pill--long"
@@ -428,7 +457,12 @@ const PreFareAlertBanner: React.ComponentType<{routes: EnrichedRoute[]}> = ({
   } else {
     // Fallback
     banner = (
-      <div className={classWithModifiers("alert-banner", ["small", getAlertColor(routes)])}>
+      <div
+        className={classWithModifiers("alert-banner", [
+          "small",
+          getAlertColor(routes),
+        ])}
+      >
         <span>
           <span className="alert-banner__attention-text">ATTENTION,</span>{" "}
           riders

--- a/assets/src/components/v2/pre_fare_single_screen_alert.tsx
+++ b/assets/src/components/v2/pre_fare_single_screen_alert.tsx
@@ -32,16 +32,24 @@ interface EnrichedRoute {
   svg_name: string;
 }
 
+interface StandardLayoutProps {
+  issue: string;
+  remedy: string;
+  effect: string;
+  location: string | null;
+  disruptionDiagram?: DisruptionDiagramData;
+}
+
 // For the standard layout, issue font can be medium or large.
 // If remedy is "Seek alternate route", font size is static. Otherwise, it uses the same font size as
 // the issue.
-const standardLayout = (
-  issue: string,
-  remedy: string,
-  effect: string,
-  location: string | null,
-  disruptionDiagram?: DisruptionDiagramData
-) => {
+const StandardLayout: React.ComponentType<StandardLayoutProps> = ({
+  issue,
+  remedy,
+  effect,
+  location,
+  disruptionDiagram,
+}) => {
   const { ref: contentBlockRef, size: contentTextSize } = useTextResizer({
     sizes: ["medium", "large"],
     maxHeight: 772,
@@ -50,8 +58,16 @@ const standardLayout = (
 
   return (
     <div className="alert-card__content-block" ref={contentBlockRef}>
-      {standardIssueSection(issue, location, contentTextSize)}
-      {remedySection(effect, remedy, contentTextSize)}
+      <StandardIssueSection
+        issue={issue}
+        location={location}
+        contentTextSize={contentTextSize}
+      />
+      <RemedySection
+        effect={effect}
+        remedy={remedy}
+        contentTextSize={contentTextSize}
+      />
       {disruptionDiagram && (
         <MapSection disruptionDiagram={disruptionDiagram} />
       )}
@@ -59,28 +75,41 @@ const standardLayout = (
   );
 };
 
+interface DownstreamLayoutProps {
+  endpoints: string[];
+  effect: string;
+  remedy: string;
+  disruptionDiagram?: DisruptionDiagramData;
+}
+
 // In the downstream layout, the map is at the top, and the font size stays constant
-const downstreamLayout = (
-  endpoints: string[],
-  effect: string,
-  remedy: string,
-  disruptionDiagram?: DisruptionDiagramData
-) => (
+const DownstreamLayout: React.ComponentType<DownstreamLayoutProps> = ({
+  endpoints,
+  effect,
+  remedy,
+  disruptionDiagram,
+}) => (
   <div className={classWithModifier("alert-card__content-block", "downstream")}>
     {disruptionDiagram && <MapSection disruptionDiagram={disruptionDiagram} />}
-    {downstreamIssueSection(endpoints)}
-    {remedySection(effect, remedy, "medium")}
+    <DownstreamIssueSection endpoints={endpoints} />
+    <RemedySection effect={effect} remedy={remedy} contentTextSize="medium" />
   </div>
 );
+
+interface MultiLineLayoutProps {
+  routes: EnrichedRoute[];
+  unaffected_routes: EnrichedRoute[];
+  disruptionDiagram?: DisruptionDiagramData;
+}
 
 // Covers the case where a station_closure only affects one line at a transfer station.
 // In the even rarer case that there are multiple branches in the routes list or unaffected routes list
 // the font size may need to shrink to accommodate.
-const multiLineLayout = (
-  routes: EnrichedRoute[],
-  unaffected_routes: EnrichedRoute[],
-  disruptionDiagram?: DisruptionDiagramData
-) => {
+const MultiLineLayout: React.ComponentType<MultiLineLayoutProps> = ({
+  routes,
+  unaffected_routes,
+  disruptionDiagram,
+}) => {
   const AffectedLinePill = STRING_TO_SVG[routes[0].svg_name];
   const affectedLineColor = getHexColor(getRouteColor(routes[0].route_id));
 
@@ -122,12 +151,19 @@ const multiLineLayout = (
   );
 };
 
-const fallbackLayout = (
-  issue: string,
-  remedy: string,
-  effect: string,
-  routes: any[]
-) => {
+interface FalloutLayoutProps {
+  issue: string;
+  remedy: string;
+  effect: string;
+  routes: any[];
+}
+
+const FallbackLayout: React.ComponentType<FalloutLayoutProps> = ({
+  issue,
+  remedy,
+  effect,
+  routes,
+}) => {
   // If there is more than 1 route in the banner, or the 1 route is longer than "GL·B"
   // the banner will be tall. Otherwise, it'll be 1-line
   const bannerHeight =
@@ -178,18 +214,24 @@ const fallbackLayout = (
   );
 };
 
-const standardIssueSection = (
-  issue: string,
-  location: string | null,
-  textSize: string
-) => (
+interface StandardIssueSectionProps {
+  issue: string;
+  location: string | null;
+  contentTextSize: string;
+}
+
+const StandardIssueSection: React.ComponentType<StandardIssueSectionProps> = ({
+  issue,
+  location,
+  contentTextSize,
+}) => (
   <div className="alert-card__issue">
     <NoServiceIcon className="alert-card__icon" />
     <div>
       <div
         className={classWithModifier(
           "alert-card__content-block__text",
-          textSize
+          contentTextSize
         )}
       >
         {issue}
@@ -201,7 +243,13 @@ const standardIssueSection = (
   </div>
 );
 
-const downstreamIssueSection = (endpoints: string[]) => (
+interface DownstreamIssueSectionProps {
+  endpoints: string[];
+}
+
+const DownstreamIssueSection: React.ComponentType<
+  DownstreamIssueSectionProps
+> = ({ endpoints }) => (
   <div className="alert-card__issue">
     <div
       className={classWithModifier("alert-card__content-block__text", "medium")}
@@ -211,12 +259,16 @@ const downstreamIssueSection = (endpoints: string[]) => (
     </div>
   </div>
 );
-
-const remedySection = (
-  effect: string,
-  remedy: string | null,
-  contentTextSize: string
-) => (
+interface RemedySectionProps {
+  effect: string;
+  remedy: string | null;
+  contentTextSize: string;
+}
+const RemedySection: React.ComponentType<RemedySectionProps> = ({
+  effect,
+  remedy,
+  contentTextSize,
+}) => (
   <div className="alert-card__remedy">
     {effect === "shuttle" ? (
       <>
@@ -308,37 +360,73 @@ const PreFareSingleScreenAlert: React.ComponentType<
    * - standard: icon + issue, and icon + remedy, and then map section
    * - downstream: map, issue without icon, then icon + remedy
    **/
-  const layoutRenderer = () => {
-    switch (true) {
-      case effect === "delay":
-        return fallbackLayout(issue, remedy, effect, routes);
-      case effect === "station_closure" && region === "here":
-        return multiLineLayout(routes, unaffected_routes, disruption_diagram);
-      case effect === "station_closure":
-        return standardLayout(
-          issue,
-          remedy,
-          effect,
-          location,
-          disruption_diagram
-        );
-      case (region === "boundary" || region === "here") &&
-        (effect === "shuttle" || effect === "suspension"):
-        return standardLayout(
-          issue,
-          remedy,
-          effect,
-          location,
-          disruption_diagram
-        );
-      case region === "outside" &&
-        endpoints &&
-        (effect === "shuttle" || effect === "suspension"):
-        return downstreamLayout(endpoints, effect, remedy, disruption_diagram);
-      default:
-        return fallbackLayout(issue, remedy, effect, routes);
-    }
-  };
+  let layout;
+  switch (true) {
+    case effect === "delay":
+      layout = (
+        <FallbackLayout
+          issue={issue}
+          remedy={remedy}
+          effect={effect}
+          routes={routes}
+        />
+      );
+      break;
+    case effect === "station_closure" && region === "here":
+      layout = (
+        <MultiLineLayout
+          routes={routes}
+          unaffected_routes={unaffected_routes}
+          disruptionDiagram={disruption_diagram}
+        />
+      );
+      break;
+    case effect === "station_closure":
+      layout = (
+        <StandardLayout
+          issue={issue}
+          remedy={remedy}
+          effect={effect}
+          location={location}
+          disruptionDiagram={disruption_diagram}
+        />
+      );
+
+      break;
+    case (region === "boundary" || region === "here") &&
+      (effect === "shuttle" || effect === "suspension"):
+      layout = (
+        <StandardLayout
+          issue={issue}
+          remedy={remedy}
+          effect={effect}
+          location={location}
+          disruptionDiagram={disruption_diagram}
+        />
+      );
+      break;
+    case region === "outside" &&
+      endpoints &&
+      (effect === "shuttle" || effect === "suspension"):
+      layout = (
+        <DownstreamLayout
+          endpoints={endpoints}
+          effect={effect}
+          remedy={remedy}
+          disruptionDiagram={disruption_diagram}
+        />
+      );
+      break;
+    default:
+      layout = (
+        <FallbackLayout
+          issue={issue}
+          remedy={remedy}
+          effect={effect}
+          routes={routes}
+        />
+      );
+  }
 
   const showBanner = !isMultiLine(effect, region);
 
@@ -353,7 +441,7 @@ const PreFareSingleScreenAlert: React.ComponentType<
         ])}
       >
         <div className="alert-card">
-          <div className="alert-card__body">{layoutRenderer()}</div>
+          <div className="alert-card__body">{layout}</div>
           <div className="alert-card__footer">
             {cause && (
               <div className="alert-card__footer__cause">

--- a/assets/src/components/v2/pre_fare_single_screen_alert.tsx
+++ b/assets/src/components/v2/pre_fare_single_screen_alert.tsx
@@ -52,7 +52,9 @@ const standardLayout = (
     <div className="alert-card__content-block" ref={contentBlockRef}>
       {standardIssueSection(issue, location, contentTextSize)}
       {remedySection(effect, remedy, contentTextSize)}
-      {mapSection(disruptionDiagram)}
+      {disruptionDiagram && (
+        <MapSection disruptionDiagram={disruptionDiagram} />
+      )}
     </div>
   );
 };
@@ -65,7 +67,7 @@ const downstreamLayout = (
   disruptionDiagram?: DisruptionDiagramData
 ) => (
   <div className={classWithModifier("alert-card__content-block", "downstream")}>
-    {mapSection(disruptionDiagram)}
+    {disruptionDiagram && <MapSection disruptionDiagram={disruptionDiagram} />}
     {downstreamIssueSection(endpoints)}
     {remedySection(effect, remedy, "medium")}
   </div>
@@ -113,7 +115,9 @@ const multiLineLayout = (
           <span>trains stop as usual</span>
         </div>
       </div>
-      {mapSection(disruptionDiagram)}
+      {disruptionDiagram && (
+        <MapSection disruptionDiagram={disruptionDiagram} />
+      )}
     </div>
   );
 };
@@ -243,30 +247,36 @@ const remedySection = (
   </div>
 );
 
-const mapSection = (disruptionDiagram?: DisruptionDiagramData) => {
+interface MapSectionProps {
+  disruptionDiagram: DisruptionDiagramData;
+}
+
+const MapSection: React.ComponentType<MapSectionProps> = ({
+  disruptionDiagram,
+}) => {
   const [diagramHeight, setDiagramHeight] = useState(0);
-  const ref = useRef(null);
+  const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (!ref.current) return;
     const resizeObserver = new ResizeObserver(() => {
       // Do what you want to do when the size of the element changes
-      setDiagramHeight(ref.current.clientHeight);
+      if (ref?.current) {
+        setDiagramHeight(ref.current.clientHeight);
+      }
     });
     resizeObserver.observe(ref.current);
     return () => resizeObserver.disconnect(); // clean up
   });
 
   return (
-    disruptionDiagram && (
-      <div
-        id="disruption-diagram-container"
-        className="disruption-diagram-container"
-        ref={ref}
-      >
-        <DisruptionDiagram {...disruptionDiagram} svgHeight={diagramHeight} />
-      </div>
-    )
+    <div
+      id="disruption-diagram-container"
+      className="disruption-diagram-container"
+      ref={ref}
+    >
+      <DisruptionDiagram {...disruptionDiagram} svgHeight={diagramHeight} />
+    </div>
   );
 };
 

--- a/assets/src/components/v2/reconstructed_takeover.tsx
+++ b/assets/src/components/v2/reconstructed_takeover.tsx
@@ -29,12 +29,14 @@ const ReconstructedTakeover: React.ComponentType<ReconAlertProps> = (alert) => {
   } = alert;
 
   const [diagramHeight, setDiagramHeight] = useState(0);
-  const ref = useRef(null);
+  const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (!ref.current) return;
     const resizeObserver = new ResizeObserver(() => {
-      setDiagramHeight(ref.current.clientHeight);
+      if (ref?.current) {
+        setDiagramHeight(ref.current.clientHeight);
+      }
     });
     resizeObserver.observe(ref.current);
     return () => resizeObserver.disconnect(); // clean up

--- a/assets/src/components/v2/reconstructed_takeover.tsx
+++ b/assets/src/components/v2/reconstructed_takeover.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useRef, useState } from "react";
 
 import { classWithModifiers, imagePath } from "Util/util";
 import DisruptionDiagram, {
@@ -28,6 +28,18 @@ const ReconstructedTakeover: React.ComponentType<ReconAlertProps> = (alert) => {
     disruption_diagram,
   } = alert;
 
+  const [diagramHeight, setDiagramHeight] = useState(0);
+  const ref = useRef(null);
+
+  useEffect(() => {
+    if (!ref.current) return;
+    const resizeObserver = new ResizeObserver(() => {
+      setDiagramHeight(ref.current.clientHeight);
+    });
+    resizeObserver.observe(ref.current);
+    return () => resizeObserver.disconnect(); // clean up
+  });
+
   return (
     <>
       <div
@@ -38,19 +50,26 @@ const ReconstructedTakeover: React.ComponentType<ReconAlertProps> = (alert) => {
       >
         <div className="alert-card alert-card--left">
           <div className="alert-card__body">
-            <img
-              className="alert-card__body__icon"
-              src={imagePath("no-service-black.svg")}
-            />
-            <div className="alert-card__body__issue">{issue}</div>
-            <div className="alert-card__body__location ">{location}</div>
-            {disruption_diagram && (
-              <div style={{ height: 408, width: 904 }}>
-                {disruption_diagram && (
-                  <DisruptionDiagram {...disruption_diagram} />
-                )}
-              </div>
-            )}
+            <div className="container">
+              <img
+                className="alert-card__body__icon"
+                src={imagePath("no-service-black.svg")}
+              />
+              <div className="alert-card__body__issue">{issue}</div>
+              <div className="alert-card__body__location ">{location}</div>
+              {disruption_diagram && (
+                <div
+                  id="disruption-diagram-container"
+                  className="disruption-diagram-container"
+                  ref={ref}
+                >
+                  <DisruptionDiagram
+                    {...disruption_diagram}
+                    svgHeight={diagramHeight}
+                  />
+                </div>
+              )}
+            </div>
           </div>
           <div className="alert-card__footer">
             <div className="alert-card__footer__cause">

--- a/lib/screens/v2/candidate_generator/widgets/reconstructed_alert.ex
+++ b/lib/screens/v2/candidate_generator/widgets/reconstructed_alert.ex
@@ -333,7 +333,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlert do
         |> Enum.flat_map(
           &case fetch_stop_name_fn.(&1) do
             :error -> []
-            "Massachusetts Avenue" -> ["Mass. Ave"]
+            "Massachusetts Avenue" -> ["Mass Ave"]
             name -> [name]
           end
         )

--- a/lib/screens/v2/widget_instance/reconstructed_alert.ex
+++ b/lib/screens/v2/widget_instance/reconstructed_alert.ex
@@ -327,8 +327,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
       informed_stations: informed_stations
     } = t
 
-    informed_stations_string =
-      informed_stations |> abbreviate_station_name() |> Util.format_name_list_to_string()
+    informed_stations_string = Util.format_name_list_to_string(informed_stations)
 
     location_text =
       case LocalizedAlert.consolidated_informed_subway_routes(t) do
@@ -510,8 +509,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
       informed_stations: informed_stations
     } = t
 
-    informed_stations_string =
-      informed_stations |> abbreviate_station_name() |> Util.format_name_list_to_string()
+    informed_stations_string = Util.format_name_list_to_string(informed_stations)
 
     %{
       issue: "Trains skip #{informed_stations_string}",
@@ -859,8 +857,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
     %{alert: %{cause: cause}, informed_stations: informed_stations} = t
     cause_text = Alert.get_cause_string(cause)
 
-    informed_stations_string =
-      informed_stations |> abbreviate_station_name() |> Util.format_name_list_to_string()
+    informed_stations_string = Util.format_name_list_to_string(informed_stations)
 
     %{
       issue: "Trains will bypass #{informed_stations_string}",

--- a/lib/screens/v2/widget_instance/reconstructed_alert.ex
+++ b/lib/screens/v2/widget_instance/reconstructed_alert.ex
@@ -327,7 +327,8 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
       informed_stations: informed_stations
     } = t
 
-    informed_stations_string = Util.format_name_list_to_string(informed_stations)
+    informed_stations_string =
+      informed_stations |> abbreviate_station_name() |> Util.format_name_list_to_string()
 
     location_text =
       case LocalizedAlert.consolidated_informed_subway_routes(t) do
@@ -509,7 +510,8 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
       informed_stations: informed_stations
     } = t
 
-    informed_stations_string = Util.format_name_list_to_string(informed_stations)
+    informed_stations_string =
+      informed_stations |> abbreviate_station_name() |> Util.format_name_list_to_string()
 
     %{
       issue: "Trains skip #{informed_stations_string}",
@@ -857,7 +859,8 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
     %{alert: %{cause: cause}, informed_stations: informed_stations} = t
     cause_text = Alert.get_cause_string(cause)
 
-    informed_stations_string = Util.format_name_list_to_string(informed_stations)
+    informed_stations_string =
+      informed_stations |> abbreviate_station_name() |> Util.format_name_list_to_string()
 
     %{
       issue: "Trains will bypass #{informed_stations_string}",
@@ -897,6 +900,9 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
     end
   end
 
+  defp abbreviate_station_name("Massachusetts Avenue"), do: "Mass Ave"
+  defp abbreviate_station_name(full_name), do: full_name
+
   def get_endpoints(ie, "Green") do
     Enum.find_value(@green_line_branches, fn branch ->
       get_endpoints(ie, branch)
@@ -921,7 +927,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
         {min_full_name, _min_abbreviated_name} = min_station_name
         {max_full_name, _max_abbreviated_name} = max_station_name
 
-        {min_full_name, max_full_name}
+        {abbreviate_station_name(min_full_name), abbreviate_station_name(max_full_name)}
     end
   end
 


### PR DESCRIPTION
**Notion task**: [[diagram, frontend] Incorrect Disruption Diagram positioning for takeover](https://www.notion.so/mbta-downtown-crossing/diagram-frontend-Incorrect-Disruption-Diagram-positioning-for-takeover-6a276e59259948feae02240bc8873322?pvs=4)

Two main things:
- Lots of changes to SVG positioning and scaling. Positions were hardcoded, but they need to be dynamic based on the amount of room in the container
  - The SVG was only scaling down to 904, but it should also scale up
  - Translations are now based on diagram height

- Abbreviate Mass Ave everywhere

- [ ] Tests added?
