### PR TITLE
Widgetize Later Departures

### DIFF
--- a/assets/css/colors.scss
+++ b/assets/css/colors.scss
@@ -10,4 +10,8 @@ $line-color-ferry: #008eaa;
 $alert-yellow: #fd0;
 
 $true-grey-70: #b2b1af;
+
 $warm-neutral-80: #cccbc8;
+$warm-neutral-90: #e5e4e1;
+
+$cool-black-15: #171f26;

--- a/assets/css/v2/lcd_common/departures.scss
+++ b/assets/css/v2/lcd_common/departures.scss
@@ -8,3 +8,4 @@
 @import "departures/time";
 @import "departures/crowding";
 @import "departures/alert";
+@import "departures/later_departures";

--- a/assets/css/v2/lcd_common/departures/later_departures.scss
+++ b/assets/css/v2/lcd_common/departures/later_departures.scss
@@ -1,0 +1,102 @@
+@use "sass:math";
+
+.later-departures__carousel {
+  position: relative;
+  display: flex;
+  flex-direction: row;
+  width: 100%;
+  transform: translateX(calc(-100% * var(--later-departures-offset)));
+}
+
+.later-departures {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  flex-shrink: 0;
+  width: 100%;
+  background-color: $warm-neutral-90;
+
+  &__header {
+    box-sizing: inherit;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    margin: 0 32px;
+    border-bottom: 4px solid $true-grey-70;
+
+    h3 {
+      box-sizing: inherit;
+      flex-shrink: 0;
+      padding: 18px 0;
+      margin: 0;
+      font-family: Inter;
+      font-size: 40px;
+      font-weight: 500;
+      line-height: 43px;
+      color: $cool-black-15;
+      text-transform: uppercase;
+      letter-spacing: 2px;
+    }
+
+    ol {
+      display: flex;
+      flex-direction: row;
+      gap: 24px;
+      justify-content: space-between;
+      list-style: none;
+
+      .route-pill {
+        // RoutePill is using some position: absolute/relative stuff to center
+        // text vertically; however, it also relies on fixed widths. To get
+        // these route pills to grow horizontally when needed (and simplify
+        // doing that) the smaller RoutePills used in the Later Departures
+        // component use flexbox to center things instead. `position: static`
+        // is the default value so this rule resets the default behavior.
+        position: static;
+        box-sizing: border-box;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: auto;
+        min-width: 86px;
+        height: 44px;
+      }
+
+      .route-pill--yellow {
+        box-shadow: 1px 1px 1px 0 rgba(0 0 0 / 25%);
+      }
+
+      .route-pill__text,
+      .route-pill__slashed-text {
+        position: static;
+        padding: 0 14px;
+        font-size: 36px;
+        line-height: 36px;
+      }
+
+      .route-pill__slashed-text {
+        display: flex;
+      }
+    }
+  }
+
+  &__route--selected {
+    position: relative;
+
+    &::after {
+      $caret-size: 16px;
+
+      position: absolute;
+      bottom: -25px;
+      left: calc(50% - math.hypot($caret-size, $caret-size) / 2);
+      box-sizing: border-box;
+      width: $caret-size;
+      height: $caret-size;
+      content: " ";
+      background-color: $warm-neutral-90;
+      border-top: 4px solid $true-grey-70;
+      border-left: 4px solid $true-grey-70;
+      transform: rotate(45deg);
+    }
+  }
+}

--- a/assets/css/v2/lcd_common/route_pill.scss
+++ b/assets/css/v2/lcd_common/route_pill.scss
@@ -36,6 +36,16 @@
     background-color: $line-color-bus;
     box-shadow: 2px 4px 2px 0 rgb(0 0 0 / 25%);
   }
+
+  &--outline {
+    background: none;
+    border: 2px solid #2e3e4d;
+    box-shadow: none;
+
+    .route-pill__slashed-text {
+      color: #2e3e4d;
+    }
+  }
 }
 
 .route-pill__text {
@@ -59,6 +69,10 @@
   &--silver,
   &--teal {
     color: white;
+  }
+
+  &--outline {
+    color: #2e3e4d;
   }
 }
 

