### PR TITLE
Tweaks for Sectional headers

### DIFF
--- a/assets/css/v2/busway/departures/header.scss
+++ b/assets/css/v2/busway/departures/header.scss
@@ -6,8 +6,7 @@
   flex-direction: row;
   align-items: center;
   justify-content: space-between;
-  font-size: 56px;
-  line-height: 67.77px;
+  font-size: 48px;
   text-transform: uppercase;
   letter-spacing: 3px;
   border-top: 4px solid $true-grey-70;

--- a/assets/css/v2/busway/departures/header.scss
+++ b/assets/css/v2/busway/departures/header.scss
@@ -9,6 +9,7 @@
   font-size: 48px;
   text-transform: uppercase;
   letter-spacing: 3px;
+  white-space: pre-line; // Allow using embedded line breaks to control wrapping
   border-top: 4px solid $true-grey-70;
 
   &:not(:empty) {

--- a/assets/stylelint.config.mjs
+++ b/assets/stylelint.config.mjs
@@ -31,6 +31,10 @@ export default {
     // We use blank lines to separate "groups" of variables.
     "scss/dollar-variable-empty-line-before": null,
 
+    // Allow single-line comments without a blank line before them, as in the
+    // standard config for CSS. Interacts poorly with enforced property order.
+    "scss/double-slash-comment-empty-line-before": null,
+
     // Conflicts with Prettier, which breaks long lines involving operators by
     // putting operators at the ends of lines.
     "scss/operator-no-newline-after": null,


### PR DESCRIPTION
* Use a smaller font size for headers, such that most existing headers don't wrap onto a second line.
* Respect embedded line break characters (`\n`) in headers, allowing manual control over wrapping when the natural wrapping creates an awkward split.

#### More about the Stylelint rule change...

The rule that `//` comments must be preceded by a blank line interacts poorly with the rule that enforces property ordering, making it difficult to comment on a specific property without breaking the properties into two visual "groups" (misleadingly, as the break has no real meaning). As an example, consider what would happen if the comment introduced in this PR were a bit longer, forcing it to be on its own line:

```scss
.departures-header {
  box-sizing: border-box;
  display: flex;
  flex-direction: row;
  align-items: center;
  justify-content: space-between;
  font-size: 48px;
  text-transform: uppercase;
  letter-spacing: 3px;
  // Allow using embedded line breaks to control wrapping.
  white-space: pre-line;
  border-top: 4px solid $true-grey-70;
}
```

With the `double-slash-comment-empty-line-before` rule enabled, the above is "fixed" to this:

```scss
.departures-header {
  box-sizing: border-box;
  display: flex;
  flex-direction: row;
  align-items: center;
  justify-content: space-between;
  font-size: 48px;
  text-transform: uppercase;
  letter-spacing: 3px;

  // Allow using embedded line breaks to control wrapping.
  white-space: pre-line;
  border-top: 4px solid $true-grey-70;
}
```

We might think to address this by breaking out the "commented" property into its own little group:

```scss
.departures-header {
  box-sizing: border-box;
  display: flex;
  flex-direction: row;
  align-items: center;
  justify-content: space-between;
  font-size: 48px;
  text-transform: uppercase;
  letter-spacing: 3px;
  border-top: 4px solid $true-grey-70;

  // Allow using embedded line breaks to control wrapping.
  white-space: pre-line;
}
```

But, because of the property ordering rule (`white-space` is now "out of order"), this is reformatted to the same thing as above.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207495619155897