### PR TITLE
temp: Change NoDeparturesMessage for Haymarket during surge.

### DIFF
--- a/assets/src/components/solari/screen_container.tsx
+++ b/assets/src/components/solari/screen_container.tsx
@@ -28,6 +28,7 @@ const DefaultScreenLayout = ({ apiResponse }): JSX.Element => {
         sectionHeaders={apiResponse.section_headers}
         currentTimeString={apiResponse.current_time}
         overhead={apiResponse.overhead}
+        stationName={apiResponse.station_name}
       />
       {apiResponse.psa_url && (
         <Psa

--- a/assets/src/components/solari/section.tsx
+++ b/assets/src/components/solari/section.tsx
@@ -11,6 +11,7 @@ import {
 import BaseDepartureDestination from "Components/eink/base_departure_destination";
 import { classWithModifier, classWithModifiers, imagePath } from "Util/util";
 import { standardTimeRepresentation } from "Util/time_representation";
+import moment from "moment";
 
 const WIDE_MINI_PILL_ROUTES = ["441/442"];
 
@@ -137,10 +138,29 @@ const PlaceholderMessage = ({ pill, text }): JSX.Element => (
   </div>
 );
 
-const NoDeparturesMessage = ({ pill }): JSX.Element => {
-  return (
-    <PlaceholderMessage pill={pill} text="No departures currently available" />
+const isDuringSurge = () => {
+  const now = moment();
+  const isDuringFirstRange = now.isBetween(
+    moment("2024-01-03T09:30:00Z"),
+    moment("2024-01-13T07:30:00Z")
   );
+
+  const isDuringSecondRange = now.isBetween(
+    moment("2024-01-16T09:30:00Z"),
+    moment("2024-01-29T07:30:00Z")
+  );
+
+  return isDuringFirstRange || isDuringSecondRange;
+};
+
+const NoDeparturesMessage = ({ pill, stationName }): JSX.Element => {
+  let placeholderText = "No departures currently available";
+
+  if (stationName === "Haymarket" && isDuringSurge()) {
+    placeholderText = "Service Suspended";
+  }
+
+  return <PlaceholderMessage pill={pill} text={placeholderText} />;
 };
 
 const NoDataMessage = ({ pill }): JSX.Element => {
@@ -544,6 +564,7 @@ const Section = ({
   pill,
   headway: { active, headsigns, range_low: rangeLow, range_high: rangeHigh },
   disabled,
+  stationName,
 }): JSX.Element => {
   departures = departures.slice(0, numRows);
 
@@ -565,7 +586,7 @@ const Section = ({
         {disabled ? (
           <NoDataMessage pill={pill} />
         ) : (
-          <NoDeparturesMessage pill={pill} />
+          <NoDeparturesMessage pill={pill} stationName={stationName} />
         )}
       </SectionFrame>
     );

--- a/assets/src/components/solari/section_list.tsx
+++ b/assets/src/components/solari/section_list.tsx
@@ -9,6 +9,7 @@ interface Props {
   sectionHeaders: string;
   currentTimeString: string;
   overhead: boolean;
+  stationName: string;
   isDummy?: boolean;
 }
 
@@ -20,6 +21,7 @@ const SectionList = React.forwardRef(
       sectionHeaders,
       currentTimeString,
       overhead,
+      stationName,
       isDummy = false,
     }: Props,
     ref
@@ -44,6 +46,7 @@ const SectionList = React.forwardRef(
               overhead={overhead}
               isAnimated={!isDummy}
               key={section.name}
+              stationName={stationName}
             />
           );
         })}

--- a/assets/src/components/solari/section_list_container.tsx
+++ b/assets/src/components/solari/section_list_container.tsx
@@ -8,6 +8,7 @@ interface Props {
   sectionHeaders: string;
   currentTimeString: string;
   overhead: boolean;
+  stationName: string;
 }
 
 const SectionListContainer = ({
@@ -15,6 +16,7 @@ const SectionListContainer = ({
   sectionHeaders,
   currentTimeString,
   overhead,
+  stationName,
 }: Props): JSX.Element => {
   const [sectionSizes, setSectionSizes] = React.useState([] as number[]);
 
@@ -27,6 +29,7 @@ const SectionListContainer = ({
           sectionHeaders={sectionHeaders}
           currentTimeString={currentTimeString}
           overhead={overhead}
+          stationName={stationName}
         />
       )}
       <SectionListSizer


### PR DESCRIPTION
**Asana task**: [GL Surge - swap departures language for Solari screens](https://app.asana.com/0/1185117109217413/1206288246229604/f)

At the request of OIOs, we need to temporarily change the GL row text at Haymarket to `Service Suspended`. I hardcoded the date range so we won't need another deploy (unless dates change for some reason).

- [ ] Tests added?
