### PR TITLE
Fix TypeScript errors and enable `tsc` in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,3 +65,21 @@ jobs:
         with:
           name: elixir-lcov
           path: cover/
+
+  js-build:
+    name: Frontend Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+      - working-directory: ./assets
+        run: npm run deploy
+
+  js-types:
+    name: Frontend Types
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+      - working-directory: ./assets
+        run: npm run tsc:check

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -40,6 +40,7 @@
         "@types/react-dom": "^17.0.9",
         "@types/react-router-dom": "^5.1.8",
         "babel-loader": "^8.2.2",
+        "concurrently": "^8.2.2",
         "copy-webpack-plugin": "^6.4.1",
         "css-loader": "^5.2.7",
         "file-loader": "^6.2.0",
@@ -5695,15 +5696,20 @@
       "dev": true
     },
     "node_modules/@babel/runtime": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.5.tgz",
-      "integrity": "sha512-TXWihFIS3Pyv5hzR7j6ihmeLkZfrXGxAr5UfSl8CHf+6q/wpiYDkUau0czckpYG8QmnCIuPpdLtuA9VmuGGyMA==",
+      "version": "7.24.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.4.tgz",
+      "integrity": "sha512-dkxf7+hn8mFBwKjs9bvBlArzLVxVbS8usaPUDd5p2a9JCL9tB8OaOVN1isD4+Xyk4ns89/xeOmbQvgdK7IIVdA==",
       "dependencies": {
-        "regenerator-runtime": "^0.13.4"
+        "regenerator-runtime": "^0.14.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@babel/runtime/node_modules/regenerator-runtime": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
     "node_modules/@babel/template": {
       "version": "7.16.0",
@@ -9179,6 +9185,159 @@
         "typedarray": "^0.0.6"
       }
     },
+    "node_modules/concurrently": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-8.2.2.tgz",
+      "integrity": "sha512-1dP4gpXFhei8IOtlXRE/T/4H88ElHgTiUzh71YUmtjTEHMSRS2Z/fgOxHSxxusGHogsRfxNq1vyAwxSC+EVyDg==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "date-fns": "^2.30.0",
+        "lodash": "^4.17.21",
+        "rxjs": "^7.8.1",
+        "shell-quote": "^1.8.1",
+        "spawn-command": "0.0.2",
+        "supports-color": "^8.1.1",
+        "tree-kill": "^1.2.2",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "conc": "dist/bin/concurrently.js",
+        "concurrently": "dist/bin/concurrently.js"
+      },
+      "engines": {
+        "node": "^14.13.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/concurrently/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/concurrently/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/concurrently/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/concurrently/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/concurrently/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/concurrently/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/console-browserify": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
@@ -9722,6 +9881,22 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
       }
     },
     "node_modules/debug": {
@@ -17257,6 +17432,21 @@
         "aproba": "^1.1.1"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/rxjs/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "dev": true
+    },
     "node_modules/safe-array-concat": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.0.0.tgz",
@@ -17543,6 +17733,15 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/shell-quote": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.1.tgz",
+      "integrity": "sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/side-channel": {
@@ -17853,6 +18052,12 @@
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
       "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==",
       "deprecated": "See https://github.com/lydell/source-map-url#deprecated",
+      "dev": true
+    },
+    "node_modules/spawn-command": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2.tgz",
+      "integrity": "sha512-zC8zGoGkmc8J9ndvml8Xksr1Amk9qBujgbF0JAIWO7kXr43w0h/0GJNM/Vustixu+YE8N/MTrQ7N31FvHUACxQ==",
       "dev": true
     },
     "node_modules/split-string": {
@@ -18523,6 +18728,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "bin": {
+        "tree-kill": "cli.js"
       }
     },
     "node_modules/ts-jest": {
@@ -24520,11 +24734,18 @@
       "dev": true
     },
     "@babel/runtime": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.5.tgz",
-      "integrity": "sha512-TXWihFIS3Pyv5hzR7j6ihmeLkZfrXGxAr5UfSl8CHf+6q/wpiYDkUau0czckpYG8QmnCIuPpdLtuA9VmuGGyMA==",
+      "version": "7.24.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.4.tgz",
+      "integrity": "sha512-dkxf7+hn8mFBwKjs9bvBlArzLVxVbS8usaPUDd5p2a9JCL9tB8OaOVN1isD4+Xyk4ns89/xeOmbQvgdK7IIVdA==",
       "requires": {
-        "regenerator-runtime": "^0.13.4"
+        "regenerator-runtime": "^0.14.0"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.14.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+          "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
+        }
       }
     },
     "@babel/template": {
@@ -27270,6 +27491,117 @@
         "typedarray": "^0.0.6"
       }
     },
+    "concurrently": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-8.2.2.tgz",
+      "integrity": "sha512-1dP4gpXFhei8IOtlXRE/T/4H88ElHgTiUzh71YUmtjTEHMSRS2Z/fgOxHSxxusGHogsRfxNq1vyAwxSC+EVyDg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.1.2",
+        "date-fns": "^2.30.0",
+        "lodash": "^4.17.21",
+        "rxjs": "^7.8.1",
+        "shell-quote": "^1.8.1",
+        "spawn-command": "0.0.2",
+        "supports-color": "^8.1.1",
+        "tree-kill": "^1.2.2",
+        "yargs": "^17.7.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "7.2.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+              "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^4.0.0"
+              }
+            }
+          }
+        },
+        "cliui": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+          "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.1",
+            "wrap-ansi": "^7.0.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "8.1.1",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "yargs": {
+          "version": "17.7.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+          "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+          "dev": true,
+          "requires": {
+            "cliui": "^8.0.1",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.3",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^21.1.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "21.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+          "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+          "dev": true
+        }
+      }
+    },
     "console-browserify": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
@@ -27691,6 +28023,15 @@
         "abab": "^2.0.3",
         "whatwg-mimetype": "^2.3.0",
         "whatwg-url": "^8.0.0"
+      }
+    },
+    "date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.21.0"
       }
     },
     "debug": {
@@ -33405,6 +33746,23 @@
         "aproba": "^1.1.1"
       }
     },
+    "rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+          "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+          "dev": true
+        }
+      }
+    },
     "safe-array-concat": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.0.0.tgz",
@@ -33614,6 +33972,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true
+    },
+    "shell-quote": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.1.tgz",
+      "integrity": "sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==",
       "dev": true
     },
     "side-channel": {
@@ -33862,6 +34226,12 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
       "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==",
+      "dev": true
+    },
+    "spawn-command": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2.tgz",
+      "integrity": "sha512-zC8zGoGkmc8J9ndvml8Xksr1Amk9qBujgbF0JAIWO7kXr43w0h/0GJNM/Vustixu+YE8N/MTrQ7N31FvHUACxQ==",
       "dev": true
     },
     "split-string": {
@@ -34384,6 +34754,12 @@
       "requires": {
         "punycode": "^2.1.1"
       }
+    },
+    "tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true
     },
     "ts-jest": {
       "version": "27.1.2",

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -7469,10 +7469,13 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "17.0.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.5.tgz",
-      "integrity": "sha512-w3mrvNXLeDYV1GKTZorGJQivK6XLCoGwpnyJFbJVK/aTBQUxOCaa/GlFAAN3OTDFcb7h5tiFG+YXCO2By+riZw==",
-      "dev": true
+      "version": "20.11.30",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.30.tgz",
+      "integrity": "sha512-dHM6ZxwlmuZaRmUPfv1p+KrdD1Dci04FbdEm/9wEMouFqxYoFl5aMkt0VMAUtYRQDyYvD41WJLukhq/ha3YuTw==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
@@ -9282,20 +9285,6 @@
         "webpack": "^4.37.0 || ^5.0.0"
       }
     },
-    "node_modules/copy-webpack-plugin/node_modules/loader-utils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-      "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
-      "dev": true,
-      "dependencies": {
-        "big.js": "^5.2.2",
-        "emojis-list": "^3.0.0",
-        "json5": "^2.1.2"
-      },
-      "engines": {
-        "node": ">=8.9.0"
-      }
-    },
     "node_modules/copy-webpack-plugin/node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -9495,20 +9484,6 @@
       },
       "peerDependencies": {
         "webpack": "^4.27.0 || ^5.0.0"
-      }
-    },
-    "node_modules/css-loader/node_modules/loader-utils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-      "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
-      "dev": true,
-      "dependencies": {
-        "big.js": "^5.2.2",
-        "emojis-list": "^3.0.0",
-        "json5": "^2.1.2"
-      },
-      "engines": {
-        "node": ">=8.9.0"
       }
     },
     "node_modules/css-loader/node_modules/schema-utils": {
@@ -10809,20 +10784,6 @@
       },
       "peerDependencies": {
         "webpack": "^4.0.0 || ^5.0.0"
-      }
-    },
-    "node_modules/file-loader/node_modules/loader-utils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-      "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
-      "dev": true,
-      "dependencies": {
-        "big.js": "^5.2.2",
-        "emojis-list": "^3.0.0",
-        "json5": "^2.1.2"
-      },
-      "engines": {
-        "node": ">=8.9.0"
       }
     },
     "node_modules/file-loader/node_modules/schema-utils": {
@@ -15252,20 +15213,6 @@
         "webpack": "^4.4.0 || ^5.0.0"
       }
     },
-    "node_modules/mini-css-extract-plugin/node_modules/loader-utils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-      "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
-      "dev": true,
-      "dependencies": {
-        "big.js": "^5.2.2",
-        "emojis-list": "^3.0.0",
-        "json5": "^2.1.2"
-      },
-      "engines": {
-        "node": ">=8.9.0"
-      }
-    },
     "node_modules/mini-css-extract-plugin/node_modules/schema-utils": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
@@ -17423,20 +17370,6 @@
         }
       }
     },
-    "node_modules/sass-loader/node_modules/loader-utils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-      "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
-      "dev": true,
-      "dependencies": {
-        "big.js": "^5.2.2",
-        "emojis-list": "^3.0.0",
-        "json5": "^2.1.2"
-      },
-      "engines": {
-        "node": ">=8.9.0"
-      }
-    },
     "node_modules/sass-loader/node_modules/schema-utils": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
