### PR TITLE
fix: Skip CSRF protection on /widget POSTs since they really fetch a new HTML page

### DIFF
--- a/assets/src/apps/v2/bus_eink.tsx
+++ b/assets/src/apps/v2/bus_eink.tsx
@@ -94,7 +94,7 @@ const App = (): JSX.Element => {
   return (
     <Router>
       <Switch>
-        <Route exact path="/v2/screen/bus_eink_v2/widget">
+        <Route exact path="/v2/widget/bus_eink_v2">
           <MappingContext.Provider value={TYPE_TO_COMPONENT}>
             <WidgetPage />
           </MappingContext.Provider>

--- a/assets/src/apps/v2/gl_eink.tsx
+++ b/assets/src/apps/v2/gl_eink.tsx
@@ -97,7 +97,7 @@ const App = (): JSX.Element => {
   return (
     <Router>
       <Switch>
-        <Route exact path="/v2/screen/gl_eink_v2/widget">
+        <Route exact path="/v2/widget/gl_eink_v2">
           <MappingContext.Provider value={TYPE_TO_COMPONENT}>
             <WidgetPage />
           </MappingContext.Provider>

--- a/lib/screens_web/router.ex
+++ b/lib/screens_web/router.ex
@@ -9,6 +9,12 @@ defmodule ScreensWeb.Router do
     plug :protect_from_forgery
   end
 
+  pipeline :browser_no_csrf do
+    plug :accepts, ["html"]
+    plug :fetch_session
+    plug :fetch_flash
+  end
+
   pipeline :api do
     plug :accepts, ["json"]
   end
@@ -79,12 +85,17 @@ defmodule ScreensWeb.Router do
   end
 
   scope "/v2", ScreensWeb.V2 do
+    scope "/widget" do
+      pipe_through [:redirect_prod_http, :browser_no_csrf]
+      post "/:app_id", ScreenController, :widget
+      get "/:app_id", ScreenController, :widget
+    end
+
     scope "/screen" do
       pipe_through [:redirect_prod_http, :browser]
 
       get "/:id", ScreenController, :index
       get "/:id/simulation", ScreenController, :simulation
-      post "/:id/widget", ScreenController, :widget
     end
 
     scope "/api/screen" do

--- a/lib/screens_web/router.ex
+++ b/lib/screens_web/router.ex
@@ -2,17 +2,15 @@ defmodule ScreensWeb.Router do
   use ScreensWeb, :router
   import Phoenix.LiveDashboard.Router
 
-  pipeline :browser do
-    plug :accepts, ["html"]
-    plug :fetch_session
-    plug :fetch_flash
-    plug :protect_from_forgery
-  end
-
   pipeline :browser_no_csrf do
     plug :accepts, ["html"]
     plug :fetch_session
     plug :fetch_flash
+  end
+
+  pipeline :browser do
+    plug :browser_no_csrf
+    plug :protect_from_forgery
   end
 
   pipeline :api do


### PR DESCRIPTION
**Asana task**: ad hoc

Phoenix normally expects a CSRF token with any POST requests to an endpoint that uses the `:browser` pipeline.
The widget endpoint is an exception, since it's basically an HTML page GET request, but we can't pass a body with a GET request.

This removes CSRF protection from the widget endpoint.

---

I also got the GET version of the endpoint working again with some fiddling! Wasn't sure how to directly test it otherwise, besides manually inspecting HTML received in Postman.

You can test the GET version with URLs like so:
```
localhost:4000/v2/widget/gl_eink_v2?widget={%22mode_cost%22:%22$2.40%22,%22mode_icon%22:%22subway-negative-black.svg%22,%22mode_text%22:%22Subway%22,%22text%22:%22For%20real-time%20predictions%20and%20fare%20purchase%20locations:%22,%22type%22:%22fare_info_footer%22,%22url%22:%22mbta.com/stops/place-hsmnl%22}
```

(Use the JS built-in `encodeURI` function to encode a JSON string for inclusion in the url.)

![image](https://github.com/mbta/screens/assets/63608771/83a0053f-e36c-44db-ab82-007559256055)

- [ ] Tests added?
