### PR TITLE
fix: Pre-fare polish -- Fix Medford/Tufts & Union Sq label

### DIFF
--- a/assets/src/components/v2/disruption_diagram/disruption_diagram.tsx
+++ b/assets/src/components/v2/disruption_diagram/disruption_diagram.tsx
@@ -242,8 +242,8 @@ const EndpointLabel: ComponentType<{ labelID: string; isArrow: boolean }> = ({
         >
           {labelParts[1].includes("&") ? (
             <>
-              {labelParts[0].replace("& ", "")}
               <tspan className="label">& </tspan>
+              {labelParts[1].replace("& ", "")}
             </>
           ) : (
             labelParts[1]


### PR DESCRIPTION
[Notion](https://www.notion.so/mbta-downtown-crossing/fd75b83b5904405fbc71ffbcdd0cec47?v=d4971a59c7eb45ae9841e522c53ad368&p=0d9a7ffb8efb48adae436848340585e9&pm=s)

Lol, I'm definitely the one who messed this up! All better now

![Screenshot 2023-12-29 at 5 14 46 PM](https://github.com/mbta/screens/assets/69368883/ce586961-2f8e-4f00-9a9f-1bd193725601)