@@ -17853,20 +17786,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/source-map-loader/node_modules/loader-utils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-      "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
-      "dev": true,
-      "dependencies": {
-        "big.js": "^5.2.2",
-        "emojis-list": "^3.0.0",
-        "json5": "^2.1.2"
-      },
-      "engines": {
-        "node": ">=8.9.0"
       }
     },
     "node_modules/source-map-loader/node_modules/schema-utils": {
@@ -18927,9 +18846,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -18953,6 +18872,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
@@ -25954,10 +25879,13 @@
       "dev": true
     },
     "@types/node": {
-      "version": "17.0.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.5.tgz",
-      "integrity": "sha512-w3mrvNXLeDYV1GKTZorGJQivK6XLCoGwpnyJFbJVK/aTBQUxOCaa/GlFAAN3OTDFcb7h5tiFG+YXCO2By+riZw==",
-      "dev": true
+      "version": "20.11.30",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.30.tgz",
+      "integrity": "sha512-dHM6ZxwlmuZaRmUPfv1p+KrdD1Dci04FbdEm/9wEMouFqxYoFl5aMkt0VMAUtYRQDyYvD41WJLukhq/ha3YuTw==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~5.26.4"
+      }
     },
     "@types/parse-json": {
       "version": "4.0.0",
@@ -27428,17 +27356,6 @@
         "webpack-sources": "^1.4.3"
       },
       "dependencies": {
-        "loader-utils": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-          "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
-          "dev": true,
-          "requires": {
-            "big.js": "^5.2.2",
-            "emojis-list": "^3.0.0",
-            "json5": "^2.1.2"
-          }
-        },
         "p-limit": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -27596,17 +27513,6 @@
         "semver": "^7.3.5"
       },
       "dependencies": {
-        "loader-utils": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-          "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
-          "dev": true,
-          "requires": {
-            "big.js": "^5.2.2",
-            "emojis-list": "^3.0.0",
-            "json5": "^2.1.2"
-          }
-        },
         "schema-utils": {
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
@@ -28619,17 +28525,6 @@
         "schema-utils": "^3.0.0"
       },
       "dependencies": {
-        "loader-utils": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-          "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
-          "dev": true,
-          "requires": {
-            "big.js": "^5.2.2",
-            "emojis-list": "^3.0.0",
-            "json5": "^2.1.2"
-          }
-        },
         "schema-utils": {
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
@@ -31988,17 +31883,6 @@
         "webpack-sources": "^1.1.0"
       },
       "dependencies": {
-        "loader-utils": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-          "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
-          "dev": true,
-          "requires": {
-            "big.js": "^5.2.2",
-            "emojis-list": "^3.0.0",
-            "json5": "^2.1.2"
-          }
-        },
         "schema-utils": {
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
@@ -33597,17 +33481,6 @@
         "semver": "^7.3.2"
       },
       "dependencies": {
-        "loader-utils": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-          "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
-          "dev": true,
-          "requires": {
-            "big.js": "^5.2.2",
-            "emojis-list": "^3.0.0",
-            "json5": "^2.1.2"
-          }
-        },
         "schema-utils": {
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
@@ -33933,17 +33806,6 @@
           "dev": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3.0.0"
-          }
-        },
-        "loader-utils": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-          "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
-          "dev": true,
-          "requires": {
-            "big.js": "^5.2.2",
-            "emojis-list": "^3.0.0",
-            "json5": "^2.1.2"
           }
         },
         "schema-utils": {
@@ -34742,9 +34604,9 @@
       }
     },
     "typescript": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true
     },
     "unbox-primitive": {
@@ -34758,6 +34620,12 @@
         "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
       }
+    },
+    "undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",

--- a/assets/package.json
+++ b/assets/package.json
@@ -7,6 +7,7 @@
     "watch": "concurrently --kill-others --prefix-colors auto npm:watch-*",
     "watch-build": "webpack --mode development --stats minimal --watch",
     "watch-tsc": "tsc --noEmit --preserveWatchOutput --watch",
+    "tsc:check": "tsc --noEmit",
     "lint": "tslint --fix -p .",
     "lint:check": "tslint -p .",
     "format": "prettier --list-different \"{.,**}/*.{js,json,ts,tsx,css,scss}\" | xargs prettier --write",

