### PR TITLE
fix: Auth request fallback

### DIFF
--- a/lib/screens_web/controllers/auth_controller.ex
+++ b/lib/screens_web/controllers/auth_controller.ex
@@ -4,6 +4,7 @@ defmodule ScreensWeb.AuthController do
   use ScreensWeb, :controller
   plug Ueberauth
 
+  # Respond with 404 instead of crashing when the path doesn't match a supported provider
   def request(conn, %{"provider" => provider}) when provider != "keycloak" do
     send_resp(conn, 404, "Not Found")
   end

--- a/lib/screens_web/controllers/auth_controller.ex
+++ b/lib/screens_web/controllers/auth_controller.ex
@@ -4,6 +4,10 @@ defmodule ScreensWeb.AuthController do
   use ScreensWeb, :controller
   plug Ueberauth
 
+  def request(conn, %{"provider" => provider}) when provider != "keycloak" do
+    send_resp(conn, 404, "Not Found")
+  end
+
   def callback(%{assigns: %{ueberauth_auth: auth}} = conn, _params) do
     username = auth.uid
     expiration = auth.credentials.expires_at


### PR DESCRIPTION
**Asana task**: ad-hoc

Every once in a while, we get a Sentry error like [this](https://mbtace.sentry.io/issues/5046527403/events/0be23ee4507a4079bf7d2d99198dc695/) one. Adding this fallback will prevent an error while also keeping out unauthorized requests.

- [ ] Tests added?
