### PR TITLE
fix: Prefare polish -- New abbreviation rule

### DIFF
--- a/assets/src/components/v2/disruption_diagram/disruption_diagram.tsx
+++ b/assets/src/components/v2/disruption_diagram/disruption_diagram.tsx
@@ -689,8 +689,8 @@ const DisruptionDiagram: ComponentType<DisruptionDiagramData> = (props) => {
             xScaleFactor,
             yScaleFactor
           );
+          setScaleFactor(factor);
           setTimeout(() => {
-            setScaleFactor(factor);
             setIsDone(true);
           }, 200);
         }

--- a/assets/src/components/v2/disruption_diagram/disruption_diagram.tsx
+++ b/assets/src/components/v2/disruption_diagram/disruption_diagram.tsx
@@ -33,6 +33,17 @@ const R = 165;
 // so the width available to the rest of the diagram is 904 - (L + R)
 const W = MAX_WIDTH - (L + R);
 
+// List of abbreviated stations
+const abbreviationList: {[string: string]: string} = {
+  "Boston University Center": "BU Central",
+  "Boston University East": "BU East",
+  "Downtown Crossing": "Downtown Xng",
+  "Government Center": "Gov't Center",
+  "Hynes Convention Center": "Hynes",
+  "Massachusetts Avenue": "Mass Ave",
+  "Tufts Medical Center": "Tufts Medical Ctr"
+}
+
 type DisruptionDiagramData =
   | ContinuousDisruptionDiagram
   | DiscreteDisruptionDiagram;
@@ -442,8 +453,8 @@ const MiddleSlotComponent: ComponentType<MiddleSlotComponentProps> = ({
           className={classWithModifier(`label-${labelTextClass}`, textModifier)}
           transform={`translate(0 -32) rotate(-45)`}
         >
-          {abbreviate || label.full === "Massachusetts Avenue"
-            ? label.abbrev
+          {abbreviate && Object.keys(abbreviationList).includes(label.full)
+            ? abbreviationList[label.full]
             : label.full}
         </text>
       )}


### PR DESCRIPTION
[Notion](https://www.notion.so/mbta-downtown-crossing/fd75b83b5904405fbc71ffbcdd0cec47?v=d4971a59c7eb45ae9841e522c53ad368&p=2c3e2b67a4b04748a7371d066b003817&pm=s)

Only abbreviate station names if they are a part of a short list of stations. 

Along the way, this fixed also revealed a situation where I noticed the diagram was getting mis-sized, and a long station name was getting cut off. Turns out that the font can take so long to render Inter that the useEffect hook thinks the diagram is smaller than it is and scales it up too much. Added a lil setTimeout on the whole hook to delay it a tiny bit longer so the font can render.