### PR TITLE
fix: replace remaining prop spreads into RoutePill

### DIFF
--- a/assets/src/components/v2/cr_departures/cr_departures_header_free.tsx
+++ b/assets/src/components/v2/cr_departures/cr_departures_header_free.tsx
@@ -11,7 +11,7 @@ const CRDeparturesHeaderFree = ({ headerPill }) => {
       <div className="departures-card__header-text">
         <span>Free Commuter Rail during</span>
         <span className="pill-container">
-          <RoutePill {...headerPill} />
+          <RoutePill pill={headerPill} />
         </span>
         <span>disruption</span>
       </div>

--- a/assets/src/components/v2/dup/departures/departure_row.tsx
+++ b/assets/src/components/v2/dup/departures/departure_row.tsx
@@ -15,8 +15,10 @@ const DepartureRow = ({
     <div className="departure-row">
       <div className="departure-row__route">
         <RoutePill
-          {...route}
-          size={isNaN(routeText) || routeText > 200 ? "small" : "large"}
+          pill={{
+            ...route,
+            size: isNaN(routeText) || routeText > 200 ? "small" : "large",
+          }}
         />
       </div>
       <div className="departure-row__destination">

--- a/assets/src/components/v2/reconstructed_alert.tsx
+++ b/assets/src/components/v2/reconstructed_alert.tsx
@@ -43,7 +43,7 @@ const ReconstructedAlert: ComponentType<ReconAlertProps> = (alert) => {
           <div className="alert-card__body">
             <div className={"alert-card__body__route-pills"}>
               {routes.map((pill) => (
-                <RoutePill {...pill} key={routePillKey(pill)} />
+                <RoutePill pill={pill} key={routePillKey(pill)} />
               ))}
             </div>
             {effect === "delay" && (


### PR DESCRIPTION
#### Description

passes the correct props to remaining `<RoutePill />` instances following #2072
