### PR TITLE
Removed bolding of 'to' from arrow labels.

### DIFF
--- a/assets/css/v2/pre_fare/disruption_diagram/disruption_diagram.scss
+++ b/assets/css/v2/pre_fare/disruption_diagram/disruption_diagram.scss
@@ -77,6 +77,10 @@
 .label--endpoint {
   font-size: 35px;
   font-weight: 700;
+
+  .label {
+    font-weight: 400;
+  }
 }
 
 .label-large {


### PR DESCRIPTION
**Notion task**: [[diagram, frontend] “to” in destination arrow labels should not be bold](https://www.notion.so/mbta-downtown-crossing/diagram-frontend-to-in-destination-arrow-labels-should-not-be-bold-4e863fd5b7cc479ea27117ee5e6d00b1?pvs=4)

Removed bolding of `to` in arrow labels.

- [ ] Tests added?
