### PR TITLE
Bidirectional mode and time filtering

### DIFF
--- a/lib/screens/v2/candidate_generator/dup/departures.ex
+++ b/lib/screens/v2/candidate_generator/dup/departures.ex
@@ -25,7 +25,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
           }
         } = config,
         now,
-        fetch_section_departures_fn \\ &Widgets.Departures.fetch_section_departures/1,
+        fetch_departures_fn \\ &Departure.fetch/2,
         fetch_alerts_fn \\ &Alert.fetch_or_empty_list/1,
         fetch_schedules_fn \\ &Screens.Schedules.Schedule.fetch/2,
         create_station_with_routes_map_fn \\ &Screens.Stops.Stop.create_station_with_routes_map/1,
@@ -34,7 +34,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
     primary_departures_instances =
       primary_sections
       |> get_sections_data(
-        fetch_section_departures_fn,
+        fetch_departures_fn,
         fetch_alerts_fn,
         create_station_with_routes_map_fn,
         now
@@ -62,7 +62,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
     secondary_departures_instances =
       secondary_sections
       |> get_sections_data(
-        fetch_section_departures_fn,
+        fetch_departures_fn,
         fetch_alerts_fn,
         create_station_with_routes_map_fn,
         now
@@ -205,7 +205,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
 
   defp get_sections_data(
          sections,
-         fetch_section_departures_fn,
+         fetch_departures_fn,
          fetch_alerts_fn,
          create_station_with_routes_map_fn,
          now
@@ -231,7 +231,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
         %{type: :no_data_section, route: primary_route_for_section}
       else
         section_departures =
-          case fetch_section_departures_fn.(section) do
+          case Widgets.Departures.fetch_section_departures(section, fetch_departures_fn) do
             {:ok, []} ->
               []
 

--- a/lib/screens/v2/candidate_generator/gl_eink.ex
+++ b/lib/screens/v2/candidate_generator/gl_eink.ex
@@ -81,20 +81,14 @@ defmodule Screens.V2.CandidateGenerator.GlEink do
         _opts,
         now \\ DateTime.utc_now(),
         fetch_destination_fn \\ &fetch_destination/2,
-        departures_instances_fn \\ &Widgets.Departures.departures_instances/3,
+        departures_instances_fn \\ &Widgets.Departures.departures_instances/2,
         alert_instances_fn \\ &Widgets.Alerts.alert_instances/1,
         evergreen_content_instances_fn \\ &Widgets.Evergreen.evergreen_content_instances/1,
         subway_status_instances_fn \\ &Widgets.SubwayStatus.subway_status_instances/2
       ) do
     [
       fn -> header_instances(config, now, fetch_destination_fn) end,
-      fn ->
-        departures_instances_fn.(
-          config,
-          &Widgets.Departures.fetch_section_departures/1,
-          &departures_post_processing/2
-        )
-      end,
+      fn -> departures_instances_fn.(config, post_process_fn: &departures_post_processing/2) end,
       fn -> alert_instances_fn.(config) end,
       fn -> footer_instances(config) end,
       fn -> line_map_instances(config, now) end,

--- a/lib/screens/v2/candidate_generator/widgets/departures.ex
+++ b/lib/screens/v2/candidate_generator/widgets/departures.ex
@@ -10,36 +10,43 @@ defmodule Screens.V2.CandidateGenerator.Widgets.Departures do
   alias ScreensConfig.V2.Departures.{Filters, Query, Section}
   alias ScreensConfig.V2.{BusEink, BusShelter, Busway, Departures, GlEink, SolariLarge}
 
-  def departures_instances(
-        %Screen{app_params: %app{}} = config,
-        fetch_section_departures_fn \\ &fetch_section_departures/1,
-        post_processing_fn \\ fn sections, _config -> sections end
-      )
+  @type options :: [
+          departure_fetch_fn: Departure.fetch(),
+          post_process_fn: ([Departure.result()], Screen.t() -> [Departure.result() | :overnight])
+        ]
+
+  @type widget ::
+          DeparturesNoData.t()
+          | DeparturesNoService.t()
+          | DeparturesWidget.t()
+          | OvernightDepartures.t()
+
+  @spec departures_instances(Screen.t()) :: [widget()]
+  @spec departures_instances(Screen.t(), options()) :: [widget()]
+  def departures_instances(%Screen{app_params: %app{}} = config, options \\ [])
       when app in [BusEink, BusShelter, Busway, GlEink, SolariLarge] do
     if Screens.Config.Cache.mode_disabled?(get_devops_mode(config)) do
       [%DeparturesNoData{screen: config, show_alternatives?: false}]
     else
-      do_departures_instances(config, fetch_section_departures_fn, post_processing_fn)
+      do_departures_instances(
+        config,
+        Keyword.get(options, :departure_fetch_fn, &Departure.fetch/2),
+        Keyword.get(options, :post_process_fn, fn results, _config -> results end)
+      )
     end
-  end
-
-  def fetch_section_departures(%Section{query: query, filters: filters}) do
-    query
-    |> fetch_departures()
-    |> filter_departures(filters)
   end
 
   defp do_departures_instances(
          %Screen{app_params: %{departures: %Departures{sections: sections}}, app_id: app_id} =
            config,
-         fetch_section_departures_fn,
-         post_processing_fn
+         departure_fetch_fn,
+         post_process_fn
        ) do
     sections_data =
       sections
-      |> Task.async_stream(fetch_section_departures_fn, timeout: 30_000)
-      |> Enum.map(fn {:ok, data} -> data end)
-      |> post_processing_fn.(config)
+      |> Task.async_stream(&fetch_section_departures(&1, departure_fetch_fn), timeout: 30_000)
+      |> Enum.map(fn {:ok, result} -> result end)
+      |> post_process_fn.(config)
 
     departures_instance =
       cond do
@@ -64,21 +71,22 @@ defmodule Screens.V2.CandidateGenerator.Widgets.Departures do
     [departures_instance]
   end
 
-  defp fetch_departures(%Query{opts: opts, params: params}) do
-    fetch_opts =
-      opts
-      |> Map.from_struct()
-      |> Keyword.new()
-
+  @spec fetch_section_departures(Section.t()) :: Departure.result()
+  @spec fetch_section_departures(Section.t(), Departure.fetch()) :: Departure.result()
+  def fetch_section_departures(
+        %Section{query: %Query{opts: opts, params: params}, filters: filters},
+        departure_fetch_fn \\ &Departure.fetch/2
+      ) do
     fetch_params = Map.from_struct(params)
+    fetch_opts = opts |> Map.from_struct() |> Keyword.new()
 
-    Departure.fetch(fetch_params, fetch_opts)
+    with {:ok, departures} <- departure_fetch_fn.(fetch_params, fetch_opts) do
+      {:ok, filter_departures(departures, filters)}
+    end
   end
 
-  def filter_departures(:error, _), do: :error
-
-  def filter_departures({:ok, departures}, %Filters{route_directions: route_directions}) do
-    {:ok, filter_by_route_direction(departures, route_directions)}
+  defp filter_departures(departures, %Filters{route_directions: route_directions}) do
+    filter_by_route_direction(departures, route_directions)
   end
 
   defp filter_by_route_direction(departures, %RouteDirections{

--- a/lib/screens/v2/departure.ex
+++ b/lib/screens/v2/departure.ex
@@ -14,9 +14,25 @@ defmodule Screens.V2.Departure do
           schedule: Screens.Schedules.Schedule.t() | nil
         }
 
-  defstruct prediction: nil,
-            schedule: nil
+  defstruct prediction: nil, schedule: nil
 
+  @type params :: %{
+          optional(:direction_id) => :both | 0 | 1,
+          optional(:route_ids) => [Route.id()],
+          optional(:route_type) => nil | :bus | :ferry | :light_rail | :rail | :subway,
+          optional(:stop_ids) => [Stop.id()]
+        }
+
+  @type opts :: [
+          include_schedules: boolean(),
+          now: DateTime.t()
+        ]
+
+  @type result :: {:ok, [t()]} | :error
+
+  @type fetch :: (params(), opts() -> result())
+
+  @spec fetch(params(), opts()) :: result()
   def fetch(params, opts \\ []) do
     # This is equivalent to an argument with a default value, so it's fine
     # credo:disable-for-next-line Screens.Checks.UntestableDateTime

--- a/test/screens/v2/candidate_generator/dup/departures_test.exs
+++ b/test/screens/v2/candidate_generator/dup/departures_test.exs
@@ -55,8 +55,8 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
       app_id: :dup_v2
     }
 
-    fetch_section_departures_fn = fn
-      %Section{query: %Query{params: %Query.Params{stop_ids: ["place-A"]}}} ->
+    fetch_departures_fn = fn
+      %{stop_ids: ["place-A"]}, _opts ->
         {:ok,
          [
            %Departure{
@@ -70,7 +70,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
            }
          ]}
 
-      %Section{query: %Query{params: %Query.Params{stop_ids: ["place-B"]}}} ->
+      %{stop_ids: ["place-B"]}, _opts ->
         {:ok,
          [
            %Departure{
@@ -120,7 +120,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
            }
          ]}
 
-      %Section{query: %Query{params: %Query.Params{stop_ids: ["place-C"]}}} ->
+      %{stop_ids: ["place-C"]}, _opts ->
         {:ok,
          [
            %Departure{
@@ -134,7 +134,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
            }
          ]}
 
-      %Section{query: %Query{params: %Query.Params{stop_ids: ["place-D"]}}} ->
+      %{stop_ids: ["place-D"]}, _opts ->
         {:ok,
          [
            %Departure{
@@ -148,7 +148,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
            }
          ]}
 
-      %Section{query: %Query{params: %Query.Params{stop_ids: ["place-F"]}}} ->
+      %{stop_ids: ["place-F"]}, _opts ->
         {:ok,
          [
            %Departure{
@@ -193,7 +193,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
            }
          ]}
 
-      %Section{query: %Query{params: %Query.Params{stop_ids: ["place-G"]}}} ->
+      %{stop_ids: ["place-G"]}, _opts ->
         {:ok,
          [
            %Departure{
@@ -206,7 +206,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
            }
          ]}
 
-      %Section{query: %Query{params: %Query.Params{stop_ids: ["place-kencl"]}}} ->
+      %{stop_ids: ["place-kencl"]}, _opts ->
         {:ok,
          [
            %Departure{
@@ -220,7 +220,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
            }
          ]}
 
-      %Section{query: %Query{params: %Query.Params{stop_ids: ["bus-A", "bus-B"]}}} ->
+      %{stop_ids: ["bus-A", "bus-B"]}, _opts ->
         {:ok,
          [
            %Departure{
@@ -234,7 +234,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
            }
          ]}
 
-      _ ->
+      _, _ ->
         {:ok, []}
     end
 
@@ -260,7 +260,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
 
     %{
       config: config,
-      fetch_section_departures_fn: fetch_section_departures_fn,
+      fetch_departures_fn: fetch_departures_fn,
       fetch_alerts_fn: fetch_alerts_fn,
       fetch_schedules_fn: fetch_schedules_fn,
       create_station_with_routes_map_fn: create_station_with_routes_map_fn,
@@ -271,7 +271,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
   describe "departures_instances/4" do
     test "returns primary and secondary departures", %{
       config: config,
-      fetch_section_departures_fn: fetch_section_departures_fn,
+      fetch_departures_fn: fetch_departures_fn,
       fetch_alerts_fn: fetch_alerts_fn,
       fetch_schedules_fn: fetch_schedules_fn,
       create_station_with_routes_map_fn: create_station_with_routes_map_fn,
@@ -425,7 +425,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
         Dup.Departures.departures_instances(
           config,
           now,
-          fetch_section_departures_fn,
+          fetch_departures_fn,
           fetch_alerts_fn,
           fetch_schedules_fn,
           create_station_with_routes_map_fn,
@@ -437,7 +437,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
 
     test "returns only primary departures if secondary is missing", %{
       config: config,
-      fetch_section_departures_fn: fetch_section_departures_fn,
+      fetch_departures_fn: fetch_departures_fn,
       fetch_alerts_fn: fetch_alerts_fn,
       fetch_schedules_fn: fetch_schedules_fn,
       create_station_with_routes_map_fn: create_station_with_routes_map_fn,
@@ -596,7 +596,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
         Dup.Departures.departures_instances(
           config,
           now,
-          fetch_section_departures_fn,
+          fetch_departures_fn,
           fetch_alerts_fn,
           fetch_schedules_fn,
           create_station_with_routes_map_fn,
@@ -608,7 +608,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
 
     test "returns only bidirectional departures if configured for that", %{
       config: config,
-      fetch_section_departures_fn: fetch_section_departures_fn,
+      fetch_departures_fn: fetch_departures_fn,
       fetch_alerts_fn: fetch_alerts_fn,
       fetch_schedules_fn: fetch_schedules_fn,
       create_station_with_routes_map_fn: create_station_with_routes_map_fn,
@@ -770,7 +770,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
         Dup.Departures.departures_instances(
           config,
           now,
-          fetch_section_departures_fn,
+          fetch_departures_fn,
           fetch_alerts_fn,
           fetch_schedules_fn,
           create_station_with_routes_map_fn,
@@ -782,7 +782,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
 
     test "returns one row for bidirectional departures if only one departure exists", %{
       config: config,
-      fetch_section_departures_fn: fetch_section_departures_fn,
+      fetch_departures_fn: fetch_departures_fn,
       fetch_alerts_fn: fetch_alerts_fn,
       fetch_schedules_fn: fetch_schedules_fn,
       create_station_with_routes_map_fn: create_station_with_routes_map_fn,
@@ -868,7 +868,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
         Dup.Departures.departures_instances(
           config,
           now,
-          fetch_section_departures_fn,
+          fetch_departures_fn,
           fetch_alerts_fn,
           fetch_schedules_fn,
           create_station_with_routes_map_fn,
@@ -880,7 +880,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
 
     test "returns 4 departures if only one section", %{
       config: config,
-      fetch_section_departures_fn: fetch_section_departures_fn,
+      fetch_departures_fn: fetch_departures_fn,
       fetch_alerts_fn: fetch_alerts_fn,
       fetch_schedules_fn: fetch_schedules_fn,
       create_station_with_routes_map_fn: create_station_with_routes_map_fn,
@@ -1056,7 +1056,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
         Dup.Departures.departures_instances(
           config,
           now,
-          fetch_section_departures_fn,
+          fetch_departures_fn,
           fetch_alerts_fn,
           fetch_schedules_fn,
           create_station_with_routes_map_fn,
@@ -1068,7 +1068,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
 
     test "returns headway sections for temporary terminal", %{
       config: config,
-      fetch_section_departures_fn: fetch_section_departures_fn,
+      fetch_departures_fn: fetch_departures_fn,
       fetch_schedules_fn: fetch_schedules_fn,
       create_station_with_routes_map_fn: create_station_with_routes_map_fn,
       fetch_vehicles_fn: fetch_vehicles_fn
@@ -1144,7 +1144,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
         Dup.Departures.departures_instances(
           config,
           now,
-          fetch_section_departures_fn,
+          fetch_departures_fn,
           fetch_alerts_fn,
           fetch_schedules_fn,
           create_station_with_routes_map_fn,
@@ -1156,7 +1156,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
 
     test "returns normal sections for upcoming alert", %{
       config: config,
-      fetch_section_departures_fn: fetch_section_departures_fn,
+      fetch_departures_fn: fetch_departures_fn,
       fetch_schedules_fn: fetch_schedules_fn,
       create_station_with_routes_map_fn: create_station_with_routes_map_fn,
       fetch_vehicles_fn: fetch_vehicles_fn
@@ -1350,7 +1350,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
         Dup.Departures.departures_instances(
           config,
           now,
-          fetch_section_departures_fn,
+          fetch_departures_fn,
           fetch_alerts_fn,
           fetch_schedules_fn,
           create_station_with_routes_map_fn,
@@ -1362,7 +1362,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
 
     test "returns normal sections for branch station for alert with branch terminal headsign", %{
       config: config,
-      fetch_section_departures_fn: fetch_section_departures_fn,
+      fetch_departures_fn: fetch_departures_fn,
       fetch_schedules_fn: fetch_schedules_fn,
       create_station_with_routes_map_fn: create_station_with_routes_map_fn,
       fetch_vehicles_fn: fetch_vehicles_fn
@@ -1507,7 +1507,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
         Dup.Departures.departures_instances(
           config,
           now,
-          fetch_section_departures_fn,
+          fetch_departures_fn,
           fetch_alerts_fn,
           fetch_schedules_fn,
           create_station_with_routes_map_fn,
@@ -1519,7 +1519,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
 
     test "returns headway sections for branch station for alert with trunk headsign", %{
       config: config,
-      fetch_section_departures_fn: fetch_section_departures_fn,
+      fetch_departures_fn: fetch_departures_fn,
       fetch_schedules_fn: fetch_schedules_fn,
       create_station_with_routes_map_fn: create_station_with_routes_map_fn,
       fetch_vehicles_fn: fetch_vehicles_fn
@@ -1623,7 +1623,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
         Dup.Departures.departures_instances(
           config,
           now,
-          fetch_section_departures_fn,
+          fetch_departures_fn,
           fetch_alerts_fn,
           fetch_schedules_fn,
           create_station_with_routes_map_fn,
@@ -1635,7 +1635,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
 
     test "returns no data sections for disabled mode", %{
       config: config,
-      fetch_section_departures_fn: fetch_section_departures_fn,
+      fetch_departures_fn: fetch_departures_fn,
       fetch_alerts_fn: fetch_alerts_fn,
       create_station_with_routes_map_fn: create_station_with_routes_map_fn,
       fetch_schedules_fn: fetch_schedules_fn,
@@ -1745,7 +1745,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
         Dup.Departures.departures_instances(
           config,
           now,
-          fetch_section_departures_fn,
+          fetch_departures_fn,
           fetch_alerts_fn,
           fetch_schedules_fn,
           create_station_with_routes_map_fn,
@@ -1757,7 +1757,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
 
     test "returns empty departures list if sections have no departures", %{
       config: config,
-      fetch_section_departures_fn: fetch_section_departures_fn,
+      fetch_departures_fn: fetch_departures_fn,
       fetch_alerts_fn: fetch_alerts_fn,
       fetch_schedules_fn: fetch_schedules_fn,
       create_station_with_routes_map_fn: create_station_with_routes_map_fn,
@@ -1788,7 +1788,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
         Dup.Departures.departures_instances(
           config,
           now,
-          fetch_section_departures_fn,
+          fetch_departures_fn,
           fetch_alerts_fn,
           fetch_schedules_fn,
           create_station_with_routes_map_fn,
@@ -1803,7 +1803,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
     test "returns normal sections with normal rows and overnight rows for routes in overnight mode",
          %{
            config: config,
-           fetch_section_departures_fn: fetch_section_departures_fn,
+           fetch_departures_fn: fetch_departures_fn,
            fetch_alerts_fn: fetch_alerts_fn,
            create_station_with_routes_map_fn: create_station_with_routes_map_fn,
            fetch_vehicles_fn: fetch_vehicles_fn
@@ -1924,7 +1924,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
         Dup.Departures.departures_instances(
           config,
           now,
-          fetch_section_departures_fn,
+          fetch_departures_fn,
           fetch_alerts_fn,
           fetch_schedules_fn,
           create_station_with_routes_map_fn,
@@ -1937,7 +1937,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
     test "returns normal sections with normal rows and overnight rows with nil scheduled times for routes in overnight mode with no scheduled trips tomorrow",
          %{
            config: config,
-           fetch_section_departures_fn: fetch_section_departures_fn,
+           fetch_departures_fn: fetch_departures_fn,
            fetch_alerts_fn: fetch_alerts_fn,
            create_station_with_routes_map_fn: create_station_with_routes_map_fn,
            fetch_vehicles_fn: fetch_vehicles_fn
@@ -2051,7 +2051,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
         Dup.Departures.departures_instances(
           config,
           now,
-          fetch_section_departures_fn,
+          fetch_departures_fn,
           fetch_alerts_fn,
           fetch_schedules_fn,
           create_station_with_routes_map_fn,
@@ -2065,7 +2065,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
     test "returns empty departures if now is after tomorrow's first schedule",
          %{
            config: config,
-           fetch_section_departures_fn: fetch_section_departures_fn,
+           fetch_departures_fn: fetch_departures_fn,
            fetch_alerts_fn: fetch_alerts_fn,
            create_station_with_routes_map_fn: create_station_with_routes_map_fn,
            fetch_vehicles_fn: fetch_vehicles_fn
@@ -2124,7 +2124,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
         Dup.Departures.departures_instances(
           config,
           now,
-          fetch_section_departures_fn,
+          fetch_departures_fn,
           fetch_alerts_fn,
           fetch_schedules_fn,
           create_station_with_routes_map_fn,
@@ -2137,7 +2137,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
     test "returns empty departures if now is before today's last schedule and there are no schedules tomorrow",
          %{
            config: config,
-           fetch_section_departures_fn: fetch_section_departures_fn,
+           fetch_departures_fn: fetch_departures_fn,
            fetch_alerts_fn: fetch_alerts_fn,
            create_station_with_routes_map_fn: create_station_with_routes_map_fn,
            fetch_vehicles_fn: fetch_vehicles_fn
@@ -2189,7 +2189,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
         Dup.Departures.departures_instances(
           config,
           now,
-          fetch_section_departures_fn,
+          fetch_departures_fn,
           fetch_alerts_fn,
           fetch_schedules_fn,
           create_station_with_routes_map_fn,
@@ -2202,7 +2202,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
     test "returns OvernightDepartures if all routes in section are overnight",
          %{
            config: config,
-           fetch_section_departures_fn: fetch_section_departures_fn,
+           fetch_departures_fn: fetch_departures_fn,
            fetch_alerts_fn: fetch_alerts_fn,
            create_station_with_routes_map_fn: create_station_with_routes_map_fn,
            fetch_vehicles_fn: fetch_vehicles_fn
@@ -2294,7 +2294,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
         Dup.Departures.departures_instances(
           config,
           now,
-          fetch_section_departures_fn,
+          fetch_departures_fn,
           fetch_alerts_fn,
           fetch_schedules_fn,
           create_station_with_routes_map_fn,
@@ -2307,7 +2307,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
     test "returns OvernightDepartures with no routes if all rotations are overnight",
          %{
            config: config,
-           fetch_section_departures_fn: fetch_section_departures_fn,
+           fetch_departures_fn: fetch_departures_fn,
            fetch_alerts_fn: fetch_alerts_fn,
            create_station_with_routes_map_fn: create_station_with_routes_map_fn,
            fetch_vehicles_fn: fetch_vehicles_fn
@@ -2354,7 +2354,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
         Dup.Departures.departures_instances(
           config,
           now,
-          fetch_section_departures_fn,
+          fetch_departures_fn,
           fetch_alerts_fn,
           fetch_schedules_fn,
           create_station_with_routes_map_fn,
@@ -2367,7 +2367,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
     test "returns OvernightDepartures for rail sections with active alert and no active vehicles",
          %{
            config: config,
-           fetch_section_departures_fn: fetch_section_departures_fn,
+           fetch_departures_fn: fetch_departures_fn,
            create_station_with_routes_map_fn: create_station_with_routes_map_fn
          } do
       config =
@@ -2436,7 +2436,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
         Dup.Departures.departures_instances(
           config,
           now,
-          fetch_section_departures_fn,
+          fetch_departures_fn,
           fetch_alerts_fn,
           fetch_schedules_fn,
           create_station_with_routes_map_fn,


### PR DESCRIPTION
Best reviewed per-commit, as there is a non-trivial refactoring and also a sneaky extra feature here (filtering by time, which is used primarily in `include_schedules` sections to avoid showing schedules too far in the future — we didn't have a standalone Asana task for this).

Note the frontend still doesn't support multiple sections, so converted Solari configs (e.g. using #2030) will continue to have odd behavior. Bidirectional mode and time filtering do work correctly on single sections, if you trim down a config to use only one section.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206932080790888