### PR TITLE
Added DUP headsign matchers for South Station and Kendall.

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -289,6 +289,36 @@ config :screens,
         alert_headsign: "Bowdoin",
         headway_headsign: "Wonderland"
       }
+    ],
+    # South Station
+    "place-sstat" => [
+      %{
+        informed: "70078",
+        not_informed: "70082",
+        alert_headsign: "Alewife",
+        headway_headsign: "Ashmont/Braintree"
+      },
+      %{
+        informed: "70081",
+        not_informed: "70077",
+        alert_headsign: "Ashmont/Braintree",
+        headway_headsign: "Alewife"
+      }
+    ],
+    # Kendall
+    "place-knncl" => [
+      %{
+        informed: "70070",
+        not_informed: "70074",
+        alert_headsign: "Alewife",
+        headway_headsign: "Ashmont/Braintree"
+      },
+      %{
+        informed: "70073",
+        not_informed: "70069",
+        alert_headsign: "Ashmont/Braintree",
+        headway_headsign: "Alewife"
+      }
     ]
   },
   prefare_alert_headsign_matchers: %{


### PR DESCRIPTION
**Asana task**: [[DUPs] Add South Station, Aquarium, Kendall to DUP headsign matchers](https://app.asana.com/0/1185117109217413/1207153943656494/f)

Have DUPs being installed at these stations soon so need these config changes for alert/headway headsigns to display correctly. 

- [ ] Tests added?
