### PR TITLE
Prefare headsigns in config is "Ashmont & Braintree" not "Ashmont/Braintree"

### DIFF
--- a/lib/screens/v2/widget_instance/reconstructed_alert.ex
+++ b/lib/screens/v2/widget_instance/reconstructed_alert.ex
@@ -98,7 +98,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
   @route_directions %{
     "Blue" => ["Bowdoin", "Wonderland"],
     "Orange" => ["Forest Hills", "Oak Grove"],
-    "Red" => ["Ashmont/Braintree", "Alewife"],
+    "Red" => ["Ashmont & Braintree", "Alewife"],
     "Green-B" => ["Boston College", "Government Center"],
     "Green-C" => ["Cleveland Circle", "Government Center"],
     "Green-D" => ["Riverside", "Union Square"],
@@ -212,7 +212,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
     ]
   end
 
-  # Split Ashmont/Braintree out into two route pills
+  # Split "Ashmont & Braintree" out into two route pills
   defp build_pills_from_headsign(route_id, "Ashmont & Braintree") do
     Enum.map(["Ashmont", "Braintree"], fn dest ->
       %{


### PR DESCRIPTION
[Notion](https://www.notion.so/mbta-downtown-crossing/fd75b83b5904405fbc71ffbcdd0cec47?v=d4971a59c7eb45ae9841e522c53ad368&p=477e30f7b8444c129eb27be7a2642150&pm=s)

