### PR TITLE
fix: missing route pills on Solari screens

### DIFF
--- a/assets/src/components/solari/route_pill.tsx
+++ b/assets/src/components/solari/route_pill.tsx
@@ -69,31 +69,33 @@ const routeToPill = (
 };
 
 const Pill = ({ routeName, routePillColor }: PillType): JSX.Element => {
-  let routeImg: JSX.Element | undefined;
+  let route: JSX.Element | string | null;
 
   if (routeName === "CR") {
-    routeImg = (
+    route = (
       <img
         className="departure-route--icon"
         src={imagePath("commuter-rail.svg")}
       ></img>
     );
   } else if (routeName === "Boat") {
-    routeImg = (
+    route = (
       <img className="departure-route--icon" src={imagePath("ferry.svg")}></img>
     );
   } else if (routeName === "BUS") {
-    routeImg = (
+    route = (
       <img
         className="departure-route--icon"
         src={imagePath("bus-black.svg")}
       ></img>
     );
+  } else {
+    route = routeName;
   }
 
   return (
     <div className={classWithModifier("departure-route", routePillColor)}>
-      {routeImg && <BaseRoutePill route={routeImg} />}
+      {route && <BaseRoutePill route={route} />}
     </div>
   );
 };


### PR DESCRIPTION
The refactor of this logic to address type errors in 1f411cb was incorrect and ended up breaking text route pills (e.g. bus numbers, commuter rail track numbers). The variable mistakenly named `routeImg` here was intended to be an image-or-string.