### PR TITLE
fix: Prefare alerts polish -- Screenplay sim sizing / page layout

### DIFF
--- a/assets/css/v2/pre_fare/simulation.scss
+++ b/assets/css/v2/pre_fare/simulation.scss
@@ -48,10 +48,6 @@
       color: #f8f9fa;
       margin-bottom: 10px;
     }
-
-    // & > *:not(.simulation__title) {
-      
-    // }
   }
 
   .simulation__left-screen {
@@ -67,8 +63,6 @@
         & > * {
           height: 1720px;
           width: 1080px;
-          // transform-origin: top left;
-          // transform: scale(17.92%);
           overflow: hidden;
         }
       }
@@ -97,8 +91,6 @@
         & > * {
           height: 1720px;
           width: 1080px;
-          // transform-origin: top left;
-          // transform: scale(17.92%);
           overflow: hidden;
         }
       }

--- a/assets/css/v2/pre_fare/simulation.scss
+++ b/assets/css/v2/pre_fare/simulation.scss
@@ -29,6 +29,11 @@
   margin-bottom: 20px;
   height: 449px;
 
+  .simulation {
+    transform-origin: top left;
+    transform: scale(17.92%);
+  }
+
   .simulation__full-page {
     max-height: 407px;
     max-width: 388px;
@@ -44,10 +49,9 @@
       margin-bottom: 10px;
     }
 
-    & > *:not(.simulation__title) {
-      transform-origin: top left;
-      transform: scale(17.92%);
-    }
+    // & > *:not(.simulation__title) {
+      
+    // }
   }
 
   .simulation__left-screen {
@@ -63,8 +67,8 @@
         & > * {
           height: 1720px;
           width: 1080px;
-          transform-origin: top left;
-          transform: scale(17.92%);
+          // transform-origin: top left;
+          // transform: scale(17.92%);
           overflow: hidden;
         }
       }
@@ -93,8 +97,8 @@
         & > * {
           height: 1720px;
           width: 1080px;
-          transform-origin: top left;
-          transform: scale(17.92%);
+          // transform-origin: top left;
+          // transform: scale(17.92%);
           overflow: hidden;
         }
       }

--- a/assets/src/components/v2/disruption_diagram/disruption_diagram.tsx
+++ b/assets/src/components/v2/disruption_diagram/disruption_diagram.tsx
@@ -709,7 +709,7 @@ const DisruptionDiagram: ComponentType<DisruptionDiagramData> = (props) => {
           xScaleFactor,
           yScaleFactor
         );
-        console.log("about to set scale factor")
+        console.log("       about to set scale factor")
         setScaleFactor(factor);
         setTimeout(() => {
           setIsDone(true);
@@ -720,18 +720,18 @@ const DisruptionDiagram: ComponentType<DisruptionDiagramData> = (props) => {
 
   // When the parent container size changes, or abbreviation setting changes,
   // re-measure the diagram and scale accordingly.
-  // The setTimeout is needed in cases where the font takes a little while to load
-  // but the diagram measurements have already been taken. This doesn't cause the
-  // diagramContainerHeight to change, so we need another way to force the hook to re-run
+  // The document.fonts.ready.then() is needed when the font takes a while to load
+  // but the diagram measurements have already been taken.
   // Example: shuttle Chinatown > Mass Ave, screen located at Back Bay
-  
+
+  // The isCurrent setting is needed to clean up the 
   useEffect(() => {
+    let isCurrent = true
     document.fonts.ready.then(() => {
-      measureDiagramAndScale()
+      if (isCurrent) measureDiagramAndScale()
     })
     return () => {
-      setScaleFactor(1)
-      setIsDone(false)
+      isCurrent = false
     }
   }, [diagramContainerHeight, doAbbreviate]);
 

--- a/assets/src/components/v2/disruption_diagram/disruption_diagram.tsx
+++ b/assets/src/components/v2/disruption_diagram/disruption_diagram.tsx
@@ -711,7 +711,9 @@ const DisruptionDiagram: ComponentType<DisruptionDiagramData> = (props) => {
         );
         console.log("about to set scale factor")
         setScaleFactor(factor);
-        setIsDone(true);
+        setTimeout(() => {
+          setIsDone(true);
+        }, 200);
       }
     }
   }

