### PR TITLE
tweak: Remove clock on Mercury E-Ink screens.

### DIFF
--- a/lib/screens/v2/widget_instance/normal_header.ex
+++ b/lib/screens/v2/widget_instance/normal_header.ex
@@ -18,6 +18,16 @@ defmodule Screens.V2.WidgetInstance.NormalHeader do
           time: DateTime.t()
         }
 
+  def serialize(
+        %__MODULE__{
+          screen: %Screen{vendor: :mercury, app_id: :gl_eink_v2},
+          icon: icon,
+          text: text
+        } = t
+      ) do
+    %{icon: icon, text: text, show_to: showing_destination?(t)}
+  end
+
   def serialize(%__MODULE__{icon: icon, text: text, time: time} = t) do
     %{icon: icon, text: text, time: DateTime.to_iso8601(time), show_to: showing_destination?(t)}
   end

--- a/test/screens/v2/widget_instance/normal_header_test.exs
+++ b/test/screens/v2/widget_instance/normal_header_test.exs
@@ -1,6 +1,7 @@
 defmodule Screens.V2.WidgetInstance.NormalHeaderTest do
   use ExUnit.Case, async: true
 
+  alias ScreensConfig.V2.{GlEink, Header}
   alias Screens.V2.WidgetInstance
 
   setup do
@@ -15,6 +16,17 @@ defmodule Screens.V2.WidgetInstance.NormalHeaderTest do
         icon: :logo,
         text: "Ruggles",
         time: ~U[2021-03-04 11:00:00Z]
+      },
+      mercury_eink_instance: %WidgetInstance.NormalHeader{
+        screen:
+          struct(ScreensConfig.Screen, %{
+            app_id: :gl_eink_v2,
+            vendor: :mercury,
+            app_params: struct(GlEink, %{header: struct(Header.Destination)})
+          }),
+        icon: :green_e,
+        text: "Medford/Tufts",
+        time: ~U[2021-03-04 11:00:00Z]
       }
     }
   end
@@ -26,6 +38,16 @@ defmodule Screens.V2.WidgetInstance.NormalHeaderTest do
   end
 
   describe "serialize/1" do
+    test "does not return time if vendor is Mercury and app is GlEink", %{
+      mercury_eink_instance: instance
+    } do
+      assert %{
+               icon: :green_e,
+               text: "Medford/Tufts",
+               show_to: true
+             } == WidgetInstance.serialize(instance)
+    end
+
     test "returns serialized text, icon and time", %{instance: instance} do
       assert %{
                icon: :logo,


### PR DESCRIPTION
**Asana task**: [[Mercury] Remove clock from takeovers](https://app.asana.com/0/1185117109217413/1206070378353406/f)
Relevant Slack link: https://mbta.slack.com/archives/C059FPCQBNG/p1701294833473189

Their client solution for the header is to render their clock instead of ours. That works for widgets that calculate time in the client, but times sent from the server need to be removed. I believe `NormalHeader` is the only widget these screens use that gets its time from the server. I added a pattern for `vendor: :mercury, app_id: :gl_eink_v2` that will send the same response as before with the time removed. The missing data does not produce any errors, just prevent time from rendering. For this to work, we need to make sure `vendor` is set correctly on the screen configs.

- [ ] Tests added?
