### PR TITLE
ci: update Asana attachment workflow

### DIFF
--- a/.github/workflows/asana-pr-opened.yml
+++ b/.github/workflows/asana-pr-opened.yml
@@ -14,11 +14,12 @@ jobs:
           trigger-phrase: "\\*\\*Asana task\\*\\*:"
           targets: '[{"project": "Screens Dev - Sprint", "section": "In Review"}]'
   create-asana-attachment-job:
+    if: contains(github.event.pull_request.body, 'https://app.asana.com')
     runs-on: ubuntu-latest
     name: Create pull request attachments on Asana tasks
     steps:
       - name: Create pull request attachments
-        uses: Asana/create-app-attachment-github-action@latest
+        uses: Asana/create-app-attachment-github-action@v1.3
         id: postAttachment
         with:
           asana-secret: ${{ secrets.ASANA_GITHUB_INTEGRATION_SECRET }}


### PR DESCRIPTION
Two small changes:

* Add an explicit action version, as the `latest` tag is apparently not being updated to consistently point to the actual latest version.

* Add a conditional so the job doesn't attempt to run (and fail) if there is no Asana link in the PR. Taken from this suggestion: https://github.com/Asana/create-app-attachment-github-action/issues/14