### PR TITLE
fix: resolve webp file-loader warnings

### DIFF
--- a/assets/src/util/util.tsx
+++ b/assets/src/util/util.tsx
@@ -28,7 +28,7 @@ export const imagePath = (fileName: string): string =>
   isOFM() ? outfrontImagePath(fileName) : `/images/${fileName}`;
 
 export const outfrontImagePath = (fileName: string): string =>
-  isTriptych() ? `triptych_images/${fileName}` : `/images/${fileName}`;
+  isTriptych() ? `triptych_images/${fileName}` : `images/${fileName}`;
 
 export const pillPath = (fileName: string): string =>
   isOFM() ? `images/pills/${fileName}` : `/images/pills/${fileName}`;

--- a/assets/webpack.config.js
+++ b/assets/webpack.config.js
@@ -119,12 +119,26 @@ module.exports = () => [
           ],
         },
         {
-          test: /\.(png|jpe?g|gif|webp)$/i,
+          test: /\.(png|jpe?g|gif)$/i,
           use: [
             {
               loader: "file-loader",
               options: {
                 name: "[name].[ext]",
+                outputPath: "/images/",
+                publicPath: "/images/",
+                useRelativePaths: true,
+              },
+            },
+          ],
+        },
+        {
+          test: /\.(webp)$/i,
+          use: [
+            {
+              loader: "file-loader",
+              options: {
+                name: "/[folder]/[name].[ext]",
                 outputPath: "/images/",
                 publicPath: "/images/",
                 useRelativePaths: true,

--- a/assets/webpack.config.js
+++ b/assets/webpack.config.js
@@ -119,28 +119,12 @@ module.exports = () => [
           ],
         },
         {
-          test: /\.(png|jpe?g|gif)$/i,
-          use: [
-            {
-              loader: "file-loader",
-              options: {
-                name: "[name].[ext]",
-                outputPath: "/images/",
-                publicPath: "/images/",
-                useRelativePaths: true,
-              },
-            },
-          ],
-        },
-        {
-          test: /\.(webp)$/i,
+          test: /\.(png|jpe?g|gif|webp)$/i,
           use: [
             {
               loader: "file-loader",
               options: {
                 name: "/[folder]/[name].[ext]",
-                outputPath: "/images/",
-                publicPath: "/images/",
                 useRelativePaths: true,
               },
             },


### PR DESCRIPTION
**Asana task**: ad-hoc

The Triptych graphics are a little special in that they are always named after the panel they display on. The existing file-loader config didn't pull in parent folder so there was a conflict between the different PSA folders. Breaking out these files and adding `[folder]` to the `name` will allow the images to coexist.

- [ ] Tests added?
