### PR TITLE
tweak: Accept `temporary_terminal` mode in signs UI config

### DIFF
--- a/lib/screens/signs_ui_config/state/parse.ex
+++ b/lib/screens/signs_ui_config/state/parse.ex
@@ -24,7 +24,7 @@ defmodule Screens.SignsUiConfig.State.Parse do
     |> Enum.into(%{})
   end
 
-  for mode <- ~w[auto headway off static_text]a do
+  for mode <- ~w[auto headway off static_text temporary_terminal]a do
     mode_string = Atom.to_string(mode)
 
     defp parse_sign_mode(unquote(mode_string)), do: unquote(mode)


### PR DESCRIPTION
**Asana task**: ad hoc

We won't do anything for now when signs are in that mode; this change just prevents the parsing logic from failing on it.

- [ ] Tests added?