--- a/assets/src/components/v2/disruption_diagram/disruption_diagram.tsx
+++ b/assets/src/components/v2/disruption_diagram/disruption_diagram.tsx
@@ -11,9 +11,6 @@ import ArrowLeftEndpoint from "../../../../static/images/svgr_bundled/disruption
 import ArrowRightEndpoint from "../../../../static/images/svgr_bundled/disruption_diagram/arrow-right-endpoint.svg";
 import ShuttleBusIcon from "../../../../static/images/svgr_bundled/disruption_diagram/shuttle-emphasis-icon.svg";
 
-import { useWhatChanged } from '@simbathesailor/use-what-changed';
-
-
 // Width of the disruption diagram, dependent on the screen width
 const DIAGRAM_WIDTH = 904;
 const SLOT_WIDTH = 24;
@@ -691,11 +688,11 @@ const DisruptionDiagram: ComponentType<DisruptionDiagramData> = (props) => {
     width = dimensions?.width ?? 0;
     console.log("current width: ", width, "current scale: ", scaleFactor)
 
-    if (diagramContainerHeight != 0 && width && height) {
+    if (!isDone && diagramContainerHeight != 0 && width && height) {
       // if scaleFactor has already been applied to the line-map, we need to reverse that
       const unscaledHeight = height / scaleFactor;
       const unscaledWidth = width / scaleFactor;
-      console.log("       unscaledWidth: ", unscaledWidth)
+      console.log("   unscaledWidth: ", unscaledWidth)
 
       // First, scale x. Then, check if it needs abbreviating. Then scale y, given the abbreviation
       let xScaleFactor = fullWidth / unscaledWidth;
@@ -714,9 +711,7 @@ const DisruptionDiagram: ComponentType<DisruptionDiagramData> = (props) => {
         );
         console.log("about to set scale factor")
         setScaleFactor(factor);
-        setTimeout(() => {
-          setIsDone(true);
-        }, 200);
+        setIsDone(true);
       }
     }
   }
@@ -728,12 +723,14 @@ const DisruptionDiagram: ComponentType<DisruptionDiagramData> = (props) => {
   // diagramContainerHeight to change, so we need another way to force the hook to re-run
   // Example: shuttle Chinatown > Mass Ave, screen located at Back Bay
   
-  useWhatChanged([diagramContainerHeight, doAbbreviate], "diagramContainerHeight, doAbbreviate")
   useEffect(() => {
-    console.log("running useeffect")
     document.fonts.ready.then(() => {
       measureDiagramAndScale()
     })
+    return () => {
+      setScaleFactor(1)
+      setIsDone(false)
+    }
   }, [diagramContainerHeight, doAbbreviate]);
 
   // This is to center the diagram along the X axis

--- a/assets/src/components/v2/disruption_diagram/disruption_diagram.tsx
+++ b/assets/src/components/v2/disruption_diagram/disruption_diagram.tsx
@@ -620,7 +620,7 @@ const DisruptionDiagram: ComponentType<DisruptionDiagramData> = (props) => {
     });
     resizeObserver.observe(ref.current);
     return () => resizeObserver.disconnect();
