### PR TITLE
tweak: Give screen simulations transparent backgrounds for better integration with Screenplay UI

### DIFF
--- a/assets/css/bus_eink_v2.scss
+++ b/assets/css/bus_eink_v2.scss
@@ -37,6 +37,7 @@
 
 @import "v2/multi_screen_page";
 
+@import "v2/simulation_common";
 @import "v2/bus_eink/simulation";
 
 body {

--- a/assets/css/bus_shelter_v2.scss
+++ b/assets/css/bus_shelter_v2.scss
@@ -43,6 +43,7 @@
 
 @import "v2/multi_screen_page";
 
+@import "v2/simulation_common";
 @import "v2/bus_shelter/simulation";
 
 body {

--- a/assets/css/dup/dup_screen_page.scss
+++ b/assets/css/dup/dup_screen_page.scss
@@ -6,7 +6,7 @@
 .simulation-screen-centering-container {
   display: flex;
   justify-content: center;
-  background: #3d5366;
+  background: transparent;
 }
 
 .simulation-screen-scrolling-container {

--- a/assets/css/dup_v2.scss
+++ b/assets/css/dup_v2.scss
@@ -30,6 +30,7 @@
 @import "v2/dup/alert/full_screen_alert";
 
 @import "v2/multi_screen_page";
+@import "v2/simulation_common";
 @import "v2/dup/simulation";
 
 @import "v2/outfront_common/debug";

--- a/assets/css/gl_eink_v2.scss
+++ b/assets/css/gl_eink_v2.scss
@@ -38,6 +38,7 @@
 
 @import "v2/multi_screen_page";
 
+@import "v2/simulation_common";
 @import "v2/gl_eink/simulation";
 
 body {

--- a/assets/css/pre_fare_v2.scss
+++ b/assets/css/pre_fare_v2.scss
@@ -60,6 +60,7 @@
 
 @import "v2/multi_screen_page";
 
+@import "v2/simulation_common";
 @import "v2/pre_fare/simulation";
 
 @import "v2/blue_bikes";

--- a/assets/css/triptych_v2.scss
+++ b/assets/css/triptych_v2.scss
@@ -60,6 +60,7 @@
 @import "v2/triptych/debug";
 
 @import "v2/triptych/evergreen";
+@import "v2/simulation_common";
 @import "v2/triptych/simulation";
 
 body {

--- a/assets/css/v2/bus_shelter/simulation.scss
+++ b/assets/css/v2/bus_shelter/simulation.scss
@@ -1,9 +1,3 @@
-.simulation-screen-centering-container {
-  display: flex;
-  justify-content: center;
-  background: #3d5366;
-}
-
 .simulation-screen-scrolling-container {
   scrollbar-color: #607180 #2E3F4D;
 

--- a/assets/css/v2/dup/simulation.scss
+++ b/assets/css/v2/dup/simulation.scss
@@ -1,9 +1,3 @@
-.simulation-screen-centering-container {
-  display: flex;
-  justify-content: center;
-  background: #3d5366;
-}
-
 .simulation-screen-scrolling-container {
   scrollbar-color: #607180 #2E3F4D;
 

--- a/assets/css/v2/gl_eink/simulation.scss
+++ b/assets/css/v2/gl_eink/simulation.scss
@@ -1,9 +1,3 @@
-.simulation-screen-centering-container {
-  display: flex;
-  justify-content: center;
-  background: #3d5366;
-}
-
 .simulation-screen-scrolling-container {
   scrollbar-color: #607180 #2E3F4D;
 

--- a/assets/css/v2/pre_fare/simulation.scss
+++ b/assets/css/v2/pre_fare/simulation.scss
@@ -1,9 +1,3 @@
-.simulation-screen-centering-container {
-  display: flex;
-  justify-content: center;
-  background: #3d5366;
-}
-
 .simulation-screen-scrolling-container {
   scrollbar-color: #607180 #2e3f4d;
 

--- a/assets/css/v2/simulation_common.scss
+++ b/assets/css/v2/simulation_common.scss
@@ -1,0 +1,5 @@
+.simulation-screen-centering-container {
+  display: flex;
+  justify-content: center;
+  background: transparent;
+}

--- a/assets/css/v2/triptych/simulation.scss
+++ b/assets/css/v2/triptych/simulation.scss
@@ -1,9 +1,3 @@
-.simulation-screen-centering-container {
-  display: flex;
-  justify-content: center;
-  background: #3d5366;
-}
-
 .simulation-screen-scrolling-container {
   scrollbar-color: #607180 #2e3f4d;
 


### PR DESCRIPTION
Task: [[Perm config] Pending screen page](https://app.asana.com/0/1185117109217413/1205973195471510/f)

The Pending page uses a darker background color for its screen simulations, than that used by the Places page.

Screen simulations previously assumed they would always have a #3d5366 background color--this changes things so that they use a transparent background. Tested and working properly in Screenplay on Firefox & Chrome.

This approach seemed more straightforward than adding support for a `?background_color=_` param on /simulation urls.

- [ ] Tests added?
