### PR TITLE
tweak: Only pair alert with CR if CR enabled

### DIFF
--- a/lib/screens/v2/widget_instance/reconstructed_alert.ex
+++ b/lib/screens/v2/widget_instance/reconstructed_alert.ex
@@ -377,6 +377,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
         screen: %Screen{
           app_params: %PreFare{
             cr_departures: %CRDepartures{
+              enabled: true,
               pair_with_alert_widget: true
             }
           }


### PR DESCRIPTION
**Asana task**: ad-hoc

Improved the pattern a bit so when only pair the widgets when CR is enabled. Can be used as a safeguard if the widget is disabled but the `pair_with_alert_widget` is not switched to `false` for the CR widget config.

- [ ] Tests added?
