### PR TITLE
Pre-fare alert fix: Ashmont & Braintree string formatting

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -326,12 +326,12 @@ config :screens,
     # Charles/MGH
     "place-chmnl" => [
       %{informed: "70072", not_informed: "70076", alert_headsign: "Alewife"},
-      %{informed: "70075", not_informed: "70071", alert_headsign: "Ashmont/Braintree"}
+      %{informed: "70075", not_informed: "70071", alert_headsign: "Ashmont & Braintree"}
     ],
     # Porter
     "place-portr" => [
       %{informed: "70064", not_informed: "70068", alert_headsign: "Alewife"},
-      %{informed: "70067", not_informed: "70063", alert_headsign: "Ashmont/Braintree"}
+      %{informed: "70067", not_informed: "70063", alert_headsign: "Ashmont & Braintree"}
     ],
     "place-welln" => [
       %{informed: "70278", not_informed: "70034", alert_headsign: "Forest Hills"},

--- a/lib/screens/v2/widget_instance/reconstructed_alert.ex
+++ b/lib/screens/v2/widget_instance/reconstructed_alert.ex
@@ -208,7 +208,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
   end
 
   # Split Ashmont/Braintree out into two route pills
-  defp build_pills_from_headsign(route_id, "Ashmont/Braintree") do
+  defp build_pills_from_headsign(route_id, "Ashmont & Braintree") do
     Enum.map(["Ashmont", "Braintree"], fn dest ->
       %{
         route_id: route_id,


### PR DESCRIPTION
We were using a destination string with a backslash ("No trains to Ashmont/Braintree") instead of with an "&" as [designed](https://www.figma.com/file/l4AZl8UXyKLAFI8OtultQk/Pre-Fare-%E2%80%94-Alerts-V2?type=design&node-id=562-13987&mode=dev), and it was messing up the issue formatting.
