### PR TITLE
fix: current station is closed and has no active routes.

### DIFF
--- a/lib/screens/route_patterns/route_pattern.ex
+++ b/lib/screens/route_patterns/route_pattern.ex
@@ -88,6 +88,9 @@ defmodule Screens.RoutePatterns.RoutePattern do
     }
 
     case get_json_fn.("route_patterns", params) do
+      {:ok, %{"data" => []}} ->
+        :error
+
       {:ok, result} ->
         {:ok, convert_platform_to_parent_station(result)}
 

--- a/lib/screens/v2/candidate_generator/dup/departures.ex
+++ b/lib/screens/v2/candidate_generator/dup/departures.ex
@@ -226,7 +226,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
       primary_route_for_section = List.first(routes)
 
       # If we know the predictions are unreliable, don't even bother fetching them.
-      if not is_nil(primary_route_for_section) and
+      if is_nil(primary_route_for_section) or
            Screens.Config.State.mode_disabled?(primary_route_for_section.type) do
         %{type: :no_data_section, route: primary_route_for_section}
       else

--- a/lib/screens/v2/candidate_generator/dup/departures.ex
+++ b/lib/screens/v2/candidate_generator/dup/departures.ex
@@ -219,14 +219,15 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
                               bidirectional: is_bidirectional
                             } = section ->
       routes = get_routes_serving_section(params, create_station_with_routes_map_fn)
-      # DUP sections will always show one mode.
+      # DUP sections will always show no more than one mode.
       # For subway, each route will have its own section.
       # If the stop is served by two different subway/light rail routes, route_ids must be populated for each section
       # Otherwise, we only need the first route in the list of routes serving the stop.
       primary_route_for_section = List.first(routes)
 
       # If we know the predictions are unreliable, don't even bother fetching them.
-      if Screens.Config.State.mode_disabled?(primary_route_for_section.type) do
+      if not is_nil(primary_route_for_section) and
+           Screens.Config.State.mode_disabled?(primary_route_for_section.type) do
         %{type: :no_data_section, route: primary_route_for_section}
       else
         section_departures =


### PR DESCRIPTION
**Asana task**: ad-hoc

When the current station is closed, there are no active routes at that station. This trips up location context code a little because we always assumed that at least one route would be active. Added a new case to catch that and return `:error` so logs will show what happened while allowing the screen to load.

- [ ] Tests added?
