### PR TITLE
fix: Prefare polish -- Use FreeText to prevent station text wrapping in subheaders

### DIFF
--- a/assets/css/v2/pre_fare/free_text.scss
+++ b/assets/css/v2/pre_fare/free_text.scss
@@ -54,3 +54,7 @@
     line-height: unset;
   }
 }
+
+.free-text__string--nowrap {
+  white-space: nowrap;
+}

--- a/assets/src/components/v2/reconstructed_takeover.tsx
+++ b/assets/src/components/v2/reconstructed_takeover.tsx
@@ -4,10 +4,11 @@ import { classWithModifiers, imagePath } from "Util/util";
 import DisruptionDiagram, {
   DisruptionDiagramData,
 } from "./disruption_diagram/disruption_diagram";
+import FreeText, { FreeTextType } from "./free_text";
 
 interface ReconAlertProps {
   issue: string | any; // shouldn't be "any"
-  location: string;
+  location: string | FreeTextType;
   cause: string;
   remedy: string;
   routes: any[]; // shouldn't be "any"
@@ -58,7 +59,9 @@ const ReconstructedTakeover: React.ComponentType<ReconAlertProps> = (alert) => {
                 src={imagePath("no-service-black.svg")}
               />
               <div className="alert-card__body__issue">{issue}</div>
-              <div className="alert-card__body__location ">{location}</div>
+              <div className="alert-card__body__location ">
+                { typeof location === "string" ? location : <FreeText lines={location} /> }
+              </div>
               {disruption_diagram && (
                 <div
                   id="disruption-diagram-container"

--- a/lib/screens/v2/widget_instance/reconstructed_alert.ex
+++ b/lib/screens/v2/widget_instance/reconstructed_alert.ex
@@ -12,7 +12,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
   alias Screens.V2.WidgetInstance.ReconstructedAlert
   alias Screens.V2.WidgetInstance.Serializer.RoutePill
   alias ScreensConfig.Screen
-  alias ScreensConfig.V2.FreeTextLine
+  alias ScreensConfig.V2.{FreeText, FreeTextLine}
 
   require Logger
 

--- a/lib/screens/v2/widget_instance/reconstructed_alert.ex
+++ b/lib/screens/v2/widget_instance/reconstructed_alert.ex
@@ -12,6 +12,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
   alias Screens.V2.WidgetInstance.ReconstructedAlert
   alias Screens.V2.WidgetInstance.Serializer.RoutePill
   alias ScreensConfig.Screen
+  alias ScreensConfig.V2.FreeTextLine
 
   require Logger
 
@@ -53,7 +54,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
           optional(:other_closures) => list(String.t()),
           issue: String.t(),
           remedy: String.t(),
-          location: String.t(),
+          location: String.t() | FreeTextLine.t(),
           cause: String.t(),
           effect: :suspension | :shuttle | :station_closure,
           updated_at: String.t(),
@@ -258,6 +259,29 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
   defp format_short_route_pill(route_id),
     do: route_id |> String.first() |> String.downcase() |> Kernel.<>("l")
 
+  # Alert subheaders should not wrap in the middle of a station name
+  # so we have to use FreeTextLines to prevent the wrapping.
+  # This function takes a list of proper noun strings and
+  # returns a list of FreeTextLines with "nowrap" applied
+  @spec format_station_name_list([String.t()]) :: list(FreeText.t())
+  defp format_station_name_list([string]), do: [%{format: :nowrap, text: "#{string}"}]
+
+  defp format_station_name_list([s1, s2]),
+    do: [
+      %{format: :nowrap, text: "#{s1}"},
+      " & ",
+      %{format: :nowrap, text: "#{s2}"}
+    ]
+
+  defp format_station_name_list(list) do
+    list
+    |> List.update_at(length(list) - 1, &" & #{&1}")
+    |> Enum.join(", #")
+    |> String.split("#")
+    |> Enum.map(fn string -> %{format: :nowrap, text: "#{string}"} end)
+    |> Enum.intersperse("")
+  end
+
   defp get_region_from_location(:inside), do: :here
 
   defp get_region_from_location(location)
@@ -338,15 +362,24 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
       informed_stations: informed_stations
     } = t
 
-    informed_stations_string = Util.format_name_list_to_string(informed_stations)
+    # Alert subheaders should not wrap in the middle of a station name
+    # so we have to use FreeTextLines to prevent the wrapping
+    informed_stations_free_text = format_station_name_list(informed_stations)
 
     location_text =
       case LocalizedAlert.consolidated_informed_subway_routes(t) do
         [route_id] ->
-          "#{route_id} Line trains skip #{informed_stations_string}"
+          %FreeTextLine{
+            icon: nil,
+            text: ["#{route_id} Line trains skip "] ++ informed_stations_free_text
+          }
 
         [route_id1, route_id2] ->
-          "The #{route_id1} Line and #{route_id2} Line skip #{informed_stations_string}"
+          %FreeTextLine{
+            icon: nil,
+            text:
+              ["The #{route_id1} Line and #{route_id2} Line skip "] ++ informed_stations_free_text
+          }
       end
 
     other_closures = List.delete(informed_stations, stop_name)

--- a/lib/screens/v2/widget_instance/reconstructed_alert.ex
+++ b/lib/screens/v2/widget_instance/reconstructed_alert.ex
@@ -275,7 +275,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
 
   defp format_station_name_list(list) do
     list
-    |> List.update_at(length(list) - 1, &" & #{&1}")
+    |> List.update_at(-1, &" & #{&1}")
     |> Enum.join(", #")
     |> String.split("#")
     |> Enum.map(fn string -> %{format: :nowrap, text: string} end)

--- a/lib/screens/v2/widget_instance/reconstructed_alert.ex
+++ b/lib/screens/v2/widget_instance/reconstructed_alert.ex
@@ -278,7 +278,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
     |> List.update_at(length(list) - 1, &" & #{&1}")
     |> Enum.join(", #")
     |> String.split("#")
-    |> Enum.map(fn string -> %{format: :nowrap, text: "#{string}"} end)
+    |> Enum.map(fn string -> %{format: :nowrap, text: string} end)
     |> Enum.intersperse("")
   end
 

--- a/lib/screens_web/views/v2/audio/reconstructed_alert_fullscreen_view.ex
+++ b/lib/screens_web/views/v2/audio/reconstructed_alert_fullscreen_view.ex
@@ -200,7 +200,7 @@ defmodule ScreensWeb.V2.Audio.ReconstructedAlertFullscreenView do
 
     list_of_lines =
       (formatted_lines_with_branches ++ lines_without_branches)
-      |> Util.format_name_list_to_string()
+      |> Util.format_name_list_to_string_audio()
 
     ~E|<%= list_of_lines %>|
   end

--- a/test/screens/v2/widget_instance/reconstructed_alert_test.exs
+++ b/test/screens/v2/widget_instance/reconstructed_alert_test.exs
@@ -542,7 +542,10 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
 
       expected = %{
         issue: "Station closed",
-        location: "Orange Line trains skip Malden Center",
+        location: %ScreensConfig.V2.FreeTextLine{
+          icon: nil,
+          text: ["Orange Line trains skip ", %{format: :nowrap, text: "Malden Center"}]
+        },
         cause: nil,
         effect: :station_closure,
         remedy: "Seek alternate route",


### PR DESCRIPTION
[Notion](https://www.notion.so/mbta-downtown-crossing/fd75b83b5904405fbc71ffbcdd0cec47?v=d4971a59c7eb45ae9841e522c53ad368&p=0f0b87cc98f349e3a4469b7d6849bca9&pm=s)

😐 ok maybe this is janky a little, but maybe it still works??

![Screenshot 2024-01-04 at 5 28 50 PM](https://github.com/mbta/screens/assets/69368883/7e854bd7-0db4-4652-90e9-197f06af0c90)
