### PR TITLE
Cm/govt ctr gl affected pill fix

### DIFF
--- a/assets/src/components/v2/pre_fare_single_screen_alert.tsx
+++ b/assets/src/components/v2/pre_fare_single_screen_alert.tsx
@@ -28,11 +28,11 @@ interface PreFareSingleScreenAlertProps {
 }
 
 interface EnrichedRoute {
-  route_id: string,
-  svg_name: string
+  route_id: string;
+  svg_name: string;
 }
 
-// For the standard layout, issue font can be medium or large. 
+// For the standard layout, issue font can be medium or large.
 // If remedy is "Seek alternate route", font size is static. Otherwise, it uses the same font size as
 // the issue.
 const standardLayout = (
@@ -79,8 +79,8 @@ const multiLineLayout = (
   unaffected_routes: EnrichedRoute[],
   disruptionDiagram?: DisruptionDiagramData
 ) => {
-  const AffectedLinePill = STRING_TO_SVG[routes[0].svg_name]
-  const affectedLineColor = getHexColor(getRouteColor(routes[0].route_id))
+  const AffectedLinePill = STRING_TO_SVG[routes[0].svg_name];
+  const affectedLineColor = getHexColor(getRouteColor(routes[0].route_id));
 
   return (
     <div className="alert-card__content-block">
@@ -89,17 +89,26 @@ const multiLineLayout = (
         <div className="alert-card__content-block__text--large">
           <AffectedLinePill
             className="alert-card__content-block__route-pill"
-            color={affectedLineColor} />
+            color={affectedLineColor}
+          />
           <span>trains are skipping this station</span>
         </div>
       </div>
       <div className="alert-card__issue">
         <InfoIcon className="alert-card__icon" />
         <div className="alert-card__content-block__text--large">
-          {unaffected_routes.map(route => {
-            const UnaffectedLinePill = STRING_TO_SVG[route.svg_name]
-            const unaffectedLineColor = getHexColor(getRouteColor(route.route_id))
-            return <UnaffectedLinePill className="alert-card__content-block__route-pill" color={unaffectedLineColor} />
+          {unaffected_routes.map((route) => {
+            const UnaffectedLinePill = STRING_TO_SVG[route.svg_name];
+            const unaffectedLineColor = getHexColor(
+              getRouteColor(route.route_id)
+            );
+            return (
+              <UnaffectedLinePill
+                key={route.route_id}
+                className="alert-card__content-block__route-pill"
+                color={unaffectedLineColor}
+              />
+            );
           })}
           <span>trains stop as usual</span>
         </div>
@@ -331,41 +340,43 @@ const PreFareSingleScreenAlert: React.ComponentType<
 };
 
 const getRouteColor = (route_id: string) => {
-  switch(route_id.substring(0, 3)) {
+  switch (route_id.substring(0, 3)) {
     case "Red":
-      return "red"
+      return "red";
     case "Ora":
-      return "orange"
+      return "orange";
     case "Blu":
-      return "blue"
+      return "blue";
     case "Gre":
-      return "green"
+      return "green";
     default:
-      return "yellow"
+      return "yellow";
   }
 };
 
 // If only one route color is represented ("gl-union" and "gl-riverside" are the same route color)
 // use that, otherwise "yellow"
 const getAlertColor = (routes: EnrichedRoute[]) => {
-  const colors = routes.map(r => getRouteColor(r.route_id))
-  const uniqueColors = new Set(colors).size
-  return uniqueColors == 1 ? colors[0] : "yellow"
-}
+  const colors = routes.map((r) => getRouteColor(r.route_id));
+  const uniqueColors = new Set(colors).size;
+  return uniqueColors == 1 ? colors[0] : "yellow";
+};
 
-const PreFareAlertBanner: React.ComponentType<{routes: EnrichedRoute[]}> = ({
-  routes
+const PreFareAlertBanner: React.ComponentType<{ routes: EnrichedRoute[] }> = ({
+  routes,
 }) => {
   let banner;
 
   if (
     routes.length === 1 &&
-    ["rl", "ol", "bl", "gl", "gl-b", "gl-c", "gl-d", "gl-e"].includes(routes[0].svg_name)
+    ["rl", "ol", "bl", "gl", "gl-b", "gl-c", "gl-d", "gl-e"].includes(
+      routes[0].svg_name
+    )
   ) {
     // One destination, short text
-    const route = routes[0]
-    const LinePill = STRING_TO_SVG[route.svg_name]
-    const color = getRouteColor(route.route_id)
+    const route = routes[0];
+    const LinePill = STRING_TO_SVG[route.svg_name];
+    const color = getRouteColor(route.route_id);
 
     banner = (
       <div className={classWithModifiers("alert-banner", ["small", color])}>
@@ -379,9 +390,9 @@ const PreFareAlertBanner: React.ComponentType<{routes: EnrichedRoute[]}> = ({
     );
   } else if (routes.length === 1) {
     // One destination, long text
-    const route = routes[0]
-    const LinePill = STRING_TO_SVG[route.svg_name]
-    const color = getRouteColor(route.route_id)
+    const route = routes[0];
+    const LinePill = STRING_TO_SVG[route.svg_name];
+    const color = getRouteColor(route.route_id);
 
     banner = (
       <div
@@ -414,7 +425,7 @@ const PreFareAlertBanner: React.ComponentType<{routes: EnrichedRoute[]}> = ({
           riders to
         </span>
         {routes.map((route) => {
-          const LinePill = STRING_TO_SVG[route.svg_name]
+          const LinePill = STRING_TO_SVG[route.svg_name];
           return (
             <LinePill
               className="alert-banner__route-pill--long"
@@ -428,7 +439,12 @@ const PreFareAlertBanner: React.ComponentType<{routes: EnrichedRoute[]}> = ({
   } else {
     // Fallback
     banner = (
-      <div className={classWithModifiers("alert-banner", ["small", getAlertColor(routes)])}>
+      <div
+        className={classWithModifiers("alert-banner", [
+          "small",
+          getAlertColor(routes),
+        ])}
+      >
         <span>
           <span className="alert-banner__attention-text">ATTENTION,</span>{" "}
           riders

--- a/lib/screens/v2/widget_instance/reconstructed_alert.ex
+++ b/lib/screens/v2/widget_instance/reconstructed_alert.ex
@@ -196,6 +196,8 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
       pills
       |> Enum.reject(&(&1.route_id == "Green"))
       |> Enum.concat([%{route_id: "Green", svg_name: "gl"}])
+    else
+      pills
     end
   end
 

--- a/lib/screens/v2/widget_instance/reconstructed_alert.ex
+++ b/lib/screens/v2/widget_instance/reconstructed_alert.ex
@@ -192,7 +192,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
       end)
       |> Enum.uniq()
 
-    if Enum.count(pills, & &1.route_id) > 1 do
+    if Enum.count(pills) > 1 and Enum.all?(pills, &(&1.route_id == "Green")) do
       pills
       |> Enum.reject(&(&1.route_id == "Green"))
       |> Enum.concat([%{route_id: "Green", svg_name: "gl"}])


### PR DESCRIPTION
**Notion task**: [[alert, backend] Wrong affected route/line for station closure including Gov Ctr](https://www.notion.so/mbta-downtown-crossing/alert-backend-Wrong-affected-route-line-for-station-closure-including-Gov-Ctr-7e306485d1dc4cf7882cc0f51a2640b1?pvs=4)

When showing affected route pills, we only ever get the first in the list because that's all we have room for. Change it so if there's more than one GL branch in the list, we just respond with the GL pills and not 4 branch pills.

- [ ] Tests added?
