### PR TITLE
tweak: E-Ink departure_time in epoch

### DIFF
--- a/lib/screens/v2/widget_instance/departures.ex
+++ b/lib/screens/v2/widget_instance/departures.ex
@@ -352,7 +352,6 @@ defmodule Screens.V2.WidgetInstance.Departures do
   defp crowding_compatible?(_, %Screen{app_id: :dup_v2}), do: false
   defp crowding_compatible?(_, _), do: true
 
-  # credo:disable-for-next-line Credo.Check.Refactor.CyclomaticComplexity
   defp serialize_time(departure, %Screen{app_id: app_id}, now)
        when app_id in [:bus_eink_v2, :gl_eink_v2] do
     departure_time = Departure.time(departure)
@@ -372,7 +371,7 @@ defmodule Screens.V2.WidgetInstance.Departures do
           serialize_timestamp(departure_time, now)
       end
 
-    %{time: time}
+    %{time: time, time_in_epoch: DateTime.to_unix(departure_time)}
   end
 
   defp serialize_time(

--- a/test/screens/v2/widget_instance/departures_test.exs
+++ b/test/screens/v2/widget_instance/departures_test.exs
@@ -609,13 +609,22 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
     end
 
     test "returns Now on e-Ink screens", %{bus_eink_screen: screen} do
-      serialized_now = [%{id: nil, crowding: nil, time: %{text: "Now", type: :text}}]
       now = ~U[2020-01-01T00:00:00Z]
+      departure_time = ~U[2020-01-01T00:00:50Z]
+
+      now_timestamp = %{
+        id: nil,
+        crowding: nil,
+        time: %{text: "Now", type: :text},
+        time_in_epoch: DateTime.to_unix(departure_time)
+      }
+
+      serialized_now = [now_timestamp]
 
       departure = %Departure{
         prediction: %Prediction{
-          arrival_time: ~U[2020-01-01T00:00:50Z],
-          departure_time: ~U[2020-01-01T00:00:50Z],
+          arrival_time: departure_time,
+          departure_time: departure_time,
           route: %Route{type: :subway}
         }
       }
@@ -623,10 +632,13 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
       assert serialized_now ==
                Departures.serialize_times_with_crowding([departure], screen, now)
 
+      departure_time = ~U[2020-01-01T00:01:10Z]
+      serialized_now = [%{now_timestamp | time_in_epoch: DateTime.to_unix(departure_time)}]
+
       departure = %Departure{
         prediction: %Prediction{
-          arrival_time: ~U[2020-01-01T00:01:10Z],
-          departure_time: ~U[2020-01-01T00:01:10Z],
+          arrival_time: departure_time,
+          departure_time: departure_time,
           route: %Route{type: :subway}
         }
       }


### PR DESCRIPTION
**Asana task**: [Mercury: Departures in Epoch Time](https://app.asana.com/0/1176097567827729/1205730972991228/f)

Added `time_in_epoch` to serialized response for e-ink. The addition of the attribute does not affect any of our client code.

- [ ] Tests added?
