### PR TITLE
chore: remove v3 api cache logging

### DIFF
--- a/lib/screens/v3_api.ex
+++ b/lib/screens/v3_api.ex
@@ -39,7 +39,6 @@ defmodule Screens.V3Api do
          {:response_success, %{status_code: 200, body: body, headers: headers}} <-
            {:response_success, response},
          {:parse, {:ok, parsed}} <- {:parse, Jason.decode(body)} do
-      Logger.info("[api_v3_get_json] response has been modified, updating cache")
       update_response_cache(url, parsed, headers)
 
       {:ok, parsed}
@@ -50,7 +49,6 @@ defmodule Screens.V3Api do
         log_api_error({:http_fetch_error, e}, url, message: Exception.message(httpoison_error))
 
       {:response_success, %{status_code: 304}} ->
-        Logger.info("[api_v3_get_json] response not modified, using cache")
         {:ok, elem(cached_response, 0)}
 
       {:response_success, %{status_code: status_code}} = response ->


### PR DESCRIPTION
Caching is working, these are really noisy. Just removes them. We can always add logs of hits, misses, size, etc. using [`Nebulex.Stats`](https://hexdocs.pm/nebulex/2.6.1/Nebulex.Stats.html) and probably [`:telemetry_poller`](https://hexdocs.pm/telemetry_poller/readme.html) or something

<details>
<summary>😵‍💫</summary>

```
info] [api_v3_get_json] response not modified, using cache
[info] [api_v3_get_json] response not modified, using cache
[info] [api_v3_get_json] response has been modified, updating cache
[info] [api_v3_get_json] response has been modified, updating cache
[info] [api_v3_get_json] response has been modified, updating cache
[info] [api_v3_get_json] response has been modified, updating cache
[info] [api_v3_get_json] response has been modified, updating cache
[info] [api_v3_get_json] response has been modified, updating cache
[info] [api_v3_get_json] response not modified, using cache
[info] [api_v3_get_json] response has been modified, updating cache
[info] [api_v3_get_json] response has been modified, updating cache
[info] [api_v3_get_json] response not modified, using cache
[info] [api_v3_get_json] response has been modified, updating cache
[info] [api_v3_get_json] response has been modified, updating cache
[info] [api_v3_get_json] response has been modified, updating cache
[info] [api_v3_get_json] response has been modified, updating cache
[info] [api_v3_get_json] response has been modified, updating cache
[info] [api_v3_get_json] response has been modified, updating cache
[info] [api_v3_get_json] response not modified, using cache
[info] [api_v3_get_json] response has been modified, updating cache
[info] [api_v3_get_json] response not modified, using cache
[info] [api_v3_get_json] response not modified, using cache
[info] [api_v3_get_json] response not modified, using cache
[info] [api_v3_get_json] response not modified, using cache
[info] [api_v3_get_json] response has been modified, updating cache
[info] [api_v3_get_json] response not modified, using cache
[info] [api_v3_get_json] response has been modified, updating cache
[info] [api_v3_get_json] response not modified, using cache
[info] [api_v3_get_json] response not modified, using cache
[info] [api_v3_get_json] response has been modified, updating cache
[info] [api_v3_get_json] response not modified, using cache
[info] [api_v3_get_json] response not modified, using cache
[info] [api_v3_get_json] response not modified, using cache
[info] [api_v3_get_json] response has been modified, updating cache
[info] [api_v3_get_json] response has been modified, updating cache
[info] [api_v3_get_json] response not modified, using cache
[info] [api_v3_get_json] response has been modified, updating cache
[info] [api_v3_get_json] response not modified, using cache
[info] [api_v3_get_json] response has been modified, updating cache
[info] [api_v3_get_json] response has been modified, updating cache
[info] [api_v3_get_json] response has been modified, updating cache
[info] [api_v3_get_json] response not modified, using cache
[info] [api_v3_get_json] response not modified, using cache
[info] [api_v3_get_json] response has been modified, updating cache
[info] [api_v3_get_json] response has been modified, updating cache
[info] [api_v3_get_json] response not modified, using cache
[info] [api_v3_get_json] response has been modified, updating cache
[info] [api_v3_get_json] response has been modified, updating cache
[info] [api_v3_get_json] response has been modified, updating cache
[info] [api_v3_get_json] response not modified, using cache
[info] [api_v3_get_json] response not modified, using cache
[info] [api_v3_get_json] response has been modified, updating cache
[info] [api_v3_get_json] response has been modified, updating cache
[info] [api_v3_get_json] response has been modified, updating cache
[info] [api_v3_get_json] response has been modified, updating cache
[info] [api_v3_get_json] response has been modified, updating cache
[info] [api_v3_get_json] response not modified, using cache
[info] [api_v3_get_json] response has been modified, updating cache
[info] [api_v3_get_json] response has been modified, updating cache
[info] [api_v3_get_json] response has been modified, updating cache
```
</details>