### PR TITLE
Gracefully handle no departures for Line Map

### DIFF
--- a/lib/screens/v2/widget_instance/line_map.ex
+++ b/lib/screens/v2/widget_instance/line_map.ex
@@ -265,6 +265,9 @@ defmodule Screens.V2.WidgetInstance.LineMap do
   def serialize_scheduled_departure(_departures, _direction_id, _stops, true = _is_terminal?),
     do: nil
 
+  def serialize_scheduled_departure([] = _departures, _direction_id, _stops, _is_terminal?),
+    do: nil
+
   def serialize_scheduled_departure(departures, direction_id, stops, _is_terminal?) do
     # Number of departures with predictions (not just schedules) in this direction
     prediction_count =

--- a/lib/screens/v2/widget_instance/line_map.ex
+++ b/lib/screens/v2/widget_instance/line_map.ex
@@ -273,23 +273,19 @@ defmodule Screens.V2.WidgetInstance.LineMap do
         &match?(%Departure{prediction: %Prediction{trip: %Trip{direction_id: ^direction_id}}}, &1)
       )
 
-    if prediction_count < 2 do
+    departure = Enum.find(departures, &is_nil(&1.prediction))
+
+    if prediction_count < 2 and not is_nil(departure) do
       %{name: origin_stop_name} = Enum.at(stops, 0)
 
-      if departure = Enum.find(departures, &is_nil(&1.prediction)) do
-        {:ok, local_time} =
-          departure
-          |> Departure.time()
-          |> DateTime.shift_zone("America/New_York")
+      {:ok, local_time} =
+        departure
+        |> Departure.time()
+        |> DateTime.shift_zone("America/New_York")
 
-        {:ok, timestamp} = Timex.format(local_time, "{h12}:{m}")
+      {:ok, timestamp} = Timex.format(local_time, "{h12}:{m}")
 
-        %{timestamp: timestamp, station_name: origin_stop_name}
-      else
-        nil
-      end
-    else
-      nil
+      %{timestamp: timestamp, station_name: origin_stop_name}
     end
   end
 end

--- a/lib/screens/v2/widget_instance/line_map.ex
+++ b/lib/screens/v2/widget_instance/line_map.ex
@@ -268,13 +268,10 @@ defmodule Screens.V2.WidgetInstance.LineMap do
   def serialize_scheduled_departure(departures, direction_id, stops, _is_terminal?) do
     # Number of departures with predictions (not just schedules) in this direction
     prediction_count =
-      departures
-      |> Stream.reject(fn %Departure{prediction: p} -> is_nil(p) end)
-      |> Stream.reject(fn %Departure{prediction: %Prediction{trip: t}} -> is_nil(t) end)
-      |> Stream.filter(fn %Departure{prediction: %Prediction{trip: %Trip{direction_id: d}}} ->
-        d == direction_id
-      end)
-      |> Enum.count()
+      Enum.count(
+        departures,
+        &match?(%Departure{prediction: %Prediction{trip: %Trip{direction_id: ^direction_id}}}, &1)
+      )
 
     if prediction_count < 2 do
       %{name: origin_stop_name} = Enum.at(stops, 0)

--- a/test/screens/v2/widget_instance/line_map_test.exs
+++ b/test/screens/v2/widget_instance/line_map_test.exs
@@ -303,6 +303,11 @@ defmodule Screens.V2.WidgetInstance.LineMapTest do
                LineMap.serialize_scheduled_departure([d1, d2], direction_id, stops, false)
     end
 
+    test "returns nil when there are no departures", %{stops: stops} do
+      direction_id = 1
+      assert nil == LineMap.serialize_scheduled_departure([], direction_id, stops, false)
+    end
+
     test "returns the correct origin", %{stops: stops} do
       direction_id = 1
 

--- a/test/screens/v2/widget_instance/line_map_test.exs
+++ b/test/screens/v2/widget_instance/line_map_test.exs
@@ -308,6 +308,12 @@ defmodule Screens.V2.WidgetInstance.LineMapTest do
       assert nil == LineMap.serialize_scheduled_departure([], direction_id, stops, false)
     end
 
+    test "returns nil when there are only predictions", %{stops: stops} do
+      direction_id = 1
+      d1 = %Departure{prediction: %Prediction{trip: %Trip{direction_id: direction_id}}}
+      assert nil == LineMap.serialize_scheduled_departure([d1], direction_id, stops, false)
+    end
+
     test "returns the correct origin", %{stops: stops} do
       direction_id = 1
 


### PR DESCRIPTION
**Asana task**: [[Screens 🐞] Gracefully handle no departures for Line Map](https://app.asana.com/0/1207094698667699/1206864414986293/f)

### Description

Handles the case when there fewer than two departures with predictions but also no departures _without_ a prediction.
- Previously this code would pass `nil` to `Screens.V2.Departure.time/1` which raised an exception 

#### Other changes

- Refactors counting of departures with predictions to use a single `Enum.count/2`
  - I'm happy to remove this if you all feel like it is out-of-place in this changeset

#### Known issues / thoughts

This doesn't eliminate all possible errors related to the `nil`ability of departures and the arrival and departure fields within schedules and predictions but is instead focused on the specific error reported to Sentry. A refactor to account for that class of errors would have a much larger surface area. Happy to address this if needed!