### PR TITLE
chore: upgrade to Node 16

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -28,7 +28,7 @@ ENV NVM_SYMLINK_CURRENT=true
 ENV PATH=${NVM_DIR}/current/bin:${PATH}
 
 # [Optional, Choice] Node.js version: none, lts/*, 16, 14, 12, 10
-ARG NODE_VERSION="14"
+ARG NODE_VERSION="16"
 
 # Install needed packages and setup non-root user. Use a separate RUN statement to add your own dependencies.
 RUN apt-get update \

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 elixir 1.15.7-otp-26
 erlang 26.2
-nodejs 14.17.0
+nodejs 16.20.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN mix do local.hex --force, local.rebar --force
 RUN mix do deps.get --only prod
 
 # next, build the frontend assets within a Node.JS container
-FROM node:14 as assets-builder
+FROM node:16 as assets-builder
 
 WORKDIR /root
 ADD . .


### PR DESCRIPTION
This is required to allow development on Apple Silicon hardware, since Node 14 is old enough that it can't be compiled (and has no precompiled binaries) for `arm64`.

This version of Node is unfortunately still past its End-of-Life (see https://github.com/nodejs/Release), but it is the newest version that works with our current frontend dependencies, in particular Webpack 4.

---

To get some confidence this won't impact anything, I built two Docker images locally, one with the Node 16 change in the `Dockerfile` and one without, then extracted and diffed their `/root` directories (where the app is built). They were identical except for the Phoenix asset digest, which only had differences in the timestamp field; this seems to record the time the asset was built, so the difference is expected.