-  });
+  }, [ref?.current]);
 
   // Measures line-map svg when the scaleFactor changes, updates state
   const measuredRef = useCallback(node => {

--- a/assets/src/components/v2/disruption_diagram/disruption_diagram.tsx
+++ b/assets/src/components/v2/disruption_diagram/disruption_diagram.tsx
@@ -624,15 +624,10 @@ const DisruptionDiagram: ComponentType<DisruptionDiagramData> = (props) => {
 
   // Measures line-map svg when the scaleFactor changes, updates state
   const measuredRef = useCallback(node => {
-    const myObserver = new ResizeObserver(() => {})
-
     if (node !== null) {
-      myObserver.observe(node)
       setLineDiagramHeight(node.getBoundingClientRect().height);
       setLineDiagramWidth(node.getBoundingClientRect().width);
-    }
-    
-    return () => myObserver.disconnect()
+    } 
   }, [scaleFactor]);
 
   // First, we need to figure out whether we're in a Screenplay simulation or not,
@@ -643,7 +638,7 @@ const DisruptionDiagram: ComponentType<DisruptionDiagramData> = (props) => {
   useEffect(() => {
     simulation = document.getElementById("simulation")
     simulationStyle = simulation && window.getComputedStyle(simulation) 
-    setSimulationTransform(new WebKitCSSMatrix(simulationStyle?.transform).m11);
+    setSimulationTransform(new DOMMatrix(simulationStyle?.transform).m11);
   }, []);
   
   const fullWidth = 904 * simulationTransform;

--- a/assets/src/components/v2/disruption_diagram/disruption_diagram.tsx
+++ b/assets/src/components/v2/disruption_diagram/disruption_diagram.tsx
@@ -708,7 +708,7 @@ const DisruptionDiagram: ComponentType<DisruptionDiagramData> = (props) => {
         const unscaledWidth = lineDiagramWidth / scaleFactor;
 
         // First, scale x. Then, check if it needs abbreviating. Then scale y, given the abbreviation
-        let xScaleFactor = fullWidth / unscaledWidth;
+        const xScaleFactor = fullWidth / unscaledWidth;
         
         const needsAbbreviating = !doAbbreviate &&
           unscaledHeight * xScaleFactor + getEmphasisHeight(xScaleFactor) * simulationTransform > diagramContainerHeight;

--- a/assets/src/components/v2/disruption_diagram/disruption_diagram.tsx
+++ b/assets/src/components/v2/disruption_diagram/disruption_diagram.tsx
@@ -625,8 +625,9 @@ const DisruptionDiagram: ComponentType<DisruptionDiagramData> = (props) => {
   // Measures line-map svg when the scaleFactor changes, updates state
   const measureLineMapNode = useCallback(node => {
     if (node !== null) {
-      setLineDiagramHeight(node.getBoundingClientRect().height);
-      setLineDiagramWidth(node.getBoundingClientRect().width);
+      const {height, width} = node.getBoundingClientRect();
+      setLineDiagramHeight(height);
+      setLineDiagramWidth(width);
     } 
   }, [scaleFactor]);
 

--- a/assets/src/components/v2/disruption_diagram/disruption_diagram.tsx
+++ b/assets/src/components/v2/disruption_diagram/disruption_diagram.tsx
@@ -623,7 +623,7 @@ const DisruptionDiagram: ComponentType<DisruptionDiagramData> = (props) => {
   }, [ref?.current]);
 
   // Measures line-map svg when the scaleFactor changes, updates state
-  const measuredRef = useCallback(node => {
+  const measureLineMapNode = useCallback(node => {
     if (node !== null) {
       setLineDiagramHeight(node.getBoundingClientRect().height);
       setLineDiagramWidth(node.getBoundingClientRect().width);
@@ -768,7 +768,7 @@ const DisruptionDiagram: ComponentType<DisruptionDiagramData> = (props) => {
         visibility={isDone ? "visible" : "hidden"}
       >
         <g transform={`translate(${L * scaleFactor} 0)`}>
-          <g id="line-map" transform={`scale(${scaleFactor})`} ref={measuredRef}>
+          <g id="line-map" transform={`scale(${scaleFactor})`} ref={measureLineMapNode}>
             {effect !== "station_closure" && (
               <EffectBackgroundComponent
                 effectRegionSlotIndexRange={props.effect_region_slot_index_range}

--- a/assets/src/components/v2/disruption_diagram/disruption_diagram.tsx
+++ b/assets/src/components/v2/disruption_diagram/disruption_diagram.tsx
@@ -695,37 +695,37 @@ const DisruptionDiagram: ComponentType<DisruptionDiagramData> = (props) => {
   });
 
   x += spaceBetween + SLOT_WIDTH;
-  
-  // Scale the line-map svg given the available screen width 
-  const measureDiagramAndScale = () => {
-    if (!isDone && diagramContainerHeight != 0) {
-      // If scaleFactor has already been applied to the line-map, we need to reverse that for calculations
-      const unscaledHeight = lineDiagramHeight / scaleFactor;
-      const unscaledWidth = lineDiagramWidth / scaleFactor;
-
-      // First, scale x. Then, check if it needs abbreviating. Then scale y, given the abbreviation
-      let xScaleFactor = fullWidth / unscaledWidth;
-      
-      const needsAbbreviating = !doAbbreviate &&
-        unscaledHeight * xScaleFactor + getEmphasisHeight(xScaleFactor) * simulationTransform > diagramContainerHeight;
-      if (needsAbbreviating) {
-        setDoAbbreviate(true);
-        // now scale y, which requires re-running this effect
-      } else {
-        const yScaleFactor = (diagramContainerHeight - getEmphasisHeight(1) * simulationTransform) / unscaledHeight
-        const factor = Math.min(
-          xScaleFactor,
-          yScaleFactor
-        );
-        setScaleFactor(factor);
-        setIsDone(true);
-      }
-    }
-  }
 
   // When the parent container size changes, or abbreviation setting changes,
   // re-measure the diagram and scale accordingly.
   useEffect(() => {
+    // Scale the line-map svg given the available screen width 
+    const measureDiagramAndScale = () => {
+      if (!isDone && diagramContainerHeight != 0) {
+        // If scaleFactor has already been applied to the line-map, we need to reverse that for calculations
+        const unscaledHeight = lineDiagramHeight / scaleFactor;
+        const unscaledWidth = lineDiagramWidth / scaleFactor;
+
+        // First, scale x. Then, check if it needs abbreviating. Then scale y, given the abbreviation
+        let xScaleFactor = fullWidth / unscaledWidth;
+        
+        const needsAbbreviating = !doAbbreviate &&
+          unscaledHeight * xScaleFactor + getEmphasisHeight(xScaleFactor) * simulationTransform > diagramContainerHeight;
+        if (needsAbbreviating) {
+          setDoAbbreviate(true);
+          // now scale y, which requires re-running this effect
+        } else {
+          const yScaleFactor = (diagramContainerHeight - getEmphasisHeight(1) * simulationTransform) / unscaledHeight
+          const factor = Math.min(
+            xScaleFactor,
+            yScaleFactor
+          );
+          setScaleFactor(factor);
+          setIsDone(true);
+        }
+      }
+    }
+
     // The isCurrent setting is needed to clean up the unused hook runs / state changes
     let isCurrent = true
     

--- a/assets/src/components/v2/disruption_diagram/disruption_diagram.tsx
+++ b/assets/src/components/v2/disruption_diagram/disruption_diagram.tsx
@@ -615,11 +615,11 @@ const DisruptionDiagram: ComponentType<DisruptionDiagramData> = (props) => {
     if (!ref.current) return;
     const resizeObserver = new ResizeObserver(() => {
       if (ref?.current) {
-        setDiagramContainerHeight(ref.current.clientHeight);
+        setDiagramContainerHeight(ref.current.clientHeight * simulationTransform);
       }
     });
     resizeObserver.observe(ref.current);
-    return () => resizeObserver.disconnect(); // clean up
+    return () => resizeObserver.disconnect();
   });
 
   // Measures line-map svg when the scaleFactor changes, updates state
@@ -712,12 +712,12 @@ const DisruptionDiagram: ComponentType<DisruptionDiagramData> = (props) => {
       let xScaleFactor = fullWidth / unscaledWidth;
       
       const needsAbbreviating = !doAbbreviate &&
-        unscaledHeight * xScaleFactor + getEmphasisHeight(xScaleFactor) > diagramContainerHeight;
+        unscaledHeight * xScaleFactor + getEmphasisHeight(xScaleFactor) * simulationTransform > diagramContainerHeight;
       if (needsAbbreviating) {
         setDoAbbreviate(true);
         // now scale y, which requires re-running this effect
       } else {
-        const yScaleFactor = (diagramContainerHeight - getEmphasisHeight(1)) / unscaledHeight
+        const yScaleFactor = (diagramContainerHeight - getEmphasisHeight(1) * simulationTransform) / unscaledHeight
         const factor = Math.min(
           xScaleFactor,
           yScaleFactor
@@ -746,7 +746,7 @@ const DisruptionDiagram: ComponentType<DisruptionDiagramData> = (props) => {
   }, [lineDiagramHeight, diagramContainerHeight, doAbbreviate]);
 
   // This is to center the diagram along the X axis
-  const translateX = (lineDiagramWidth && (fullWidth - lineDiagramWidth) / 2) || 0;
+  const translateX = (lineDiagramWidth && (fullWidth - lineDiagramWidth) / 2 / simulationTransform) || 0;
   
   // Next is to align the diagram at the top of the svg, which involves adjusting the SVG viewbox
 
@@ -766,7 +766,7 @@ const DisruptionDiagram: ComponentType<DisruptionDiagramData> = (props) => {
     - MAX_ENDPOINT_HEIGHT * scaleFactor / 2
 
   return (
-    <div style={{width: "100%", height: "100%"}} id="diagram-container" ref={ref}>
+    <div style={{width: "100%", height: "100%"}} ref={ref}>
       <svg
         viewBox={`0 ${-viewBoxOffset} ${DIAGRAM_WIDTH} ${originalHeight + getEmphasisHeight(scaleFactor)}`}
         transform={`translate(${translateX})`}

--- a/assets/src/components/v2/disruption_diagram/disruption_diagram.tsx
+++ b/assets/src/components/v2/disruption_diagram/disruption_diagram.tsx
@@ -635,10 +635,9 @@ const DisruptionDiagram: ComponentType<DisruptionDiagramData> = (props) => {
   // because unfortunately, the CSS transform on those simulations messes up the widget's
   // ability to measure itself in the DOM. So, we need to get the original height of the
   // diagram, pre-scaled, to accurately set its viewbox dimensions.
-  let simulation, simulationStyle;
   useEffect(() => {
-    simulation = document.getElementById("simulation")
-    simulationStyle = simulation && window.getComputedStyle(simulation) 
+    const simulation = document.getElementById("simulation")
+    const simulationStyle = simulation && window.getComputedStyle(simulation) 
     setSimulationTransform(new DOMMatrix(simulationStyle?.transform).m11);
   }, []);
   

--- a/assets/src/components/v2/pre_fare/simulation_screen_container.tsx
+++ b/assets/src/components/v2/pre_fare/simulation_screen_container.tsx
@@ -40,10 +40,7 @@ const SimulationScreenLayout: ComponentType<SimulationScreenLayoutProps> = ({
         {apiResponse && (
           <div className="simulation__full-page">
             <div className="simulation__title">Live view</div>
-            <div
-              className="simulation"
-              id={`simulation`}
-            >
+            <div className="simulation" id="simulation">
               <WidgetTreeErrorBoundary>
                 <Widget data={fullPage} />
               </WidgetTreeErrorBoundary>

--- a/assets/src/components/v2/pre_fare/simulation_screen_container.tsx
+++ b/assets/src/components/v2/pre_fare/simulation_screen_container.tsx
@@ -31,6 +31,9 @@ const SimulationScreenLayout: ComponentType<SimulationScreenLayoutProps> = ({
     );
   }
 
+  const isPageListActive = leftScreenPages && leftScreenPages.length > 1
+                        && rightScreenPages && rightScreenPages.length > 1
+
   return (
     <div className="simulation-screen-centering-container">
       <div className="simulation-screen-scrolling-container">
@@ -47,9 +50,8 @@ const SimulationScreenLayout: ComponentType<SimulationScreenLayoutProps> = ({
             </div>
           </div>
         )}
-        {/* {flexZone && <div className="divider"></div>} */}
-        {/* Change this to 1 */}
-        {leftScreenPages && leftScreenPages.length > 0 && (
+        {isPageListActive && <div className="divider"></div>}
+        {leftScreenPages && leftScreenPages.length > 1 && (
           <div className="simulation__left-screen">
             <div className="simulation__title">
               Left panel ({leftScreenPages.length})
@@ -82,7 +84,6 @@ const SimulationScreenLayout: ComponentType<SimulationScreenLayoutProps> = ({
                     <div
                       key={`page${index}`}
                       className="simulation simulation__right-screen-widget"
-                      id={`simulation`} // add index
                     >
                       <Widget data={flexZonePage} />
                     </div>

--- a/assets/src/components/v2/pre_fare/simulation_screen_container.tsx
+++ b/assets/src/components/v2/pre_fare/simulation_screen_container.tsx
@@ -37,12 +37,18 @@ const SimulationScreenLayout: ComponentType<SimulationScreenLayoutProps> = ({
         {apiResponse && (
           <div className="simulation__full-page">
             <div className="simulation__title">Live view</div>
-            <WidgetTreeErrorBoundary>
-              <Widget data={fullPage} />
-            </WidgetTreeErrorBoundary>
+            <div
+              className="simulation"
+              id={`simulation`}
+            >
+              <WidgetTreeErrorBoundary>
+                <Widget data={fullPage} />
+              </WidgetTreeErrorBoundary>
+            </div>
           </div>
         )}
-        {flexZone && <div className="divider"></div>}
+        {/* {flexZone && <div className="divider"></div>} */}
+        {/* Change this to 1 */}
         {leftScreenPages && leftScreenPages.length > 0 && (
           <div className="simulation__left-screen">
             <div className="simulation__title">
@@ -54,7 +60,7 @@ const SimulationScreenLayout: ComponentType<SimulationScreenLayoutProps> = ({
                   return (
                     <div
                       key={`page${index}`}
-                      className="simulation__left-screen-widget"
+                      className="simulation simulation__left-screen-widget"
                     >
                       <Widget data={flexZonePage} />
                     </div>
@@ -64,7 +70,7 @@ const SimulationScreenLayout: ComponentType<SimulationScreenLayoutProps> = ({
             </div>
           </div>
         )}
-        {rightScreenPages && rightScreenPages.length > 0 && (
+        {rightScreenPages && rightScreenPages.length > 1 && (
           <div className="simulation__right-screen">
             <div className="simulation__title">
               Flex zone ({rightScreenPages.length})
@@ -75,7 +81,8 @@ const SimulationScreenLayout: ComponentType<SimulationScreenLayoutProps> = ({
                   return (
                     <div
                       key={`page${index}`}
-                      className="simulation__right-screen-widget"
+                      className="simulation simulation__right-screen-widget"
+                      id={`simulation`} // add index
                     >
                       <Widget data={flexZonePage} />
                     </div>

--- a/assets/src/components/v2/pre_fare_single_screen_alert.tsx
+++ b/assets/src/components/v2/pre_fare_single_screen_alert.tsx
@@ -324,7 +324,7 @@ const MapSection: React.ComponentType<MapSectionProps> = ({
       className="disruption-diagram-container"
       ref={ref}
     >
-      <DisruptionDiagram {...disruptionDiagram} svgHeight={diagramHeight} />
+      <DisruptionDiagram {...disruptionDiagram} />
     </div>
   );
 };

--- a/assets/src/components/v2/pre_fare_single_screen_alert.tsx
+++ b/assets/src/components/v2/pre_fare_single_screen_alert.tsx
@@ -303,26 +303,11 @@ interface MapSectionProps {
 const MapSection: React.ComponentType<MapSectionProps> = ({
   disruptionDiagram,
 }) => {
-  const [diagramHeight, setDiagramHeight] = useState(0);
-  const ref = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!ref.current) return;
-    const resizeObserver = new ResizeObserver(() => {
-      // Do what you want to do when the size of the element changes
-      if (ref?.current) {
-        setDiagramHeight(ref.current.clientHeight);
-      }
-    });
-    resizeObserver.observe(ref.current);
-    return () => resizeObserver.disconnect(); // clean up
-  });
 
   return (
     <div
       id="disruption-diagram-container"
       className="disruption-diagram-container"
-      ref={ref}
     >
       <DisruptionDiagram {...disruptionDiagram} />
     </div>

--- a/assets/src/components/v2/reconstructed_takeover.tsx
+++ b/assets/src/components/v2/reconstructed_takeover.tsx
@@ -70,7 +70,6 @@ const ReconstructedTakeover: React.ComponentType<ReconAlertProps> = (alert) => {
                 >
                   <DisruptionDiagram
                     {...disruption_diagram}
-                    svgHeight={diagramHeight}
                   />
                 </div>
               )}

--- a/assets/src/components/v2/reconstructed_takeover.tsx
+++ b/assets/src/components/v2/reconstructed_takeover.tsx
@@ -29,20 +29,6 @@ const ReconstructedTakeover: React.ComponentType<ReconAlertProps> = (alert) => {
     disruption_diagram,
   } = alert;
 
-  const [diagramHeight, setDiagramHeight] = useState(0);
-  const ref = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!ref.current) return;
-    const resizeObserver = new ResizeObserver(() => {
-      if (ref?.current) {
-        setDiagramHeight(ref.current.clientHeight);
-      }
-    });
-    resizeObserver.observe(ref.current);
-    return () => resizeObserver.disconnect(); // clean up
-  });
-
   return (
     <>
       <div
@@ -66,11 +52,8 @@ const ReconstructedTakeover: React.ComponentType<ReconAlertProps> = (alert) => {
                 <div
                   id="disruption-diagram-container"
                   className="disruption-diagram-container"
-                  ref={ref}
                 >
-                  <DisruptionDiagram
-                    {...disruption_diagram}
-                  />
+                  <DisruptionDiagram {...disruption_diagram} />
                 </div>
               )}
             </div>


### PR DESCRIPTION
[No task]

Gosh this was a wonky thing to fix. It was most complex in situations where there were two diagrams in the simulation for multiple disruption pages. I tried to clear things up with comments, but now the file is so so full of comments that it might be a bit overzealous. Let me know what you think!