### PR TITLE
fix: use CR abbreviations in Later Departures

### DIFF
--- a/assets/src/components/v2/alert.tsx
+++ b/assets/src/components/v2/alert.tsx
@@ -48,7 +48,11 @@ const BaseAlert: ComponentType<BaseAlertProps> = ({
             )}
           >
             {routePills.map((pill) => (
-              <RoutePill {...pill} key={routePillKey(pill)} />
+              <RoutePill
+                pill={pill}
+                useRouteAbbrev={true}
+                key={routePillKey(pill)}
+              />
             ))}
           </div>
           <div className="alert-widget__content__icon">

--- a/assets/src/components/v2/departures/departure_row.tsx
+++ b/assets/src/components/v2/departures/departure_row.tsx
@@ -30,7 +30,7 @@ const DepartureRow: ComponentType<DepartureRow> = ({
           "departure-row__route" + (headsign.variation ? "" : " center")
         }
       >
-        <RoutePill {...route} />
+        <RoutePill pill={route} />
       </div>
       <div className="departure-row__destination">
         <Destination {...headsign} />

--- a/assets/src/components/v2/departures/later_departures.tsx
+++ b/assets/src/components/v2/departures/later_departures.tsx
@@ -70,7 +70,11 @@ const LaterDepatures = ({ rows }: { rows: DepartureRow[] }) => {
                     "later-departures__route--selected": i === j,
                   })}
                 >
-                  <RoutePill pill={d.route} outline={i !== j} />
+                  <RoutePill
+                    pill={d.route}
+                    outline={i !== j}
+                    useRouteAbbrev={true}
+                  />
                 </li>
               ))}
             </ol>

--- a/assets/src/components/v2/departures/later_departures.tsx
+++ b/assets/src/components/v2/departures/later_departures.tsx
@@ -70,7 +70,7 @@ const LaterDepatures = ({ rows }: { rows: DepartureRow[] }) => {
                     "later-departures__route--selected": i === j,
                   })}
                 >
-                  <RoutePill {...d.route} outline={i !== j} />
+                  <RoutePill pill={d.route} outline={i !== j} />
                 </li>
               ))}
             </ol>

