### PR TITLE
fix: update version of phoenix_html JS package

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -80,7 +80,7 @@
       "license": "MIT"
     },
     "../deps/phoenix_html": {
-      "version": "3.0.4"
+      "version": "4.1.0"
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.0",


### PR DESCRIPTION
The `phoenix_html` elixir package was upgraded. This updates the `package-lock.json` to reflect the new JS package version