### PR TITLE
fix: Make stop sequence fetch work again for non-pre-fare apps

### DIFF
--- a/lib/screens/route_patterns/route_pattern.ex
+++ b/lib/screens/route_patterns/route_pattern.ex
@@ -100,9 +100,9 @@ defmodule Screens.RoutePatterns.RoutePattern do
     }
 
     params =
-      if is_boolean(canonical_only?) do
-        Map.put(params, "filter[canonical]", canonical_only?)
-      end
+      if is_boolean(canonical_only?),
+        do: Map.put(params, "filter[canonical]", canonical_only?),
+        else: params
 
     case get_json_fn.("route_patterns", params) do
       {:ok, result} ->

--- a/lib/screens/stops/stop.ex
+++ b/lib/screens/stops/stop.ex
@@ -541,7 +541,7 @@ defmodule Screens.Stops.Stop do
   defp fetch_tagged_stop_sequences_by_app(app, stop_id, routes_at_stop)
        when app in [Dup, Triptych] do
     route_ids = Route.route_ids(routes_at_stop)
-    RoutePattern.fetch_tagged_parent_station_sequences_through_stop(stop_id, route_ids, false)
+    RoutePattern.fetch_tagged_parent_station_sequences_through_stop(stop_id, route_ids)
   end
 
   defp fetch_tagged_stop_sequences_by_app(app, stop_id, routes_at_stop)


### PR DESCRIPTION
**Notion task**: [[regression] Possible regression for DUP backend / RoutePattern stop sequence functions](https://www.notion.so/mbta-downtown-crossing/regression-Possible-regression-for-DUP-backend-RoutePattern-stop-sequence-functions-55e3dc918a4d421baed00c94057c9c73?pvs=4)

This fixes a couple silly mistakes I made in my changes to the stop-sequence-fetching functions:
1. When the new `canonical_only?` argument was a non-Boolean, it was setting the query params to `nil` since the `if` didn't have an `else` clause.
2. For DUP and triptych apps, we were passing `false` for `canonical_only?`, which caused the V3 API to only return _non-canonical_ route patterns. So, just the weird ones that we don't want.

- [ ] Tests added?
