### PR TITLE
fix: Crowding App alert logic

### DIFF
--- a/lib/screens/v2/candidate_generator/widgets/train_crowding.ex
+++ b/lib/screens/v2/candidate_generator/widgets/train_crowding.ex
@@ -303,7 +303,9 @@ defmodule Screens.V2.CandidateGenerator.Widgets.TrainCrowding do
   # Given alerts at this station, check to see if any alert make this a temporary terminal
   defp any_alert_makes_this_a_terminal?(alerts, location_context) do
     Enum.any?(alerts, fn alert ->
-      temporary_terminal?(%{alert: alert, location_context: location_context})
+      if Alert.happening_now?(alert) do
+        temporary_terminal?(%{alert: alert, location_context: location_context})
+      end
     end)
   end
 

--- a/lib/screens/v2/candidate_generator/widgets/train_crowding.ex
+++ b/lib/screens/v2/candidate_generator/widgets/train_crowding.ex
@@ -100,7 +100,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.TrainCrowding do
       }
 
       get_instance(
-        any_alert_makes_this_a_terminal?(alerts, location_context),
+        any_alert_makes_this_a_terminal?(alerts, location_context, now),
         common_params
       )
     else
@@ -301,9 +301,9 @@ defmodule Screens.V2.CandidateGenerator.Widgets.TrainCrowding do
   end
 
   # Given alerts at this station, check to see if any alert make this a temporary terminal
-  defp any_alert_makes_this_a_terminal?(alerts, location_context) do
+  defp any_alert_makes_this_a_terminal?(alerts, location_context, now) do
     Enum.any?(alerts, fn alert ->
-      if Alert.happening_now?(alert) do
+      if Alert.happening_now?(alert, now) do
         temporary_terminal?(%{alert: alert, location_context: location_context})
       end
     end)

--- a/test/screens/v2/candidate_generator/widgets/train_crowding_test.exs
+++ b/test/screens/v2/candidate_generator/widgets/train_crowding_test.exs
@@ -29,6 +29,8 @@ defmodule Screens.V2.CandidateGenerator.Widgets.TrainCrowdingTest do
       app_id: :triptych_v2
     }
 
+    now = ~U[2023-08-16 21:04:00Z]
+
     next_train_prediction =
       struct(Prediction, %{
         vehicle:
@@ -135,7 +137,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.TrainCrowdingTest do
           %{direction_id: nil, route: "Orange", route_type: 1, stop: "place-state"},
           %{direction_id: nil, route: "Orange", route_type: 1, stop: "place-tumnl"}
         ],
-        active_period: [{~U[2023-08-16 20:04:00Z], ~U[2023-08-16 22:04:06Z]}],
+        active_period: [{DateTime.add(now, -1, :hour), DateTime.add(now, 2, :hour)}],
         lifecycle: "NEW",
         timeframe: nil,
         created_at: ~U[2023-08-16 20:04:02Z],
@@ -149,7 +151,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.TrainCrowdingTest do
     %{
       config: config,
       logging_options: %{is_real_screen: false, screen_id: "TEST", triptych_pane: nil},
-      now: ~U[2023-08-16 21:04:00Z],
+      now: now,
       next_train_prediction: next_train_prediction,
       fetch_predictions_fn: fn _ -> {:ok, [next_train_prediction]} end,
       fetch_location_context_fn: fn _, _, _ -> {:ok, location_context} end,


### PR DESCRIPTION
**Asana task**: ad-hoc

When looking at alerts in the crowding app CG, we were not filtering out upcoming. This means `any_alert_makes_this_a_terminal?/2` was returning true if an upcoming alert made the stop a terminal. 

- [ ] Tests added?
