### PR TITLE
Changed label to display on a single line.

### DIFF
--- a/assets/src/components/v2/disruption_diagram/disruption_diagram.tsx
+++ b/assets/src/components/v2/disruption_diagram/disruption_diagram.tsx
@@ -88,7 +88,7 @@ const endLabelIDMap: { [labelID: string]: string[] } = {
   "place-mdftf": ["MEDFORD/TUFTS"],
   "place-hsmnl": ["HEATH ST"],
   "place-kencl": ["KENMORE"],
-  "place-kencl+west": ["KENMORE", "& WEST"],
+  "place-kencl+west": ["KENMORE & WEST"],
   "place-mdftf+place-unsqu": ["MEDFORD/TUFTS", "& UNION SQ"],
   "place-north+place-pktrm": ["NORTH STATION", "& PARK ST"],
   "place-coecl+west": ["COPLEY & WEST"],


### PR DESCRIPTION
**Asana task**: [[diagram, frontend] “to KENMORE & WEST” label split onto 2 lines](https://www.notion.so/mbta-downtown-crossing/diagram-frontend-to-KENMORE-WEST-label-split-onto-2-lines-ab8547b13035453aa9fb82871fd15366?pvs=4)

Changed label to one line.

- [ ] Tests added?
