### PR TITLE
fix: use Later Departures when it saves space

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,15 @@ jobs:
       - working-directory: ./assets
         run: npm run styles:check
 
+  js-tests:
+    name: Frontend Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+      - working-directory: ./assets
+        run: npm test
+
   js-types:
     name: Frontend Types
     runs-on: ubuntu-latest

--- a/assets/src/components/v2/departures/header.tsx
+++ b/assets/src/components/v2/departures/header.tsx
@@ -4,7 +4,7 @@ import Arrow45 from "Images/svgr_bundled/Arrow-45-no-padding.svg";
 
 type CardinalDirection = "n" | "ne" | "e" | "se" | "s" | "sw" | "w" | "nw";
 
-interface Props {
+export interface Props {
   title: string | null;
   arrow: CardinalDirection | null;
 }

--- a/assets/src/components/v2/departures/later_departures.tsx
+++ b/assets/src/components/v2/departures/later_departures.tsx
@@ -14,6 +14,11 @@ import useRefreshRate from "Hooks/v2/use_refresh_rate";
 import DepartureRow from "./departure_row";
 import RoutePill from "./route_pill";
 
+// Breakpoint where folding departures into Later Departures is likely to save
+// space rather than take up more of it. Below this number of Later Departures,
+// the component is not used, even if enabled.
+export const MIN_LATER_DEPARTURES = 3;
+
 const MAX_LATER_DEPARTURES = 5;
 
 // "Magic" number carried over from Solari. Prevents a Later Departures

--- a/assets/src/components/v2/departures/later_departures.tsx
+++ b/assets/src/components/v2/departures/later_departures.tsx
@@ -37,6 +37,7 @@ const LaterDepatures = ({ rows }: { rows: DepartureRow[] }) => {
 
   useEffect(() => {
     if (departures.length < 2) return;
+
     const pageDurationMs = Math.min(
       MAX_PAGE_RATE_MS,
       refreshRateMs / departures.length,

--- a/assets/src/components/v2/departures/normal_departures.tsx
+++ b/assets/src/components/v2/departures/normal_departures.tsx
@@ -9,7 +9,7 @@ import weakKey from "weak-key";
 
 import NormalSection from "./normal_section";
 import NoticeSection from "./notice_section";
-import { Section, trimSections, toSectionWithLaterRows } from "./section";
+import { Section, trimSections, toFoldedSection } from "./section";
 
 import { warn } from "Util/sentry";
 import { hasOverflowY } from "Util/util";
@@ -20,37 +20,34 @@ type NormalDepartures = {
 
 const NormalDepartures: ComponentType<NormalDepartures> = ({ sections }) => {
   const ref = useRef<HTMLDivElement>(null);
-  const sectionsWithLaterRows = useMemo(
-    () => sections.map(toSectionWithLaterRows),
+  const initialSections = useMemo(
+    () => sections.map(toFoldedSection),
     [sections],
   );
-  const [trimmedSections, setTrimmedSections] = useState(sectionsWithLaterRows);
+  const [foldedSections, setFoldedSections] = useState(initialSections);
 
-  // Restart trimming if the sections prop is changed (i.e. new data).
-  useLayoutEffect(
-    () => setTrimmedSections(sectionsWithLaterRows),
-    [sectionsWithLaterRows],
-  );
+  // Restart trimming if the original sections are changed (i.e. new data).
+  useLayoutEffect(() => setFoldedSections(initialSections), [initialSections]);
 
   // Iteratively trim sections until the container doesn't overflow.
   useLayoutEffect(() => {
     if (hasOverflowY(ref)) {
-      const newSections = trimSections(trimmedSections);
+      const newSections = trimSections(foldedSections);
 
-      if (trimmedSections != newSections) {
-        setTrimmedSections(newSections);
+      if (foldedSections != newSections) {
+        setFoldedSections(newSections);
       } else {
         warn("layout failed: departures will overflow");
       }
     }
-  }, [trimmedSections]);
+  }, [foldedSections]);
 
   return (
     <div className="departures-container" ref={ref}>
-      {trimmedSections.map((section) => {
+      {foldedSections.map((section) => {
         const key = weakKey(section);
 
-        if (section.type === "normal_section") {
+        if (section.type === "folded_section") {
           return <NormalSection {...section} key={key} />;
         } else {
           return <NoticeSection {...section} key={key} />;

--- a/assets/src/components/v2/departures/normal_section.tsx
+++ b/assets/src/components/v2/departures/normal_section.tsx
@@ -4,7 +4,7 @@ import weakKey from "weak-key";
 import DepartureRow from "./departure_row";
 import NoticeRow from "./notice_row";
 import Header, { type Props as HeaderProps } from "./header";
-import LaterDepartures from "./later_departures";
+import LaterDepartures, { MIN_LATER_DEPARTURES } from "./later_departures";
 
 export type Layout = {
   base: number | null;
@@ -51,7 +51,7 @@ const NormalSection: ComponentType<FoldedNormalSection> = ({
         }
       })}
 
-      {includeLater && belowFold.length > 0 && (
+      {includeLater && belowFold.length >= MIN_LATER_DEPARTURES && (
         <LaterDepartures rows={belowFold} />
       )}
     </div>

--- a/assets/src/components/v2/departures/normal_section.tsx
+++ b/assets/src/components/v2/departures/normal_section.tsx
@@ -3,8 +3,8 @@ import weakKey from "weak-key";
 
 import DepartureRow from "./departure_row";
 import NoticeRow from "./notice_row";
-import Header from "./header";
-import LaterDepatures from "./later_departures";
+import Header, { type Props as HeaderProps } from "./header";
+import LaterDepartures from "./later_departures";
 
 export type Layout = {
   base: number | null;
@@ -17,34 +17,42 @@ export type Row =
   | (DepartureRow & { type: "departure_row" })
   | (NoticeRow & { type: "notice_row" });
 
-export interface NormalSection {
+export type NormalSection = {
   layout: Layout;
-  header: React.ComponentProps<typeof Header>;
+  header: HeaderProps;
   rows: Row[];
-}
+};
 
-export interface NormalSectionWithLaterRows extends NormalSection {
-  laterRows: DepartureRow[];
-}
+export type FoldedNormalSection = {
+  layout: Layout;
+  header: HeaderProps;
+  rows: FoldedRows;
+};
 
-const NormalSection: ComponentType<NormalSectionWithLaterRows> = ({
+type FoldedRows = {
+  aboveFold: Row[];
+  belowFold: DepartureRow[];
+};
+
+const NormalSection: ComponentType<FoldedNormalSection> = ({
   header,
-  layout,
-  rows,
-  laterRows,
+  layout: { include_later: includeLater },
+  rows: { aboveFold, belowFold },
 }) => {
   return (
     <div className="departures-section">
       <Header {...header} />
-      {rows.map((row) => {
+
+      {aboveFold.map((row) => {
         if (row.type === "departure_row") {
           return <DepartureRow {...row} key={row.id} />;
         } else {
           return <NoticeRow row={row} key={weakKey(row)} />;
         }
       })}
-      {layout.include_later && laterRows.length > 0 && (
-        <LaterDepatures rows={laterRows} />
+
+      {includeLater && belowFold.length > 0 && (
+        <LaterDepartures rows={belowFold} />
       )}
     </div>
   );

--- a/assets/src/components/v2/departures/section.ts
+++ b/assets/src/components/v2/departures/section.ts
@@ -3,7 +3,7 @@ import _ from "lodash";
 import type {
   Layout,
   NormalSection,
-  NormalSectionWithLaterRows,
+  FoldedNormalSection,
 } from "./normal_section";
 import NoticeSection from "./notice_section";
 
@@ -11,31 +11,35 @@ export type Section =
   | (NormalSection & { type: "normal_section" })
   | (NoticeSection & { type: "notice_section" });
 
-export type SectionWithLaterRows =
-  | (NormalSectionWithLaterRows & { type: "normal_section" })
+export type FoldedSection =
+  | (FoldedNormalSection & { type: "folded_section" })
   | (NoticeSection & { type: "notice_section" });
 
-export const toSectionWithLaterRows = (
-  section: Section,
-): SectionWithLaterRows => {
-  if (section.type !== "normal_section") return section;
+export const toFoldedSection = (section: Section): FoldedSection => {
+  switch (section.type) {
+    case "normal_section":
+      return {
+        ...section,
+        type: "folded_section",
+        rows: {
+          aboveFold: section.rows,
+          belowFold: [],
+        },
+      };
 
-  return {
-    ...section,
-    laterRows: [],
-  };
+    case "notice_section":
+      return section;
+  }
 };
 
 /**
- * Perform one iteration of "section trimming", i.e. the process of removing
- * departures from sections while respecting their desired layouts until they
- * all fit in a container without overflow.
+ * Perform one iteration of "section trimming", i.e. the process of shifting
+ * departures from above-the-fold to below-the-fold while respecting sections'
+ * desired layouts, until they all fit in a container without overflow.
  *
  * Operates immutably. If no sections could be trimmed, returns the same array.
  */
-export const trimSections = (
-  sections: SectionWithLaterRows[],
-): SectionWithLaterRows[] => {
+export const trimSections = (sections: FoldedSection[]): FoldedSection[] => {
   const trimmed = _.cloneDeep(sections);
 
   const sortedSizedSections = trimmed
@@ -49,11 +53,11 @@ export const trimSections = (
   return sections;
 };
 
-// Determine how many "items" a section contains, for the purposes of deciding
-// which sections should be trimmed first.
-const sectionLength = (section: Section | SectionWithLaterRows): number => {
-  if (section.type == "normal_section") {
-    return section.rows.reduce(
+// Determine how many above-the-fold departure "items" a section contains, for
+// the purposes of deciding which sections should be trimmed first.
+const sectionLength = (section: FoldedSection): number => {
+  if (section.type == "folded_section") {
+    return section.rows.aboveFold.reduce(
       (sum, row) =>
         sum +
         (row.type == "departure_row" ? row.times_with_crowding.length : 1),
@@ -64,81 +68,85 @@ const sectionLength = (section: Section | SectionWithLaterRows): number => {
   }
 };
 
-type SizedSectionWithLaterRows = {
+type SizedFoldedSection = {
   length: number;
-  section: SectionWithLaterRows;
+  section: FoldedSection;
 };
 
 // Functions which destructively trim departures from sections, returning `true`
 // if any trimming occurred. Each iteration of section trimming tries each one
 // of these in sequence until one succeeds or they have all been tried. Assumes
 // the given sections are reverse-sorted by length (largest first).
-const trimStages: Record<
-  string,
-  (sections: SizedSectionWithLaterRows[]) => boolean
-> = {
-  // Trim all sections with more departures than their `max` until they have
-  // exactly as many as their `max` (if defined).
-  allToMax: (sections) => {
-    return sections.reduce((didTrim, { section, length }) => {
-      if (section.type == "normal_section" && section.layout.max) {
-        for (let l = length; l > section.layout.max; l--) {
-          if (trimSection(section)) {
-            // Trimmed this section; may be able to trim more, so keep going.
-            didTrim ||= true;
-          } else {
-            // This section can't be trimmed further, so return early.
-            return didTrim;
+const trimStages: Record<string, (sections: SizedFoldedSection[]) => boolean> =
+  {
+    // Trim all sections with more departures than their `max` until they have
+    // exactly as many as their `max` (if defined).
+    allToMax: (sections) => {
+      return sections.reduce((didTrim, { section, length }) => {
+        if (section.type == "folded_section" && section.layout.max) {
+          for (let l = length; l > section.layout.max; l--) {
+            if (trimSection(section)) {
+              // Trimmed this section; may be able to trim more, so keep going.
+              didTrim ||= true;
+            } else {
+              // This section can't be trimmed further, so return early.
+              return didTrim;
+            }
           }
         }
-      }
 
-      return didTrim;
-    }, false);
-  },
+        return didTrim;
+      }, false);
+    },
 
-  // Trim one departure from the section with the most, among those with more
-  // than their `base`. If no `base` is defined, acts as `oneOverMin`.
-  oneTowardsBase: (sections) =>
-    trimOneBy(sections, (length, { min, base }) => length > (base || min)),
+    // Trim one departure from the section with the most, among those with more
+    // than their `base`. If no `base` is defined, acts as `oneOverMin`.
+    oneTowardsBase: (sections) =>
+      trimOneBy(sections, (length, { min, base }) => length > (base || min)),
 
-  // Trim one departure from the section with the most, among those with more
-  // than their `min`.
-  oneTowardsMin: (sections) =>
-    trimOneBy(sections, (length, { min }) => length > min),
-};
+    // Trim one departure from the section with the most, among those with more
+    // than their `min`.
+    oneTowardsMin: (sections) =>
+      trimOneBy(sections, (length, { min }) => length > min),
+  };
 
 const trimOneBy = (
-  sections: SizedSectionWithLaterRows[],
+  sections: SizedFoldedSection[],
   condition: (length: number, layout: Layout) => boolean,
 ): boolean => {
   for (const { section, length } of sections) {
-    if (section.type == "normal_section" && condition(length, section.layout))
+    if (section.type == "folded_section" && condition(length, section.layout)) {
       if (trimSection(section)) return true;
+    }
   }
 
   return false;
 };
 
-// Destructively trim the last departure time from a section, if possible.
-// Returns `true` if the section was trimmed.
-const trimSection = (section: SectionWithLaterRows): boolean => {
-  if (section.type == "normal_section") {
-    for (let rowIndex = section.rows.length - 1; rowIndex >= 0; rowIndex--) {
-      const row = section.rows[rowIndex];
+// Destructively shift the last above-the-fold departure time in a section to
+// below-the-fold, if possible. Returns `true` if the section was trimmed.
+const trimSection = (section: FoldedSection): boolean => {
+  if (section.type == "folded_section") {
+    const {
+      rows: { aboveFold, belowFold },
+    } = section;
+
+    for (let aboveIndex = aboveFold.length - 1; aboveIndex >= 0; aboveIndex--) {
+      const row = aboveFold[aboveIndex];
 
       if (row.type == "departure_row") {
         const trimmedTimeWithCrowding = _.last(row.times_with_crowding);
+
         if (row.times_with_crowding.length > 1) {
           // More than one departure time; trim the last one.
           row.times_with_crowding.splice(row.times_with_crowding.length - 1);
         } else {
           // Only one departure time; trim this row entirely.
-          section.rows.splice(rowIndex, 1);
+          aboveFold.splice(aboveIndex, 1);
         }
 
         if (trimmedTimeWithCrowding != null) {
-          section.laterRows.unshift({
+          belowFold.unshift({
             ...row,
             id: _.uniqueId(`${row.id}_`),
             times_with_crowding: [trimmedTimeWithCrowding],

--- a/assets/tests/components/v2/departures/factories.ts
+++ b/assets/tests/components/v2/departures/factories.ts
@@ -1,15 +1,14 @@
 import { Factory } from "fishery";
 
-import { SectionWithLaterRows } from "Components/v2/departures/section";
+import { Section } from "Components/v2/departures/section";
 import { Row } from "Components/v2/departures/normal_section";
 import { TimeWithCrowding } from "Components/v2/departures/departure_times";
 
-export const normalSection = Factory.define<SectionWithLaterRows>(() => ({
+export const normalSection = Factory.define<Section>(() => ({
   type: "normal_section",
   layout: { min: 1, base: null, max: null, include_later: false },
   rows: departureRow.buildList(1),
   header: { title: null, arrow: null },
-  laterRows: [],
 }));
 
 export const departureRow = Factory.define<Row>(({ sequence }) => ({


### PR DESCRIPTION
We may not always want to display "Later Departures" even when it is enabled and some rows have been trimmed, because the carousel itself can take up more space than just displaying the departures normally would have.

The "magic constant" 3 is an imperfect guess that errs on the side of not introducing Later Departures unless it will almost certainly save space (it also happens to be the same constant used in the v1 Solari logic). Using layout effects to measure how much space is actually taken up by each approach is left as a potential future improvement.

#### About the refactor commit...

At some point I was convinced that to do this correctly, the section component would need access to the _original_ departure rows, without the destructive trimming applied. That prompted a refactor where the trio of original rows, trimmed rows, and "rows that were trimmed" were all available as part of the processed sections. To be clear about which were which, I named these the "original", "above-the-fold", and "below-the-fold" departures, and then thought it made sense to name the sections themselves "folded sections" (also more concise than "sections with later rows").

Eventually I worked out that not only was having the original rows unnecessary, it also prevented auto-sizing from working as expected with the `max` field set. So, this refactor is now purely one of naming/structure ("original rows" not included), and could be reverted without affecting anything. I think it's still a (minor) improvement in legibility, but please review it in that light!

### Example

This is a representative case where the new logic allows the two departures that would have otherwise been in Later Departures to be displayed at the same time (and even saves a few pixels of space).

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td>
<img src="https://github.com/mbta/screens/assets/394835/a1b6c53a-a79b-4f26-a94f-08cab488c4df">
</td>
<td>
<img src="https://github.com/mbta/screens/assets/394835/ec881b8d-fcbc-4d5f-8889-177becda752b">
</td>
</tr>
</table>

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207519791642956