### PR TITLE
Skip node station when determining which RL branches are affected by alert

### DIFF
--- a/lib/screens/v2/widget_instance/reconstructed_alert.ex
+++ b/lib/screens/v2/widget_instance/reconstructed_alert.ex
@@ -150,7 +150,8 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
     {direction_id, route_id} =
       if length(list_of_directions_and_routes) == 1 do
         hd(list_of_directions_and_routes)
-      # If there are multiple route ids in that informed entities list, then the alert includes branching
+
+        # If there are multiple route ids in that informed entities list, then the alert includes branching
       else
         select_direction_and_route(list_of_directions_and_routes)
       end
@@ -236,7 +237,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
       |> elem(0)
 
     if {direction_id, "Red"} in list_of_directions_and_routes or
-          ({direction_id, "Red-Ashmont"} in list_of_directions_and_routes and
+         ({direction_id, "Red-Ashmont"} in list_of_directions_and_routes and
             {direction_id, "Red-Braintree"} in list_of_directions_and_routes) do
       {direction_id, "Red"}
     else

--- a/lib/screens/v2/widget_instance/reconstructed_alert.ex
+++ b/lib/screens/v2/widget_instance/reconstructed_alert.ex
@@ -150,21 +150,9 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
     {direction_id, route_id} =
       if length(list_of_directions_and_routes) == 1 do
         hd(list_of_directions_and_routes)
-
-        # If there are multiple route ids in that informed entities list, then the alert includes branching
+      # If there are multiple route ids in that informed entities list, then the alert includes branching
       else
-        direction_id =
-          list_of_directions_and_routes
-          |> hd()
-          |> elem(0)
-
-        if {direction_id, "Red"} in list_of_directions_and_routes or
-             ({direction_id, "Red-Ashmont"} in list_of_directions_and_routes and
-                {direction_id, "Red-Braintree"} in list_of_directions_and_routes) do
-          {direction_id, "Red"}
-        else
-          {direction_id, "Green-trunk"}
-        end
+        select_direction_and_route(list_of_directions_and_routes)
       end
 
     cond do
@@ -239,6 +227,22 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
 
   defp get_direction_and_route_from_entity(%{direction_id: direction_id, route: route}, _),
     do: {direction_id, route}
+
+  # Select 1 direction + route from this list of directions + routes for multiple branches
+  defp select_direction_and_route(list_of_directions_and_routes) do
+    direction_id =
+      list_of_directions_and_routes
+      |> hd()
+      |> elem(0)
+
+    if {direction_id, "Red"} in list_of_directions_and_routes or
+          ({direction_id, "Red-Ashmont"} in list_of_directions_and_routes and
+            {direction_id, "Red-Braintree"} in list_of_directions_and_routes) do
+      {direction_id, "Red"}
+    else
+      {direction_id, "Green-trunk"}
+    end
+  end
 
   defp get_route_pills(t, location \\ nil)
 

--- a/lib/screens/v2/widget_instance/reconstructed_alert.ex
+++ b/lib/screens/v2/widget_instance/reconstructed_alert.ex
@@ -236,10 +236,11 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
       |> hd()
       |> elem(0)
 
-   case list_of_directions_and_routes do
-       [{direction_id, "Red" <> _} | _] -> {direction_id, "Red"}
-       _ -> {direction_id, "Green-trunk"}
-   end
+    case list_of_directions_and_routes do
+      [{direction_id, "Red" <> _} | _] -> {direction_id, "Red"}
+      _ -> {direction_id, "Green-trunk"}
+    end
+  end
 
   defp get_route_pills(t, location \\ nil)
 

--- a/lib/screens/v2/widget_instance/reconstructed_alert.ex
+++ b/lib/screens/v2/widget_instance/reconstructed_alert.ex
@@ -150,7 +150,8 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
     {direction_id, route_id} =
       if length(list_of_directions_and_routes) == 1 do
         hd(list_of_directions_and_routes)
-      # If there are multiple route ids in that informed entities list, then the alert includes branching
+
+        # If there are multiple route ids in that informed entities list, then the alert includes branching
       else
         direction_id =
           list_of_directions_and_routes
@@ -158,10 +159,8 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
           |> elem(0)
 
         if {direction_id, "Red"} in list_of_directions_and_routes or
-              (
-                {direction_id, "Red-Ashmont"} in list_of_directions_and_routes and
-                {direction_id, "Red-Braintree"} in list_of_directions_and_routes
-              ) do
+             ({direction_id, "Red-Ashmont"} in list_of_directions_and_routes and
+                {direction_id, "Red-Braintree"} in list_of_directions_and_routes) do
           {direction_id, "Red"}
         else
           {direction_id, "Green-trunk"}
@@ -188,7 +187,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
 
   # Given an entity and the directionality of the alert from the home stop,
   # return a tuple with the affected direction_id and route_id
-  
+
   # Skip processing JFK, because it is a branching node station. The other stations in the alert
   # will determine the destination needed for this alert
   defp get_direction_and_route_from_entity(%{stop: "place-jfk"}, _location), do: nil
@@ -257,9 +256,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
 
   defp get_route_pills(%__MODULE__{} = t, location) do
     affected_routes = LocalizedAlert.consolidated_informed_subway_routes(t)
-    |> IO.inspect(label: "affected routes")
     routes_at_stop = LocalizedAlert.active_routes_at_stop(t)
-    |> IO.inspect(label: "routes at stop")
 
     affected_routes
     # Filter alert-affected routes by which routes are at the current stop
@@ -270,7 +267,6 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
       "Green" <> _ -> Enum.find(routes_at_stop, &String.starts_with?(&1, "Green"))
       route -> route in routes_at_stop
     end)
