### PR TITLE
Added padding-top to layout when there is no banner.

### DIFF
--- a/assets/css/v2/pre_fare/prefare_single_screen_alert.scss
+++ b/assets/css/v2/pre_fare/prefare_single_screen_alert.scss
@@ -144,6 +144,10 @@
   }
 }
 
+.alert-container--no-banner {
+  padding-top: 32px;
+}
+
 .alert-container--right {
   position: absolute;
   top: 0;

--- a/assets/src/components/v2/pre_fare_single_screen_alert.tsx
+++ b/assets/src/components/v2/pre_fare_single_screen_alert.tsx
@@ -302,13 +302,16 @@ const PreFareSingleScreenAlert: React.ComponentType<
     }
   };
 
+  const showBanner = !isMultiLine(effect, region);
+
   return (
     <div className="pre-fare-alert__page">
-      {!isMultiLine(effect, region) && <PreFareAlertBanner routes={routes} />}
+      {showBanner && <PreFareAlertBanner routes={routes} />}
       <div
         className={classWithModifiers("alert-container", [
           "single-page",
           getAlertColor(routes),
+          showBanner ? "with-banner" : "no-banner",
         ])}
       >
         <div className="alert-card">


### PR DESCRIPTION
**Notion task**: [[alert, frontend] alert card missing top margin when banner is omitted](https://www.notion.so/mbta-downtown-crossing/alert-frontend-alert-card-missing-top-margin-when-banner-is-omitted-5969b6cfd32d4dd599bff01d43cfd230?pvs=4)

Added padding to layout if there is no banner.

- [ ] Tests added?
