### PR TITLE
fix: support Mattapan line in no-data states

### DIFF
--- a/assets/css/v2/dup/free_text.scss
+++ b/assets/css/v2/dup/free_text.scss
@@ -66,7 +66,8 @@
     background: $line-color-blue;
   }
 
-  &--red {
+  &--red,
+  &--mattapan {
     background: $line-color-red;
   }
 

--- a/assets/css/v2/lcd_common/free_text.scss
+++ b/assets/css/v2/lcd_common/free_text.scss
@@ -58,7 +58,8 @@
     background: $line-color-blue;
   }
 
-  &--red {
+  &--red,
+  &--mattapan {
     background: $line-color-red;
   }
 

--- a/assets/css/v2/pre_fare/free_text.scss
+++ b/assets/css/v2/pre_fare/free_text.scss
@@ -35,7 +35,8 @@
     background: $line-color-blue;
   }
 
-  &--red {
+  &--red,
+  &--mattapan {
     background: $line-color-red;
   }
 

--- a/assets/src/components/v2/free_text.tsx
+++ b/assets/src/components/v2/free_text.tsx
@@ -3,8 +3,18 @@ import _ from "lodash";
 
 import { classWithModifier, classWithModifiers, imagePath } from "Util/util";
 
-const textPills = ["red", "blue", "orange", "green", "silver"];
-const iconPills = ["cr", "bus"];
+const textPills = [
+  "red",
+  "blue",
+  "orange",
+  "green",
+  "silver",
+  "green_b",
+  "green_c",
+  "green_d",
+  "green_e",
+];
+const iconPills = ["cr", "bus", "ferry"];
 
 const iconPaths: { [key: string]: string } = _.mapValues(
   {

--- a/assets/src/components/v2/free_text.tsx
+++ b/assets/src/components/v2/free_text.tsx
@@ -13,6 +13,7 @@ const textPills = [
   "green_c",
   "green_d",
   "green_e",
+  "mattapan",
 ];
 const iconPills = ["cr", "bus", "ferry"];
 
@@ -109,6 +110,7 @@ const TextRoutePill = ({ route }: { route: string }) => {
     green_c: "GL·C",
     green_d: "GL·D",
     green_e: "GL·E",
+    mattapan: "M",
   }[route];
 
   const branch = route.startsWith("green_") ? "branch" : "trunk";

--- a/lib/screens/routes/route.ex
+++ b/lib/screens/routes/route.ex
@@ -34,7 +34,7 @@ defmodule Screens.Routes.Route do
 
   @typep name_colors :: :blue | :green | :orange | :red | :silver
   @type color :: name_colors() | :purple | :teal | :yellow
-  @type icon :: name_colors() | :bus | :cr | :ferry
+  @type icon :: name_colors() | :bus | :cr | :ferry | :mattapan
 
   @spec by_id(id()) :: {:ok, t()} | :error
   def by_id(route_id) do
@@ -168,6 +168,7 @@ defmodule Screens.Routes.Route do
   def icon(%{id: "Boat-" <> _}), do: :ferry
   def icon(%{id: "CR-" <> _}), do: :cr
   def icon(%{id: "Green" <> _}), do: :green
+  def icon(%{id: "Mattapan"}), do: :mattapan
   def icon(%{id: "Orange"}), do: :orange
   def icon(%{id: "Red"}), do: :red
   def icon(%{id: id}) when id in @sl_route_ids, do: :silver

--- a/lib/screens/v2/candidate_generator/dup/departures.ex
+++ b/lib/screens/v2/candidate_generator/dup/departures.ex
@@ -609,9 +609,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
 
   defp get_route_pills_for_rotation(sections) do
     sections
-    |> Enum.flat_map(fn %{routes: routes} ->
-      Enum.map(routes, &Route.get_icon_or_color_from_route/1)
-    end)
+    |> Enum.flat_map(fn %{routes: routes} -> Enum.map(routes, &Route.icon/1) end)
     |> Enum.uniq()
   end
 end

--- a/lib/screens/v2/candidate_generator/widgets/departures.ex
+++ b/lib/screens/v2/candidate_generator/widgets/departures.ex
@@ -150,7 +150,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.Departures do
     [
       %{
         text: %FreeTextLine{
-          icon: if(route?, do: Route.get_icon_or_color_from_route(route?), else: nil),
+          icon: if(route?, do: Route.icon(route?), else: nil),
           text: ["No departures currently available"]
         }
       }

--- a/lib/screens/v2/disruption_diagram/builder.ex
+++ b/lib/screens/v2/disruption_diagram/builder.ex
@@ -114,7 +114,7 @@ defmodule Screens.V2.DisruptionDiagram.Builder do
 
     with {:ok, route_id, stop_sequence, branch} <-
            get_builder_data(localized_alert, informed_stop_ids) do
-      line = Route.get_color_for_route(route_id)
+      line = Route.color(route_id)
 
       stop_id_to_name = Stop.stop_id_to_name(route_id)
 

--- a/lib/screens/v2/widget_instance/departures.ex
+++ b/lib/screens/v2/widget_instance/departures.ex
@@ -109,7 +109,7 @@ defmodule Screens.V2.WidgetInstance.Departures do
 
   def serialize_section(%{type: :no_data_section, route: route}, _screen, _) do
     text = %FreeTextLine{
-      icon: Route.get_icon_or_color_from_route(route),
+      icon: Route.icon(route),
       text: ["Updates unavailable"]
     }
 
@@ -121,7 +121,7 @@ defmodule Screens.V2.WidgetInstance.Departures do
         _screen,
         is_only_section
       ) do
-    pill_color = Route.get_color_for_route(route)
+    pill_color = Route.color(route)
     layout = if is_only_section, do: :full_screen, else: :row
 
     formatted_route =
@@ -183,7 +183,7 @@ defmodule Screens.V2.WidgetInstance.Departures do
   def serialize_section(%{type: :overnight_section, routes: routes}, _, _) do
     route_pill =
       routes
-      |> Enum.map(&Route.get_icon_or_color_from_route/1)
+      |> Enum.map(&Route.icon/1)
       |> List.first()
 
     text = %FreeTextLine{

--- a/lib/screens/v2/widget_instance/serializer/route_pill.ex
+++ b/lib/screens/v2/widget_instance/serializer/route_pill.ex
@@ -151,11 +151,14 @@ defmodule Screens.V2.WidgetInstance.Serializer.RoutePill do
       :cr ->
         %{type: :icon, icon: :rail, color: :purple}
 
-      :silver ->
-        %{type: :text, text: "SL", color: :silver}
-
       :ferry ->
         %{type: :icon, icon: :boat, color: :teal}
+
+      :mattapan ->
+        %{type: :text, text: "M", color: :red}
+
+      :silver ->
+        %{type: :text, text: "SL", color: :silver}
 
       route_color ->
         pill = route_color |> to_string |> String.capitalize() |> do_serialize(%{})

--- a/lib/screens/v2/widget_instance/serializer/route_pill.ex
+++ b/lib/screens/v2/widget_instance/serializer/route_pill.ex
@@ -11,21 +11,21 @@ defmodule Screens.V2.WidgetInstance.Serializer.RoutePill do
           text: String.t(),
           route_abbrev: String.t() | nil,
           branches: [String.t()] | nil,
-          color: color()
+          color: Route.color()
         }
 
   @type icon_pill :: %{
           type: :icon,
           icon: icon(),
           route_abbrev: String.t() | nil,
-          color: color()
+          color: Route.color()
         }
 
   @type slashed_route_pill :: %{
           type: :slashed,
           part1: String.t(),
           part2: String.t(),
-          color: color()
+          color: Route.color()
         }
 
   @type audio_route :: %{
@@ -35,8 +35,6 @@ defmodule Screens.V2.WidgetInstance.Serializer.RoutePill do
         }
 
   @type icon :: :bus | :light_rail | :rail | :boat
-
-  @type color :: :red | :orange | :green | :blue | :purple | :yellow | :teal
 
   @cr_line_abbreviations %{
     "Haverhill" => "HVL",
@@ -78,7 +76,7 @@ defmodule Screens.V2.WidgetInstance.Serializer.RoutePill do
         })
       end
 
-    Map.put(route, :color, Route.get_color_for_route(route_id, route_type))
+    Map.put(route, :color, Route.color(route_id, route_type))
   end
 
   @spec serialize_for_audio_departure(Route.id(), String.t(), RouteType.t(), pos_integer() | nil) ::
@@ -124,7 +122,7 @@ defmodule Screens.V2.WidgetInstance.Serializer.RoutePill do
   def serialize_route_for_alert(route_id, gl_long \\ true) do
     route = do_serialize(route_id, %{gl_long: gl_long, gl_branch: true})
 
-    Map.merge(route, %{color: Route.get_color_for_route(route_id)})
+    Map.merge(route, %{color: Route.color(route_id)})
   end
 
   def serialize_route_for_reconstructed_alert(route_id_group, opts \\ %{})
@@ -141,9 +139,10 @@ defmodule Screens.V2.WidgetInstance.Serializer.RoutePill do
 
   def serialize_route_for_reconstructed_alert({route_id, _}, opts) do
     route = do_serialize(route_id, opts)
-    Map.merge(route, %{color: Route.get_color_for_route(route_id)})
+    Map.merge(route, %{color: Route.color(route_id)})
   end
 
+  @spec serialize_icon(Route.icon()) :: t()
   def serialize_icon(icon) do
     case icon do
       :bus ->


### PR DESCRIPTION
Includes a separate refactor commit. This allows the "no departures" message on Sectionals to correctly display an "M" pill instead of falling back to an "RL" pill.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207633106220713