### PR TITLE
feat: Consistent description of disrupted stop ranges throughout pre-fare alerts

### DIFF
--- a/lib/screens/alerts/informed_entity.ex
+++ b/lib/screens/alerts/informed_entity.ex
@@ -24,4 +24,9 @@ defmodule Screens.Alerts.InformedEntity do
       ie
     )
   end
+
+  @spec parent_station?(t()) :: boolean
+  def parent_station?(ie) do
+    match?(%{stop: "place-" <> _}, ie)
+  end
 end

--- a/lib/screens/stops/stop.ex
+++ b/lib/screens/stops/stop.ex
@@ -435,6 +435,19 @@ defmodule Screens.Stops.Stop do
     Enum.map(@green_line_branches, &get_route_stop_sequence/1)
   end
 
+  @doc """
+  Returns an unordered MapSet of all GL stops west of Copley.
+  """
+  @spec get_gl_stops_west_of_copley() :: MapSet.t(id())
+  def get_gl_stops_west_of_copley do
+    get_gl_stop_sequences()
+    |> Enum.flat_map(fn stop_sequence ->
+      [_copley | west_of_copley] = Enum.drop_while(stop_sequence, &(&1 != "place-coecl"))
+      west_of_copley
+    end)
+    |> MapSet.new()
+  end
+
   defp sequence_match?(stop_sequence, informed_entities) do
     ie_stops =
       informed_entities

--- a/lib/screens/v2/widget_instance/reconstructed_alert.ex
+++ b/lib/screens/v2/widget_instance/reconstructed_alert.ex
@@ -1,10 +1,10 @@
 defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
   @moduledoc false
 
-  alias ScreensConfig.Routes.Route
-  alias Screens.Alerts.InformedEntity
   alias Screens.Alerts.Alert
+  alias Screens.Alerts.InformedEntity
   alias Screens.LocationContext
+  alias Screens.Routes.Route
   alias Screens.Stops.Stop
   alias Screens.Util
   alias Screens.V2.DisruptionDiagram

--- a/lib/screens/v2/widget_instance/reconstructed_alert.ex
+++ b/lib/screens/v2/widget_instance/reconstructed_alert.ex
@@ -1,6 +1,8 @@
 defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
   @moduledoc false
 
+  alias ScreensConfig.Routes.Route
+  alias Screens.Alerts.InformedEntity
   alias Screens.Alerts.Alert
   alias Screens.LocationContext
   alias Screens.Stops.Stop
@@ -284,7 +286,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
         [route_id] -> route_id
       end
 
