### PR TITLE
fix: expand match in `RoutePattern.stops_by_route_and_direction/2`

### DIFF
--- a/lib/screens/route_patterns/route_pattern.ex
+++ b/lib/screens/route_patterns/route_pattern.ex
@@ -35,7 +35,7 @@ defmodule Screens.RoutePatterns.RoutePattern do
            RoutePatterns.Parser.parse_result(route_patterns, route_id) do
       {:ok, parsed_result}
     else
-      :error -> :error
+      _ -> :error
     end
   end
 


### PR DESCRIPTION
[Asana](https://app.asana.com/0/1185117109217413/1207496878226131/f)

fixes Sentry issue [SCREENS-80](https://mbtace.sentry.io/issues/5039566709/?project=6061747&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=14d&stream_index=1)

Looking at the history of this file I think this was just a mistake. This `with` used to be a `case` with a `_ -> :error` match: https://github.com/mbta/screens/commit/7679cc6d1bb7d905e94db4874ace652f8b124d4a#diff-e96db1e1a5ac37886d83f672f7378fd59a409425061ee9e90232002b4fd223dbL34


