### PR TITLE
fix: Pre-fare polish -- Station closed takeover text wrapping

### DIFF
--- a/assets/css/v2/pre_fare/alert-banner.scss
+++ b/assets/css/v2/pre_fare/alert-banner.scss
@@ -51,6 +51,6 @@
   padding: 86px 74px 102px 74px;
 }
 .alert-banner--small {
-  padding: 64px 65px;
+  padding: 52px 88px;
   align-items: center;
 }

--- a/assets/css/v2/pre_fare/prefare_single_screen_alert.scss
+++ b/assets/css/v2/pre_fare/prefare_single_screen_alert.scss
@@ -7,7 +7,6 @@
 @mixin small-text {
   font-size: 35px;
   line-height: 42px;
-  font-weight: 600;
 }
 
 .pre-fare-alert__page {

--- a/assets/css/v2/pre_fare/reconstructed_alert.scss
+++ b/assets/css/v2/pre_fare/reconstructed_alert.scss
@@ -184,8 +184,7 @@ $alert-card-footer-height: 80px;
 
     &__body {
       height: $takeover-card-height - $takeover-card-footer-height;
-      width: 904px;
-      padding-left: 56px;
+      padding: 0 56px;
       box-sizing: border-box;
       font-family: Inter, sans-serif;
       font-size: 200px;

--- a/assets/src/components/v2/pre_fare_single_screen_alert.tsx
+++ b/assets/src/components/v2/pre_fare_single_screen_alert.tsx
@@ -14,9 +14,15 @@ import WalkingIcon from "../../../static/images/svgr_bundled/nearby.svg";
 import ShuttleBusIcon from "../../../static/images/svgr_bundled/bus.svg";
 
 const SCREEN_HEIGHT = 1720,
+  // The footer has effect type and updated time
   FOOTER_HEIGHT = 84,
-  BOTTOM_MARGIN = 32,
-  ALERT_CARD_PADDING = 120 + 32;
+  // Color margin at the very edge of the alert
+  BOTTOM_MARGIN = 32
+
+const getBannerPadding = (effect: string) => {
+  if (effect === "shuttle") return 80
+  else return 120
+}
 
 interface PreFareSingleScreenAlertProps {
   issue: string;
@@ -59,7 +65,7 @@ const StandardLayout: React.ComponentType<StandardLayoutProps> = ({
 }) => {
   const maxTextHeight =
     SCREEN_HEIGHT -
-    (FOOTER_HEIGHT + BOTTOM_MARGIN + ALERT_CARD_PADDING + bannerHeight);
+    (FOOTER_HEIGHT + BOTTOM_MARGIN + getBannerPadding(effect) + bannerHeight);
 
   const { ref: contentBlockRef, size: contentTextSize } = useTextResizer({
     sizes: ["medium", "large"],
@@ -177,7 +183,7 @@ const FallbackLayout: React.ComponentType<FallbackLayoutProps> = ({
 }) => {
   const maxTextHeight =
     SCREEN_HEIGHT -
-    (FOOTER_HEIGHT + BOTTOM_MARGIN + ALERT_CARD_PADDING + bannerHeight);
+    (FOOTER_HEIGHT + BOTTOM_MARGIN + getBannerPadding(effect) + bannerHeight);
 
   const { ref: pioTextBlockRef, size: pioSecondaryTextSize } = useTextResizer({
     sizes: ["small", "medium"],


### PR DESCRIPTION
[Notion](https://www.notion.so/mbta-downtown-crossing/fd75b83b5904405fbc71ffbcdd0cec47?v=d4971a59c7eb45ae9841e522c53ad368&p=25d66d44207748ce955a5b90501f89c4&pm=s)

Small, easy fix for the text wrapping