-    endpoints = get_endpoints(informed_entities, route_id)
+    endpoints = get_endpoints(informed_entities, route_id, t.location_context.home_stop)
 
     %{
       issue: "No trains",
@@ -308,7 +310,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
         [route_id] -> route_id
       end
 
-    endpoints = get_endpoints(informed_entities, route_id)
+    endpoints = get_endpoints(informed_entities, route_id, t.location_context.home_stop)
 
     %{
       issue: "No trains",
@@ -373,7 +375,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
         [route_id] -> route_id
       end
 
-    endpoints = get_endpoints(informed_entities, route_id)
+    endpoints = get_endpoints(informed_entities, route_id, t.location_context.home_stop)
     destination = get_destination(t, location)
 
     {issue, location_text} =
@@ -427,7 +429,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
         [route_id] -> route_id
       end
 
-    endpoints = get_endpoints(informed_entities, route_id)
+    endpoints = get_endpoints(informed_entities, route_id, t.location_context.home_stop)
     destination = get_destination(t, location)
 
     {issue, location_text, remedy} =
@@ -792,7 +794,9 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
       cause_text = Alert.get_cause_string(cause)
 
       location_text =
-        informed_entities |> get_endpoints(hd(affected_routes)) |> format_endpoint_string()
+        informed_entities
+        |> get_endpoints(hd(affected_routes), t.location_context.home_stop)
+        |> format_endpoint_string()
 
       issue =
         if is_nil(direction_id) do
@@ -833,7 +837,9 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
       cause_text = Alert.get_cause_string(cause)
 
       location_text =
-        informed_entities |> get_endpoints(hd(affected_routes)) |> format_endpoint_string()
+        informed_entities
+        |> get_endpoints(hd(affected_routes), t.location_context.home_stop)
+        |> format_endpoint_string()
 
       issue =
         if is_nil(direction_id) do
@@ -904,13 +910,21 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
   defp abbreviate_station_name("Massachusetts Avenue"), do: "Mass Ave"
   defp abbreviate_station_name(full_name), do: full_name
 
-  def get_endpoints(ie, "Green") do
+  @spec get_endpoints(list(Alert.informed_entity()), Route.id(), Stop.id()) ::
+          {String.t(), String.t()} | nil
+  defp get_endpoints(informed_entities, route_id, home_stop) do
+    with {left_endpoint, right_endpoint} <- do_get_endpoints(informed_entities, route_id) do
+      orient_endpoints({left_endpoint, right_endpoint}, informed_entities, route_id, home_stop)
+    end
+  end
+
+  def do_get_endpoints(ie, "Green") do
     Enum.find_value(@green_line_branches, fn branch ->
-      get_endpoints(ie, branch)
+      do_get_endpoints(ie, branch)
     end)
   end
 
-  def get_endpoints(informed_entities, route_id) do
+  def do_get_endpoints(informed_entities, route_id) do
     case Stop.get_stop_sequence(informed_entities, route_id) do
       nil ->
         nil
@@ -932,14 +946,56 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
     end
   end
 
+  # In certain cases, we want to describe an alert's endpoints in the opposite direction,
+  # i.e. direction ID 1 instead of 0, so we need to flip the endpoints tuple before it gets formatted to string.
+  #
+  # Endpoints should be passed to this function in the order of direction ID 0.
+  # For example, orient_endpoints({"place-wondl", "place-gover"}, ...) and not orient_endpoints({"place-gover", "place-wondl"}, ...)
+
+  # All Blue Line alerts
+  defp orient_endpoints({left_endpoint, right_endpoint}, _informed_entities, "Blue", _home_stop) do
+    {right_endpoint, left_endpoint}
+  end
+
+  # All Green Line alerts *except* those where the alert's informed stops ++ the screen's home stop satisfy these conditions:
+  #   - includes at least one GLX stop
+  #   - does not include any stops west of Copley
+  defp orient_endpoints({left_endpoint, right_endpoint}, informed_entities, route_id, home_stop)
+       when route_id in ["Green" | @green_line_branches] do
+    if glx_oriented_alert?(informed_entities, home_stop) do
+      {left_endpoint, right_endpoint}
+    else
+      {right_endpoint, left_endpoint}
+    end
+  end
+
+  # Otherwise, we don't need to flip the endpoints.
+  defp orient_endpoints({left_endpoint, right_endpoint}, _ies, _route_id, _home_stop) do
+    {left_endpoint, right_endpoint}
+  end
+
+  defp glx_oriented_alert?(informed_entities, home_stop) do
+    parent_station_ies = Enum.filter(informed_entities, &InformedEntity.parent_station?/1)
+
+    # It's ok if the home stop is duplicated in this list due to also being informed by the alert.
+    relevant_parent_stations = [home_stop | Enum.map(parent_station_ies, & &1.stop)]
+
+    includes_glx = Enum.any?(relevant_parent_stations, &Stop.on_glx?/1)
+
+    stops_west_of_copley = Stop.get_gl_stops_west_of_copley()
+    includes_west_of_copley = Enum.any?(relevant_parent_stations, &(&1 in stops_west_of_copley))
+
+    includes_glx and not includes_west_of_copley
+  end
+
   def format_endpoint_string(nil), do: nil
 
+  def format_endpoint_string({station, station}) do
+    "at #{station}"
+  end
+
   def format_endpoint_string({min_station, max_station}) do
-    if min_station == max_station do
-      "at #{min_station}"
-    else
-      "between #{min_station} and #{max_station}"
-    end
+    "between #{min_station} and #{max_station}"
   end
 
   def serialize(widget, log_fn \\ &Logger.warn/1)

--- a/test/screens/v2/widget_instance/reconstructed_alert_test.exs
+++ b/test/screens/v2/widget_instance/reconstructed_alert_test.exs
@@ -1426,13 +1426,22 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
           ie(stop: "place-north", route: "Green-C", route_type: 0),
           ie(stop: "place-north", route: "Green-D", route_type: 0),
           ie(stop: "place-north", route: "Green-E", route_type: 0),
+          ie(stop: "place-spmnl", route: "Green-D", route_type: 0),
           ie(stop: "place-spmnl", route: "Green-E", route_type: 0)
         ])
         |> put_cause(:unknown)
         |> put_tagged_stop_sequences(%{
+          "Green-D" => [
+            [
+              "place-spmnl",
+              "place-north",
+              "place-haecl",
+              "place-gover"
+            ]
+          ],
           "Green-E" => [
             [
-              "place-symcl",
+              "place-spmnl",
               "place-north",
               "place-haecl",
               "place-gover"
@@ -1460,13 +1469,273 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
 
       expected = %{
         issue: "No trains",
-        location: "between Science Park/West End and North Station",
+        location: "between North Station and Science Park/West End",
         cause: "",
         routes: [%{color: :green, text: "GREEN LINE", type: :text}],
         effect: :shuttle,
         urgent: false,
         region: :outside,
         remedy: "Use shuttle bus"
+      }
+
+      assert expected == ReconstructedAlert.serialize(widget, &fake_log/1)
+    end
+  end
+
+  describe "endpoint reversal" do
+    setup [:setup_screen_config, :setup_now, :setup_active_period]
+
+    test "reverses endpoints for BL alerts", %{widget: widget} do
+      widget =
+        widget
+        |> put_home_stop(PreFare, "place-mvbcl")
+        |> put_effect(:shuttle)
+        |> put_informed_entities([
+          ie(stop: "place-orhte", route: "Blue", route_type: 0),
+          ie(stop: "place-wimnl", route: "Blue", route_type: 0),
+          ie(stop: "place-aport", route: "Blue", route_type: 0)
+        ])
+        |> put_cause(:unknown)
+        |> put_tagged_stop_sequences(%{
+          "Blue" => [
+            [
+              "place-wondl",
+              "place-rbmnl",
+              "place-bmmnl",
+              "place-sdmnl",
+              "place-orhte",
+              "place-wimnl",
+              "place-aport",
+              "place-mvbcl",
+              "place-aqucl",
+              "place-state",
+              "place-gover",
+              "place-bomnl"
+            ]
+          ]
+        })
+        |> put_routes_at_stop([
+          %{
+            route_id: "Blue",
+            active?: true,
+            direction_destinations: nil,
+            long_name: nil,
+            short_name: nil,
+            type: :subway
+          }
+        ])
+
+      expected = %{
+        issue: "No trains",
+        location: "between Airport and Orient Heights",
+        cause: "",
+        routes: [%{color: :blue, text: "BLUE LINE", type: :text}],
+        effect: :shuttle,
+        urgent: false,
+        region: :outside,
+        remedy: "Use shuttle bus"
+      }
+
+      assert expected == ReconstructedAlert.serialize(widget, &fake_log/1)
+    end
+
+    test "reverses endpoints for GL trunk alert", %{widget: widget} do
+      widget =
+        widget
+        |> put_home_stop(PreFare, "place-gover")
+        |> put_effect(:suspension)
+        |> put_informed_entities([
+          ie(stop: "place-pktrm", route: "Green-B", route_type: 0),
+          ie(stop: "place-pktrm", route: "Green-C", route_type: 0),
+          ie(stop: "place-pktrm", route: "Green-D", route_type: 0),
+          ie(stop: "place-pktrm", route: "Green-E", route_type: 0),
+          ie(stop: "place-boyls", route: "Green-B", route_type: 0),
+          ie(stop: "place-boyls", route: "Green-C", route_type: 0),
+          ie(stop: "place-boyls", route: "Green-D", route_type: 0),
+          ie(stop: "place-boyls", route: "Green-E", route_type: 0),
+          ie(stop: "place-armnl", route: "Green-B", route_type: 0),
+          ie(stop: "place-armnl", route: "Green-C", route_type: 0),
+          ie(stop: "place-armnl", route: "Green-D", route_type: 0),
+          ie(stop: "place-armnl", route: "Green-E", route_type: 0)
+        ])
+        |> put_cause(:unknown)
+        |> put_tagged_stop_sequences(%{
+          "Green-B" => [
+            [
+              "place-haecl",
+              "place-gover",
+              "place-pktrm",
+              "place-boyls",
+              "place-armnl"
+            ]
+          ],
+          "Green-C" => [
+            [
+              "place-haecl",
+              "place-gover",
+              "place-pktrm",
+              "place-boyls",
+              "place-armnl"
+            ]
+          ],
+          "Green-D" => [
+            [
+              "place-haecl",
+              "place-gover",
+              "place-pktrm",
+              "place-boyls",
+              "place-armnl"
+            ]
+          ],
+          "Green-E" => [
+            [
+              "place-haecl",
+              "place-gover",
+              "place-pktrm",
+              "place-boyls",
+              "place-armnl"
+            ]
+          ]
+        })
+        |> put_routes_at_stop([
+          %{
+            route_id: "Green-B",
+            active?: true,
+            direction_destinations: nil,
+            long_name: nil,
+            short_name: nil,
+            type: :subway
+          },
+          %{
+            route_id: "Green-C",
+            active?: true,
+            direction_destinations: nil,
+            long_name: nil,
+            short_name: nil,
+            type: :subway
+          },
+          %{
+            route_id: "Green-D",
+            active?: true,
+            direction_destinations: nil,
+            long_name: nil,
+            short_name: nil,
+            type: :subway
+          },
+          %{
+            route_id: "Green-E",
+            active?: true,
+            direction_destinations: nil,
+            long_name: nil,
+            short_name: nil,
+            type: :subway
+          }
+        ])
+
+      expected = %{
+        issue: "No trains",
+        location: "between Arlington and Park Street",
+        cause: "",
+        routes: [%{color: :green, text: "GREEN LINE", type: :text}],
+        effect: :suspension,
+        urgent: false,
+        region: :outside,
+        remedy: "Seek alternate route"
+      }
+
+      assert expected == ReconstructedAlert.serialize(widget, &fake_log/1)
+    end
+
+    test "reverses endpoints for GL western branch alert", %{widget: widget} do
+      widget =
+        widget
+        |> put_home_stop(PreFare, "place-symcl")
+        |> put_effect(:suspension)
+        |> put_informed_entities([
+          ie(stop: "place-mfa", route: "Green-E", route_type: 0),
+          ie(stop: "place-lngmd", route: "Green-E", route_type: 0),
+          ie(stop: "place-brmnl", route: "Green-E", route_type: 0)
+        ])
+        |> put_cause(:unknown)
+        |> put_tagged_stop_sequences(%{
+          "Green-E" => [
+            [
+              "place-symcl",
+              "place-nuniv",
+              "place-mfa",
+              "place-lngmd",
+              "place-brmnl"
+            ]
+          ]
+        })
+        |> put_routes_at_stop([
+          %{
+            route_id: "Green-E",
+            active?: true,
+            direction_destinations: nil,
+            long_name: nil,
+            short_name: nil,
+            type: :subway
+          }
+        ])
+
+      expected = %{
+        issue: "No trains",
+        location: "between Brigham Circle and Museum of Fine Arts",
+        cause: "",
+        routes: [%{color: :green, text: "GREEN LINE", type: :text, branches: ["E"]}],
+        effect: :suspension,
+        urgent: false,
+        region: :outside,
+        remedy: "Seek alternate route"
+      }
+
+      assert expected == ReconstructedAlert.serialize(widget, &fake_log/1)
+    end
+
+    test "does not reverse endpoints for GLX alert", %{
+      widget: widget
+    } do
+      widget =
+        widget
+        |> put_home_stop(PreFare, "place-esomr")
+        |> put_effect(:suspension)
+        |> put_informed_entities([
+          ie(stop: "place-balsq", route: "Green-E", route_type: 0),
+          ie(stop: "place-mgngl", route: "Green-E", route_type: 0),
+          ie(stop: "place-gilmn", route: "Green-E", route_type: 0)
+        ])
+        |> put_cause(:unknown)
+        |> put_tagged_stop_sequences(%{
+          "Green-E" => [
+            [
+              "place-balsq",
+              "place-mgngl",
+              "place-gilmn",
+              "place-esomr"
+            ]
+          ]
+        })
+        |> put_routes_at_stop([
+          %{
+            route_id: "Green-E",
+            active?: true,
+            direction_destinations: nil,
+            long_name: nil,
+            short_name: nil,
+            type: :subway
+          }
+        ])
+
+      expected = %{
+        issue: "No trains",
+        location: "between Ball Square and Gilman Square",
+        cause: "",
+        routes: [%{color: :green, text: "GREEN LINE", type: :text, branches: ["E"]}],
+        effect: :suspension,
+        urgent: false,
+        region: :outside,
+        remedy: "Seek alternate route"
       }
 
       assert expected == ReconstructedAlert.serialize(widget, &fake_log/1)


### PR DESCRIPTION
**Notion task**: [[alert, frontend] Inconsistency? With affected stop range description](https://www.notion.so/mbta-downtown-crossing/alert-frontend-Inconsistency-With-affected-stop-range-description-9571590061054c859e4b0d0d3f95555b?pvs=4)

I ended up making a relatively narrow change to `get_endpoints` for this, instead of actually changing the widget struct's data directly.
The idea is that this is presentational in the same way as formatting a DateTime is. The logic can still work under the assumptions that all stop sequences are in direction ID 0 order, and we only flip it, as needed, when "presenting" it in the serialized response.

- [x] Tests added?
