### PR TITLE
2024 GL Surge alert suppressions

### DIFF
--- a/lib/screens/v2/widget_instance/reconstructed_alert.ex
+++ b/lib/screens/v2/widget_instance/reconstructed_alert.ex
@@ -653,8 +653,8 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
 
   def valid_candidate?(%__MODULE__{} = t) do
     # Suppress GL Surge alerts at Government Center.
-    test_surge_alerts = ["143269", "143277"]
-    prod_surge_alerts = ["535276", "536905", "537181"]
+    test_surge_alerts = ["155040"]
+    prod_surge_alerts = ["544008", "544114", "544112"]
 
     suppressed =
       t.alert.id in (test_surge_alerts ++ prod_surge_alerts) and


### PR DESCRIPTION
Updated IDs to suppress at Gov't Ctr during the surge.