### PR TITLE
Fixed D branch headsign.

### DIFF
--- a/lib/screens/v2/widget_instance/reconstructed_alert.ex
+++ b/lib/screens/v2/widget_instance/reconstructed_alert.ex
@@ -99,7 +99,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
     "Red" => ["Ashmont/Braintree", "Alewife"],
     "Green-B" => ["Boston College", "Government Center"],
     "Green-C" => ["Cleveland Circle", "Government Center"],
-    "Green-D" => ["Riverside", "North Station"],
+    "Green-D" => ["Riverside", "North Station & North"],
     "Green-E" => ["Heath Street", "Union Square"]
   }
 


### PR DESCRIPTION
**Asana task**: [[frontend] Terminal station closure causes JS errors](https://www.notion.so/mbta-downtown-crossing/frontend-Terminal-station-closure-causes-JS-errors-7f00d9f3653d43d4a048c2be61328044?pvs=4)

This ended up being a server issue. When building the banner, we use the `North Station & North` icon in the banner but the headsign was only `North Station`. Because the key was missing, the svg filename was `nil`.

- [ ] Tests added?