-    |> IO.inspect()
     |> Enum.flat_map(fn
       route_id ->
         # Boundary alerts shouldn't have headsign in the banner
@@ -278,7 +274,6 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
           unless get_region_from_location(location) === :boundary do
             get_destination(t, location, route_id)
           end
-          |> IO.inspect(label: "headsign")
 
         build_pills_from_headsign(route_id, headsign)
     end)

--- a/lib/screens/v2/widget_instance/reconstructed_alert.ex
+++ b/lib/screens/v2/widget_instance/reconstructed_alert.ex
@@ -144,19 +144,28 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
     list_of_directions_and_routes =
       informed_entities
       |> Enum.map(fn entity -> get_direction_and_route_from_entity(entity, location) end)
+      |> Enum.filter(& &1)
       |> Enum.uniq()
 
     {direction_id, route_id} =
       if length(list_of_directions_and_routes) == 1 do
         hd(list_of_directions_and_routes)
-        # If there are multiple route ids in that informed entities list, we're on a branch
+      # If there are multiple route ids in that informed entities list, then the alert includes branching
       else
         direction_id =
           list_of_directions_and_routes
           |> hd()
           |> elem(0)
 
-        {direction_id, "Green-trunk"}
+        if {direction_id, "Red"} in list_of_directions_and_routes or
+              (
+                {direction_id, "Red-Ashmont"} in list_of_directions_and_routes and
+                {direction_id, "Red-Braintree"} in list_of_directions_and_routes
+              ) do
+          {direction_id, "Red"}
+        else
+          {direction_id, "Green-trunk"}
+        end
       end
 
     cond do
@@ -179,6 +188,10 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
 
   # Given an entity and the directionality of the alert from the home stop,
   # return a tuple with the affected direction_id and route_id
+  
+  # Skip processing JFK, because it is a branching node station. The other stations in the alert
+  # will determine the destination needed for this alert
+  defp get_direction_and_route_from_entity(%{stop: "place-jfk"}, _location), do: nil
 
   # If the route is red and the alert is downstream, we have to figure out whether the alert
   # only affects one branch or both
@@ -244,7 +257,9 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
 
   defp get_route_pills(%__MODULE__{} = t, location) do
     affected_routes = LocalizedAlert.consolidated_informed_subway_routes(t)
+    |> IO.inspect(label: "affected routes")
     routes_at_stop = LocalizedAlert.active_routes_at_stop(t)
+    |> IO.inspect(label: "routes at stop")
 
     affected_routes
     # Filter alert-affected routes by which routes are at the current stop
@@ -255,6 +270,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
       "Green" <> _ -> Enum.find(routes_at_stop, &String.starts_with?(&1, "Green"))
       route -> route in routes_at_stop
     end)
+    |> IO.inspect()
     |> Enum.flat_map(fn
       route_id ->
         # Boundary alerts shouldn't have headsign in the banner
@@ -262,6 +278,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
           unless get_region_from_location(location) === :boundary do
             get_destination(t, location, route_id)
           end
+          |> IO.inspect(label: "headsign")
 
         build_pills_from_headsign(route_id, headsign)
     end)

