### PR TITLE
fix: Add filter to make sure ID is a number.

### DIFF
--- a/assets/src/components/v2/elevator_status.tsx
+++ b/assets/src/components/v2/elevator_status.tsx
@@ -294,7 +294,11 @@ const StationRow: ComponentType<Station> = ({
         </div>
         <div className="elevator-status__station-row__station-name">{name}</div>
         <div className="elevator-status__station-row__ids">
-          {formatElevatorIds(elevatorClosures.map(({ elevator_id: id }) => id))}
+          {formatElevatorIds(
+            elevatorClosures
+              .filter(({ elevator_id: id }) => !isNaN(parseInt(id)))
+              .map(({ elevator_id: id }) => id)
+          )}
         </div>
         {isAtHomeStop && (
           <div className="elevator-status__station-row__you-are-here-icon">


### PR DESCRIPTION
**Asana task**: ad-hoc

Slack thread for context: https://mbta.slack.com/archives/C4K7CFULT/p1699306126326219

Tl;dr: Some elevators do not have posted numbers. In those cases, a fake ID is assigned. We need to make sure that the ID is actually a number before displaying it.

- [ ] Tests added?
