### PR TITLE
fix: revert addition of generic font fallbacks

### DIFF
--- a/assets/css/connection_error.scss
+++ b/assets/css/connection_error.scss
@@ -10,7 +10,7 @@
   position: absolute;
   margin-top: 40px;
   margin-left: 1000px;
-  font-family: Inter, sans-serif;
+  font-family: Inter;
   font-size: 72px;
   line-height: 72px;
   color: #fff;

--- a/assets/css/dup/screen_container.scss
+++ b/assets/css/dup/screen_container.scss
@@ -152,7 +152,7 @@
 .headway-section-list__message {
   display: inline-block;
   width: 1544px;
-  font-family: Inter, sans-serif;
+  font-family: Inter;
   font-size: 144px;
   line-height: 160px;
   color: #171f26;
@@ -177,7 +177,7 @@
 .headway-section-list__link-text {
   display: inline-block;
   margin-left: 72px;
-  font-family: Inter, sans-serif;
+  font-family: Inter;
   font-size: 108px;
   vertical-align: middle;
 }

--- a/assets/css/dup/section.scss
+++ b/assets/css/dup/section.scss
@@ -13,7 +13,7 @@
   }
 
   &--headway {
-    font-family: Inter, sans-serif;
+    font-family: Inter;
     font-size: 138px;
     line-height: 128px;
     color: #171f26;

--- a/assets/css/eink/loading.scss
+++ b/assets/css/eink/loading.scss
@@ -31,7 +31,7 @@
 }
 
 .page-load-no-data__header-text {
-  font-family: neue-haas-grotesk-display, sans-serif;
+  font-family: neue-haas-grotesk-display;
   font-size: 88px;
   font-weight: 700;
   line-height: 88px;

--- a/assets/css/fonts/inter_font_face.scss
+++ b/assets/css/fonts/inter_font_face.scss
@@ -1,5 +1,5 @@
 @font-face {
-  font-family: Inter, sans-serif;
+  font-family: Inter;
   font-style: normal;
   font-weight: 100;
   src:
@@ -9,7 +9,7 @@
 }
 
 @font-face {
-  font-family: Inter, sans-serif;
+  font-family: Inter;
   font-style: normal;
   font-weight: 200;
   src:
@@ -19,7 +19,7 @@
 }
 
 @font-face {
-  font-family: Inter, sans-serif;
+  font-family: Inter;
   font-style: normal;
   font-weight: 300;
   src:
@@ -29,7 +29,7 @@
 }
 
 @font-face {
-  font-family: Inter, sans-serif;
+  font-family: Inter;
   font-style: normal;
   font-weight: 400;
   src:
@@ -39,7 +39,7 @@
 }
 
 @font-face {
-  font-family: Inter, sans-serif;
+  font-family: Inter;
   font-style: normal;
   font-weight: 500;
   src:
@@ -49,7 +49,7 @@
 }
 
 @font-face {
-  font-family: Inter, sans-serif;
+  font-family: Inter;
   font-style: normal;
   font-weight: 600;
   src:
@@ -59,7 +59,7 @@
 }
 
 @font-face {
-  font-family: Inter, sans-serif;
+  font-family: Inter;
   font-style: normal;
   font-weight: 700;
   src:
@@ -69,7 +69,7 @@
 }
 
 @font-face {
-  font-family: Inter, sans-serif;
+  font-family: Inter;
   font-style: normal;
   font-weight: 800;
   src:
@@ -79,7 +79,7 @@
 }
 
 @font-face {
-  font-family: Inter, sans-serif;
+  font-family: Inter;
   font-style: normal;
   font-weight: 900;
   src:

--- a/assets/css/v2/blue_bikes.scss
+++ b/assets/css/v2/blue_bikes.scss
@@ -191,7 +191,7 @@
       top: 55px;
       left: 780px;
       height: 44px;
-      font-family: Inter, sans-serif;
+      font-family: Inter;
       font-size: 32px;
       font-weight: normal;
       line-height: 44px;
@@ -216,7 +216,7 @@
 
     .blue-bikes__station__out-of-service-alt-text {
       height: 44px;
-      font-family: Inter, sans-serif;
+      font-family: Inter;
       font-size: 32px;
       font-weight: normal;
       line-height: 44px;

--- a/assets/css/v2/bus_eink/departures/time.scss
+++ b/assets/css/v2/bus_eink/departures/time.scss
@@ -16,7 +16,7 @@
 
 .departure-time {
   display: inline-block;
-  font-family: Inter, sans-serif;
+  font-family: Inter;
   color: black;
   vertical-align: middle;
 }

--- a/assets/css/v2/bus_shelter/link_footer.scss
+++ b/assets/css/v2/bus_shelter/link_footer.scss
@@ -23,7 +23,7 @@
 
 .link-footer__message {
   display: inline-block;
-  font-family: Inter, sans-serif;
+  font-family: Inter;
   font-size: 48px;
   line-height: 48px;
   color: #000;

--- a/assets/css/v2/dup/departures/route_pill.scss
+++ b/assets/css/v2/dup/departures/route_pill.scss
@@ -84,7 +84,7 @@
 .route-pill__slashed-text {
   position: absolute;
   width: 100%;
-  font-family: neue-haas-grotesk-text, sans-serif;
+  font-family: neue-haas-grotesk-text;
   font-size: 32px;
   font-weight: 700;
   line-height: 74px;

--- a/assets/css/v2/eink/departures/alert.scss
+++ b/assets/css/v2/eink/departures/alert.scss
@@ -2,7 +2,7 @@
   display: inline-block;
   height: 72px;
   margin-left: 24px;
-  font-family: Inter, sans-serif;
+  font-family: Inter;
   font-size: 40px;
   line-height: 72px;
   color: white;

--- a/assets/css/v2/eink/departures/overnight.scss
+++ b/assets/css/v2/eink/departures/overnight.scss
@@ -8,7 +8,7 @@
   position: absolute;
   top: 40px;
   right: 40px;
-  font-family: Inter, sans-serif;
+  font-family: Inter;
   font-size: 72px;
   line-height: 72px;
   color: #fff;

--- a/assets/css/v2/eink/link_footer.scss
+++ b/assets/css/v2/eink/link_footer.scss
@@ -24,7 +24,7 @@
 .link-footer__message {
   display: inline-block;
   width: 952px;
-  font-family: Inter, sans-serif;
+  font-family: Inter;
   font-size: 40px;
   line-height: 52px;
   color: #fff;

--- a/assets/css/v2/eink/no_data.scss
+++ b/assets/css/v2/eink/no_data.scss
@@ -94,7 +94,7 @@
   position: absolute;
   top: 40px;
   right: 40px;
-  font-family: Inter, sans-serif;
+  font-family: Inter;
   font-size: 72px;
   line-height: 72px;
   color: #fff;

--- a/assets/css/v2/eink/normal_header.scss
+++ b/assets/css/v2/eink/normal_header.scss
@@ -61,7 +61,7 @@
   position: absolute;
   top: 40px;
   right: 40px;
-  font-family: Inter, sans-serif;
+  font-family: Inter;
   font-size: 72px;
   line-height: 72px;
   color: #fff;
@@ -76,7 +76,7 @@
 }
 
 .normal-header-updated__text {
-  font-family: Inter, sans-serif;
+  font-family: Inter;
   font-size: 24px;
   font-weight: 500;
   line-height: 28px;

--- a/assets/css/v2/eink/page_load_no_data.scss
+++ b/assets/css/v2/eink/page_load_no_data.scss
@@ -33,7 +33,7 @@
 }
 
 .page-load-no-data__header-text {
-  font-family: neue-haas-grotesk-display, sans-serif;
+  font-family: neue-haas-grotesk-display;
   font-size: 88px;
   font-weight: 700;
   line-height: 88px;

--- a/assets/css/v2/eink/route_pill.scss
+++ b/assets/css/v2/eink/route_pill.scss
@@ -9,7 +9,7 @@
 .route-pill__text {
   position: absolute;
   width: 100%;
-  font-family: neue-haas-grotesk-text, sans-serif;
+  font-family: neue-haas-grotesk-text;
   font-size: 120px;
   font-weight: 700;
   line-height: 144px;
@@ -24,7 +24,7 @@
 .route-pill__slashed-text {
   position: absolute;
   width: 100%;
-  font-family: neue-haas-grotesk-text, sans-serif;
+  font-family: neue-haas-grotesk-text;
   font-size: 64px;
   font-weight: 700;
   line-height: 144px;

--- a/assets/css/v2/gl_eink/departures/time.scss
+++ b/assets/css/v2/gl_eink/departures/time.scss
@@ -17,7 +17,7 @@
 
 .departure-time {
   margin-right: 32px;
-  font-family: Inter, sans-serif;
+  font-family: Inter;
   color: black;
   text-align: right;
 }

--- a/assets/css/v2/gl_eink/line_map.scss
+++ b/assets/css/v2/gl_eink/line_map.scss
@@ -11,7 +11,7 @@
 }
 
 .line-map__stop-label {
-  font-family: neue-haas-grotesk-text, sans-serif;
+  font-family: neue-haas-grotesk-text;
   font-size: 24px;
   line-height: 32px;
 
@@ -36,7 +36,7 @@
 }
 
 .line-map__vehicle-label {
-  font-family: neue-haas-grotesk-text, sans-serif;
+  font-family: neue-haas-grotesk-text;
 }
 
 .line-map__vehicle-label--text {
@@ -55,7 +55,7 @@
 }
 
 .line-map__scheduled-departure {
-  font-family: neue-haas-grotesk-text, sans-serif;
+  font-family: neue-haas-grotesk-text;
   fill: #999;
 
   &--time {

--- a/assets/css/v2/lcd_common/departures/alert.scss
+++ b/assets/css/v2/lcd_common/departures/alert.scss
@@ -8,7 +8,7 @@
   display: inline-block;
   height: 56px;
   margin-left: 16px;
-  font-family: Inter, sans-serif;
+  font-family: Inter;
   font-size: 36px;
   line-height: 56px;
   color: white;

--- a/assets/css/v2/lcd_common/departures/time.scss
+++ b/assets/css/v2/lcd_common/departures/time.scss
@@ -34,7 +34,7 @@
 
 .departure-time {
   display: inline-block;
-  font-family: Inter, sans-serif;
+  font-family: Inter;
   color: #171f26;
   vertical-align: middle;
 }

--- a/assets/css/v2/lcd_common/normal_header.scss
+++ b/assets/css/v2/lcd_common/normal_header.scss
@@ -42,7 +42,7 @@
   position: absolute;
   top: 40px;
   right: 40px;
-  font-family: Inter, sans-serif;
+  font-family: Inter;
   font-size: 56px;
   line-height: 56px;
   color: #fff;

--- a/assets/css/v2/lcd_common/route_pill.scss
+++ b/assets/css/v2/lcd_common/route_pill.scss
@@ -41,7 +41,7 @@
 .route-pill__text {
   position: absolute;
   width: 100%;
-  font-family: neue-haas-grotesk-text, sans-serif;
+  font-family: neue-haas-grotesk-text;
   font-size: 48px;
   font-weight: 700;
   line-height: 74px;
@@ -76,7 +76,7 @@
 .route-pill__slashed-text {
   position: absolute;
   width: 100%;
-  font-family: neue-haas-grotesk-text, sans-serif;
+  font-family: neue-haas-grotesk-text;
   font-size: 32px;
   font-weight: 700;
   line-height: 74px;

--- a/assets/css/v2/pre_fare/alert-banner.scss
+++ b/assets/css/v2/pre_fare/alert-banner.scss
@@ -2,7 +2,7 @@
   display: flex;
   flex-wrap: wrap;
   width: 100%;
-  font-family: Inter, sans-serif;
+  font-family: Inter;
   font-size: 60px;
   font-weight: 600;
   line-height: 72px;

--- a/assets/css/v2/pre_fare/normal_header.scss
+++ b/assets/css/v2/pre_fare/normal_header.scss
@@ -49,7 +49,7 @@
   position: absolute;
   top: 40px;
   right: 40px;
-  font-family: Inter, sans-serif;
+  font-family: Inter;
   font-size: 56px;
   font-weight: 600;
   line-height: 56px;

--- a/assets/css/v2/pre_fare/prefare_single_screen_alert.scss
+++ b/assets/css/v2/pre_fare/prefare_single_screen_alert.scss
@@ -21,7 +21,7 @@
   width: 1080px;
   min-height: 0;
   padding: 0 32px 32px;
-  font-family: Inter, sans-serif;
+  font-family: Inter;
 
   /* Background colors */
 

--- a/assets/css/v2/pre_fare/reconstructed_alert.scss
+++ b/assets/css/v2/pre_fare/reconstructed_alert.scss
@@ -6,7 +6,7 @@ $alert-card-footer-height: 80px;
 
 .alert-container {
   // Takeover fonts
-  font-family: Inter, sans-serif;
+  font-family: Inter;
   color: #171f26;
 
   .x-large-text {
@@ -117,7 +117,7 @@ $alert-card-footer-height: 80px;
       position: relative;
       width: fit-content;
       padding: 0 40px;
-      font-family: neue-haas-grotesk-text, sans-serif;
+      font-family: neue-haas-grotesk-text;
       font-size: 60px;
       line-height: 80px;
       text-transform: uppercase;

--- a/assets/css/v2/pre_fare/shuttle_bus_info.scss
+++ b/assets/css/v2/pre_fare/shuttle_bus_info.scss
@@ -34,7 +34,7 @@
         left: 216px;
 
         &--english {
-          font-family: Inter, sans-serif;
+          font-family: Inter;
           font-size: 80px;
           font-weight: bold;
           line-height: 80px;
@@ -43,7 +43,7 @@
 
         &--spanish {
           margin-top: 8px;
-          font-family: Inter, sans-serif;
+          font-family: Inter;
           font-size: 48px;
           font-weight: normal;
           line-height: 66px;
@@ -75,7 +75,7 @@
         left: 216px;
 
         &--english {
-          font-family: Inter, sans-serif;
+          font-family: Inter;
           font-size: 48px;
           font-weight: bold;
           line-height: 64px;
@@ -85,7 +85,7 @@
 
         &--spanish {
           margin-top: 8px;
-          font-family: Inter, sans-serif;
+          font-family: Inter;
           font-size: 36px;
           font-weight: normal;
           line-height: 44px;
@@ -113,7 +113,7 @@
 
         &--english {
           margin-right: 24px;
-          font-family: Inter, sans-serif;
+          font-family: Inter;
           font-size: 40px;
           font-weight: bold;
           line-height: 52px;
@@ -121,7 +121,7 @@
         }
 
         &--spanish {
-          font-family: Inter, sans-serif;
+          font-family: Inter;
           font-size: 32px;
           font-weight: normal;
           line-height: 44px;
@@ -149,7 +149,7 @@
 
           &--english {
             margin-right: 24px;
-            font-family: Inter, sans-serif;
+            font-family: Inter;
             font-size: 40px;
             font-weight: bold;
             line-height: 52px;
@@ -157,7 +157,7 @@
           }
 
           &--spanish {
-            font-family: Inter, sans-serif;
+            font-family: Inter;
             font-size: 32px;
             font-weight: normal;
             line-height: 44px;
@@ -186,7 +186,7 @@
           margin-right: 44px;
 
           &--english {
-            font-family: Inter, sans-serif;
+            font-family: Inter;
             font-size: 32px;
             font-weight: bold;
             line-height: 44px;
@@ -194,7 +194,7 @@
           }
 
           &--spanish {
-            font-family: Inter, sans-serif;
+            font-family: Inter;
             font-size: 24px;
             font-weight: normal;
             line-height: 36px;

--- a/assets/css/v2/pre_fare/simulation.scss
+++ b/assets/css/v2/pre_fare/simulation.scss
@@ -34,7 +34,7 @@
 
     .simulation__title {
       margin-bottom: 10px;
-      font-family: Inter, sans-serif;
+      font-family: Inter;
       font-size: 16px;
       font-weight: 700;
       line-height: 24px;
@@ -63,7 +63,7 @@
 
     .simulation__title {
       margin-bottom: 10px;
-      font-family: Inter, sans-serif;
+      font-family: Inter;
       font-size: 16px;
       font-weight: 400;
       line-height: 24px;
@@ -92,7 +92,7 @@
 
     .simulation__title {
       margin-bottom: 10px;
-      font-family: Inter, sans-serif;
+      font-family: Inter;
       font-size: 16px;
       font-weight: 400;
       line-height: 24px;

--- a/assets/css/v2/solari_large/normal_header.scss
+++ b/assets/css/v2/solari_large/normal_header.scss
@@ -41,7 +41,7 @@
   position: absolute;
   top: 40px;
   right: 40px;
-  font-family: Inter, sans-serif;
+  font-family: Inter;
   font-size: 96px;
   line-height: 96px;
   color: #fff;

--- a/assets/stylelint.config.mjs
+++ b/assets/stylelint.config.mjs
@@ -9,6 +9,11 @@ export default {
     // We use blank lines to separate "groups" of imports.
     "at-rule-empty-line-before": null,
 
+    // Disabled for now since adding generic fallbacks caused issues with some
+    // devices, where the display incorrectly settles on the generic font rather
+    // than the intended one.
+    "font-family-no-missing-generic-family-keyword": null,
+
     // Docs: "We recommend turning this rule off if you use a lot of nesting."
     "no-descending-specificity": null,
 


### PR DESCRIPTION
This reverts the specific changes in 83d806c that added generic font fallbacks, and disables the Stylelint rule that required them. We found this caused problems with (at least) DUP and Bus e-Ink rendering on real hardware.