### PR TITLE
fix: Prefare polish -- Reorder audio with alerts before subway status

### DIFF
--- a/lib/screens/v2/widget_instance/reconstructed_alert.ex
+++ b/lib/screens/v2/widget_instance/reconstructed_alert.ex
@@ -1170,7 +1170,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
     case serialize(t) do
       %{urgent: true} -> [1]
       %{effect: effect} when effect in [:delay] -> [1, 1]
-      _ -> [1, 0]
+      _ -> [1, 2]
     end
   end
 

--- a/lib/screens/v2/widget_instance/reconstructed_alert.ex
+++ b/lib/screens/v2/widget_instance/reconstructed_alert.ex
@@ -1164,13 +1164,13 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
     serialize_single_screen_alert(t, location)
   end
 
-  def audio_sort_key(%__MODULE__{is_full_screen: true}), do: [2]
+  def audio_sort_key(%__MODULE__{is_full_screen: true}), do: [1]
 
   def audio_sort_key(%__MODULE__{} = t) do
     case serialize(t) do
-      %{urgent: true} -> [2]
-      %{effect: effect} when effect in [:delay] -> [2, 2]
-      _ -> [2, 1]
+      %{urgent: true} -> [1]
+      %{effect: effect} when effect in [:delay] -> [1, 1]
+      _ -> [1, 0]
     end
   end
 

--- a/lib/screens/v2/widget_instance/subway_status.ex
+++ b/lib/screens/v2/widget_instance/subway_status.ex
@@ -95,7 +95,7 @@ defmodule Screens.V2.WidgetInstance.SubwayStatus do
 
     def audio_serialize(t), do: serialize(t)
 
-    def audio_sort_key(_instance), do: [1]
+    def audio_sort_key(_instance), do: [2]
 
     def audio_valid_candidate?(%{screen: %Screen{app_params: %PreFare{}}}), do: true
     def audio_valid_candidate?(_instance), do: false

--- a/lib/screens_web/views/v2/audio/content_summary_view.ex
+++ b/lib/screens_web/views/v2/audio/content_summary_view.ex
@@ -2,7 +2,7 @@ defmodule ScreensWeb.V2.Audio.ContentSummaryView do
   use ScreensWeb, :view
 
   def render("_widget.ssml", %{lines_at_station: lines}) do
-    ~E|<p><s>You will hear the subway service overview, the current alerts for the <%= render_lines_at_station(lines) %>, and system elevator closures</s></p>|
+    ~E|<p><s>You will hear the current alerts for the <%= render_lines_at_station(lines) %>, the subway service overview, and system elevator closures</s></p>|
   end
 
   defp render_lines_at_station([line]) do

--- a/test/screens/v2/widget_instance/reconstructed_alert_test.exs
+++ b/test/screens/v2/widget_instance/reconstructed_alert_test.exs
@@ -1909,7 +1909,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
   describe "audio_sort_key/1" do
     setup @alert_widget_context_setup_group ++ [:setup_active_period]
 
-    test "returns [2] when alert is urgent", %{widget: widget} do
+    test "returns [1] when alert is urgent", %{widget: widget} do
       widget =
         widget
         |> put_effect(:suspension)
@@ -1919,10 +1919,10 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
         |> put_cause(:unknown)
         |> put_is_full_screen(true)
 
-      assert [2] == WidgetInstance.audio_sort_key(widget)
+      assert [1] == WidgetInstance.audio_sort_key(widget)
     end
 
-    test "returns [2, 1] when alert is not urgent", %{widget: widget} do
+    test "returns [1, 2] when alert is not urgent", %{widget: widget} do
       widget =
         widget
         |> put_effect(:station_closure)
@@ -1932,10 +1932,10 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
         ])
         |> put_cause(:construction)
 
-      assert [2, 1] == WidgetInstance.audio_sort_key(widget)
+      assert [1, 2] == WidgetInstance.audio_sort_key(widget)
     end
 
-    test "returns [2, 2] when alert effect is :delay", %{widget: widget} do
+    test "returns [1, 1] when alert effect is :delay", %{widget: widget} do
       widget =
         widget
         |> put_effect(:delay)
@@ -1945,7 +1945,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
         |> put_cause(:unknown)
         |> put_alert_header("Test Alert")
 
-      assert [2, 2] == WidgetInstance.audio_sort_key(widget)
+      assert [1, 1] == WidgetInstance.audio_sort_key(widget)
     end
   end
 

--- a/test/screens/v2/widget_instance/subway_status_test.exs
+++ b/test/screens/v2/widget_instance/subway_status_test.exs
@@ -1572,9 +1572,9 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
   end
 
   describe "audio_sort_key/1" do
-    test "returns [1]" do
+    test "returns [2]" do
       instance = %SubwayStatus{}
-      assert [1] == WidgetInstance.audio_sort_key(instance)
+      assert [2] == WidgetInstance.audio_sort_key(instance)
     end
   end
 


### PR DESCRIPTION
[Notion](https://www.notion.so/mbta-downtown-crossing/fd75b83b5904405fbc71ffbcdd0cec47?v=d4971a59c7eb45ae9841e522c53ad368&p=cab9f47a242e4d7e9d878c8f9cf76dab&pm=s)