--- a/assets/package.json
+++ b/assets/package.json
@@ -4,7 +4,9 @@
   "scripts": {
     "deploy": "webpack --mode production",
     "test": "jest",
-    "watch": "webpack --mode development --watch",
+    "watch": "concurrently --kill-others --prefix-colors auto npm:watch-*",
+    "watch-build": "webpack --mode development --stats minimal --watch",
+    "watch-tsc": "tsc --noEmit --preserveWatchOutput --watch",
     "lint": "tslint --fix -p .",
     "lint:check": "tslint -p .",
     "format": "prettier --list-different \"{.,**}/*.{js,json,ts,tsx,css,scss}\" | xargs prettier --write",
@@ -46,6 +48,7 @@
     "@types/react-dom": "^17.0.9",
     "@types/react-router-dom": "^5.1.8",
     "babel-loader": "^8.2.2",
+    "concurrently": "^8.2.2",
     "copy-webpack-plugin": "^6.4.1",
     "css-loader": "^5.2.7",
     "file-loader": "^6.2.0",

--- a/assets/src/components/admin/admin_add_modal.tsx
+++ b/assets/src/components/admin/admin_add_modal.tsx
@@ -106,6 +106,7 @@ const AddModal = ({ setData, closeModal }): JSX.Element => {
   const addScreen = () => {
     const newRow = {
       app_id: formValues.app_id,
+      // @ts-expect-error
       app_params: defaultAppParamsByAppId[formValues.app_id],
       device_id: formValues.device_id,
       disabled: false,
@@ -126,7 +127,7 @@ const AddModal = ({ setData, closeModal }): JSX.Element => {
         {fields.map(({ key, label, FormCell }) => (
           <div key={key}>
             <div>{label}</div>
-            <FormCell header={key} setFormValues={setFormValues} />
+            <FormCell value="" header={key} setFormValues={setFormValues} />
           </div>
         ))}
         <div>

--- a/assets/src/components/admin/admin_cells.tsx
+++ b/assets/src/components/admin/admin_cells.tsx
@@ -59,7 +59,7 @@ const EditableNumberInput = ({
     if (!isNaN(value)) {
       doUpdate(index, mutator || id, value);
     } else {
-      alert(`Integer value expected in ${id} for Screen ID ${rowValues.id}`);
+      alert(`Integer value expected in ${id}`);
     }
   };
 
@@ -119,6 +119,7 @@ const EditableSelect = ({
       disabled={!editable}
     >
       {options.map((opt) => (
+        // @ts-expect-error
         <option value={opt} key={opt}>
           {opt}
         </option>
@@ -154,10 +155,10 @@ const EditableTextarea = ({
 };
 
 const IndeterminateCheckbox = ({ indeterminate, ...rest }) => {
-  const ref = useRef();
+  const ref = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
-    ref.current.indeterminate = indeterminate;
+    if (ref.current) ref.current.indeterminate = indeterminate;
   }, [ref, indeterminate]);
 
   return (

--- a/assets/src/components/admin/admin_edit_modal.tsx
+++ b/assets/src/components/admin/admin_edit_modal.tsx
@@ -4,7 +4,6 @@ import _ from "lodash";
 const EditModal = ({
   columns,
   data,
-  setData,
   selectedRowIds,
   setShowEditModal,
   setTableVersion,
@@ -18,7 +17,7 @@ const EditModal = ({
   const [formValues, setFormValues] = useState(initialFormValues);
 
   const applyChanges = () => {
-    columns.forEach(({ Header, FormCell, id, accessor, mutator }) => {
+    columns.forEach(({ Header, accessor, mutator }) => {
       const value = formValues[Header];
       if (value !== undefined) {
         const columnIdOrMutator =
@@ -38,7 +37,7 @@ const EditModal = ({
   return (
     <div className="admin-modal__background">
       <div className="admin-modal__content">
-        {columns.map(({ Header, FormCell, accessor }, i) => {
+        {columns.map(({ Header, FormCell, accessor }) => {
           if (FormCell) {
             const selectedRowValues = selectedRows.map((row) => {
               if (typeof accessor === "function") {

--- a/assets/src/components/admin/admin_filters.tsx
+++ b/assets/src/components/admin/admin_filters.tsx
@@ -36,6 +36,7 @@ const SelectColumnFilter = ({
     >
       <option value="">All</option>
       {options.map((option, i) => (
+        // @ts-expect-error
         <option key={i} value={option}>
           {option}
         </option>

--- a/assets/src/components/admin/admin_form.tsx
+++ b/assets/src/components/admin/admin_form.tsx
@@ -70,11 +70,13 @@ const AdminConfirmControls = ({ confirmPath, setEditable, configRef }): JSX.Elem
 
 const AdminForm = ({ fetchConfig, validatePath, confirmPath }): JSX.Element => {
   const [editable, setEditable] = useState(true);
-  const configRef = useRef(null);
+  const configRef = useRef<HTMLTextAreaElement>(null);
 
   const setEditorContents = async () => {
-    const config = await fetchConfig();
-    configRef.current.value = JSON.stringify(config, null, 2);
+    if (configRef.current) {
+      const config = await fetchConfig();
+      configRef.current.value = JSON.stringify(config, null, 2);
+    }
   };
 
   useEffect(() => {

--- a/assets/src/components/admin/admin_form_cells.tsx
+++ b/assets/src/components/admin/admin_form_cells.tsx
@@ -16,7 +16,7 @@ const FormTextCell = ({ value, header, setFormValues }) => {
   return <input defaultValue={value} onBlur={onBlur} />;
 };
 
-const buildFormSelect = (options, isNumber) => {
+const buildFormSelect = (options, isNumber?) => {
   const FormSelect = ({ value, header, setFormValues }) => {
     const onChange = (e) => {
       let newValue = e.target.value;
@@ -66,9 +66,9 @@ const FormBoolean = ({ value, header, setFormValues }) => {
 
   return (
     <select onChange={onChange} defaultValue={value}>
-      <option value={undefined}></option>
-      <option value={true}>True</option>
-      <option value={false}>False</option>
+      <option></option>
+      <option value="true">True</option>
+      <option value="false">False</option>
     </select>
   );
 };

--- a/assets/src/components/admin/admin_image_manager.tsx
+++ b/assets/src/components/admin/admin_image_manager.tsx
@@ -77,10 +77,11 @@ const ImageManagerContainer = ({}): JSX.Element => {
 
 const ImageUpload = ({}): JSX.Element => {
   const [stagedImageUpload, setStagedImageUpload] =
-    useState<FileWithPreview>(null);
+    useState<FileWithPreview | null>(null);
   const [isUploading, setIsUploading] = useState(false);
 
   const handleClickUpload = async () => {
+    if (!stagedImageUpload) return;
     setIsUploading(true);
 
     const formData = new FormData();

--- a/assets/src/components/admin/admin_table.tsx
+++ b/assets/src/components/admin/admin_table.tsx
@@ -243,7 +243,6 @@ const AdminTableControls = ({
         <EditModal
           columns={columns}
           data={data}
-          setData={setData}
           selectedRowIds={selectedRowIds}
           setShowEditModal={setShowEditModal}
           setTableVersion={setTableVersion}
@@ -258,7 +257,7 @@ const AdminTableControls = ({
 };
 
 const AdminTable = ({ columns, dataFilter }): JSX.Element => {
-  const [data, setData] = useState([]);
+  const [data, setData] = useState<any[]>([]);
   const [editable, setEditable] = useState(true);
   const [tableVersion, setTableVersion] = useState(0);
 

--- a/assets/src/components/admin/admin_table.tsx
+++ b/assets/src/components/admin/admin_table.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo, useRef } from "react";
+import React, { useState, useEffect } from "react";
 import { useTable, useFilters, useRowSelect } from "react-table";
 import _ from "lodash";
 
@@ -52,10 +52,6 @@ const Table = ({
     headerGroups,
     rows,
     prepareRow,
-    state,
-    visibleColumns,
-    preGlobalFilteredRows,
-    setGlobalFilter,
     state: { selectedRowIds },
   } = useTable(
     {
@@ -103,7 +99,7 @@ const Table = ({
         </thead>
 
         <tbody {...getTableBodyProps()}>
-          {rows.map((row, i) => {
+          {rows.map((row) => {
             prepareRow(row);
             return (
               <tr {...row.getRowProps()}>

--- a/assets/src/components/admin/devops.tsx
+++ b/assets/src/components/admin/devops.tsx
@@ -23,7 +23,7 @@ const DisableModeRow = ({ mode, modeDisabled, onChange }) => {
 };
 
 const Devops = () => {
-  const [disabledModes, setDisabledModes] = useState([]);
+  const [disabledModes, setDisabledModes] = useState<any[]>([]);
   const [loaded, setLoaded] = useState(false);
 
   useEffect(() => {

--- a/assets/src/components/dup/destination.tsx
+++ b/assets/src/components/dup/destination.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState, useEffect, useLayoutEffect } from "react";
+import React, { useRef, useState, useLayoutEffect } from "react";
 import _ from "lodash";
 
 const LINE_HEIGHT = 138; // px

--- a/assets/src/components/dup/destination.tsx
+++ b/assets/src/components/dup/destination.tsx
@@ -44,8 +44,8 @@ const RenderedDestination = ({ parts, index1, index2, currentPageIndex }) => {
 };
 
 const Destination = ({ destination, currentPage }) => {
-  const firstLineRef = useRef(null);
-  const secondLineRef = useRef(null);
+  const firstLineRef = useRef<HTMLDivElement>(null);
+  const secondLineRef = useRef<HTMLDivElement>(null);
 
   let parts = destination.split(" ");
 

--- a/assets/src/components/dup/dup_screen_page.tsx
+++ b/assets/src/components/dup/dup_screen_page.tsx
@@ -8,11 +8,12 @@ import { useStationName } from "Hooks/outfront";
 import { fetchDatasetValue } from "Util/dataset";
 import { DUP_SIMULATION_REFRESH_MS } from "Constants";
 
-const DupScreenPage = ({
-  screenContainer: ScreenContainer,
-}: {
-  screenContainer: React.ComponentType;
-}): JSX.Element => {
+type QueryParams = {
+  id?: string
+  rotationIndex?: string
+}
+
+const DupScreenPage = ({ screenContainer: ScreenContainer }): JSX.Element => {
   const station = useStationName();
 
   if (station !== null) {
@@ -25,30 +26,20 @@ const DupScreenPage = ({
 
 const DevelopmentScreenPage = ({
   screenContainer: ScreenContainer,
-}: {
-  screenContainer: React.ComponentType;
 }): JSX.Element => {
-  const { id, rotationIndex } = useParams();
+  const { id, rotationIndex } = useParams<QueryParams>();
   return <ScreenContainer id={id} rotationIndex={rotationIndex} />;
 };
 
-const ScreenPage = ({
-  screenContainer,
-}: {
-  screenContainer: React.ComponentType;
-}): JSX.Element =>
+const ScreenPage = ({ screenContainer }): JSX.Element =>
   isDup() ? (
     <DupScreenPage screenContainer={screenContainer} />
   ) : (
     <DevelopmentScreenPage screenContainer={screenContainer} />
   );
 
-const RotationPage = ({
-  screenContainer: ScreenContainer,
-}: {
-  screenContainer: React.ComponentType;
-}): JSX.Element => {
-  const { id } = useParams();
+const RotationPage = ({ screenContainer: ScreenContainer }): JSX.Element => {
+  const { id } = useParams<QueryParams>();
   return (
     <div className="rotation-page">
       <ScreenContainer id={id} rotationIndex={0} />
@@ -58,12 +49,8 @@ const RotationPage = ({
   );
 };
 
-const SimulationPage = ({
-  screenContainer: ScreenContainer,
-}: {
-  screenContainer: React.ComponentType;
-}): JSX.Element => {
-  const { id } = useParams();
+const SimulationPage = ({ screenContainer: ScreenContainer }): JSX.Element => {
+  const { id } = useParams<QueryParams>();
   return (
     <div className="simulation-screen-centering-container">
       <div className="simulation-screen-scrolling-container">
@@ -91,8 +78,6 @@ const SimulationPage = ({
 
 const MultiRotationPage = ({
   screenContainer: ScreenContainer,
-}: {
-  screenContainer: React.ComponentType;
 }): JSX.Element => {
   const screenIds = JSON.parse(fetchDatasetValue("screenIds")) as string[];
 

--- a/assets/src/components/dup/free_text.tsx
+++ b/assets/src/components/dup/free_text.tsx
@@ -39,6 +39,8 @@ const getKey = (elt) => {
     return `special--${elt.special}`;
   } else if (elt.icon !== undefined) {
     return `icon--${elt.icon}`;
+  } else {
+    throw new Error("empty free text element");
   }
 };
 

--- a/assets/src/components/dup/header.tsx
+++ b/assets/src/components/dup/header.tsx
@@ -28,13 +28,21 @@ const Pattern = ({ pattern }: { pattern: string }): JSX.Element => {
   );
 };
 
+type Props = {
+  text: string | null
+  currentTimeString?: string
+  pattern?: string
+  color?: string
+  code?: string
+}
+
 const Header = ({
   text,
   currentTimeString,
   pattern,
   color,
   code,
-}): JSX.Element => {
+} : Props): JSX.Element => {
   const environmentName = getDatasetValue("environmentName");
 
   const className = color
@@ -46,7 +54,7 @@ const Header = ({
   return (
     <div className={className}>
       <div className="header__environment">
-        {["screens-dev", "screens-dev-green"].includes(environmentName)
+        {["screens-dev", "screens-dev-green"].includes(environmentName!)
           ? environmentName
           : ""}
       </div>

--- a/assets/src/components/dup/screen_container.tsx
+++ b/assets/src/components/dup/screen_container.tsx
@@ -67,7 +67,7 @@ const REPLACEMENTS = {
 
 const NoDataLayout = ({ code }: { code?: string }): JSX.Element => {
   let stationName = useStationName();
-  stationName = REPLACEMENTS[stationName] || stationName;
+  stationName = REPLACEMENTS[stationName!] || stationName;
 
   return (
     <div className={classWithModifier("screen-container", "no-data")}>
@@ -95,7 +95,7 @@ const NoDataLayout = ({ code }: { code?: string }): JSX.Element => {
 
 const LoadingLayout = (): JSX.Element => {
   let stationName = useStationName();
-  stationName = REPLACEMENTS[stationName] || stationName;
+  stationName = REPLACEMENTS[stationName!] || stationName;
 
   return (
     <div className={classWithModifier("screen-container", "loading")}>

--- a/assets/src/components/dup/section.tsx
+++ b/assets/src/components/dup/section.tsx
@@ -49,7 +49,7 @@ const Section = ({
   );
 };
 
-const HeadwaySection = ({ headway, pill }): JSX.Element => {
+const HeadwaySection = ({ headway }): JSX.Element => {
   return (
     <div className="section section--headway">
       <div className="partial-alert partial-alert--dark">

--- a/assets/src/components/dup/section_list.tsx
+++ b/assets/src/components/dup/section_list.tsx
@@ -51,7 +51,7 @@ const LinkArrow = ({ width }) => {
   );
 };
 
-const HeadwaySectionList = ({ section: { pill, headway } }): JSX.Element => {
+const HeadwaySectionList = ({ section: { headway } }): JSX.Element => {
   return (
     <div className={classWithModifier("section-list", "headway")}>
       <div

--- a/assets/src/components/dup/section_list.tsx
+++ b/assets/src/components/dup/section_list.tsx
@@ -87,7 +87,7 @@ const SectionList = ({
     <div className="section-list">
       {sections.map(({ departures, pill, headway }) => {
         if (headway) {
-          return <HeadwaySection headway={headway} pill={pill} key={pill} />;
+          return <HeadwaySection headway={headway} key={pill} />;
         } else {
           return (
             <Section

--- a/assets/src/components/dup/time.tsx
+++ b/assets/src/components/dup/time.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React from "react";
 
 import {
   standardTimeRepresentation,

--- a/assets/src/components/eink/base_departure_destination.tsx
+++ b/assets/src/components/eink/base_departure_destination.tsx
@@ -5,15 +5,15 @@ const splitDestination = (destination) => {
   const parenPattern = /(.+) (\(.+)/;
 
   if (viaPattern.test(destination)) {
-    return viaPattern.exec(destination).slice(1);
+    return viaPattern.exec(destination)!.slice(1);
   } else if (parenPattern.test(destination)) {
-    return parenPattern.exec(destination).slice(1);
+    return parenPattern.exec(destination)!.slice(1);
   } else {
     return [destination];
   }
 };
 
-const BaseDepartureDestination = ({ destination }): JSX.Element => {
+const BaseDepartureDestination = ({ destination }): JSX.Element | null => {
   if (!destination) {
     return null;
   }

--- a/assets/src/components/eink/base_departure_time.tsx
+++ b/assets/src/components/eink/base_departure_time.tsx
@@ -10,16 +10,18 @@ interface BaseDepartureTimeProps {
 const BaseDepartureTime = ({
   time,
   hideAmPm,
-}: BaseDepartureTimeProps): JSX.Element => {
+}: BaseDepartureTimeProps): JSX.Element | null => {
   if (time.type.toUpperCase() === "TEXT") {
     return (
       <div className="base-departure-time">
+        { /* @ts-expect-error */ }
         <span className="base-departure-time__text">{time.text}</span>
       </div>
     );
   } else if (time.type.toUpperCase() === "MINUTES") {
     return (
       <div className="base-departure-time">
+        { /* @ts-expect-error */ }
         <span className="base-departure-time__minutes">{time.minutes}</span>
         <span className="base-departure-time__minutes-label">m</span>
       </div>
@@ -27,8 +29,10 @@ const BaseDepartureTime = ({
   } else if (time.type.toUpperCase() === "TIMESTAMP") {
     return (
       <div className="base-departure-time">
+        { /* @ts-expect-error */ }
         <span className="base-departure-time__timestamp">{time.timestamp}</span>
         {!hideAmPm && (
+          /* @ts-expect-error */
           <span className="base-departure-time__ampm">{time.ampm}</span>
         )}
       </div>

--- a/assets/src/components/eink/bus/departure_group.tsx
+++ b/assets/src/components/eink/bus/departure_group.tsx
@@ -4,6 +4,12 @@ import DepartureRow from "Components/eink/bus/departure_row";
 import InlineAlert from "Components/eink/bus/inline_alert";
 import { classWithModifier } from "Util/util";
 
+type Props = {
+  currentTimeString: string
+  departures: object[]
+  size: string
+}
+
 const DepartureGroup = ({
   currentTimeString,
   departures,
@@ -37,4 +43,5 @@ const DepartureGroup = ({
   );
 };
 
+export { Props };
 export default DepartureGroup;

--- a/assets/src/components/eink/bus/departures.tsx
+++ b/assets/src/components/eink/bus/departures.tsx
@@ -39,7 +39,7 @@ const Departures = forwardRef(
     const departureGroups = buildDepartureGroups(departures);
     return (
       <div className="departures" ref={ref}>
-        {departureGroups.map((group, i) => (
+        {departureGroups.map((group) => (
           <DepartureGroup
             currentTimeString={currentTimeString}
             departures={group}

--- a/assets/src/components/eink/bus/departures.tsx
+++ b/assets/src/components/eink/bus/departures.tsx
@@ -1,4 +1,6 @@
-import DepartureGroup from "Components/eink/bus/departure_group";
+import DepartureGroup, {
+  Props as DepartureGroupProps
+} from "Components/eink/bus/departure_group";
 import React, { forwardRef } from "react";
 
 const buildDepartureGroups = (departures) => {
@@ -6,7 +8,7 @@ const buildDepartureGroups = (departures) => {
     return [];
   }
 
-  const groups = [];
+  const groups : any[] = [];
 
   departures.forEach((departure) => {
     if (groups.length === 0) {
@@ -31,8 +33,8 @@ const buildDepartureGroups = (departures) => {
   return groups;
 };
 
-const Departures = forwardRef(
-  ({ currentTimeString, departures, size }, ref): JSX.Element => {
+const Departures = forwardRef<HTMLDivElement, DepartureGroupProps>(
+  ({ currentTimeString, departures, size }, ref): JSX.Element | null => {
     if (!departures || departures.length === 0) {
       return null;
     }

--- a/assets/src/components/eink/bus/flex_zone_container.tsx
+++ b/assets/src/components/eink/bus/flex_zone_container.tsx
@@ -1,12 +1,21 @@
 import React, { forwardRef } from "react";
 
 import Departures from "Components/eink/bus/departures";
+import {
+  Props as DepartureGroupProps
+} from "Components/eink/bus/departure_group";
 import NearbyConnections from "Components/eink/bus/nearby_connections";
 import ServiceMap from "Components/eink/bus/service_map";
 import GlobalAlert from "Components/eink/global_alert";
 import TakeoverAlert from "Components/eink/takeover_alert";
 
-const FlexZoneContainer = forwardRef(
+type Props = Omit<DepartureGroupProps, "size"> & {
+  globalAlert: object
+  nearbyConnections: object[]
+  psaUrl: string
+}
+
+const FlexZoneContainer = forwardRef<HTMLDivElement, Props>(
   (
     { currentTimeString, departures, globalAlert, nearbyConnections, psaUrl },
     ref
@@ -70,4 +79,5 @@ const FlexZoneContainer = forwardRef(
   }
 );
 
+export { Props };
 export default FlexZoneContainer;

--- a/assets/src/components/eink/bus/header.tsx
+++ b/assets/src/components/eink/bus/header.tsx
@@ -7,13 +7,12 @@ const Header = ({ stopName, currentTimeString }): JSX.Element => {
   const SIZES = ["small", "large"];
   const MAX_HEIGHT = 216;
 
-  const ref = useRef(null);
+  const ref = useRef<HTMLDivElement>(null);
   const [stopSize, setStopSize] = useState(1);
   const currentTime = formatTimeString(currentTimeString);
 
   useLayoutEffect(() => {
-    const height = ref.current.clientHeight;
-    if (height > MAX_HEIGHT) {
+    if (ref.current && ref.current.clientHeight > MAX_HEIGHT) {
       setStopSize(stopSize - 1);
     }
   });
@@ -23,7 +22,7 @@ const Header = ({ stopName, currentTimeString }): JSX.Element => {
   return (
     <div className="header">
       <div className="header__environment">
-        {["screens-dev", "screens-dev-green"].includes(environmentName)
+        {["screens-dev", "screens-dev-green"].includes(environmentName!)
           ? environmentName
           : ""}
       </div>

--- a/assets/src/components/eink/bus/nearby_connections.tsx
+++ b/assets/src/components/eink/bus/nearby_connections.tsx
@@ -61,7 +61,7 @@ const NearbyConnectionsRow = ({ name, distance, routes }): JSX.Element => {
   );
 };
 
-const NearbyConnections = ({ nearbyConnections }): JSX.Element => {
+const NearbyConnections = ({ nearbyConnections }): JSX.Element | null => {
   if (!nearbyConnections || nearbyConnections.length === 0) {
     return null;
   }

--- a/assets/src/components/eink/bus/screen_container.tsx
+++ b/assets/src/components/eink/bus/screen_container.tsx
@@ -1,8 +1,13 @@
 import React, { forwardRef, useRef } from "react";
 
 import Departures from "Components/eink/bus/departures";
+import {
+  Props as DepartureGroupProps
+} from "Components/eink/bus/departure_group";
 import FareInfo from "Components/eink/bus/fare_info";
-import FlexZoneContainer from "Components/eink/bus/flex_zone_container";
+import FlexZoneContainer, {
+  Props as FlexZoneContainerProps
+} from "Components/eink/bus/flex_zone_container";
 import Header from "Components/eink/bus/header";
 import DigitalBridge from "Components/eink/digital_bridge";
 import NoService from "Components/eink/no_service";
@@ -17,7 +22,10 @@ import NoConnectionBottom from "Components/eink/no_connection_bottom";
 import NoConnectionTop from "Components/eink/no_connection_top";
 import LoadingTop from "Components/eink/loading_top";
 
-const TopScreenLayout = forwardRef(
+type TopScreenLayoutProps =
+  Omit<DepartureGroupProps, "size"> & { stopName: string }
+
+const TopScreenLayout = forwardRef<HTMLDivElement, TopScreenLayoutProps>(
   ({ currentTimeString, stopName, departures }, ref): JSX.Element => {
     return (
       <div className="single-screen-container">
@@ -33,7 +41,9 @@ const TopScreenLayout = forwardRef(
   }
 );
 
-const BottomScreenLayout = forwardRef(
+type BottomScreenLayoutProps = FlexZoneContainerProps & { stopId: string }
+
+const BottomScreenLayout = forwardRef<HTMLDivElement, BottomScreenLayoutProps>(
   (
     {
       currentTimeString,

--- a/assets/src/components/eink/green_line/departures.tsx
+++ b/assets/src/components/eink/green_line/departures.tsx
@@ -66,7 +66,7 @@ const DepartureList = ({
   currentTimeString,
   destination,
   headway,
-}: DepartureListProps): JSX.Element[] => {
+}: DepartureListProps): JSX.Element => {
   const renderedDepartures = departures.map(({ id, time }) => (
     <Departure time={time} currentTimeString={currentTimeString} key={id} />
   ));
@@ -82,15 +82,19 @@ const DepartureList = ({
     );
   }
 
-  return [
-    ...renderedDepartures.slice(0, 1),
-    <div className="departures__hairline" key="departure-list-hairline" />,
-    ...renderedDepartures.slice(1, 2),
-  ];
+  return (
+    <>
+      {[
+        ...renderedDepartures.slice(0, 1),
+        <div className="departures__hairline" key="departure-list-hairline" />,
+        ...renderedDepartures.slice(1, 2)
+      ]}
+    </>
+  );
 };
 
 interface DepartureListProps {
-  departures: { time: string }[];
+  departures: { id: string, time: string }[];
   currentTimeString: string;
   destination: string;
   headway: number;

--- a/assets/src/components/eink/green_line/double/screen_container.tsx
+++ b/assets/src/components/eink/green_line/double/screen_container.tsx
@@ -23,7 +23,6 @@ const TopScreenLayout = ({
   currentTimeString,
   stopName,
   departures,
-  stopId,
   routeId,
   headway,
   lineMapData,

--- a/assets/src/components/eink/green_line/double/screen_container.tsx
+++ b/assets/src/components/eink/green_line/double/screen_container.tsx
@@ -42,6 +42,7 @@ const TopScreenLayout = ({
         currentTimeString={currentTimeString}
         showVehicles={!isHeadwayMode}
       />
+      { /* @ts-expect-error */ }
       <Departures
         departures={departures}
         headway={headway}
@@ -93,7 +94,6 @@ const DefaultScreenLayout = ({ apiResponse }): JSX.Element => {
         currentTimeString={apiResponse.current_time}
         stopName={apiResponse.stop_name}
         departures={apiResponse.departures}
-        stopId={apiResponse.stop_id}
         routeId={apiResponse.route_id}
         lineMapData={apiResponse.line_map}
         headway={apiResponse.headway}

--- a/assets/src/components/eink/green_line/header.tsx
+++ b/assets/src/components/eink/green_line/header.tsx
@@ -56,13 +56,12 @@ const Header = ({ stopName, routeId, currentTimeString }): JSX.Element => {
   const SIZES = ["small", "large"];
   const MAX_HEIGHT = 216;
 
-  const ref = useRef(null);
+  const ref = useRef<HTMLDivElement>(null);
   const [stopSize, setStopSize] = useState(1);
   const currentTime = formatTimeString(currentTimeString);
 
   useLayoutEffect(() => {
-    const height = ref.current.clientHeight;
-    if (height > MAX_HEIGHT) {
+    if (ref.current && ref.current.clientHeight > MAX_HEIGHT) {
       setStopSize(stopSize - 1);
     }
   });
@@ -74,7 +73,7 @@ const Header = ({ stopName, routeId, currentTimeString }): JSX.Element => {
   return (
     <div className="header">
       <div className="header__environment">
-        {["screens-dev", "screens-dev-green"].includes(environmentName)
+        {["screens-dev", "screens-dev-green"].includes(environmentName!)
           ? environmentName
           : ""}
       </div>

--- a/assets/src/components/eink/green_line/inline_alert.tsx
+++ b/assets/src/components/eink/green_line/inline_alert.tsx
@@ -26,7 +26,7 @@ const parseSeverity = (severity) => {
   };
 };
 
-const InlineAlert = ({ alertData }): JSX.Element => {
+const InlineAlert = ({ alertData }): JSX.Element | null => {
   if (alertData === undefined || alertData === null) {
     return null;
   }

--- a/assets/src/components/eink/green_line/line_map.tsx
+++ b/assets/src/components/eink/green_line/line_map.tsx
@@ -407,10 +407,6 @@ const LineMapStops = (): JSX.Element => {
     showOriginStop,
     lastVisibleStopIndex,
     stopNames,
-    radius,
-    dy,
-    height,
-    stopMarginTop,
   } = useContext(LineMapContext);
   return (
     <g>
@@ -435,7 +431,6 @@ const LineMapBase = (): JSX.Element => {
 const LineMapContainer = ({
   data,
   height,
-  width,
   currentTimeString,
   showVehicles,
 }: {

--- a/assets/src/components/eink/green_line/line_map.tsx
+++ b/assets/src/components/eink/green_line/line_map.tsx
@@ -33,7 +33,7 @@ interface LineMapData {
   vehicles: LineMapVehicle[];
 }
 
-const LineMapContext = createContext();
+const LineMapContext = createContext<any>({});
 
 const ScheduledDepartureIcon = ({ x, y, iconRadius }): JSX.Element => {
   return (
@@ -137,6 +137,8 @@ const LineMapStopLabel = ({ x, y, lines, current, origin }): JSX.Element => {
         </tspan>
       </text>
     );
+  } else {
+    throw new Error(`unexpected value for lines: ${lines}`);
   }
 };
 
@@ -206,7 +208,7 @@ const LineMapVehicleLabel = ({
   y,
   time,
   currentTimeString,
-}): JSX.Element => {
+}): JSX.Element | null => {
   const timeRep = einkTimeRepresentation(time, currentTimeString);
   if (timeRep.type === "TEXT") {
     return (
@@ -256,7 +258,7 @@ const LineMapVehicleIcon = ({ x, y, size }): JSX.Element => {
   );
 };
 
-const LineMapVehicle = ({ vehicle, currentTimeString }): JSX.Element => {
+const LineMapVehicle = ({ vehicle, currentTimeString }): JSX.Element | null => {
   const { lineWidth, radius, dy, height, stopMarginTop } =
     useContext(LineMapContext);
 

--- a/assets/src/components/eink/green_line/nearby_departures.tsx
+++ b/assets/src/components/eink/green_line/nearby_departures.tsx
@@ -50,7 +50,7 @@ const NearbyDeparturesRow = ({
         <NearbyDeparturesDestination destination={destination} />
         <NearbyDeparturesTime
           time={time}
-          currentTimeStirng={currentTimeString}
+          currentTimeString={currentTimeString}
         />
       </div>
       <div className="nearby-departures__hairline"></div>
@@ -58,7 +58,7 @@ const NearbyDeparturesRow = ({
   );
 };
 
-const NearbyDepartures = ({ data, currentTimeString }): JSX.Element => {
+const NearbyDepartures = ({ data, currentTimeString }): JSX.Element | null => {
   if (!data || data.length === 0 || data.includes(null)) {
     return null;
   }

--- a/assets/src/components/eink/overnight_departures.tsx
+++ b/assets/src/components/eink/overnight_departures.tsx
@@ -1,4 +1,4 @@
-import moment from "moment";
+import "moment";
 import "moment-timezone";
 import React from "react";
 

--- a/assets/src/components/eink/screen_page.tsx
+++ b/assets/src/components/eink/screen_page.tsx
@@ -3,11 +3,7 @@ import React, { useState } from "react";
 import { useParams } from "react-router-dom";
 import { fetchDatasetValue } from "Util/dataset";
 
-const MultiScreenPage = ({
-  screenContainer: ScreenContainer,
-}: {
-  screenContainer: React.ComponentType;
-}): JSX.Element => {
+const MultiScreenPage = ({ screenContainer: ScreenContainer }): JSX.Element => {
   const screenIds = JSON.parse(fetchDatasetValue("screenIds"));
 
   return (
@@ -19,20 +15,14 @@ const MultiScreenPage = ({
   );
 };
 
-const ScreenPage = ({
-  screenContainer: ScreenContainer,
-}: {
-  screenContainer: React.ComponentType;
-}): JSX.Element => {
-  const { id } = useParams();
+type QueryParams = { id?: string }
+
+const ScreenPage = ({ screenContainer: ScreenContainer }): JSX.Element => {
+  const { id } = useParams<QueryParams>();
   return <ScreenContainer id={id} />;
 };
 
-const AuditScreenPage = ({
-  screenLayout: ScreenLayout,
-}: {
-  screenLayout: React.ComponentType;
-}): JSX.Element => {
+const AuditScreenPage = ({ screenLayout: ScreenLayout }): JSX.Element => {
   const [data, setData] = useState("");
 
   const handleChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {

--- a/assets/src/components/solari/departure.tsx
+++ b/assets/src/components/solari/departure.tsx
@@ -43,7 +43,7 @@ const OverheadDepartureTimeAndCrowding = ({
   currentTimeString,
 }) => {
   const [showCrowding, setShowCrowding] = useState(false);
-  const ref = useRef(null);
+  const ref = useRef<HTMLDivElement>(null);
 
   // When we load new data, show the time, which is styled to animate in from the right.
   useEffect(() => {
@@ -64,6 +64,8 @@ const OverheadDepartureTimeAndCrowding = ({
           ref.current.removeEventListener("animationend", onAnimationEnd);
         }
       };
+    } else {
+      return () => {};
     }
   });
 
@@ -128,7 +130,7 @@ const Departure = ({
   const timeAnimationModifier =
     timeRepresentation.type === "TEXT" ? "animated" : "static";
 
-  const containerModifiers = [];
+  const containerModifiers: string[] = [];
   if (groupStart) {
     containerModifiers.push("group-start");
   }

--- a/assets/src/components/solari/departure.tsx
+++ b/assets/src/components/solari/departure.tsx
@@ -53,7 +53,7 @@ const OverheadDepartureTimeAndCrowding = ({
   // Timing is controlled by the timings on the animation. The animation on the time element
   // ends after 10s, then the animationend event toggles crowding on.
   useEffect(() => {
-    const onAnimationEnd = (e) => {
+    const onAnimationEnd = () => {
       setShowCrowding(true);
     };
 

--- a/assets/src/components/solari/header.tsx
+++ b/assets/src/components/solari/header.tsx
@@ -17,7 +17,7 @@ const Header = ({
   return (
     <div className="header">
       <div className="header__environment">
-        {["screens-dev", "screens-dev-green"].includes(environmentName)
+        {["screens-dev", "screens-dev-green"].includes(environmentName!)
           ? environmentName
           : ""}
       </div>

--- a/assets/src/components/solari/route_pill.tsx
+++ b/assets/src/components/solari/route_pill.tsx
@@ -69,19 +69,21 @@ const routeToPill = (
 };
 
 const Pill = ({ routeName, routePillColor }: PillType): JSX.Element => {
+  let routeImg: JSX.Element | undefined;
+
   if (routeName === "CR") {
-    routeName = (
+    routeImg = (
       <img
         className="departure-route--icon"
         src={imagePath("commuter-rail.svg")}
       ></img>
     );
   } else if (routeName === "Boat") {
-    routeName = (
+    routeImg = (
       <img className="departure-route--icon" src={imagePath("ferry.svg")}></img>
     );
   } else if (routeName === "BUS") {
-    routeName = (
+    routeImg = (
       <img
         className="departure-route--icon"
         src={imagePath("bus-black.svg")}
@@ -91,7 +93,7 @@ const Pill = ({ routeName, routePillColor }: PillType): JSX.Element => {
 
   return (
     <div className={classWithModifier("departure-route", routePillColor)}>
-      {routeName && <BaseRoutePill route={routeName} />}
+      {routeImg && <BaseRoutePill route={routeImg} />}
     </div>
   );
 };

--- a/assets/src/components/solari/screen_container.tsx
+++ b/assets/src/components/solari/screen_container.tsx
@@ -79,7 +79,7 @@ const ScreenLayout = ({ apiResponse }): JSX.Element => {
 
 const ScreenContainer = ({ id }): JSX.Element => {
   const query = new URLSearchParams(useLocation().search);
-  const datetime = query.get("datetime");
+  const datetime = query.get("datetime") || undefined;
 
   const apiResponse = useApiResponse({
     id,

--- a/assets/src/components/solari/section.tsx
+++ b/assets/src/components/solari/section.tsx
@@ -211,8 +211,9 @@ class PagedDeparture extends React.Component<
     const { pageCount, departures } = this.props;
     return (
       pageCount === otherProps.pageCount &&
-      departures.length === otherProps.departures.length &&
-      departures.every((d, i) => d.id === otherProps.departures[i].id)
+        departures.length === otherProps.departures.length &&
+        // @ts-expect-error
+        departures.every((d, i) => d.id === otherProps.departures[i].id)
     );
   }
 
@@ -280,11 +281,13 @@ class PagedDeparture extends React.Component<
       this.props.pageCount - (this.state.currentPageNumber + 1);
     const numWidePillsToTheRight = this.props.departures
       .slice(this.state.currentPageNumber + 1)
+      // @ts-expect-error
       .filter(({ route }) => WIDE_MINI_PILL_ROUTES.includes(route)).length;
     const numNormalPillsToTheRight =
       selectedRightOffset - numWidePillsToTheRight;
 
     const currentPillIsWide = WIDE_MINI_PILL_ROUTES.includes(
+      // @ts-expect-error
       currentPagedDeparture.route
     );
     const pillCenterOffset = currentPillIsWide ? 64.5 : 30; // px
@@ -312,6 +315,7 @@ class PagedDeparture extends React.Component<
             {this.props.departures.map((departure, i) => {
               const rightOffset = this.props.pageCount - (i + 1);
               return (
+                // @ts-expect-error
                 <React.Fragment key={departure.id}>
                   {rightOffset === 0 && (
                     <div
@@ -322,7 +326,9 @@ class PagedDeparture extends React.Component<
                     ></div>
                   )}
                   <PagedDepartureRoutePill
+                    // @ts-expect-error
                     route={departure.route}
+                    // @ts-expect-error
                     routeId={departure.route_id}
                     selected={i === this.state.currentPageNumber}
                   />
@@ -340,7 +346,9 @@ class PagedDeparture extends React.Component<
           </div>
         </div>
         <Departure
+          // @ts-expect-error
           {...camelizeDepartureObject(currentPagedDeparture)}
+          // @ts-expect-error
           currentTimeString={this.props.currentTimeString}
           overhead={this.props.overhead}
           groupStart={true}
@@ -352,7 +360,7 @@ class PagedDeparture extends React.Component<
 }
 
 interface DepartureListProps {
-  departure: object;
+  departures: any[];
   currentTimeString: string;
   isAnimated: boolean;
   overhead: boolean;
@@ -499,6 +507,7 @@ const PagedSection = ({
   overhead,
   isAnimated,
   currentTimeString,
+  // @ts-expect-error
   disabled,
 }: PagedSectionProps): JSX.Element => {
   const pageCount = getPageCount(departures, numRows);
@@ -521,6 +530,7 @@ const PagedSection = ({
         {disabled ? (
           <NoDataMessage pill={pill} />
         ) : (
+          // @ts-expect-error
           <NoDeparturesMessage pill={pill} />
         )}
       </SectionFrame>

--- a/assets/src/components/solari/section.tsx
+++ b/assets/src/components/solari/section.tsx
@@ -199,7 +199,7 @@ class PagedDeparture extends React.Component<
     this.stopPaging();
   }
 
-  componentDidUpdate(prevProps, prevState) {
+  componentDidUpdate(prevProps) {
     if (!this.propsEqual(prevProps)) {
       this.stopPaging();
       this.setState({ currentPageNumber: 0 });

--- a/assets/src/components/solari/section_list.tsx
+++ b/assets/src/components/solari/section_list.tsx
@@ -4,7 +4,7 @@ import { PagedSection, Section } from "Components/solari/section";
 import { classWithModifier } from "Util/util";
 
 interface Props {
-  sections: object[];
+  sections: any[];
   sectionSizes: number[];
   sectionHeaders: string;
   currentTimeString: string;
@@ -13,7 +13,7 @@ interface Props {
   isDummy?: boolean;
 }
 
-const SectionList = React.forwardRef(
+const SectionList = React.forwardRef<HTMLDivElement, Props>(
   (
     {
       sections,
@@ -23,7 +23,7 @@ const SectionList = React.forwardRef(
       overhead,
       stationName,
       isDummy = false,
-    }: Props,
+    },
     ref
   ): JSX.Element => {
     const className = isDummy

--- a/assets/src/components/solari/section_list_sizer.tsx
+++ b/assets/src/components/solari/section_list_sizer.tsx
@@ -35,7 +35,7 @@ const allRoundings = (
   );
 };
 
-const assignSectionSizes = (sections: object[], numRows: number): number[] => {
+const assignSectionSizes = (sections: any[], numRows: number): number[] => {
   // set the sizes for all empty sections to 1, to accomodate the "no departures" placeholder message
   const indexedAssignedEmpties = _.mapValues(
     _.pickBy({ ...sections }, (section) => section.departures.length === 0),
@@ -61,7 +61,7 @@ const assignSectionSizes = (sections: object[], numRows: number): number[] => {
 };
 
 const assignSectionSizesHelper = (
-  sections: Record<number, object>,
+  sections: Record<number, any>,
   numRows: number
 ): Record<number, number> => {
   const initialSizes = _.mapValues(sections, (section) => {
@@ -89,7 +89,7 @@ const assignSectionSizesHelper = (
     );
   });
 
-  return roundedSizes;
+  return roundedSizes!;
 };
 
 interface Props {
@@ -189,6 +189,7 @@ class SectionListSizer extends React.Component<Props, State> {
       this.props;
 
     return (
+      // @ts-expect-error
       <SectionList
         sections={sections}
         sectionSizes={this.state.sectionSizes}

--- a/assets/src/components/v2/alert.tsx
+++ b/assets/src/components/v2/alert.tsx
@@ -91,7 +91,7 @@ const BodyTextSizer: ComponentType<BodyTextSizerProps> = ({
   maxHeight,
 }) => {
   const [isSmall, setSmall] = useState(false);
-  const ref = useRef(null);
+  const ref = useRef<HTMLDivElement>(null);
 
   useLayoutEffect(() => {
     if (ref.current && !isSmall && ref.current.clientHeight > maxHeight) {

--- a/assets/src/components/v2/bus_shelter/link_footer.tsx
+++ b/assets/src/components/v2/bus_shelter/link_footer.tsx
@@ -1,6 +1,4 @@
 import React from "react";
-
-import { imagePath } from "Util/util";
 import DefaultLinkFooter from "Components/v2/link_footer";
 
 const LinkFooter = ({ text, url }) => {

--- a/assets/src/components/v2/departures/departure_alerts.tsx
+++ b/assets/src/components/v2/departures/departure_alerts.tsx
@@ -21,6 +21,7 @@ const DepartureAlerts = ({ alerts }) => {
   return (
     <div className="departure-alerts">
       {alerts.map(({ id, ...data }) => (
+        // @ts-expect-error
         <DepartureAlert {...data} key={id} />
       ))}
     </div>

--- a/assets/src/components/v2/departures/departure_alerts.tsx
+++ b/assets/src/components/v2/departures/departure_alerts.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import FreeText, { srcForIcon } from "Components/v2/free_text";
 
-const DepartureAlert = ({ color, icon, text }) => {
+const DepartureAlert = ({ icon, text }) => {
   const imgSrc = srcForIcon(icon);
 
   return (

--- a/assets/src/components/v2/departures/departure_time.tsx
+++ b/assets/src/components/v2/departures/departure_time.tsx
@@ -21,14 +21,23 @@ const TimestampDepartureTime = ({ hour, minute }) => {
   return <div className="departure-time__timestamp">{timestamp}</div>;
 };
 
-const DepartureTime = ({ type, ...data }) => {
+type Props =
+  | (TextDeparture & { type: "text" })
+  | (MinutesDeparture & { type: "minutes" })
+  | (TimestampDeparture & { type: "timestamp" });
+
+interface TextDeparture { text: string }
+interface MinutesDeparture { minutes: number }
+interface TimestampDeparture { hour: number, minute: number }
+
+const DepartureTime = ({ type, ...data }: Props) => {
   let inner;
   if (type === "text") {
-    inner = <TextDepartureTime {...data} />;
+    inner = <TextDepartureTime {...data as TextDeparture} />;
   } else if (type === "minutes") {
-    inner = <MinutesDepartureTime {...data} />;
+    inner = <MinutesDepartureTime {...data as MinutesDeparture} />;
   } else if (type === "timestamp") {
-    inner = <TimestampDepartureTime {...data} />;
+    inner = <TimestampDepartureTime {...data as TimestampDeparture} />;
   }
 
   return (

--- a/assets/src/components/v2/departures/normal_departures.tsx
+++ b/assets/src/components/v2/departures/normal_departures.tsx
@@ -33,7 +33,7 @@ const NormalDeparturesRenderer = forwardRef(
 );
 
 const trimRows = (rows, n) => {
-  const { trimmed, count } = rows.reduce(
+  const { trimmed } = rows.reduce(
     ({ count, trimmed }, row: Row) => {
       if (row.type == "notice_row") {
         if (count < n) {

--- a/assets/src/components/v2/departures/normal_departures.tsx
+++ b/assets/src/components/v2/departures/normal_departures.tsx
@@ -11,7 +11,8 @@ import NormalSection from "Components/v2/departures/normal_section";
 import NoticeSection from "Components/v2/departures/notice_section";
 import { LastFetchContext } from "../screen_container";
 
-const NormalDeparturesRenderer = forwardRef(
+// TODO: fully define the type of sections and their contents, replace `any`
+const NormalDeparturesRenderer = forwardRef<HTMLDivElement, any>(
   ({ sections, sectionSizes }, ref) => {
     return (
       <div className="departures-container">
@@ -24,6 +25,8 @@ const NormalDeparturesRenderer = forwardRef(
               );
             } else if (type === "notice_section") {
               return <NoticeSection {...data} key={i} />;
+            } else {
+              throw new Error(`section type not implemented: ${type}`);
             }
           })}
         </div>
@@ -92,12 +95,12 @@ const NormalDeparturesSizer = ({ sections, onDoneSizing }) => {
   const [tempSectionSizes, setTempSectionSizes] = useState(
     getInitialSectionSizes(sections)
   );
-  const ref = useRef();
+  const ref = useRef<HTMLDivElement>(null);
 
   useLayoutEffect(() => {
     if (
-      ref.current &&
-      ref.current.clientHeight > ref.current.parentNode.parentNode.clientHeight
+      ref.current?.parentElement?.parentElement &&
+      ref.current.clientHeight > ref.current.parentElement.parentElement.clientHeight
     ) {
       setTempSectionSizes((sectionSizes) => {
         return [sectionSizes[0] - 1];

--- a/assets/src/components/v2/departures/normal_section.tsx
+++ b/assets/src/components/v2/departures/normal_section.tsx
@@ -13,6 +13,8 @@ const NormalSection = ({ rows }) => {
             return <DepartureRow {...data} key={id} />;
           } else if (type === "notice_row") {
             return <NoticeRow row={row} key={"notice" + index} />;
+          } else {
+            throw new Error(`unimplemented row type: ${type}`);
           }
         })}
       </div>

--- a/assets/src/components/v2/departures/route_pill.tsx
+++ b/assets/src/components/v2/departures/route_pill.tsx
@@ -15,6 +15,7 @@ interface BasePill {
 interface TextPill extends BasePill {
   text: string;
   size?: string;
+  branches?: string[];
 }
 
 interface IconPill extends BasePill {
@@ -89,7 +90,7 @@ const SlashedRoutePill: ComponentType<SlashedPill> = ({ part1, part2 }) => {
 const RoutePill: ComponentType<Pill> = (pill) => {
   const modifiers: string[] = [pill.color];
 
-  let innerContent = null;
+  let innerContent: JSX.Element | null = null;
   switch (pill.type) {
     case "text":
       innerContent = <TextRoutePill {...pill} />;
@@ -101,8 +102,8 @@ const RoutePill: ComponentType<Pill> = (pill) => {
       innerContent = <SlashedRoutePill {...pill} />;
   }
 
-  let branches = null;
-  if (pill.branches) {
+  let branches: JSX.Element[] | null = null;
+  if (pill.type == "text" && pill.branches) {
     branches = pill.branches.map((branch: string) => (
       <div
         key={branch}

--- a/assets/src/components/v2/dup/departures/destination.tsx
+++ b/assets/src/components/v2/dup/departures/destination.tsx
@@ -43,8 +43,8 @@ const RenderedDestination = ({ parts, index1, index2, currentPageIndex }) => {
 };
 
 const Destination = ({ headsign, currentPage }) => {
-  const firstLineRef = useRef(null);
-  const secondLineRef = useRef(null);
+  const firstLineRef = useRef<HTMLDivElement>(null);
+  const secondLineRef = useRef<HTMLDivElement>(null);
 
   let parts = headsign.split(" ");
 

--- a/assets/src/components/v2/dup/departures/normal_departures.tsx
+++ b/assets/src/components/v2/dup/departures/normal_departures.tsx
@@ -25,6 +25,8 @@ const NormalDepartures = ({ sections }) => {
             case "overnight_section":
               return <OvernightSection text={data.text} key={i} />;
           }
+
+          throw new Error(`unimplemented section type: ${type}`);
         })}
       </div>
     </div>

--- a/assets/src/components/v2/dup/departures/normal_section.tsx
+++ b/assets/src/components/v2/dup/departures/normal_section.tsx
@@ -5,24 +5,26 @@ import NoticeRow from "Components/v2/departures/notice_row";
 import useCurrentPage from "Hooks/use_current_dup_page";
 
 const NormalSection = ({ rows }) => {
+  if (rows.length == 0) return null;
+
   const currentPage = useCurrentPage();
 
   return (
-    rows.length > 0 && (
-      <div className="departures-section">
-        {rows.map((row, index) => {
-          const { id, type, ...data } = row;
-          if (type === "departure_row") {
-            return (
-              <DepartureRow {...data} key={id} currentPage={currentPage} />
-            );
-          } else if (type === "notice_row") {
-            return <NoticeRow row={row} key={"notice" + index} />;
-          }
-        })}
-      </div>
-    )
-  );
+    <div className="departures-section">
+      {rows.map((row, index) => {
+        const { id, type, ...data } = row;
+        if (type === "departure_row") {
+          return (
+            <DepartureRow {...data} key={id} currentPage={currentPage} />
+          );
+        } else if (type === "notice_row") {
+          return <NoticeRow row={row} key={"notice" + index} />;
+        } else {
+          throw new Error(`unimplemented row type: ${type}`);
+        }
+      })}
+    </div>
+  )
 };
 
 export default NormalSection;

--- a/assets/src/components/v2/eink/link_footer.tsx
+++ b/assets/src/components/v2/eink/link_footer.tsx
@@ -1,6 +1,4 @@
 import React from "react";
-
-import { imagePath } from "Util/util";
 import DefaultLinkFooter from "Components/v2/link_footer";
 
 const LinkFooter = ({ text, url }) => {

--- a/assets/src/components/v2/free_text.tsx
+++ b/assets/src/components/v2/free_text.tsx
@@ -43,10 +43,12 @@ const getKey = (elt: string | FreeTextElementType) => {
     return `special--${elt.special}`;
   } else if (elt.icon !== undefined) {
     return `icon--${elt.icon}`;
+  } else {
+    throw new Error("empty free text element");
   }
 };
 
-const Icon = ({ icon }: { icon: string }) => {
+const Icon = ({ icon }: { icon?: string }) => {
   let iconElt;
 
   if (!icon) {
@@ -173,7 +175,7 @@ const FreeTextLine = ({
   icon,
   text,
 }: {
-  icon: string;
+  icon?: string;
   text: (string | FreeTextElementType)[];
 }) => {
   return (
@@ -189,7 +191,7 @@ const FreeTextLine = ({
 };
 
 export interface FreeTextType {
-  icon: string;
+  icon?: string;
   text: FreeTextElementType[];
 }
 

--- a/assets/src/components/v2/gl_eink_double/line_map.tsx
+++ b/assets/src/components/v2/gl_eink_double/line_map.tsx
@@ -155,7 +155,7 @@ const BaseMapStops = ({ stops }) => {
           />
         );
 
-        let stopLabel = null;
+        let stopLabel: JSX.Element | null = null;
         let labelText = abbreviateStop(label);
         if (downstream || current || terminal) {
           let modifier;
@@ -417,7 +417,7 @@ const Vehicle = ({ index, label }) => {
   );
 };
 
-const Vehicles = ({ vehicles, stops }) => {
+const Vehicles = ({ vehicles, stops }: { vehicles: Vehicle[], stops: Stop[] }) => {
   const maxIndex = stops.length;
   vehicles = vehicles.filter(({ index }) => index <= maxIndex);
 
@@ -444,11 +444,35 @@ const showScheduledDeparture = (stops) => {
   );
 };
 
+type Props = {
+  stops: Stop[];
+  vehicles: Vehicle[];
+  scheduled_departure: ScheduledDeparture;
+}
+
+type Stop = {
+  label: string;
+  downstream: boolean;
+  current: boolean;
+  terminal: boolean;
+}
+
+type Vehicle = {
+  id: string;
+  index: number;
+  label: string;
+}
+
+type ScheduledDeparture = {
+  timestamp: string;
+  station_name: string;
+}
+
 const LineMap = ({
   stops,
   vehicles,
   scheduled_departure: scheduledDeparture,
-}) => {
+}: Props) => {
   stops = truncateStops(stops);
 
   return (

--- a/assets/src/components/v2/gl_eink_double/line_map.tsx
+++ b/assets/src/components/v2/gl_eink_double/line_map.tsx
@@ -404,7 +404,7 @@ const VehicleLabel = ({ cx, cy, label }) => {
   return null;
 };
 
-const Vehicle = ({ id, index, label }) => {
+const Vehicle = ({ index, label }) => {
   const cx = LEFT_MARGIN + LINE_WIDTH / 2;
   const cy = TOP_MARGIN + index * STOP_SPACING;
 

--- a/assets/src/components/v2/normal_header.tsx
+++ b/assets/src/components/v2/normal_header.tsx
@@ -65,7 +65,7 @@ interface NormalHeaderTitleProps {
   fullName: boolean;
 }
 
-const NormalHeaderTitle: ComponentType<NormalHeaderTitleProps> = forwardRef(
+const NormalHeaderTitle = forwardRef<HTMLDivElement, NormalHeaderTitleProps>(
   ({ icon, text, size, showTo, fullName }, ref) => {
     const abbreviatedText = fullName ? text : abbreviateText(text);
     const environmentName = getDatasetValue("environmentName") || "";

--- a/assets/src/components/v2/pre_fare_single_screen_alert.tsx
+++ b/assets/src/components/v2/pre_fare_single_screen_alert.tsx
@@ -1,5 +1,5 @@
 import useTextResizer from "Hooks/v2/use_text_resizer";
-import React, { useEffect, useRef, useState } from "react";
+import React from "react";
 import { getHexColor, STRING_TO_SVG } from "Util/svg_utils";
 import DisruptionDiagram, {
   DisruptionDiagramData,

--- a/assets/src/components/v2/reconstructed_takeover.tsx
+++ b/assets/src/components/v2/reconstructed_takeover.tsx
@@ -15,6 +15,7 @@ interface ReconAlertProps {
   effect: string;
   updated_at: string;
   disruption_diagram?: DisruptionDiagramData;
+  urgent: boolean;
 }
 
 const ReconstructedTakeover: React.ComponentType<ReconAlertProps> = (alert) => {

--- a/assets/src/components/v2/reconstructed_takeover.tsx
+++ b/assets/src/components/v2/reconstructed_takeover.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import React from "react";
 
 import { classWithModifiers, imagePath } from "Util/util";
 import DisruptionDiagram, {

--- a/assets/src/components/v2/screen_container.tsx
+++ b/assets/src/components/v2/screen_container.tsx
@@ -96,7 +96,12 @@ const ScreenLayout: ComponentType<ScreenLayoutProps> = ({
   const responseMapper = useContext(ResponseMapperContext);
   const ErrorBoundaryOrFragment = isOFM() ? Fragment : WidgetTreeErrorBoundary;
 
-  const widgetData = responseMapper(apiResponse);
+  // We know this can only be `WidgetData` and not `SimulationApiResponse` here
+  // because `ScreenPage` is only used in contexts where a "non-simulation" API
+  // response will be received (and vice-versa for `SimulationScreenLayout`).
+  // TODO: Refactor how this works so the cast isn't needed, since it suppresses
+  // any real type errors we might have.
+  const widgetData = responseMapper(apiResponse) as WidgetData;
 
   return (
     <div className="screen-container">

--- a/assets/src/components/v2/simulation_screen_container.tsx
+++ b/assets/src/components/v2/simulation_screen_container.tsx
@@ -6,6 +6,7 @@ import {
 import Widget, { WidgetData } from "./widget";
 import {
   ApiResponse,
+  SimulationApiResponse,
   useSimulationApiResponse,
 } from "Hooks/v2/use_api_response";
 import WidgetTreeErrorBoundary from "Components/v2/widget_tree_error_boundary";
@@ -20,7 +21,8 @@ const SimulationScreenLayout: ComponentType<SimulationScreenLayoutProps> = ({
   opts,
 }) => {
   const responseMapper = useContext(ResponseMapperContext);
-  const data = responseMapper(apiResponse);
+  // See `ScreenLayout` for the explanation of this cast.
+  const data = responseMapper(apiResponse) as SimulationApiResponse;
   const { fullPage, flexZone } = data;
 
   // If "alternateView" was provided as an option, we use the simulation version of screen normal

--- a/assets/src/components/v2/subway_status/lcd_subway_status.tsx
+++ b/assets/src/components/v2/subway_status/lcd_subway_status.tsx
@@ -217,7 +217,7 @@ const BasicAlert = forwardRef<HTMLDivElement, BasicAlertProps>(
     }
 
     let textContainerClassName = "subway-status_alert_text-container";
-    const textContainerModifiers = [];
+    const textContainerModifiers: string[] = [];
     if (hideOverflow) {
       textContainerModifiers.push("hide-overflow");
     }

--- a/assets/src/components/v2/widget.tsx
+++ b/assets/src/components/v2/widget.tsx
@@ -6,9 +6,7 @@ interface Props {
   data: WidgetData;
 }
 
-const MappingContext = React.createContext(
-  {} as Record<string, React.ComponentType>
-);
+const MappingContext = React.createContext({});
 
 const Widget: React.ComponentType<Props> = ({ data }) => {
   if (data == null) {

--- a/assets/src/components/v2/widget_page.tsx
+++ b/assets/src/components/v2/widget_page.tsx
@@ -3,9 +3,8 @@ import React from "react";
 import Widget from "./widget";
 
 const WidgetPage = () => {
-  const widgetJson = JSON.parse(getDatasetValue("widgetData"))
-
-  return widgetJson ? <Widget data={widgetJson} /> : null
+  const widgetData = getDatasetValue("widgetData");
+  return widgetData ? <Widget data={JSON.parse(widgetData)} /> : null;
 };
 
 export default WidgetPage;

--- a/assets/src/custom.d.ts
+++ b/assets/src/custom.d.ts
@@ -1,0 +1,6 @@
+// Allow importing and using any SVG file as though it were a React component.
+
+declare module "*.svg" {
+  const content: React.FunctionComponent<React.SVGAttributes<SVGElement>>;
+  export default content;
+}

--- a/assets/src/hooks/use_api_response.tsx
+++ b/assets/src/hooks/use_api_response.tsx
@@ -13,8 +13,8 @@ const LOADING_RESPONSE = { type: "loading" };
 const doFailureBuffer = (
   lastSuccess: number | null,
   failureModeElapsedMs: number,
-  setApiResponse: React.Dispatch<React.SetStateAction<object>>,
-  apiResponse: object = FAILURE_RESPONSE,
+  setApiResponse: React.Dispatch<React.SetStateAction<Record<string, any>>>,
+  apiResponse: Record<string, any> = FAILURE_RESPONSE,
 ) => {
   if (lastSuccess == null) {
     // We haven't had a successful request since initial page load.
@@ -70,7 +70,7 @@ const useApiResponse = ({
   withWatchdog = false,
   failureModeElapsedMs = MINUTE_IN_MS,
 }: UseApiResponseArgs) => {
-  const [apiResponse, setApiResponse] = useState<object | null>(
+  const [apiResponse, setApiResponse] = useState<Record<string, any> | null>(
     LOADING_RESPONSE,
   );
   const [lastSuccess, setLastSuccess] = useState<number | null>(null);

--- a/assets/src/hooks/use_current_dup_page.tsx
+++ b/assets/src/hooks/use_current_dup_page.tsx
@@ -26,6 +26,8 @@ const useCurrentPage = () => {
         setPage((p) => 1 - p);
       }, 3750);
       return () => clearInterval(interval);
+    } else {
+      return () => {};
     }
   }, [paging]);
 

--- a/assets/src/hooks/v2/use_api_response.tsx
+++ b/assets/src/hooks/v2/use_api_response.tsx
@@ -1,7 +1,7 @@
 import { WidgetData } from "Components/v2/widget";
 import useDriftlessInterval from "Hooks/use_driftless_interval";
 import React, { useEffect, useMemo, useState } from "react";
-import { getDataset, getDatasetValue } from "Util/dataset";
+import { fetchDatasetValue, getDatasetValue } from "Util/dataset";
 import { isDup, isOFM, isTriptych, getTriptychPane } from "Util/outfront";
 import { getScreenSide, isRealScreen } from "Util/util";
 import * as SentryLogger from "Util/sentry";
@@ -186,10 +186,11 @@ const useBaseApiResponse = ({
   const [apiResponse, setApiResponse] = useState<ApiResponse>(LOADING_RESPONSE);
   const [requestCount, setRequestCount] = useState<number>(0);
   const [lastSuccess, setLastSuccess] = useState<number | null>(null);
-  const { refreshRate, refreshRateOffset, screenIdsWithOffsetMap } =
-    getDataset();
-  const refreshMs = parseInt(refreshRate, 10) * 1000;
-  let refreshRateOffsetMs = parseInt(refreshRateOffset, 10) * 1000;
+  const refreshRate = fetchDatasetValue("refreshRate");
+  const refreshRateOffset = fetchDatasetValue("refreshRateOffset");
+  const screenIdsWithOffsetMap = getDatasetValue("screenIdsWithOffsetMap");
+  const refreshMs = parseInt(refreshRate!, 10) * 1000;
+  let refreshRateOffsetMs = parseInt(refreshRateOffset!, 10) * 1000;
   const apiPath = useMemo(() => getApiPath(id, routePart), [id, routePart]);
 
   if (screenIdsWithOffsetMap) {

--- a/assets/src/util/outfront.tsx
+++ b/assets/src/util/outfront.tsx
@@ -80,7 +80,7 @@ export const getTriptychPane = (): TriptychPane | null => {
 };
 
 const getTriptychPaneFromTags = () => {
-  let pane = null;
+  let pane: TriptychPane | null = null;
 
   const tags = getTags();
   if (tags !== null) {
@@ -110,7 +110,7 @@ export const getStationName = (): string | null => {
 };
 
 const getTags = (): OFMTag[] | null => {
-  let tags = null;
+  let tags: OFMTag[] | null = null;
 
   const mraid = getMRAID();
   if (mraid) {

--- a/assets/src/util/time_representation.tsx
+++ b/assets/src/util/time_representation.tsx
@@ -11,22 +11,17 @@ export type TimeRepresentation =
 export const timeRepresentationsEqual = (rep1, rep2) => {
   if (!rep1 || !rep2) {
     return false;
-  }
-  if (rep1.type !== rep2.type) {
+  } else if (rep1.type !== rep2.type) {
     return false;
-  }
-
-  if (rep1.type === "TIMESTAMP") {
+  } else if (rep1.type === "TIMESTAMP") {
     return rep1.ampm === rep2.ampm && rep1.timestamp === rep2.timestamp;
-  }
-
-  if (rep1.type === "MINUTES") {
+  } else if (rep1.type === "MINUTES") {
     return rep1.minutes === rep2.minutes;
-  }
-
-  if (rep1.type === "TEXT") {
+  } else if (rep1.type === "TEXT") {
     return rep1.text === rep2.text;
   }
+
+  return false; // impossible?
 };
 
 export const standardTimeRepresentation = (
@@ -34,8 +29,8 @@ export const standardTimeRepresentation = (
   currentTimeString: string,
   vehicleStatus: string,
   stopType: string,
-  noMinutes: boolean,
-  forceTimestamp: boolean
+  noMinutes?: boolean,
+  forceTimestamp?: boolean
 ): TimeRepresentation => {
   const departureTime = moment(departureTimeString);
   const currentTime = moment(currentTimeString);

--- a/assets/tsconfig.json
+++ b/assets/tsconfig.json
@@ -27,7 +27,7 @@
 
     /* Strict Type-Checking Options */
     "strict": true /* Enable all strict type-checking options. */,
-    "noImplicitAny": true /* Raise error on expressions and declarations with an implied 'any' type. */,
+    "noImplicitAny": false /* Raise error on expressions and declarations with an implied 'any' type. */,
     "strictNullChecks": true /* Enable strict null checks. */,
     "strictFunctionTypes": true /* Enable strict checking of function types. */,
     "strictBindCallApply": true /* Enable strict 'bind', 'call', and 'apply' methods on functions. */,

--- a/assets/tsconfig.json
+++ b/assets/tsconfig.json
@@ -48,7 +48,7 @@
       "Components/*": ["components/*"],
       "Hooks/*": ["hooks/*"],
       "Util/*": ["util/*"],
-      "Constants/*": ["constants/*"]
+      "Constants": ["constants"],
     },                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                       /* List of folders to include type definitions from. */

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -11,16 +11,7 @@ config :screens, ScreensWeb.Endpoint,
   debug_errors: true,
   code_reloader: true,
   check_origin: false,
-  watchers: [
-    node: [
-      "node_modules/webpack/bin/webpack.js",
-      "--mode",
-      "development",
-      "--watch",
-      cd: Path.expand("../assets", __DIR__)
-    ]
-  ],
-  check_origin: false
+  watchers: [npm: ["run", "watch", cd: "assets"]]
 
 config :screens,
   default_api_v3_url: System.get_env("API_V3_URL", "https://api-v3.mbta.com/"),


### PR DESCRIPTION
This adds type-checking to CI and resolves all existing type errors that are not due to implicit `any` types — in other words, all cases where the code or the type annotations are wrong in a way the compiler can prove without needing full type annotations. (This is more limited than it sounds; to catch all errors, explicit annotations are needed on most function arguments and return values, which is why `noImplicitAny` exists and is enabled by default in strict mode. For now, I've disabled it here, since we have such a huge number of implicit `any`s that it would explode the scope of this task.)

The "magic comment" `@ts-expect-error` suppresses any error that would be reported on the next line, and is used here to punt on situations that would be non-trivial to resolve, particularly in non-v2 code where we may never have to resolve them. Note this differs from `@ts-ignore` in that if there is _no_ error on the next line, this is reported as an error — so if a future improvement to our types or the compiler results in the error being resolved, we'll know and can remove the comment.

There are a few general issues which are all fixed in similar ways:

* When the compiler can't prove the conditions of an `if` or `switch` cover all possibilities, and there is no fallback `else` or `default`, we have to add one. In most cases we can just throw an error, as we expect the code path to never be reached.

* Several places in existing type definitions were trying to use `object` as though it meant "object with unspecified fields of unspecified types". However, `object` actually means an "opaque" object: it only permits operations that would be allowed on _any_ object, which does not include accessing any specific properties (which might not exist). The correct way to do this is `Record<string, any>`, though in some cases involving React props the best we can do without filling in a more detailed type is `any`.

* A type annotation is required on variables initialized to `null` or `undefined` and later assigned, or arrays initially declared as `[]` and later populated. The compiler does not backtrack to fill in the variable's type based on later usage; it only looks at the initial value.

* Similar to the above, `useState` requires a type parameter for the values that will later be assigned, if the type cannot be inferred from the initial value.

* Also similar to the above, `useRef` and `forwardRef` require a type parameter for the DOM element the ref will later be associated with. Due to a quirk of how the types are implemented for this function, `null` must also be explicitly provided as the initial value (we were already doing this in most places).

* The value in a ref is `null` during the initial render, so code that accesses properties of `ref.current` needs to account for this, even if we expect it to never happen (e.g. inside a `useLayoutEffect`).

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207055911773551