### PR TITLE
fix: refresh-rate-offset should not be required

### DIFF
--- a/assets/src/hooks/v2/use_api_response.tsx
+++ b/assets/src/hooks/v2/use_api_response.tsx
@@ -187,10 +187,10 @@ const useBaseApiResponse = ({
   const [requestCount, setRequestCount] = useState<number>(0);
   const [lastSuccess, setLastSuccess] = useState<number | null>(null);
   const refreshRate = fetchDatasetValue("refreshRate");
-  const refreshRateOffset = fetchDatasetValue("refreshRateOffset");
+  const refreshRateOffset = getDatasetValue("refreshRateOffset") || "0";
   const screenIdsWithOffsetMap = getDatasetValue("screenIdsWithOffsetMap");
   const refreshMs = parseInt(refreshRate!, 10) * 1000;
-  let refreshRateOffsetMs = parseInt(refreshRateOffset!, 10) * 1000;
+  let refreshRateOffsetMs = parseInt(refreshRateOffset, 10) * 1000;
   const apiPath = useMemo(() => getApiPath(id, routePart), [id, routePart]);
 
   if (screenIdsWithOffsetMap) {


### PR DESCRIPTION
This was causing a crash / blank page on the "all screens" views, which do not provide a refresh rate offset in the top-level HTML element. From the immediate context it seemed like this value must have been required, since it was passed into `parseInt` which would return a `NaN` if undefined — but it appears later code was tolerant of this.

This changes the value to specifically default to `0` at the time it is loaded from the HTML.