--- a/lib/screens/v2/widget_instance/reconstructed_alert.ex
+++ b/lib/screens/v2/widget_instance/reconstructed_alert.ex
@@ -236,14 +236,10 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
       |> hd()
       |> elem(0)
 
-    if {direction_id, "Red"} in list_of_directions_and_routes or
-         ({direction_id, "Red-Ashmont"} in list_of_directions_and_routes and
-            {direction_id, "Red-Braintree"} in list_of_directions_and_routes) do
-      {direction_id, "Red"}
-    else
-      {direction_id, "Green-trunk"}
-    end
-  end
+   case list_of_directions_and_routes do
+       [{direction_id, "Red" <> _} | _] -> {direction_id, "Red"}
+       _ -> {direction_id, "Green-trunk"}
+   end
 
   defp get_route_pills(t, location \\ nil)
 

--- a/test/screens/v2/widget_instance/reconstructed_alert_test.exs
+++ b/test/screens/v2/widget_instance/reconstructed_alert_test.exs
@@ -1627,6 +1627,324 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
 
       assert expected == ReconstructedAlert.serialize(widget, &fake_log/1)
     end
+
+    test "gets correct destination for RL alert affecting trunk and a whole branch", %{
+      widget: widget
+    } do
+      widget =
+        widget
+        |> put_home_stop(PreFare, "place-portr")
+        |> put_effect(:shuttle)
+        |> put_informed_entities([
+          ie(stop: "place-andrw", route: "Red", route_type: 1),
+          ie(stop: "place-asmnl", route: "Red", route_type: 1),
+          ie(stop: "place-brdwy", route: "Red", route_type: 1),
+          ie(stop: "place-fldcr", route: "Red", route_type: 1),
+          ie(stop: "place-jfk", route: "Red", route_type: 1),
+          ie(stop: "place-shmnl", route: "Red", route_type: 1),
+          ie(stop: "place-smmnl", route: "Red", route_type: 1)
+        ])
+        |> put_tagged_stop_sequences(%{
+          "Red" => [
+            [
+              "place-alfcl",
+              "place-davis",
+              "place-portr",
+              "place-harsq",
+              "place-cntsq",
+              "place-knncl",
+              "place-chmnl",
+              "place-pktrm",
+              "place-dwnxg",
+              "place-sstat",
+              "place-brdwy",
+              "place-andrw",
+              "place-jfk",
+              "place-nqncy",
+              "place-wlsta",
+              "place-qnctr",
+              "place-qamnl",
+              "place-brntn"
+            ],
+            [
+              "place-alfcl",
+              "place-davis",
+              "place-portr",
+              "place-harsq",
+              "place-cntsq",
+              "place-knncl",
+              "place-chmnl",
+              "place-pktrm",
+              "place-dwnxg",
+              "place-sstat",
+              "place-brdwy",
+              "place-andrw",
+              "place-jfk",
+              "place-shmnl",
+              "place-fldcr",
+              "place-smmnl",
+              "place-asmnl"
+            ]
+          ]
+        })
+        |> put_routes_at_stop([
+          %{
+            type: :subway,
+            route_id: "Red",
+            short_name: "",
+            active?: true,
+            long_name: "Red Line",
+            direction_destinations: ["Ashmont/Braintree", "Alewife"]
+          }
+        ])
+        |> put_is_full_screen(true)
+
+      expected = %{
+        cause: nil,
+        location: nil,
+        effect: :shuttle,
+        issue: "No trains",
+        remedy: "Shuttle buses available",
+        updated_at: "Friday, 5:00 am",
+        region: :outside,
+        routes: [
+          %{headsign: "Ashmont", route_id: "Red", svg_name: "rl-ashmont"},
+          %{headsign: "Braintree", route_id: "Red", svg_name: "rl-braintree"}
+        ],
+        endpoints: {"Broadway", "Ashmont"},
+        is_transfer_station: false,
+        disruption_diagram: %{
+          line: :red,
+          effect: :shuttle,
+          slots: [
+            %{type: :terminal, label_id: "place-alfcl"},
+            %{label: %{full: "Davis", abbrev: "Davis"}, show_symbol: true},
+            %{label: %{full: "Porter", abbrev: "Porter"}, show_symbol: true},
+            %{label: %{full: "Harvard", abbrev: "Harvard"}, show_symbol: true},
+            %{label: %{full: "Central", abbrev: "Central"}, show_symbol: true},
+            %{
+              label: %{full: "…via Downtown Crossing", abbrev: "…via Downt'n Xng"},
+              show_symbol: false
+            },
+            %{label: %{full: "South Station", abbrev: "South Sta"}, show_symbol: true},
+            %{label: %{full: "Broadway", abbrev: "Broadway"}, show_symbol: true},
+            %{label: %{full: "Andrew", abbrev: "Andrew"}, show_symbol: true},
+            %{label: %{full: "JFK/UMass", abbrev: "JFK/UMass"}, show_symbol: true},
+            %{label: %{full: "Savin Hill", abbrev: "Savin Hill"}, show_symbol: true},
+            %{
+              label: %{full: "Fields Corner", abbrev: "Fields Cnr"},
+              show_symbol: true
+            },
+            %{label: %{full: "Shawmut", abbrev: "Shawmut"}, show_symbol: true},
+            %{type: :terminal, label_id: "place-asmnl"}
+          ],
+          current_station_slot_index: 2,
+          effect_region_slot_index_range: {7, 13}
+        }
+      }
+
+      assert expected == ReconstructedAlert.serialize(widget, &fake_log/1)
+    end
+
+    test "gets correct destination for RL alert affecting one branch starting at JFK", %{
+      widget: widget
+    } do
+      widget =
+        widget
+        |> put_home_stop(PreFare, "place-portr")
+        |> put_effect(:shuttle)
+        |> put_informed_entities([
+          ie(stop: "place-asmnl", route: "Red", route_type: 1),
+          ie(stop: "place-fldcr", route: "Red", route_type: 1),
+          ie(stop: "place-jfk", route: "Red", route_type: 1),
+          ie(stop: "place-shmnl", route: "Red", route_type: 1),
+          ie(stop: "place-smmnl", route: "Red", route_type: 1)
+        ])
+        |> put_tagged_stop_sequences(%{
+          "Red" => [
+            [
+              "place-alfcl",
+              "place-davis",
+              "place-portr",
+              "place-harsq",
+              "place-cntsq",
+              "place-knncl",
+              "place-chmnl",
+              "place-pktrm",
+              "place-dwnxg",
+              "place-sstat",
+              "place-brdwy",
+              "place-andrw",
+              "place-jfk",
+              "place-nqncy",
+              "place-wlsta",
+              "place-qnctr",
+              "place-qamnl",
+              "place-brntn"
+            ],
+            [
+              "place-alfcl",
+              "place-davis",
+              "place-portr",
+              "place-harsq",
+              "place-cntsq",
+              "place-knncl",
+              "place-chmnl",
+              "place-pktrm",
+              "place-dwnxg",
+              "place-sstat",
+              "place-brdwy",
+              "place-andrw",
+              "place-jfk",
+              "place-shmnl",
+              "place-fldcr",
+              "place-smmnl",
+              "place-asmnl"
+            ]
+          ]
+        })
+        |> put_routes_at_stop([
+          %{
+            type: :subway,
+            route_id: "Red",
+            short_name: "",
+            active?: true,
+            long_name: "Red Line",
+            direction_destinations: ["Ashmont/Braintree", "Alewife"]
+          }
+        ])
+        |> put_is_full_screen(true)
+
+      expected = %{
+        cause: nil,
+        location: nil,
+        effect: :shuttle,
+        issue: "No trains",
+        remedy: "Shuttle buses available",
+        updated_at: "Friday, 5:00 am",
+        region: :outside,
+        routes: [
+          %{headsign: "Ashmont", route_id: "Red", svg_name: "rl-ashmont"}
+        ],
+        endpoints: {"JFK/UMass", "Ashmont"},
+        is_transfer_station: false,
+        disruption_diagram: %{
+          line: :red,
+          effect: :shuttle,
+          slots: [
+            %{type: :terminal, label_id: "place-alfcl"},
+            %{label: %{full: "Davis", abbrev: "Davis"}, show_symbol: true},
+            %{label: %{full: "Porter", abbrev: "Porter"}, show_symbol: true},
+            %{label: %{full: "Harvard", abbrev: "Harvard"}, show_symbol: true},
+            %{label: %{full: "Central", abbrev: "Central"}, show_symbol: true},
+            %{
+              label: %{full: "…via Downtown Crossing", abbrev: "…via Downt'n Xng"},
+              show_symbol: false
+            },
+            %{label: %{full: "Andrew", abbrev: "Andrew"}, show_symbol: true},
+            %{label: %{full: "JFK/UMass", abbrev: "JFK/UMass"}, show_symbol: true},
+            %{label: %{full: "Savin Hill", abbrev: "Savin Hill"}, show_symbol: true},
+            %{
+              label: %{full: "Fields Corner", abbrev: "Fields Cnr"},
+              show_symbol: true
+            },
+            %{label: %{full: "Shawmut", abbrev: "Shawmut"}, show_symbol: true},
+            %{type: :terminal, label_id: "place-asmnl"}
+          ],
+          current_station_slot_index: 2,
+          effect_region_slot_index_range: {7, 11}
+        }
+      }
+
+      assert expected == ReconstructedAlert.serialize(widget, &fake_log/1)
+    end
+
+    test "gets correct destination for RL alert affecting both branches", %{widget: widget} do
+      widget =
+        widget
+        |> put_home_stop(PreFare, "place-portr")
+        |> put_effect(:shuttle)
+        |> put_alert_header("Simulation of PIO text")
+        |> put_informed_entities([
+          ie(stop: "place-nqncy", route: "Red", route_type: 1),
+          ie(stop: "place-asmnl", route: "Red", route_type: 1),
+          ie(stop: "place-fldcr", route: "Red", route_type: 1),
+          ie(stop: "place-jfk", route: "Red", route_type: 1),
+          ie(stop: "place-shmnl", route: "Red", route_type: 1),
+          ie(stop: "place-smmnl", route: "Red", route_type: 1)
+        ])
+        |> put_tagged_stop_sequences(%{
+          "Red" => [
+            [
+              "place-alfcl",
+              "place-davis",
+              "place-portr",
+              "place-harsq",
+              "place-cntsq",
+              "place-knncl",
+              "place-chmnl",
+              "place-pktrm",
+              "place-dwnxg",
+              "place-sstat",
+              "place-brdwy",
+              "place-andrw",
+              "place-jfk",
+              "place-nqncy",
+              "place-wlsta",
+              "place-qnctr",
+              "place-qamnl",
+              "place-brntn"
+            ],
+            [
+              "place-alfcl",
+              "place-davis",
+              "place-portr",
+              "place-harsq",
+              "place-cntsq",
+              "place-knncl",
+              "place-chmnl",
+              "place-pktrm",
+              "place-dwnxg",
+              "place-sstat",
+              "place-brdwy",
+              "place-andrw",
+              "place-jfk",
+              "place-shmnl",
+              "place-fldcr",
+              "place-smmnl",
+              "place-asmnl"
+            ]
+          ]
+        })
+        |> put_routes_at_stop([
+          %{
+            type: :subway,
+            route_id: "Red",
+            short_name: "",
+            active?: true,
+            long_name: "Red Line",
+            direction_destinations: ["Ashmont/Braintree", "Alewife"]
+          }
+        ])
+        |> put_is_full_screen(true)
+
+      expected = %{
+        cause: "",
+        effect: :shuttle,
+        issue: nil,
+        location: nil,
+        remedy: nil,
+        routes: [
+          %{headsign: "Ashmont", route_id: "Red", svg_name: "rl-ashmont"},
+          %{headsign: "Braintree", route_id: "Red", svg_name: "rl-braintree"}
+        ],
+        updated_at: "Friday, 5:00 am",
+        region: :outside,
+        remedy_bold: "Simulation of PIO text"
+      }
+
+      assert expected == ReconstructedAlert.serialize(widget, &fake_log/1)
+    end
   end
 
   describe "endpoint reversal" do


### PR DESCRIPTION
**Asana task**: [Bug: GL text can appear on RL pre-fare alerts](https://app.asana.com/0/1185117109217413/1206815194782600)

It's a little tricky figuring out which RL destination sign to show when the alert affects both the RL trunk and branch. So here are the cases we need to support
- issue is downstream, JFK - Ashmont and no Braintree stations included: should say riders to Ashmont
- issue is downstream, Broadway - Ashmont: should say riders to both branches
- issue is downstream, JFK - Braintree and no Ashmont stations included: should say riders to Braintree

Omitting the branching node (JFK) helps us decide whether the trunk/branch is affected

- [x] Tests added?
