### PR TITLE
fix: Pre-fare polish -- Downstream shuttle endpoint should be a circle

### DIFF
--- a/assets/src/components/v2/disruption_diagram/disruption_diagram.tsx
+++ b/assets/src/components/v2/disruption_diagram/disruption_diagram.tsx
@@ -290,7 +290,7 @@ const EndSlotComponent: ComponentType<EndSlotComponentProps> = ({
     );
   } else if (isAffected && isCurrentStop) {
     icon = <LargeXStopIcon iconSize={61} color="#ee2e24" />;
-  } else if (isAffected) {
+  } else if (isAffected && effect != "shuttle") {
     icon = <LargeXStopIcon iconSize={61} />;
   } else if (isCurrentStop && line === "red") {
     icon = <CurrentStopOpenDiamondIcon iconSize={MAX_ENDPOINT_HEIGHT} />;


### PR DESCRIPTION
[Notion task](https://www.notion.so/mbta-downtown-crossing/fd75b83b5904405fbc71ffbcdd0cec47?v=d4971a59c7eb45ae9841e522c53ad368&p=6271faa6312e49b8952ea243ff73fc5a&pm=s)

Before:
![Screenshot 2023-12-29 at 4 55 24 PM](https://github.com/mbta/screens/assets/69368883/2ac6d44a-bfe0-406a-97ad-a41051fb985a)

After:
![Screenshot 2023-12-29 at 4 55 51 PM](https://github.com/mbta/screens/assets/69368883/9cfd1f2c-1c36-4391-98a4-5542ebd0aa60)