--- a/assets/src/components/v2/departures/route_pill.tsx
+++ b/assets/src/components/v2/departures/route_pill.tsx
@@ -9,7 +9,7 @@ type Pill =
 
 interface BasePill {
   color: Color;
-  outline?: boolean;
+  route_abbrev?: string;
 }
 
 interface TextPill extends BasePill {
@@ -39,19 +39,23 @@ type Color =
 
 type PillIcon = "bus" | "light_rail" | "rail" | "boat";
 
-const TextRoutePill: ComponentType<TextPill> = ({
+const TextRoutePill: ComponentType<TextPill & { outline?: boolean }> = ({
   color,
   text,
   outline,
   size,
 }) => {
   const modifiers: string[] = [color];
+
   if (outline) {
     modifiers.push("outline");
   }
 
   if (size) {
     modifiers.push(size);
+  } else {
+    const routeNum = Number(text);
+    modifiers.push(isNaN(routeNum) || routeNum > 199 ? "small" : "large");
   }
 
   return (
@@ -87,39 +91,54 @@ const SlashedRoutePill: ComponentType<SlashedPill> = ({ part1, part2 }) => {
   );
 };
 
-const RoutePill: ComponentType<Pill> = (pill) => {
-  const modifiers: string[] = [pill.color];
+type Props = {
+  pill: Pill;
+  outline?: boolean;
+  useRouteAbbrev?: boolean;
+};
 
-  if (pill.outline) modifiers.push("outline");
+const RoutePill: ComponentType<Props> = ({ pill, outline, useRouteAbbrev }) => {
+  const modifiers: string[] = [pill.color];
+  if (outline) modifiers.push("outline");
 
   let innerContent: JSX.Element | null = null;
-  switch (pill.type) {
-    case "text": {
-      const routeNum = Number(pill.text);
-      const size = isNaN(routeNum) || routeNum > 199 ? "small" : "large";
-      innerContent = <TextRoutePill size={size} {...pill} />;
-      break;
-    }
-    case "icon":
-      innerContent = <IconRoutePill {...pill} />;
-      break;
-    case "slashed":
-      innerContent = <SlashedRoutePill {...pill} />;
-  }
-
   let branches: JSX.Element[] | null = null;
-  if (pill.type == "text" && pill.branches) {
-    branches = pill.branches.map((branch: string) => (
-      <div
-        key={branch}
-        className={classWithModifiers(
-          "route-pill",
-          modifiers.concat(["branch"]),
-        )}
-      >
-        <TextRoutePill {...pill} text={branch} />
-      </div>
-    ));
+
+  if (useRouteAbbrev && pill.route_abbrev) {
+    innerContent = (
+      <TextRoutePill
+        text={pill.route_abbrev}
+        color={pill.color}
+        outline={outline}
+      />
+    );
+  } else {
+    switch (pill.type) {
+      case "text":
+        innerContent = <TextRoutePill {...pill} outline={outline} />;
+        break;
+
+      case "icon":
+        innerContent = <IconRoutePill {...pill} />;
+        break;
+
+      case "slashed":
+        innerContent = <SlashedRoutePill {...pill} />;
+    }
+
+    if (pill.type == "text" && pill.branches) {
+      branches = pill.branches.map((branch: string) => (
+        <div
+          key={branch}
+          className={classWithModifiers(
+            "route-pill",
+            modifiers.concat(["branch"]),
+          )}
+        >
+          <TextRoutePill {...pill} text={branch} />
+        </div>
+      ));
+    }
   }
 
   return (

--- a/assets/src/components/v2/dup/overnight_departures.tsx
+++ b/assets/src/components/v2/dup/overnight_departures.tsx
@@ -27,7 +27,7 @@ const OvernightDepartures: ComponentType<Props> = ({ routes }) => {
         {routes.length > 0 && (
           <div className="overnight-departures__route-pill-container">
             {routes.map((route) => (
-              <RoutePill {...route} key={route.color} />
+              <RoutePill pill={route} key={route.color} />
             ))}
           </div>
         )}

--- a/test/screens/v2/widget_instance/departures_test.exs
+++ b/test/screens/v2/widget_instance/departures_test.exs
@@ -430,7 +430,7 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
         prediction: %Prediction{route: %Route{id: "CR-Providence", type: :rail}}
       }
 
-      assert %{type: :icon, icon: :rail, color: :purple} ==
+      assert %{type: :icon, icon: :rail, color: :purple, route_abbrev: "PVD"} ==
                Departures.serialize_route([departure], serializer)
     end
 
@@ -448,7 +448,7 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
         prediction: %Prediction{route: %Route{id: "CR-Providence", type: :rail}, track_number: 7}
       }
 
-      assert %{type: :text, text: "TR7", color: :purple} ==
+      assert %{type: :text, text: "TR7", color: :purple, route_abbrev: "PVD"} ==
                Departures.serialize_route([departure], serializer)
     end
   end

--- a/test/screens/v2/widget_instance/serializer/route_pill_test.exs
+++ b/test/screens/v2/widget_instance/serializer/route_pill_test.exs
@@ -4,14 +4,14 @@ defmodule Screens.V2.WidgetInstance.Serializer.RoutePillTest do
   import Screens.V2.WidgetInstance.Serializer.RoutePill
 
   describe "serialize_for_departure/4" do
-    test "Uses track number if not nil" do
-      assert %{type: :text, text: "TR3", color: :purple} ==
-               serialize_for_departure("CR-Fairmount", "", :rail, 3)
+    test "Returns rail icon with a route abbreviation for Commuter Rail" do
+      assert %{type: :icon, icon: :rail, color: :purple, route_abbrev: "FMT"} ==
+               serialize_for_departure("CR-Fairmount", "", :rail, nil)
     end
 
-    test "Returns rail icon if route type is :rail" do
-      assert %{type: :icon, icon: :rail, color: :purple} ==
-               serialize_for_departure("CR-Fairmount", "", :rail, nil)
+    test "Returns track number with route abbreviation for CR when not nil" do
+      assert %{type: :text, text: "TR3", color: :purple, route_abbrev: "FMT"} ==
+               serialize_for_departure("CR-Fairmount", "", :rail, 3)
     end
 
     test "Returns boat icon if route type is :ferry" do
@@ -70,8 +70,9 @@ defmodule Screens.V2.WidgetInstance.Serializer.RoutePillTest do
                serialize_route_for_alert("Green-B")
     end
 
-    test "Abbreviates Commuter Rail route names" do
-      assert %{type: :text, text: "LWL", color: :purple} == serialize_route_for_alert("CR-Lowell")
+    test "Includes a text abbreviation for Commuter Rail routes" do
+      assert %{type: :icon, icon: :rail, color: :purple, route_abbrev: "LWL"} ==
+               serialize_route_for_alert("CR-Lowell")
     end
 
     test "Returns boat icon for ferry routes" do


### PR DESCRIPTION
"Route abbreviations" (formally named in this changeset) are short text codes that stand in for the names of routes which would otherwise be represented by a "mode icon" in route pills. Currently this only applies to Commuter Rail, though could conceivably apply to ferry in the future.

Previously, whether a "route abbreviation" was used was controlled at the time the route pill was serialized — the result from the client's perspective would either be an "icon pill" with the mode icon or a "text pill" with the abbreviation. However, the "Later Departures" feature requires that the client know both of these pieces of information at once, since which one is used depends on context that is not known until the widget is rendered.

Accordingly, this adds a field `route_abbrev` to the serialized form of icon and text pills (needed for text pills as well because Commuter Rail departures where the train has a track assignment are represented with a "TRx" text pill). The client's `RoutePill` component gains a prop that determines whether to use the abbreviation in the pill data. If true, it renders a text pill with the abbreviation as the content.

<img width="338" alt="Screenshot 2024-06-13 at 11 45 46 AM" src="https://github.com/mbta/screens/assets/394835/e5a7bf40-0cd1-4922-8434-f524a50870c9">


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207495619155884