### PR TITLE
tweak: Prevent new sign modes from breaking signs UI parser

### DIFF
--- a/lib/screens/signs_ui_config/state/parse.ex
+++ b/lib/screens/signs_ui_config/state/parse.ex
@@ -29,4 +29,6 @@ defmodule Screens.SignsUiConfig.State.Parse do
 
     defp parse_sign_mode(unquote(mode_string)), do: unquote(mode)
   end
+
+  defp parse_sign_mode(_), do: :unknown
 end


### PR DESCRIPTION
**Asana task**: ad hoc

Prevent new sign modes from breaking signs UI parser, since we really only care if the mode is "headway" or not.

- [ ] Tests added?
