### PR TITLE
Add Park Street and Arlington to DUP headsign configs

### DIFF
--- a/assets/src/components/admin/admin_add_modal.tsx
+++ b/assets/src/components/admin/admin_add_modal.tsx
@@ -17,6 +17,7 @@ const fields = [
       "bus_shelter_v2",
       "busway_v2",
       "dup",
+      "dup_v2",
       "gl_eink_double",
       "gl_eink_single",
       "gl_eink_v2",

--- a/config/config.exs
+++ b/config/config.exs
@@ -319,6 +319,68 @@ config :screens,
         alert_headsign: "Ashmont/Braintree",
         headway_headsign: "Alewife"
       }
+    ],
+    # Park Street
+    "place-pktrm" => [
+      # Green Line
+      # Government Center -> Park Street -> Boylston
+      %{
+        # Government Center
+        not_informed: "70202",
+        # Boylston
+        informed: "70159",
+        alert_headsign: "Copley & West",
+        headway_headsign: "Northbound"
+      },
+      # Boylston -> Park Street -> Government Center
+      %{
+        # Boylston
+        not_informed: "70158",
+        # Government Center
+        informed: "70201",
+        alert_headsign: "Northbound",
+        headway_headsign: "Copley & West"
+      },
+      # Red Line
+      # Charles/MGH -> Park Street -> Downtown Crossing (Southbound)
+      %{
+        # Charles/MGH
+        not_informed: "70073",
+        # Downtown Crossing
+        informed: "70077",
+        alert_headsign: "Ashmont/Braintree",
+        headway_headsign: "Alewife"
+      },
+      # Downtown Crossing -> Park Street -> Charles/MGH (Northbound)
+      %{
+        # Downtown Crossing
+        not_informed: "70078",
+        # Charles/MGH
+        informed: "70074",
+        alert_headsign: "Alewife",
+        headway_headsign: "Ashmont/Braintree"
+      }
+    ],
+    # Arlington
+    "place-armnl" => [
+      # Boylston -> Arlington -> Copley
+      %{
+        # Boylston
+        not_informed: "70159",
+        # Copley
+        informed: "70155",
+        alert_headsign: "Copley & West",
+        headway_headsign: "Northbound"
+      },
+      # Copley -> Arlington -> Boylston
+      %{
+        # Copley
+        not_informed: "70154",
+        # Boylston
+        informed: "70158",
+        alert_headsign: "Northbound",
+        headway_headsign: "Copley & West"
+      }
     ]
   },
   prefare_alert_headsign_matchers: %{


### PR DESCRIPTION
**Asana task**: [Add Park Street and Arlington to DUP headsign configs](https://app.asana.com/0/1185117109217422/1207171583176322/f)

#### Description

<details>
<summary>Non-exhaustive examples 🖼️</summary>

![Screen Shot 2024-05-30 at 07 59 16](https://github.com/mbta/screens/assets/1699281/fb715253-f812-41a8-ab9f-f70929f10f2e)
![Screen Shot 2024-05-30 at 08 00 46](https://github.com/mbta/screens/assets/1699281/8515d553-8a8b-497e-a471-0154e4bed6da)
![Screen Shot 2024-05-30 at 08 02 27](https://github.com/mbta/screens/assets/1699281/df88868e-83aa-4434-8c58-9cfccb9a3300)
![Screen Shot 2024-05-30 at 08 04 26](https://github.com/mbta/screens/assets/1699281/b2a42b85-c3ec-4597-ba86-27169178055d)
![Screen Shot 2024-05-30 at 08 05 16](https://github.com/mbta/screens/assets/1699281/2b54fa30-ebc2-4a8e-8247-4fe2295e4a1c)

</details>