### PR TITLE
Fix DUP route pill font weight

### DIFF
--- a/assets/css/v2/dup/free_text.scss
+++ b/assets/css/v2/dup/free_text.scss
@@ -92,6 +92,7 @@
 .free-text__route-pill__text,
 .free-text__text-pill__text {
   font-family: Helvetica, sans-serif;
+  font-weight: 700;
 
   &--branch {
     font-size: 84px;


### PR DESCRIPTION
**Asana task**: [Fix DUP route pill font weights](https://app.asana.com/0/1185117109217413/1207447516868331/f)

#### Description

Route pills within free text were not bold. This fixes that.

| Before | After |
| - | - |
| ![Screen Shot 2024-05-30 at 08 05 16](https://github.com/mbta/screens/assets/1699281/1eb5b99b-1a67-4cb4-819a-3b69aaf739e5) | ![Screen Shot 2024-05-31 at 12 46 05](https://github.com/mbta/screens/assets/1699281/7d880cb7-abb8-4752-919e-fe217da2362b) |
| ![Screen Shot 2024-05-30 at 08 04 26](https://github.com/mbta/screens/assets/1699281/cf7af9ae-e924-4687-8a2d-83efdb8da4d7) | ![Screen Shot 2024-05-31 at 12 37 42](https://github.com/mbta/screens/assets/1699281/96e96853-27da-4a0d-a7a0-550c862a5136) |
| ![Screen Shot 2024-05-30 at 08 00 46](https://github.com/mbta/screens/assets/1699281/ff537343-9874-4a3a-ba16-f8eaf58e4ed6) | ![Screen Shot 2024-05-31 at 12 44 46](https://github.com/mbta/screens/assets/1699281/b36425bb-0527-4f6c-885c-1a1bfe5893a7) |