--- a/assets/src/components/v2/departures/later_departures.tsx
+++ b/assets/src/components/v2/departures/later_departures.tsx
@@ -1,0 +1,87 @@
+import React, {
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import _ from "lodash";
+import cx from "classnames";
+
+import { hasOverflowX } from "Util/util";
+import useRefreshRate from "Hooks/v2/use_refresh_rate";
+
+import DepartureRow from "./departure_row";
+import RoutePill from "./route_pill";
+
+const MAX_LATER_DEPARTURES = 5;
+
+// "Magic" number carried over from Solari. Prevents a Later Departures
+// component from paging through departures very slowly when there are only a
+// few later departures
+const MAX_PAGE_RATE_MS = 3750;
+
+const LaterDepatures = ({ rows }: { rows: DepartureRow[] }) => {
+  const { refreshRateMs } = useRefreshRate();
+  const [limit, setLimit] = useState(MAX_LATER_DEPARTURES);
+  const departures = useMemo(() => _.take(rows, limit), [rows, limit]);
+
+  const ref = useRef<HTMLDivElement>(null);
+  const [currentDepartureIdx, setCurrentDepartureIdx] = useState(0);
+
+  useLayoutEffect(() => {
+    if (hasOverflowX(ref)) {
+      setLimit(Math.max(0, limit - 1));
+    }
+  }, [limit]);
+
+  useEffect(() => {
+    if (departures.length < 2) return;
+    const pageDurationMs = Math.min(
+      MAX_PAGE_RATE_MS,
+      refreshRateMs / departures.length,
+    );
+
+    const interval = setInterval(() => {
+      setCurrentDepartureIdx((i) => (i + 1) % departures.length);
+    }, pageDurationMs);
+
+    return () => clearInterval(interval);
+  }, [refreshRateMs, departures.length]);
+
+  return (
+    <div
+      className="later-departures__carousel"
+      style={
+        {
+          "--later-departures-offset": currentDepartureIdx,
+        } as React.CSSProperties
+      }
+    >
+      {departures.map((departure, i) => (
+        <div className="later-departures" key={departure.id}>
+          <div className="later-departures__header" ref={ref}>
+            <h3>Later Departures</h3>
+            <ol>
+              {departures.map((d, j) => (
+                <li
+                  key={d.id}
+                  className={cx({
+                    "later-departures__route--selected": i === j,
+                  })}
+                >
+                  <RoutePill {...d.route} outline={i !== j} />
+                </li>
+              ))}
+            </ol>
+          </div>
+          <div>
+            <DepartureRow {...departure} />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default LaterDepatures;

--- a/assets/src/components/v2/departures/normal_departures.tsx
+++ b/assets/src/components/v2/departures/normal_departures.tsx
@@ -1,9 +1,15 @@
-import React, { ComponentType, useLayoutEffect, useRef, useState } from "react";
+import React, {
+  ComponentType,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import weakKey from "weak-key";
 
 import NormalSection from "./normal_section";
 import NoticeSection from "./notice_section";
-import { Section, trimSections } from "./section";
+import { Section, trimSections, toSectionWithLaterRows } from "./section";
 
 import { warn } from "Util/sentry";
 import { hasOverflowY } from "Util/util";
@@ -14,10 +20,17 @@ type NormalDepartures = {
 
 const NormalDepartures: ComponentType<NormalDepartures> = ({ sections }) => {
   const ref = useRef<HTMLDivElement>(null);
-  const [trimmedSections, setTrimmedSections] = useState(sections);
+  const sectionsWithLaterRows = useMemo(
+    () => sections.map(toSectionWithLaterRows),
+    [sections],
+  );
+  const [trimmedSections, setTrimmedSections] = useState(sectionsWithLaterRows);
 
   // Restart trimming if the sections prop is changed (i.e. new data).
-  useLayoutEffect(() => setTrimmedSections(sections), [sections]);
+  useLayoutEffect(
+    () => setTrimmedSections(sectionsWithLaterRows),
+    [sectionsWithLaterRows],
+  );
 
   // Iteratively trim sections until the container doesn't overflow.
   useLayoutEffect(() => {

--- a/assets/src/components/v2/departures/normal_section.tsx
+++ b/assets/src/components/v2/departures/normal_section.tsx
@@ -4,24 +4,35 @@ import weakKey from "weak-key";
 import DepartureRow from "./departure_row";
 import NoticeRow from "./notice_row";
 import Header from "./header";
+import LaterDepatures from "./later_departures";
 
 export type Layout = {
   base: number | null;
   max: number | null;
   min: number;
+  include_later: boolean;
 };
 
 export type Row =
   | (DepartureRow & { type: "departure_row" })
   | (NoticeRow & { type: "notice_row" });
 
-type NormalSection = {
+export interface NormalSection {
   layout: Layout;
   header: React.ComponentProps<typeof Header>;
   rows: Row[];
-};
+}
 
-const NormalSection: ComponentType<NormalSection> = ({ rows, header }) => {
+export interface NormalSectionWithLaterRows extends NormalSection {
+  laterRows: DepartureRow[];
+}
+
+const NormalSection: ComponentType<NormalSectionWithLaterRows> = ({
+  header,
+  layout,
+  rows,
+  laterRows,
+}) => {
   return (
     <div className="departures-section">
       <Header {...header} />
@@ -32,6 +43,9 @@ const NormalSection: ComponentType<NormalSection> = ({ rows, header }) => {
           return <NoticeRow row={row} key={weakKey(row)} />;
         }
       })}
+      {layout.include_later && laterRows.length > 0 && (
+        <LaterDepatures rows={laterRows} />
+      )}
     </div>
   );
 };

--- a/assets/src/components/v2/departures/route_pill.tsx
+++ b/assets/src/components/v2/departures/route_pill.tsx
@@ -90,6 +90,8 @@ const SlashedRoutePill: ComponentType<SlashedPill> = ({ part1, part2 }) => {
 const RoutePill: ComponentType<Pill> = (pill) => {
   const modifiers: string[] = [pill.color];
 
+  if (pill.outline) modifiers.push("outline");
+
   let innerContent: JSX.Element | null = null;
   switch (pill.type) {
     case "text": {

--- a/assets/src/components/v2/departures/section.ts
+++ b/assets/src/components/v2/departures/section.ts
@@ -1,11 +1,30 @@
 import _ from "lodash";
 
-import NormalSection, { Layout } from "./normal_section";
+import type {
+  Layout,
+  NormalSection,
+  NormalSectionWithLaterRows,
+} from "./normal_section";
 import NoticeSection from "./notice_section";
 
 export type Section =
   | (NormalSection & { type: "normal_section" })
   | (NoticeSection & { type: "notice_section" });
+
+export type SectionWithLaterRows =
+  | (NormalSectionWithLaterRows & { type: "normal_section" })
+  | (NoticeSection & { type: "notice_section" });
+
+export const toSectionWithLaterRows = (
+  section: Section,
+): SectionWithLaterRows => {
+  if (section.type !== "normal_section") return section;
+
+  return {
+    ...section,
+    laterRows: [],
+  };
+};
 
 /**
  * Perform one iteration of "section trimming", i.e. the process of removing
@@ -14,7 +33,9 @@ export type Section =
  *
  * Operates immutably. If no sections could be trimmed, returns the same array.
  */
-export const trimSections = (sections: Section[]): Section[] => {
+export const trimSections = (
+  sections: SectionWithLaterRows[],
+): SectionWithLaterRows[] => {
   const trimmed = _.cloneDeep(sections);
 
   const sortedSizedSections = trimmed
@@ -30,7 +51,7 @@ export const trimSections = (sections: Section[]): Section[] => {
 
 // Determine how many "items" a section contains, for the purposes of deciding
 // which sections should be trimmed first.
-const sectionLength = (section: Section): number => {
+const sectionLength = (section: Section | SectionWithLaterRows): number => {
   if (section.type == "normal_section") {
     return section.rows.reduce(
       (sum, row) =>
@@ -43,16 +64,19 @@ const sectionLength = (section: Section): number => {
   }
 };
 
-type SizedSection = {
+type SizedSectionWithLaterRows = {
   length: number;
-  section: Section;
+  section: SectionWithLaterRows;
 };
 
 // Functions which destructively trim departures from sections, returning `true`
 // if any trimming occurred. Each iteration of section trimming tries each one
 // of these in sequence until one succeeds or they have all been tried. Assumes
 // the given sections are reverse-sorted by length (largest first).
-const trimStages: Record<string, (sections: SizedSection[]) => boolean> = {
+const trimStages: Record<
+  string,
+  (sections: SizedSectionWithLaterRows[]) => boolean
+> = {
   // Trim all sections with more departures than their `max` until they have
   // exactly as many as their `max` (if defined).
   allToMax: (sections) => {
@@ -85,7 +109,7 @@ const trimStages: Record<string, (sections: SizedSection[]) => boolean> = {
 };
 
 const trimOneBy = (
-  sections: SizedSection[],
+  sections: SizedSectionWithLaterRows[],
   condition: (length: number, layout: Layout) => boolean,
 ): boolean => {
   for (const { section, length } of sections) {
@@ -98,18 +122,27 @@ const trimOneBy = (
 
 // Destructively trim the last departure time from a section, if possible.
 // Returns `true` if the section was trimmed.
-const trimSection = (section: Section): boolean => {
+const trimSection = (section: SectionWithLaterRows): boolean => {
   if (section.type == "normal_section") {
     for (let rowIndex = section.rows.length - 1; rowIndex >= 0; rowIndex--) {
       const row = section.rows[rowIndex];
 
       if (row.type == "departure_row") {
+        const trimmedTimeWithCrowding = _.last(row.times_with_crowding);
         if (row.times_with_crowding.length > 1) {
           // More than one departure time; trim the last one.
           row.times_with_crowding.splice(row.times_with_crowding.length - 1);
         } else {
           // Only one departure time; trim this row entirely.
           section.rows.splice(rowIndex, 1);
+        }
+
+        if (trimmedTimeWithCrowding != null) {
+          section.laterRows.unshift({
+            ...row,
+            id: _.uniqueId(`${row.id}_`),
+            times_with_crowding: [trimmedTimeWithCrowding],
+          });
         }
 
         return true;

--- a/assets/src/components/v2/multi_screen_page.tsx
+++ b/assets/src/components/v2/multi_screen_page.tsx
@@ -6,6 +6,7 @@ import ScreenContainer, {
 } from "Components/v2/screen_container";
 import { MappingContext } from "Components/v2/widget";
 import { fetchDatasetValue } from "Util/dataset";
+import { ScreenIDProvider } from "Hooks/v2/use_screen_id";
 
 const MultiScreenPage = ({
   components,
@@ -20,11 +21,13 @@ const MultiScreenPage = ({
     <div className="multi-screen-page">
       {screenIds.map((screen) => (
         <div key={screen.id}>
-          <MappingContext.Provider value={components}>
-            <ResponseMapperContext.Provider value={responseMapper}>
-              <ScreenContainer id={screen.id} />
-            </ResponseMapperContext.Provider>
-          </MappingContext.Provider>
+          <ScreenIDProvider id={screen.id}>
+            <MappingContext.Provider value={components}>
+              <ResponseMapperContext.Provider value={responseMapper}>
+                <ScreenContainer id={screen.id} />
+              </ResponseMapperContext.Provider>
+            </MappingContext.Provider>
+          </ScreenIDProvider>
         </div>
       ))}
     </div>

--- a/assets/src/components/v2/screen_page.tsx
+++ b/assets/src/components/v2/screen_page.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useParams } from "react-router-dom";
 import ScreenContainer from "Components/v2/screen_container";
+import { ScreenIDProvider } from "Hooks/v2/use_screen_id";
 
 interface Props {
   id?: string;
@@ -8,7 +9,11 @@ interface Props {
 
 const ScreenPage = ({ id }: Props) => {
   const screenId = id ?? (useParams() as { id: string }).id;
-  return <ScreenContainer id={screenId} />;
+  return (
+    <ScreenIDProvider id={screenId}>
+      <ScreenContainer id={screenId} />;
+    </ScreenIDProvider>
+  );
 };
 
 export default ScreenPage;

--- a/assets/src/hooks/v2/use_refresh_rate.ts
+++ b/assets/src/hooks/v2/use_refresh_rate.ts
@@ -1,0 +1,37 @@
+import _ from "lodash";
+import { useMemo } from "react";
+import { fetchDatasetValue, getDatasetValue } from "Util/dataset";
+import { isOFM } from "Util/outfront";
+import { useScreenID } from "./use_screen_id";
+
+interface RefreshRateConfig {
+  refreshRateMs: number;
+  refreshRateOffsetMs: number;
+}
+
+const useRefreshRate = (): RefreshRateConfig => {
+  const screenId = useScreenID();
+  // Live OFM screens ignore any configured refreshRate.
+  // Hardcoding to 0 prevents an interval from being started unnecessarily.
+  const refreshRate = isOFM() ? "0" : fetchDatasetValue("refreshRate");
+  const refreshRateOffset = getDatasetValue("refreshRateOffset") || "0";
+  const screenIdsWithOffsetMap = getDatasetValue("screenIdsWithOffsetMap");
+
+  const refreshRateMs = parseFloat(refreshRate) * 1000;
+
+  const refreshRateOffsetMs = useMemo(() => {
+    if (screenIdsWithOffsetMap) {
+      const screens = JSON.parse(screenIdsWithOffsetMap);
+      return _.find(screens, { id: screenId }).refresh_rate_offset * 1000;
+    }
+
+    return parseFloat(refreshRateOffset) * 1000;
+  }, []);
+
+  return {
+    refreshRateMs,
+    refreshRateOffsetMs,
+  };
+};
+
+export default useRefreshRate;

--- a/assets/src/hooks/v2/use_screen_id.tsx
+++ b/assets/src/hooks/v2/use_screen_id.tsx
@@ -1,0 +1,15 @@
+import React, { useContext } from "react";
+
+const ScreenIDContext = React.createContext<string>("");
+
+export const ScreenIDProvider = ({
+  id,
+  children,
+}: {
+  id: string;
+  children: React.ReactNode;
+}) => (
+  <ScreenIDContext.Provider value={id}>{children}</ScreenIDContext.Provider>
+);
+
+export const useScreenID = (): string => useContext(ScreenIDContext);

--- a/assets/src/util/util.tsx
+++ b/assets/src/util/util.tsx
@@ -29,6 +29,9 @@ export const formatTimeString = (timeString: string) =>
 export const hasOverflowY = (ref: RefObject<Element>): boolean =>
   !!ref.current && ref.current.scrollHeight > ref.current.clientHeight;
 
+export const hasOverflowX = (ref: RefObject<Element>): boolean =>
+  !!ref.current && ref.current.scrollWidth > ref.current.clientWidth;
+
 export const imagePath = (fileName: string): string =>
   isOFM() ? outfrontImagePath(fileName) : `/images/${fileName}`;
 

--- a/assets/tests/components/v2/departures/factories.ts
+++ b/assets/tests/components/v2/departures/factories.ts
@@ -1,14 +1,15 @@
 import { Factory } from "fishery";
 
-import { Section } from "Components/v2/departures/section";
+import { SectionWithLaterRows } from "Components/v2/departures/section";
 import { Row } from "Components/v2/departures/normal_section";
 import { TimeWithCrowding } from "Components/v2/departures/departure_times";
 
-export const normalSection = Factory.define<Section>(() => ({
+export const normalSection = Factory.define<SectionWithLaterRows>(() => ({
   type: "normal_section",
-  layout: { min: 1, base: null, max: null },
+  layout: { min: 1, base: null, max: null, include_later: false },
   rows: departureRow.buildList(1),
   header: { title: null, arrow: null },
+  laterRows: [],
 }));
 
 export const departureRow = Factory.define<Row>(({ sequence }) => ({

--- a/assets/tests/components/v2/departures/section.test.ts
+++ b/assets/tests/components/v2/departures/section.test.ts
@@ -1,13 +1,15 @@
 import { describe, expect, test } from "@jest/globals";
 
-import { Section } from "Components/v2/departures/section";
-import { trimSections } from "Components/v2/departures/section";
+import {
+  trimSections,
+  type SectionWithLaterRows,
+} from "Components/v2/departures/section";
 
 import { departureRow, normalSection, timeWithCrowding } from "./factories";
 
 describe("trimSections", () => {
   test("does nothing with notice sections", () => {
-    const sections: Section[] = [
+    const sections: SectionWithLaterRows[] = [
       {
         type: "notice_section",
         text: { text: [{ text: "text" }] },
@@ -19,9 +21,9 @@ describe("trimSections", () => {
 
   test("trims all sections to their `max` if any exceed it", () => {
     const rowsA = departureRow.buildList(3);
-    const [rowA1, rowA2] = rowsA;
+    const [rowA1, rowA2, ...trimmedA] = rowsA;
     const rowsB = departureRow.buildList(5);
-    const [rowB1, rowB2, rowB3] = rowsB;
+    const [rowB1, rowB2, rowB3, ...trimmedB] = rowsB;
 
     const sections = [
       normalSection.build({ layout: { max: 2 }, rows: rowsA }),
@@ -29,14 +31,14 @@ describe("trimSections", () => {
     ];
 
     expect(trimSections(sections)).toEqual([
-      { ...sections[0], rows: [rowA1, rowA2] },
-      { ...sections[1], rows: [rowB1, rowB2, rowB3] },
+      { ...sections[0], rows: [rowA1, rowA2], trimmedRows: trimmedA },
+      { ...sections[1], rows: [rowB1, rowB2, rowB3], trimmedRows: trimmedB },
     ]);
   });
 
   test("trims one departure from the largest section above its `base`", () => {
     const rowsB = departureRow.buildList(5);
-    const [rowB1, rowB2, rowB3, rowB4] = rowsB;
+    const [rowB1, rowB2, rowB3, rowB4, ...trimmedB] = rowsB;
 
     const sections = [
       normalSection.build({
@@ -52,14 +54,18 @@ describe("trimSections", () => {
 
     expect(trimSections(sections)).toEqual([
       { ...sections[0] },
-      { ...sections[1], rows: [rowB1, rowB2, rowB3, rowB4] },
+      {
+        ...sections[1],
+        rows: [rowB1, rowB2, rowB3, rowB4],
+        trimmedRows: trimmedB,
+      },
       { ...sections[2] },
     ]);
   });
 
   test("treats sections with a null `base` as being equal to `min`", () => {
     const rowsA = departureRow.buildList(3);
-    const [rowA1, rowA2] = rowsA;
+    const [rowA1, rowA2, ...trimmedA] = rowsA;
 
     const sections = [
       normalSection.build({ layout: { min: 1, base: null }, rows: rowsA }),
@@ -70,14 +76,14 @@ describe("trimSections", () => {
     ];
 
     expect(trimSections(sections)).toEqual([
-      { ...sections[0], rows: [rowA1, rowA2] },
+      { ...sections[0], rows: [rowA1, rowA2], trimmedRows: trimmedA },
       { ...sections[1] },
     ]);
   });
 
   test("trims one departure from the largest section above its `min`", () => {
     const rowsA = departureRow.buildList(3);
-    const [rowA1, rowA2] = rowsA;
+    const [rowA1, rowA2, ...trimmedA] = rowsA;
 
     const sections = [
       normalSection.build({ layout: { min: 1 }, rows: rowsA }),
@@ -92,7 +98,7 @@ describe("trimSections", () => {
     ];
 
     expect(trimSections(sections)).toEqual([
-      { ...sections[0], rows: [rowA1, rowA2] },
+      { ...sections[0], rows: [rowA1, rowA2], trimmedRows: trimmedA },
       { ...sections[1] },
       { ...sections[2] },
     ]);
@@ -111,14 +117,15 @@ describe("trimSections", () => {
 
   test("trims individual departure times from rows with multiple", () => {
     const times = timeWithCrowding.buildList(3);
-    const [time1, time2] = times;
+    const [time1, time2, ...trimmedTimes] = times;
     const row = departureRow.build({ times_with_crowding: times });
-    const trimmedRow = { ...row, times_with_crowding: [time1, time2] };
+    const partialRow = { ...row, times_with_crowding: [time1, time2] };
+    const trimmedRow = { ...row, times_with_crowding: trimmedTimes };
 
     const sections = [normalSection.build({ rows: [row] })];
 
     expect(trimSections(sections)).toEqual([
-      { ...sections[0], rows: [trimmedRow] },
+      { ...sections[0], rows: [partialRow], trimmedRows: [trimmedRow] },
     ]);
   });
 });


### PR DESCRIPTION
**Asana task**: [Departures: Widgetize "Later departures"](https://app.asana.com/0/1207094698667699/1206645864760369/f)

#### Description

- Tracks `trimmedRows` in sections layout helpers
- Renders `trimmedRows` in a "Later Departures" component when `include_later === true`

<details>
<summary>Recordings 📹</summary>

https://github.com/mbta/screens/assets/1699281/dc5cb717-7cdf-4fb2-b51b-5c8030c078d9

https://github.com/mbta/screens/assets/1699281/884fb4be-4b9c-4e61-87d6-57111ac245db

</summary>