### PR TITLE
tweak/fix: Remove `ordered: false` from Task.async_stream calls to avoid process leak

### DIFF
--- a/lib/screens/v2/candidate_generator/bus_eink.ex
+++ b/lib/screens/v2/candidate_generator/bus_eink.ex
@@ -61,7 +61,7 @@ defmodule Screens.V2.CandidateGenerator.BusEink do
       fn -> bottom_screen_filler_instances(config) end,
       fn -> subway_status_instances_fn.(config, now) end
     ]
-    |> Task.async_stream(& &1.(), ordered: false, timeout: 30_000)
+    |> Task.async_stream(& &1.(), timeout: 30_000)
     |> Enum.flat_map(fn {:ok, instances} -> instances end)
   end
 

--- a/lib/screens/v2/candidate_generator/bus_shelter.ex
+++ b/lib/screens/v2/candidate_generator/bus_shelter.ex
@@ -64,7 +64,7 @@ defmodule Screens.V2.CandidateGenerator.BusShelter do
       fn -> evergreen_content_instances_fn.(config) end,
       fn -> survey_instances(config) end
     ]
-    |> Task.async_stream(& &1.(), ordered: false, timeout: 20_000)
+    |> Task.async_stream(& &1.(), timeout: 20_000)
     |> Enum.flat_map(fn {:ok, instances} -> instances end)
   end
 

--- a/lib/screens/v2/candidate_generator/dup.ex
+++ b/lib/screens/v2/candidate_generator/dup.ex
@@ -89,7 +89,7 @@ defmodule Screens.V2.CandidateGenerator.Dup do
       fn -> departures_instances_fn.(config, now) end,
       fn -> evergreen_content_instances_fn.(config) end
     ]
-    |> Task.async_stream(& &1.(), ordered: false, timeout: 30_000)
+    |> Task.async_stream(& &1.(), timeout: 30_000)
     |> Enum.flat_map(fn {:ok, instances} -> instances end)
   end
 

--- a/lib/screens/v2/candidate_generator/gl_eink.ex
+++ b/lib/screens/v2/candidate_generator/gl_eink.ex
@@ -91,7 +91,7 @@ defmodule Screens.V2.CandidateGenerator.GlEink do
       fn -> bottom_screen_filler_instances(config) end,
       fn -> subway_status_instances_fn.(config, now) end
     ]
-    |> Task.async_stream(& &1.(), ordered: false, timeout: 30_000)
+    |> Task.async_stream(& &1.(), timeout: 30_000)
     |> Enum.flat_map(fn {:ok, instances} -> instances end)
   end
 

--- a/lib/screens/v2/candidate_generator/pre_fare.ex
+++ b/lib/screens/v2/candidate_generator/pre_fare.ex
@@ -85,7 +85,7 @@ defmodule Screens.V2.CandidateGenerator.PreFare do
       fn -> blue_bikes_instances_fn.(config) end,
       fn -> shuttle_bus_info_instances(config, now) end
     ]
-    |> Task.async_stream(& &1.(), ordered: false, timeout: 20_000)
+    |> Task.async_stream(& &1.(), timeout: 20_000)
     |> Enum.flat_map(fn {:ok, instances} -> instances end)
   end
 
@@ -100,7 +100,7 @@ defmodule Screens.V2.CandidateGenerator.PreFare do
       fn -> alerts_intro_instances(widgets, config) end,
       fn -> alerts_outro_instances(widgets, config) end
     ]
-    |> Task.async_stream(& &1.(), ordered: false, timeout: 20_000)
+    |> Task.async_stream(& &1.(), timeout: 20_000)
     |> Enum.flat_map(fn {:ok, instances} -> instances end)
   end
 

--- a/lib/screens/v2/candidate_generator/solari.ex
+++ b/lib/screens/v2/candidate_generator/solari.ex
@@ -34,7 +34,7 @@ defmodule Screens.V2.CandidateGenerator.Solari do
       fn -> departures_instances_fn.(config) end,
       fn -> placeholder_instances() end
     ]
-    |> Task.async_stream(& &1.(), ordered: false, timeout: 15_000)
+    |> Task.async_stream(& &1.(), timeout: 15_000)
     |> Enum.flat_map(fn {:ok, instances} -> instances end)
   end
 

--- a/lib/screens/v2/candidate_generator/solari_large.ex
+++ b/lib/screens/v2/candidate_generator/solari_large.ex
@@ -34,7 +34,7 @@ defmodule Screens.V2.CandidateGenerator.SolariLarge do
       fn -> departures_instances_fn.(config) end,
       fn -> placeholder_instances() end
     ]
-    |> Task.async_stream(& &1.(), ordered: false, timeout: 15_000)
+    |> Task.async_stream(& &1.(), timeout: 15_000)
     |> Enum.flat_map(fn {:ok, instances} -> instances end)
   end
 

--- a/lib/screens/v2/candidate_generator/triptych.ex
+++ b/lib/screens/v2/candidate_generator/triptych.ex
@@ -30,7 +30,7 @@ defmodule Screens.V2.CandidateGenerator.Triptych do
       fn -> evergreen_content_instances_fn.(config) end,
       fn -> local_evergreen_set_instances_fn.(config) end
     ]
-    |> Task.async_stream(& &1.(), ordered: false, timeout: 20_000)
+    |> Task.async_stream(& &1.(), timeout: 20_000)
     |> Enum.flat_map(fn {:ok, instances} -> instances end)
   end
 


### PR DESCRIPTION
**Asana task**: ad hoc

elixir-lang/elixir#11760

We're on elixir 1.13 in our deployment environments, and it seems to still suffer from this bug.

Removing `ordered: false` shouldn't make a difference here--the number of tasks spawned is small and the stream is immediately passed to `Enum.flat_map`, which needs to get the full list of resulting widget instance structs before it can return anything anyway.

- [ ] Tests added?
