### PR TITLE
Fixed icon display when current stop is affected.

### DIFF
--- a/assets/src/components/v2/disruption_diagram/disruption_diagram.tsx
+++ b/assets/src/components/v2/disruption_diagram/disruption_diagram.tsx
@@ -473,7 +473,7 @@ const MiddleSlotComponent: ComponentType<MiddleSlotComponentProps> = ({
   let icon;
   if (slot.show_symbol) {
     if (isCurrentStop) {
-      if (isAffected && effect === "station_closure") {
+      if (isAffected) {
         icon = (
           <StationClosureStopIcon
             x={x}


### PR DESCRIPTION
**Notion task**: [[diagram, frontend] Incorrect symbol for “you are here” + “shuttled” combo](https://www.notion.so/mbta-downtown-crossing/diagram-frontend-Incorrect-symbol-for-you-are-here-shuttled-combo-ddf95fe7475b4357883ed13b4046d040?pvs=4)

See title.

- [ ] Tests added?
