### PR TITLE
fix: Prefare polish -- Sub-header for takeover alert is now regular weight

### DIFF
--- a/assets/css/v2/pre_fare/reconstructed_alert.scss
+++ b/assets/css/v2/pre_fare/reconstructed_alert.scss
@@ -212,7 +212,7 @@ $alert-card-footer-height: 80px;
 
       &__location {
         font-size: 60px;
-        font-weight: 500;
+        font-weight: 400;
         margin-bottom: 32px;
       }
 


### PR DESCRIPTION
[Notion](https://www.notion.so/mbta-downtown-crossing/fd75b83b5904405fbc71ffbcdd0cec47?v=d4971a59c7eb45ae9841e522c53ad368&p=505c4dc5144c46c79472a8da02a2a545&pm=s)
