### PR TITLE
fix: Added a DUP headsign matcher for Maverick.

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -280,6 +280,21 @@ config :screens,
         alert_headsign: "Braintree",
         headway_headsign: "Alewife"
       }
+    ],
+    # Maverick
+    "place-mvbcl" => [
+      %{
+        informed: "70048",
+        not_informed: "70044",
+        alert_headsign: "Wonderland",
+        headway_headsign: "Bowdoin"
+      },
+      %{
+        informed: "70043",
+        not_informed: "70047",
+        alert_headsign: "Bowdoin",
+        headway_headsign: "Wonderland"
+      }
     ]
   },
   prefare_alert_headsign_matchers: %{


### PR DESCRIPTION
**Asana task**: ad-hoc

There was no headsign matcher for Maverick, so the current BL shuttle alert was breaking the screen. Adding this will allow us to properly render the alert.

- [ ] Tests added?
