### PR TITLE
[Prefare Alerts] Station names should not split across lines

### DIFF
--- a/assets/src/components/v2/pre_fare_single_screen_alert.tsx
+++ b/assets/src/components/v2/pre_fare_single_screen_alert.tsx
@@ -6,6 +6,8 @@ import DisruptionDiagram, {
 } from "./disruption_diagram/disruption_diagram";
 import { classWithModifier, classWithModifiers, formatCause } from "Util/util";
 
+import FreeText, { type FreeTextType } from "./free_text";
+
 import ClockIcon from "Images/svgr_bundled/clock-negative.svg";
 import NoServiceIcon from "Images/svgr_bundled/no-service.svg";
 import InfoIcon from "Images/svgr_bundled/info.svg";
@@ -13,15 +15,34 @@ import ISAIcon from "Images/svgr_bundled/isa.svg";
 import WalkingIcon from "Images/svgr_bundled/nearby.svg";
 import ShuttleBusIcon from "Images/svgr_bundled/bus.svg";
 
+type StringOrFreeText = string | FreeTextType | Array<string | FreeTextType>;
+
+const Text = ({ children: text }: { children?: StringOrFreeText | null }) => {
+  if (text == null) return null;
+
+  if (typeof text === "string") return <span>{text}</span>;
+  if (Array.isArray(text)) {
+    return (
+      <>
+        {text.map((el, i) => (
+          <Text key={i}>{el}</Text>
+        ))}
+      </>
+    );
+  }
+
+  return <FreeText lines={text} />;
+};
+
 interface PreFareSingleScreenAlertProps {
-  issue: string;
-  location: string;
+  issue: StringOrFreeText;
+  location: StringOrFreeText;
   cause: string;
   remedy: string;
   remedy_bold?: string;
   routes: EnrichedRoute[];
   unaffected_routes: EnrichedRoute[];
-  endpoints: string[];
+  endpoints: [string, string];
   effect: string;
   region: string;
   updated_at: string;
@@ -34,10 +55,10 @@ interface EnrichedRoute {
 }
 
 interface StandardLayoutProps {
-  issue: string;
+  issue: StringOrFreeText;
   remedy: string;
   effect: string;
-  location: string | null;
+  location: StringOrFreeText | null;
   disruptionDiagram?: DisruptionDiagramData;
 }
 
@@ -86,7 +107,7 @@ const StandardLayout: React.ComponentType<StandardLayoutProps> = ({
 };
 
 interface DownstreamLayoutProps {
-  endpoints: string[];
+  endpoints: [string, string];
   effect: string;
   remedy: string;
   disruptionDiagram?: DisruptionDiagramData;
@@ -162,7 +183,7 @@ const MultiLineLayout: React.ComponentType<MultiLineLayoutProps> = ({
 };
 
 interface FallbackLayoutProps {
-  issue: string;
+  issue: StringOrFreeText;
   remedy: string;
   remedyBold?: string;
   effect: string;
@@ -192,7 +213,11 @@ const FallbackLayout: React.ComponentType<FallbackLayoutProps> = ({
   return (
     <div className="alert-card__fallback">
       {icon}
-      {issue && <div className="alert-card__fallback__issue-text">{issue}</div>}
+      {issue && (
+        <div className="alert-card__fallback__issue-text">
+          <Text>{issue}</Text>
+        </div>
+      )}
       {remedy && (
         <div
           className={classWithModifier(
@@ -214,8 +239,8 @@ const FallbackLayout: React.ComponentType<FallbackLayoutProps> = ({
 };
 
 interface StandardIssueSectionProps {
-  issue: string;
-  location: string | null;
+  issue: StringOrFreeText;
+  location: StringOrFreeText | null;
   contentTextSize: string;
 }
 
@@ -233,17 +258,19 @@ const StandardIssueSection: React.ComponentType<StandardIssueSectionProps> = ({
           contentTextSize,
         )}
       >
-        {issue}
+        <Text>{issue}</Text>
       </div>
       {location && (
-        <div className="alert-card__issue__location">{location}</div>
+        <div className="alert-card__issue__location">
+          <Text>{location}</Text>
+        </div>
       )}
     </div>
   </div>
 );
 
 interface DownstreamIssueSectionProps {
-  endpoints: string[];
+  endpoints: [string, string];
 }
 
 const DownstreamIssueSection: React.ComponentType<

--- a/assets/src/components/v2/pre_fare_single_screen_alert.tsx
+++ b/assets/src/components/v2/pre_fare_single_screen_alert.tsx
@@ -253,8 +253,10 @@ const DownstreamIssueSection: React.ComponentType<
     <div
       className={classWithModifier("alert-card__content-block__text", "medium")}
     >
-      No trains <span style={{ fontWeight: 500 }}>between</span> {endpoints[0]}{" "}
-      <span style={{ fontWeight: 500 }}>&</span> {endpoints[1]}
+      No trains <span style={{ fontWeight: 500 }}>between</span>{" "}
+      <span className="free-text__string--nowrap">{endpoints[0]}</span>{" "}
+      <span style={{ fontWeight: 500 }}>&</span>{" "}
+      <span className="free-text__string--nowrap">{endpoints[1]}</span>
     </div>
   </div>
 );

--- a/test/screens/v2/widget_instance/reconstructed_alert_test.exs
+++ b/test/screens/v2/widget_instance/reconstructed_alert_test.exs
@@ -536,8 +536,16 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
         |> put_is_full_screen(true)
 
       expected = %{
-        issue: "No trains to Forest Hills",
-        location: "No Orange Line trains between Malden Center and Wellington",
+        issue: %{text: ["No trains to ", %{format: :nowrap, text: "Forest Hills"}]},
+        location: %{
+          text: [
+            "No Orange Line trains ",
+            "between ",
+            %{format: :nowrap, text: "Malden Center"},
+            " and ",
+            %{format: :nowrap, text: "Wellington"}
+          ]
+        },
         cause: nil,
         effect: :suspension,
         remedy: "Seek alternate route",
@@ -576,8 +584,16 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
         |> put_is_full_screen(true)
 
       expected = %{
-        issue: "No trains to Forest Hills",
-        location: "Shuttle buses between Wellington and Assembly",
+        issue: %{text: ["No trains to ", %{format: :nowrap, text: "Forest Hills"}]},
+        location: %{
+          text: [
+            "Shuttle buses ",
+            "between ",
+            %{format: :nowrap, text: "Wellington"},
+            " and ",
+            %{format: :nowrap, text: "Assembly"}
+          ]
+        },
         cause: nil,
         effect: :shuttle,
         remedy: "Use shuttle bus",
@@ -655,8 +671,16 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
         |> put_is_full_screen(true)
 
       expected = %{
-        issue: "No trains to Forest Hills",
-        location: "No Orange Line trains between Wellington and Assembly",
+        issue: %{text: ["No trains to ", %{format: :nowrap, text: "Forest Hills"}]},
+        location: %{
+          text: [
+            "No Orange Line trains ",
+            "between ",
+            %{format: :nowrap, text: "Wellington"},
+            " and ",
+            %{format: :nowrap, text: "Assembly"}
+          ]
+        },
         cause: :construction,
         effect: :suspension,
         remedy: "Seek alternate route",
@@ -696,7 +720,15 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
 
       expected = %{
         issue: "No trains",
-        location: "No Orange Line trains between Oak Grove and Malden Center",
+        location: %{
+          text: [
+            "No Orange Line trains ",
+            "between ",
+            %{format: :nowrap, text: "Oak Grove"},
+            " and ",
+            %{format: :nowrap, text: "Malden Center"}
+          ]
+        },
         cause: nil,
         effect: :suspension,
         remedy: "Seek alternate route",
@@ -734,7 +766,15 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
 
       expected = %{
         issue: "No trains",
-        location: "Shuttle buses replace Orange Line trains between Oak Grove and Malden Center",
+        location: %{
+          text: [
+            "Shuttle buses replace Orange Line trains ",
+            "between ",
+            %{format: :nowrap, text: "Oak Grove"},
+            " and ",
+            %{format: :nowrap, text: "Malden Center"}
+          ]
+        },
         cause: nil,
         effect: :shuttle,
         remedy: "Use shuttle bus",
@@ -774,8 +814,16 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
         |> put_is_full_screen(true)
 
       expected = %{
-        issue: "No trains to Oak Grove",
-        location: "No Orange Line trains between Oak Grove and Malden Center",
+        issue: %{text: ["No trains to ", %{format: :nowrap, text: "Oak Grove"}]},
+        location: %{
+          text: [
+            "No Orange Line trains ",
+            "between ",
+            %{format: :nowrap, text: "Oak Grove"},
+            " and ",
+            %{format: :nowrap, text: "Malden Center"}
+          ]
+        },
         cause: nil,
         routes: [%{route_id: "Orange", svg_name: "ol"}],
         effect: :suspension,
@@ -813,8 +861,16 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
         |> put_is_full_screen(true)
 
       expected = %{
-        issue: "No trains to Oak Grove",
-        location: "Shuttle buses between Oak Grove and Malden Center",
+        issue: %{text: ["No trains to ", %{format: :nowrap, text: "Oak Grove"}]},
+        location: %{
+          text: [
+            "Shuttle buses ",
+            "between ",
+            %{format: :nowrap, text: "Oak Grove"},
+            " and ",
+            %{format: :nowrap, text: "Malden Center"}
+          ]
+        },
         cause: nil,
         routes: [%{route_id: "Orange", svg_name: "ol"}],
         effect: :shuttle,
@@ -1103,7 +1159,15 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
         endpoints: {"Haymarket", "Chinatown"},
         is_transfer_station: true,
         issue: "No Orange Line trains",
-        location: "No Orange Line trains between Haymarket and Chinatown",
+        location: %{
+          text: [
+            "No Orange Line trains ",
+            "between ",
+            %{format: :nowrap, text: "Haymarket"},
+            " and ",
+            %{format: :nowrap, text: "Chinatown"}
+          ]
+        },
         region: :here,
         remedy: "Seek alternate route",
         routes: [%{route_id: "Orange", svg_name: "ol"}],
@@ -1143,7 +1207,15 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
         issue: "No Orange Line trains",
         remedy: "Use shuttle bus",
         cause: nil,
-        location: "Shuttle buses between State and Chinatown",
+        location: %{
+          text: [
+            "Shuttle buses ",
+            "between ",
+            %{format: :nowrap, text: "State"},
+            " and ",
+            %{format: :nowrap, text: "Chinatown"}
+          ]
+        },
         routes: [%{route_id: "Orange", svg_name: "ol"}],
         effect: :shuttle,
         updated_at: "Friday, 5:00 am",
@@ -1262,7 +1334,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
         |> put_cause(:unknown)
 
       expected = %{
-        issue: "No Alewife trains",
+        issue: %{text: ["No ", %{format: :nowrap, text: "Alewife"}, " trains"]},
         location: "",
         cause: "",
         routes: [%{color: :red, text: "RED LINE", type: :text}],
@@ -1286,7 +1358,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
         |> put_cause(:unknown)
 
       expected = %{
-        issue: "No Alewife trains",
+        issue: %{text: ["No ", %{format: :nowrap, text: "Alewife"}, " trains"]},
         location: "",
         cause: "",
         routes: [%{color: :red, text: "RED LINE", type: :text}],
@@ -1337,7 +1409,9 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
         |> put_severity(10)
 
       expected = %{
-        issue: "Alewife trains may be delayed over 60 minutes",
+        issue: %{
+          text: [%{format: :nowrap, text: "Alewife"}, " trains may be delayed over 60 minutes"]
+        },
         location: "",
         cause: "",
         routes: [%{color: :red, text: "RED LINE", type: :text}],
@@ -1362,7 +1436,9 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
         |> put_severity(10)
 
       expected = %{
-        issue: "Alewife trains may be delayed over 60 minutes",
+        issue: %{
+          text: [%{format: :nowrap, text: "Alewife"}, " trains may be delayed over 60 minutes"]
+        },
         location: "",
         cause: "due to construction",
         routes: [%{color: :red, text: "RED LINE", type: :text}],
@@ -1389,8 +1465,8 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
         |> put_cause(:unknown)
 
       expected = %{
-        issue: "No Oak Grove trains",
-        location: "at Wellington",
+        issue: %{text: ["No ", %{format: :nowrap, text: "Oak Grove"}, " trains"]},
+        location: ["at ", %{format: :nowrap, text: "Wellington"}],
         cause: "",
         routes: [%{color: :orange, text: "ORANGE LINE", type: :text}],
         effect: :suspension,
@@ -1414,7 +1490,12 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
 
       expected = %{
         issue: "No trains",
-        location: "between Wellington and Assembly",
+        location: [
+          "between ",
+          %{format: :nowrap, text: "Wellington"},
+          " and ",
+          %{format: :nowrap, text: "Assembly"}
+        ],
         cause: "",
         routes: [%{color: :orange, text: "ORANGE LINE", type: :text}],
         effect: :suspension,
@@ -1437,8 +1518,13 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
         |> put_cause(:unknown)
 
       expected = %{
-        issue: "No Oak Grove trains",
-        location: "between Wellington and Assembly",
+        issue: %{text: ["No ", %{format: :nowrap, text: "Oak Grove"}, " trains"]},
+        location: [
+          "between ",
+          %{format: :nowrap, text: "Wellington"},
+          " and ",
+          %{format: :nowrap, text: "Assembly"}
+        ],
         cause: "",
         routes: [%{color: :orange, text: "ORANGE LINE", type: :text}],
         effect: :suspension,
@@ -1461,7 +1547,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
 
       expected = %{
         issue: "No Oak Grove trains",
-        location: "at Wellington",
+        location: ["at ", %{format: :nowrap, text: "Wellington"}],
         cause: "",
         routes: [%{color: :orange, text: "ORANGE LINE", type: :text}],
         effect: :shuttle,
@@ -1484,7 +1570,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
         |> put_informed_stations(["Wellington"])
 
       expected = %{
-        issue: "Trains will bypass Wellington",
+        issue: %{text: ["Trains will bypass ", %{format: :nowrap, text: "Wellington"}]},
         location: "",
         cause: "",
         routes: [
@@ -1534,7 +1620,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
         |> put_informed_stations(["Wellington"])
 
       expected = %{
-        issue: "Trains will bypass Wellington",
+        issue: %{text: ["Trains will bypass ", %{text: "Wellington", format: :nowrap}]},
         location: "",
         cause: "due to construction",
         routes: [
@@ -1658,7 +1744,12 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
 
       expected = %{
         issue: "No trains",
-        location: "between North Station and Science Park/West End",
+        location: [
+          "between ",
+          %{format: :nowrap, text: "North Station"},
+          " and ",
+          %{format: :nowrap, text: "Science Park/West End"}
+        ],
         cause: "",
         routes: [%{color: :green, text: "GREEN LINE", type: :text}],
         effect: :shuttle,
@@ -2034,7 +2125,12 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
 
       expected = %{
         issue: "No trains",
-        location: "between Airport and Orient Heights",
+        location: [
+          "between ",
+          %{format: :nowrap, text: "Airport"},
+          " and ",
+          %{format: :nowrap, text: "Orient Heights"}
+        ],
         cause: "",
         routes: [%{color: :blue, text: "BLUE LINE", type: :text}],
         effect: :shuttle,
@@ -2141,7 +2237,12 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
 
       expected = %{
         issue: "No trains",
-        location: "between Arlington and Park Street",
+        location: [
+          "between ",
+          %{format: :nowrap, text: "Arlington"},
+          " and ",
+          %{format: :nowrap, text: "Park Street"}
+        ],
         cause: "",
         routes: [%{color: :green, text: "GREEN LINE", type: :text}],
         effect: :suspension,
@@ -2188,7 +2289,12 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
 
       expected = %{
         issue: "No trains",
-        location: "between Brigham Circle and Museum of Fine Arts",
+        location: [
+          "between ",
+          %{format: :nowrap, text: "Brigham Circle"},
+          " and ",
+          %{format: :nowrap, text: "Museum of Fine Arts"}
+        ],
         cause: "",
         routes: [%{color: :green, text: "GREEN LINE", type: :text, branches: ["E"]}],
         effect: :suspension,
@@ -2236,7 +2342,12 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
 
       expected = %{
         issue: "No trains",
-        location: "between Ball Square and Gilman Square",
+        location: [
+          "between ",
+          %{format: :nowrap, text: "Ball Square"},
+          " and ",
+          %{format: :nowrap, text: "Gilman Square"}
+        ],
         cause: "",
         routes: [%{color: :green, text: "GREEN LINE", type: :text, branches: ["E"]}],
         effect: :suspension,
@@ -2590,7 +2701,12 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
       # Flexzone test
       expected = %{
         issue: "No trains",
-        location: "between North Station and Back Bay",
+        location: [
+          "between ",
+          %{format: :nowrap, text: "North Station"},
+          " and ",
+          %{format: :nowrap, text: "Back Bay"}
+        ],
         cause: "",
         routes: [%{color: :orange, text: "ORANGE LINE", type: :text}],
         effect: :suspension,
@@ -2981,7 +3097,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
 
       # Flexzone test
       expected = %{
-        issue: "No North Station & North trains",
+        issue: %{text: ["No ", %{text: "North Station & North", format: :nowrap}, " trains"]},
         location: "",
         cause: "",
         routes: [%{color: :green, text: "GREEN LINE", type: :text}],


### PR DESCRIPTION
**Asana task**: [title](https://app.asana.com/0/1185117109217413/1206489686303752/f)

### Description

- Prevents line breaks in station names by using free text with a `format: :nowrap` when sending station names

<details>
<summary>Non-exhaustive examples</summary>

![Pasted image 20240612092310](https://github.com/mbta/screens/assets/1699281/24cdc9ee-50b7-45fc-95ea-b313e86883a1)

![Screen Shot 2024-06-12 at 11 50 48](https://github.com/mbta/screens/assets/1699281/2703ea1e-8a67-4b7e-9155-8d6b8bd83332)


</details>