### PR TITLE
Added missing word.

### DIFF
--- a/lib/screens_web/views/v2/audio/reconstructed_alert_fullscreen_view.ex
+++ b/lib/screens_web/views/v2/audio/reconstructed_alert_fullscreen_view.ex
@@ -31,7 +31,7 @@ defmodule ScreensWeb.V2.Audio.ReconstructedAlertFullscreenView do
         ~E|Attention, riders. |
       end
     else
-      ~E|Attention, <%= hd(routes).route_id %> riders. |
+      ~E|Attention, <%= hd(routes).route_id %> line riders. |
     end
   end
 


### PR DESCRIPTION
**Notion task**: [[audio] Banner readout omits “line”](https://www.notion.so/mbta-downtown-crossing/audio-Banner-readout-omits-line-4716f29b47e14a8c96b414ed61cb6418?pvs=4)

`Line` was missing in audio.

- [ ] Tests added?
