### PR TITLE
tweak: add time_in_epoch to line map vehicles

### DIFF
--- a/lib/screens/v2/widget_instance/line_map.ex
+++ b/lib/screens/v2/widget_instance/line_map.ex
@@ -239,7 +239,8 @@ defmodule Screens.V2.WidgetInstance.LineMap do
       if index < 0 do
         []
       else
-        [%{id: vehicle_id, index: index, label: label}]
+        departure_time_epoch = d |> Departure.time() |> DateTime.to_unix()
+        [%{id: vehicle_id, index: index, label: label, time_in_epoch: departure_time_epoch}]
       end
     end
   end


### PR DESCRIPTION
**Asana task**: [[Mercury] Add epoch time to vehicles on line diagram](https://app.asana.com/0/1185117109217413/1206443958613162/f)

Added `time_in_epoch` to line map vehicles for Mercury. Will only be used in their code.
