### PR TITLE
fix: rogue semicolon on screen pages

### DIFF
--- a/assets/src/components/v2/screen_page.tsx
+++ b/assets/src/components/v2/screen_page.tsx
@@ -11,7 +11,7 @@ const ScreenPage = ({ id }: Props) => {
   const screenId = id ?? (useParams() as { id: string }).id;
   return (
     <ScreenIDProvider id={screenId}>
-      <ScreenContainer id={screenId} />;
+      <ScreenContainer id={screenId} />
     </ScreenIDProvider>
   );
 };


### PR DESCRIPTION
Huh, that's weird... why is the screen page 1939.2px tall, rather than 1920px?

<img width="163" alt="Screenshot 2024-06-20 at 5 50 12 PM" src="https://github.com/mbta/screens/assets/394835/369c407a-03a6-4830-b048-40582a4f4352">

Nothing seems out of place here...

<img width="400" src="https://github.com/mbta/screens/assets/394835/c440123d-0d9c-4762-914b-bb074bc43226">

Wait... zoom in...

<img width="400" src="https://github.com/mbta/screens/assets/394835/2a273c3f-429b-4494-8bd7-012e4f8469fb">

THERE

![Screenshot 2024-06-20 at 5 46 09 PM](https://github.com/mbta/screens/assets/394835/1eabd789-e8c9-44b7-9ce5-af668bb0e84f)