### PR TITLE
fix: expand patterns to prevent CaseClauseError

### DIFF
--- a/lib/screens/v2/candidate_generator/widgets/departures.ex
+++ b/lib/screens/v2/candidate_generator/widgets/departures.ex
@@ -135,8 +135,8 @@ defmodule Screens.V2.CandidateGenerator.Widgets.Departures do
 
     route =
       case route_fetch_fn.(fetch_params) do
-        {:ok, [route]} -> route
-        :error -> nil
+        {:ok, [route | _]} -> route
+        _ -> nil
       end
 
     {:no_data, route}

--- a/test/screens/v2/candidate_generator/widgets/departures_test.exs
+++ b/test/screens/v2/candidate_generator/widgets/departures_test.exs
@@ -148,6 +148,36 @@ defmodule Screens.V2.CandidateGenerator.Widgets.DeparturesTest do
                )
     end
 
+    test "with multiple sections, returns DeparturesWidget with notice rows in empty sections if route_fetch_fn returns no routes" do
+      config = build_config(["A", "B"])
+      departure_b = build_departure("B", 0)
+      departure_fetch_fn = build_fetch_fn(%{"A" => {:ok, []}, "B" => {:ok, [departure_b]}})
+      route_fetch_fn = fn %{ids: ["A"]} -> {:ok, []} end
+
+      assert [
+               %DeparturesWidget{
+                 section_data: [
+                   %{
+                     type: :normal_section,
+                     rows: [
+                       %{
+                         text: %FreeTextLine{
+                           icon: nil,
+                           text: ["No departures currently available"]
+                         }
+                       }
+                     ]
+                   },
+                   %{type: :normal_section, rows: [^departure_b]}
+                 ]
+               }
+             ] =
+               departures_instances(config,
+                 departure_fetch_fn: departure_fetch_fn,
+                 route_fetch_fn: route_fetch_fn
+               )
+    end
+
     test "with multiple sections, returns a notice row when a mode is devops-disabled" do
       # use a screen type that does not get entirely disabled based on mode
       config = %Screen{build_config(["A", "B"]) | app_id: :busway_v2}

--- a/test/screens/v2/candidate_generator/widgets/departures_test.exs
+++ b/test/screens/v2/candidate_generator/widgets/departures_test.exs
@@ -148,7 +148,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.DeparturesTest do
                )
     end
 
-    test "with multiple sections, returns DeparturesWidget with notice rows in empty sections if route_fetch_fn returns no routes" do
+    test "with multiple sections, returns notice row with no icon if no routes are found" do
       config = build_config(["A", "B"])
       departure_b = build_departure("B", 0)
       departure_fetch_fn = build_fetch_fn(%{"A" => {:ok, []}, "B" => {:ok, [departure_b]}})


### PR DESCRIPTION
**Sentry issue**: [SCREENS-A5](https://mbtace.sentry.io/issues/5459051453/)
**Asana:** [Fix crash on MUL-108](https://app.asana.com/0/1207094698667699/1207495619155907/f)

Updates `case` to take any non-empty list and return the first value and return `nil` for anything else.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207495619155907