### PR TITLE
feat: add logging/spans around DUP candidate generator

### DIFF
--- a/lib/screens/alerts/alert.ex
+++ b/lib/screens/alerts/alert.ex
@@ -172,18 +172,20 @@ defmodule Screens.Alerts.Alert do
 
   @spec fetch(keyword()) :: {:ok, list(t())} | :error
   def fetch(opts \\ [], get_json_fn \\ &V3Api.get_json/2) do
-    params =
-      opts
-      |> Enum.flat_map(&format_query_param/1)
-      |> Enum.into(%{})
+    Screens.Telemetry.span([:screens, :alerts, :alert, :fetch], fn ->
+      params =
+        opts
+        |> Enum.flat_map(&format_query_param/1)
+        |> Enum.into(%{})
 
-    case get_json_fn.("alerts", params) do
-      {:ok, result} ->
-        {:ok, Screens.Alerts.Parser.parse_result(result)}
+      case get_json_fn.("alerts", params) do
+        {:ok, result} ->
+          {:ok, Screens.Alerts.Parser.parse_result(result)}
 
-      _ ->
-        :error
-    end
+        _ ->
+          :error
+      end
+    end)
   end
 
   @doc """

--- a/lib/screens/application.ex
+++ b/lib/screens/application.ex
@@ -10,6 +10,7 @@ defmodule Screens.Application do
 
     # List all child processes to be supervised
     children = [
+      Screens.Telemetry,
       # Start the PubSub system
       {Phoenix.PubSub, name: ScreensWeb.PubSub},
       # Start the endpoint when the application starts

--- a/lib/screens/telemetry.ex
+++ b/lib/screens/telemetry.ex
@@ -1,0 +1,146 @@
+defmodule Screens.Telemetry do
+  @moduledoc """
+  `:telemetry` based span logging
+  """
+  use GenServer
+  require Logger
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, [], opts)
+  end
+
+  @impl GenServer
+  def init(_) do
+    handlers = [
+      # V3 API
+      handle_span(~w[screens v3_api get_json]a, metadata: ~w[url cached]a),
+      # Stops
+      handle_span(~w[screens stops stop fetch_stop_name]a, metadata: ~w[stop_id]),
+      handle_span(~w[screens stops stop fetch_location_context]a, metadata: ~w[app stop_id]),
+      # Alerts
+      handle_span(~w[screens alerts alert fetch]a),
+      # Routes
+      handle_span(~w[screens routes route fetch_routes_by_stop]a,
+        metadata: ~w[stop_id type_filters]a
+      ),
+      # DUP Candidate Generator
+      handle_span(~w[screens v2 candidate_generator dup departures_instances]a),
+      handle_span(~w[screens v2 candidate_generator dup departures get_section_data]a),
+      handle_span(~w[screens v2 candidate_generator dup departures get_sections_data]a),
+      handle_span(~w[screens v2 candidate_generator dup header_instances]a),
+      handle_span(~w[screens v2 candidate_generator dup alerts_instances]a),
+      handle_span(~w[screens v2 candidate_generator dup evergreen_content_instances]a)
+    ]
+
+    for {name, event_names, config} <- handlers do
+      :ok = :telemetry.attach_many(name, event_names, &Screens.Telemetry.handle_event/4, config)
+    end
+
+    :ignore
+  end
+
+  @doc """
+  Dispatch a series span events `start`, `stop`, and/or `exception`.
+
+  Adds `span_id`, `parent_id`, and `correlation_id` to each event's metadata.
+
+  Span IDs are tracked via process registry. If you want to link a span started
+  in another process use `Screens.Telemetry.context/0` to generate the
+  appropriate metadata and pass those values to via arguments or closure to
+  the spawned process.
+  """
+  def span(name, meta \\ %{}, fun) do
+    ctx = context()
+
+    meta =
+      ctx
+      |> Map.merge(meta)
+      |> Map.put_new_lazy(:span_id, &generate_span_id/0)
+
+    previous_span_id = Process.put(:span_id, meta[:span_id])
+    meta = Map.put_new(meta, :parent_id, previous_span_id)
+
+    :telemetry.span(name, meta, fn ->
+      result = fun.()
+      Process.put(:span_id, previous_span_id)
+      {result, meta}
+    end)
+  end
+
+  def context do
+    %{correlation_id: get_correlation_id(), parent_id: get_parent_span_id()}
+  end
+
+  def generate_span_id do
+    binary = :crypto.strong_rand_bytes(12)
+    Base.url_encode64(binary)
+  end
+
+  def handle_event(name, measurements, metadata, config) do
+    measurements = Map.take(measurements, Map.get(config, :measurements, []))
+    metadata = Map.take(metadata, Map.get(config, :metadata, []))
+
+    Logger.info(fn ->
+      [
+        "[#{Enum.join(name, ".")}]",
+        " ",
+        to_log_iodata(metadata),
+        " ",
+        to_log_iodata(measurements)
+      ]
+    end)
+  end
+
+  defp get_parent_span_id do
+    Process.get(:span_id)
+  end
+
+  defp get_correlation_id do
+    correlation_id = Process.get(:correlation_id)
+
+    if correlation_id do
+      correlation_id
+    else
+      correlation_id = generate_span_id()
+      Process.put(:correlation_id, correlation_id)
+      correlation_id
+    end
+  end
+
+  @default_metadata ~w[span_id parent_id correlation_id]a
+  @default_measurements ~w[duration]a
+
+  defp handle_span(name, config \\ []) when is_list(name) do
+    metadata =
+      config
+      |> Keyword.get(:metadata, [])
+      |> Enum.concat(@default_metadata)
+      |> Enum.uniq()
+
+    measurements =
+      config
+      |> Keyword.get(:measurements, [])
+      |> Enum.concat(@default_measurements)
+      |> Enum.uniq()
+
+    config = %{
+      metadata: metadata,
+      measurements: measurements
+    }
+
+    events = [
+      name ++ [:start],
+      name ++ [:stop],
+      name ++ [:exception]
+    ]
+
+    {Enum.join(name, "."), events, config}
+  end
+
+  defp to_log_iodata(enum) do
+    for {k, v} <- enum do
+      [to_string(k), "=", to_string(v)]
+    end
+    |> Enum.intersperse(" ")
+  end
+end

--- a/lib/screens/telemetry.ex
+++ b/lib/screens/telemetry.ex
@@ -89,13 +89,14 @@ defmodule Screens.Telemetry do
     metadata = Map.take(metadata, Map.get(config, :metadata, []))
 
     Logger.info(fn ->
-      [
-        "[#{Enum.join(name, ".")}]",
-        " ",
-        to_log_iodata(metadata),
-        " ",
-        to_log_iodata(measurements)
-      ]
+      measurements =
+        Map.replace_lazy(
+          measurements,
+          :duration,
+          &:erlang.convert_time_unit(&1, :native, :millisecond)
+        )
+
+      ["event=", Enum.join(name, "."), " ", to_log(metadata), " ", to_log(measurements)]
     end)
   end
 
@@ -145,9 +146,9 @@ defmodule Screens.Telemetry do
     {Enum.join(name, "."), events, config}
   end
 
-  defp to_log_iodata(enum) do
+  defp to_log(enum) do
     for {k, v} <- enum do
-      [to_string(k), "=", to_string(v)]
+      [to_string(k), "=", inspect(v)]
     end
     |> Enum.intersperse(" ")
   end

--- a/lib/screens/telemetry.ex
+++ b/lib/screens/telemetry.ex
@@ -68,7 +68,15 @@ defmodule Screens.Telemetry do
   end
 
   def context do
-    %{correlation_id: get_correlation_id(), parent_id: get_parent_span_id()}
+    ctx = %{correlation_id: get_correlation_id(), parent_id: get_parent_span_id()}
+    request_id = Process.get(:request_id) || Logger.metadata()[:request_id]
+
+    if request_id do
+      Process.put(:request_id, request_id)
+      Map.put(ctx, :request_id, request_id)
+    else
+      ctx
+    end
   end
 
   def generate_span_id do
@@ -107,7 +115,7 @@ defmodule Screens.Telemetry do
     end
   end
 
-  @default_metadata ~w[span_id parent_id correlation_id]a
+  @default_metadata ~w[span_id parent_id correlation_id request_id]a
   @default_measurements ~w[duration]a
 
   defp handle_span(name, config \\ []) when is_list(name) do

--- a/lib/screens/v2/candidate_generator/dup.ex
+++ b/lib/screens/v2/candidate_generator/dup.ex
@@ -83,14 +83,22 @@ defmodule Screens.V2.CandidateGenerator.Dup do
         departures_instances_fn \\ &DeparturesInstances.departures_instances/2,
         alerts_instances_fn \\ &AlertsInstances.alert_instances/2
       ) do
-    [
-      fn -> header_instances(config, now, fetch_stop_name_fn) end,
-      fn -> alerts_instances_fn.(config, now) end,
-      fn -> departures_instances_fn.(config, now) end,
-      fn -> evergreen_content_instances_fn.(config) end
-    ]
-    |> Task.async_stream(& &1.(), timeout: 30_000)
-    |> Enum.flat_map(fn {:ok, instances} -> instances end)
+    Screens.Telemetry.span([:screens, :v2, :candidate_generator, :dup], fn ->
+      ctx = Screens.Telemetry.context()
+
+      [
+        span_thunk(:header_instances, ctx, fn ->
+          header_instances(config, now, fetch_stop_name_fn)
+        end),
+        span_thunk(:alerts_instances, ctx, fn -> alerts_instances_fn.(config, now) end),
+        span_thunk(:departures_instances, ctx, fn -> departures_instances_fn.(config, now) end),
+        span_thunk(:evergreen_content_instances, ctx, fn ->
+          evergreen_content_instances_fn.(config)
+        end)
+      ]
+      |> Task.async_stream(& &1.(), timeout: 30_000)
+      |> Enum.flat_map(fn {:ok, instances} -> instances end)
+    end)
   end
 
   @impl CandidateGenerator
@@ -116,5 +124,11 @@ defmodule Screens.V2.CandidateGenerator.Dup do
       end
 
     List.duplicate(%NormalHeader{screen: config, icon: :logo, text: stop_name, time: now}, 3)
+  end
+
+  defp span_thunk(name, meta, fun) when is_atom(name) and is_function(fun, 0) do
+    fn ->
+      Screens.Telemetry.span([:screens, :v2, :candidate_generator, :dup, name], meta, fun)
+    end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -81,6 +81,7 @@ defmodule Screens.MixProject do
       {:stream_data, "~> 1.1", only: :test},
       {:memcachex, "~> 0.5.5"},
       {:aja, "~> 0.6.2"},
+      {:telemetry, "~> 1.2"},
       {:telemetry_poller, "~> 0.4"},
       {:telemetry_metrics, "~> 0.4"},
       {:screens_config,


### PR DESCRIPTION
Instrument most portions of DUP candidate generation. includes start & stop events, duration in ms, generated span_ids, parent_ids, correlation_ids, and links to request_id when possible. also supports logging additional metadata

<details>
<summary>Example output</summary>

```
[info] GET /v2/api/screen/DUP-AIR-DUP-002
[debug] Processing with ScreensWeb.V2.ScreenApiController.show/2
  Parameters: %{"id" => "DUP-AIR-DUP-002", "last_refresh" => "2024-06-26T12:16:18.630529Z"}
  Pipelines: [:redirect_prod_http, :api, :browser]
[info] event=screens.v2.candidate_generator.dup.header_instances.start request_id="F9yM_aesq1sJfV0AAApE" span_id="OOq9TkXnrcFsJD5O" parent_id="mNf25ySqPZ0tM29t" correlation_id="ZE2s3j5XzDPJpHou" 
[info] event=screens.stops.stop.fetch_stop_name.start span_id="jzVEsWqOJ3mLQOx6" parent_id="OOq9TkXnrcFsJD5O" correlation_id="3-NkXOasyT85Fayv" 
[info] event=screens.v2.candidate_generator.dup.alerts_instances.start request_id="F9yM_aesq1sJfV0AAApE" span_id="AuOOk9_ypObVSO1e" parent_id="mNf25ySqPZ0tM29t" correlation_id="ZE2s3j5XzDPJpHou" 
[info] event=screens.v2.candidate_generator.dup.departures_instances.start request_id="F9yM_aesq1sJfV0AAApE" span_id="ClDUq0ACUgNPH_N2" parent_id="mNf25ySqPZ0tM29t" correlation_id="ZE2s3j5XzDPJpHou" 
[info] event=screens.stops.stop.fetch_stop_name.start span_id="FSPN6gcYxXwyfV_D" parent_id="AuOOk9_ypObVSO1e" correlation_id="u3QoVTnF7Tf7Rig8" 
[info] event=screens.v2.candidate_generator.dup.departures.get_sections_data.start span_id="84ps0t8q1koInaur" parent_id="ClDUq0ACUgNPH_N2" correlation_id="ieKTBrgWuc2EFYsO" 
[info] event=screens.v2.candidate_generator.dup.evergreen_content_instances.start request_id="F9yM_aesq1sJfV0AAApE" span_id="ZcaJzZfxgTpTZLLD" parent_id="mNf25ySqPZ0tM29t" correlation_id="ZE2s3j5XzDPJpHou" 
[info] event=screens.v3_api.get_json.start cached=true url="https://api-v3.mbta.com/stops?filter%5Bid%5D=place-aport" span_id="F5Im0pwu6PUgy696" parent_id="FSPN6gcYxXwyfV_D" correlation_id="u3QoVTnF7Tf7Rig8" 
[info] event=screens.v2.candidate_generator.dup.departures.get_section_data.start span_id="xseHEQGPvK0T_7WY" parent_id="84ps0t8q1koInaur" correlation_id="ieKTBrgWuc2EFYsO" 
[info] event=screens.v3_api.get_json.start cached=true url="https://api-v3.mbta.com/stops?filter%5Bid%5D=place-aport" span_id="4Cq9AcRbHaX1RIll" parent_id="jzVEsWqOJ3mLQOx6" correlation_id="3-NkXOasyT85Fayv" 
[info] event=screens.v2.candidate_generator.dup.evergreen_content_instances.stop request_id="F9yM_aesq1sJfV0AAApE" span_id="ZcaJzZfxgTpTZLLD" parent_id="mNf25ySqPZ0tM29t" correlation_id="ZE2s3j5XzDPJpHou" duration=0
[info] event=screens.v3_api.get_json.start cached=true url="https://api-v3.mbta.com/routes?filter%5Bstop%5D=place-aport" span_id="tkJU9mQ8oPKRjUzf" parent_id="xseHEQGPvK0T_7WY" correlation_id="50cRgOuY-ZNbsfd9" 
[info] event=screens.v3_api.get_json.stop cached=true url="https://api-v3.mbta.com/routes?filter%5Bstop%5D=place-aport" span_id="tkJU9mQ8oPKRjUzf" parent_id="xseHEQGPvK0T_7WY" correlation_id="50cRgOuY-ZNbsfd9" duration=74
[info] event=screens.v3_api.get_json.start cached=true url="https://api-v3.mbta.com/predictions?filter%5Broute%5D=Blue&filter%5Bstop%5D=place-aport&include=route%2Cstop%2Ctrip%2Ctrip.stops%2Cvehicle%2Calerts&sort=departure_time" span_id="YUbzhjqkwUHhEXEC" parent_id="xseHEQGPvK0T_7WY" correlation_id="50cRgOuY-ZNbsfd9" 
[info] event=screens.v3_api.get_json.stop cached=true url="https://api-v3.mbta.com/stops?filter%5Bid%5D=place-aport" span_id="4Cq9AcRbHaX1RIll" parent_id="jzVEsWqOJ3mLQOx6" correlation_id="3-NkXOasyT85Fayv" duration=77
[info] event=screens.stops.stop.fetch_stop_name.stop span_id="jzVEsWqOJ3mLQOx6" parent_id="OOq9TkXnrcFsJD5O" correlation_id="3-NkXOasyT85Fayv" duration=78
[info] event=screens.v2.candidate_generator.dup.header_instances.stop request_id="F9yM_aesq1sJfV0AAApE" span_id="OOq9TkXnrcFsJD5O" parent_id="mNf25ySqPZ0tM29t" correlation_id="ZE2s3j5XzDPJpHou" duration=78
[info] event=screens.v3_api.get_json.stop cached=true url="https://api-v3.mbta.com/stops?filter%5Bid%5D=place-aport" span_id="F5Im0pwu6PUgy696" parent_id="FSPN6gcYxXwyfV_D" correlation_id="u3QoVTnF7Tf7Rig8" duration=93
[info] event=screens.stops.stop.fetch_stop_name.stop span_id="FSPN6gcYxXwyfV_D" parent_id="AuOOk9_ypObVSO1e" correlation_id="u3QoVTnF7Tf7Rig8" duration=94
[info] event=screens.stops.stop.fetch_location_context.start span_id="6PpHjH4MQe7zh51q" parent_id="AuOOk9_ypObVSO1e" correlation_id="u3QoVTnF7Tf7Rig8" 
[info] event=screens.routes.route.fetch_routes_by_stop.start span_id="5MRK1jAmeIH997Ia" parent_id="6PpHjH4MQe7zh51q" correlation_id="u3QoVTnF7Tf7Rig8" stop_id="place-aport" type_filters=[:light_rail, :subway] 
[info] event=screens.v3_api.get_json.start cached=true url="https://api-v3.mbta.com/routes/?filter%5Bstop%5D=place-aport&filter%5Btype%5D=0%2C1" span_id="ezc6DW5ymeKk3CBl" parent_id="5MRK1jAmeIH997Ia" correlation_id="u3QoVTnF7Tf7Rig8" 
[info] event=screens.v3_api.get_json.stop cached=true url="https://api-v3.mbta.com/routes/?filter%5Bstop%5D=place-aport&filter%5Btype%5D=0%2C1" span_id="ezc6DW5ymeKk3CBl" parent_id="5MRK1jAmeIH997Ia" correlation_id="u3QoVTnF7Tf7Rig8" duration=43
[info] event=screens.v3_api.get_json.start cached=true url="https://api-v3.mbta.com/routes/?filter%5Bdate%5D=2024-06-26&filter%5Bstop%5D=place-aport" span_id="99K3egD4EbgrLFE2" parent_id="5MRK1jAmeIH997Ia" correlation_id="u3QoVTnF7Tf7Rig8" 
[info] event=screens.v3_api.get_json.stop cached=true url="https://api-v3.mbta.com/predictions?filter%5Broute%5D=Blue&filter%5Bstop%5D=place-aport&include=route%2Cstop%2Ctrip%2Ctrip.stops%2Cvehicle%2Calerts&sort=departure_time" span_id="YUbzhjqkwUHhEXEC" parent_id="xseHEQGPvK0T_7WY" correlation_id="50cRgOuY-ZNbsfd9" duration=102
[info] event=screens.alerts.alert.fetch.start span_id="sm7tREe6AzEQVSBN" parent_id="xseHEQGPvK0T_7WY" correlation_id="50cRgOuY-ZNbsfd9" 
[info] event=screens.v3_api.get_json.start cached=true url="https://api-v3.mbta.com/alerts?filter%5Broute%5D=Blue&filter%5Broute_type%5D=0%2C1&filter%5Bstop%5D=place-aport" span_id="pJGJYySfmDsiRR-2" parent_id="sm7tREe6AzEQVSBN" correlation_id="50cRgOuY-ZNbsfd9" 
[info] event=screens.v3_api.get_json.stop cached=true url="https://api-v3.mbta.com/routes/?filter%5Bdate%5D=2024-06-26&filter%5Bstop%5D=place-aport" span_id="99K3egD4EbgrLFE2" parent_id="5MRK1jAmeIH997Ia" correlation_id="u3QoVTnF7Tf7Rig8" duration=53
[info] event=screens.routes.route.fetch_routes_by_stop.stop span_id="5MRK1jAmeIH997Ia" parent_id="6PpHjH4MQe7zh51q" correlation_id="u3QoVTnF7Tf7Rig8" stop_id="place-aport" type_filters=[:light_rail, :subway] duration=97
[info] event=screens.v3_api.get_json.start cached=true url="https://api-v3.mbta.com/route_patterns?filter%5Bdirection_id%5D=0&filter%5Broute%5D=Blue&filter%5Bstop%5D=place-aport&include=representative_trip.stops%2Croute" span_id="csM5DtOdgzNY0czz" parent_id="6PpHjH4MQe7zh51q" correlation_id="u3QoVTnF7Tf7Rig8" 
[info] event=screens.v3_api.get_json.stop cached=true url="https://api-v3.mbta.com/alerts?filter%5Broute%5D=Blue&filter%5Broute_type%5D=0%2C1&filter%5Bstop%5D=place-aport" span_id="pJGJYySfmDsiRR-2" parent_id="sm7tREe6AzEQVSBN" correlation_id="50cRgOuY-ZNbsfd9" duration=43
[info] event=screens.alerts.alert.fetch.stop span_id="sm7tREe6AzEQVSBN" parent_id="xseHEQGPvK0T_7WY" correlation_id="50cRgOuY-ZNbsfd9" duration=43
[info] event=screens.v2.candidate_generator.dup.departures.get_section_data.stop span_id="xseHEQGPvK0T_7WY" parent_id="84ps0t8q1koInaur" correlation_id="ieKTBrgWuc2EFYsO" duration=221
[info] event=screens.v2.candidate_generator.dup.departures.get_sections_data.stop span_id="84ps0t8q1koInaur" parent_id="ClDUq0ACUgNPH_N2" correlation_id="ieKTBrgWuc2EFYsO" duration=221
[info] event=screens.v2.candidate_generator.dup.departures.get_sections_data.start span_id="iYqe8eeYivLAsoUI" parent_id="ClDUq0ACUgNPH_N2" correlation_id="ieKTBrgWuc2EFYsO" 
[info] event=screens.v2.candidate_generator.dup.departures.get_section_data.start span_id="I9jo4F1BJDrJ8vWG" parent_id="iYqe8eeYivLAsoUI" correlation_id="ieKTBrgWuc2EFYsO" 
[info] event=screens.v3_api.get_json.start cached=true url="https://api-v3.mbta.com/routes?filter%5Bstop%5D=place-aport" span_id="acy32MmJn7DkAZwC" parent_id="I9jo4F1BJDrJ8vWG" correlation_id="rMnsvmZgeICF8nWX" 
[info] event=screens.v3_api.get_json.stop cached=true url="https://api-v3.mbta.com/route_patterns?filter%5Bdirection_id%5D=0&filter%5Broute%5D=Blue&filter%5Bstop%5D=place-aport&include=representative_trip.stops%2Croute" span_id="csM5DtOdgzNY0czz" parent_id="6PpHjH4MQe7zh51q" correlation_id="u3QoVTnF7Tf7Rig8" duration=43
[info] event=screens.stops.stop.fetch_stop_name.start span_id="6ohTUk_l4DTCoX0t" parent_id="6PpHjH4MQe7zh51q" correlation_id="u3QoVTnF7Tf7Rig8" 
[info] event=screens.v3_api.get_json.start cached=true url="https://api-v3.mbta.com/stops?filter%5Bid%5D=place-aport" span_id="KAQGK6EHvCGubL95" parent_id="6ohTUk_l4DTCoX0t" correlation_id="u3QoVTnF7Tf7Rig8" 
[info] event=screens.v3_api.get_json.stop cached=true url="https://api-v3.mbta.com/routes?filter%5Bstop%5D=place-aport" span_id="acy32MmJn7DkAZwC" parent_id="I9jo4F1BJDrJ8vWG" correlation_id="rMnsvmZgeICF8nWX" duration=45
[info] event=screens.v3_api.get_json.start cached=true url="https://api-v3.mbta.com/predictions?filter%5Broute%5D=171%2C743&filter%5Bstop%5D=place-aport&include=route%2Cstop%2Ctrip%2Ctrip.stops%2Cvehicle%2Calerts&sort=departure_time" span_id="GYrhegwHWWmt8wDi" parent_id="I9jo4F1BJDrJ8vWG" correlation_id="rMnsvmZgeICF8nWX" 
[info] event=screens.v3_api.get_json.stop cached=true url="https://api-v3.mbta.com/stops?filter%5Bid%5D=place-aport" span_id="KAQGK6EHvCGubL95" parent_id="6ohTUk_l4DTCoX0t" correlation_id="u3QoVTnF7Tf7Rig8" duration=44
[info] event=screens.stops.stop.fetch_stop_name.stop span_id="6ohTUk_l4DTCoX0t" parent_id="6PpHjH4MQe7zh51q" correlation_id="u3QoVTnF7Tf7Rig8" duration=44
[info] event=screens.stops.stop.fetch_location_context.stop span_id="6PpHjH4MQe7zh51q" parent_id="AuOOk9_ypObVSO1e" correlation_id="u3QoVTnF7Tf7Rig8" duration=186
[info] event=screens.alerts.alert.fetch.start span_id="BAyQKVr9FrYhjotO" parent_id="AuOOk9_ypObVSO1e" correlation_id="u3QoVTnF7Tf7Rig8" 
[info] event=screens.v3_api.get_json.start cached=true url="https://api-v3.mbta.com/alerts?filter%5Broute%5D=Blue" span_id="71kXPLEb2mNG7JKv" parent_id="BAyQKVr9FrYhjotO" correlation_id="u3QoVTnF7Tf7Rig8" 
[info] event=screens.v3_api.get_json.stop cached=true url="https://api-v3.mbta.com/alerts?filter%5Broute%5D=Blue" span_id="71kXPLEb2mNG7JKv" parent_id="BAyQKVr9FrYhjotO" correlation_id="u3QoVTnF7Tf7Rig8" duration=43
[info] event=screens.alerts.alert.fetch.stop span_id="BAyQKVr9FrYhjotO" parent_id="AuOOk9_ypObVSO1e" correlation_id="u3QoVTnF7Tf7Rig8" duration=43
[info] event=screens.v2.candidate_generator.dup.alerts_instances.stop request_id="F9yM_aesq1sJfV0AAApE" span_id="AuOOk9_ypObVSO1e" parent_id="mNf25ySqPZ0tM29t" correlation_id="ZE2s3j5XzDPJpHou" duration=324
[info] event=screens.v3_api.get_json.stop cached=true url="https://api-v3.mbta.com/predictions?filter%5Broute%5D=171%2C743&filter%5Bstop%5D=place-aport&include=route%2Cstop%2Ctrip%2Ctrip.stops%2Cvehicle%2Calerts&sort=departure_time" span_id="GYrhegwHWWmt8wDi" parent_id="I9jo4F1BJDrJ8vWG" correlation_id="rMnsvmZgeICF8nWX" duration=82
[info] event=screens.alerts.alert.fetch.start span_id="-W5m2KrnzhOu4n_W" parent_id="I9jo4F1BJDrJ8vWG" correlation_id="rMnsvmZgeICF8nWX" 
[info] event=screens.v3_api.get_json.start cached=true url="https://api-v3.mbta.com/alerts?filter%5Broute%5D=171%2C743&filter%5Broute_type%5D=0%2C1&filter%5Bstop%5D=place-aport" span_id="E6_dccB91wYS_tnR" parent_id="-W5m2KrnzhOu4n_W" correlation_id="rMnsvmZgeICF8nWX" 
[info] event=screens.v3_api.get_json.stop cached=true url="https://api-v3.mbta.com/alerts?filter%5Broute%5D=171%2C743&filter%5Broute_type%5D=0%2C1&filter%5Bstop%5D=place-aport" span_id="E6_dccB91wYS_tnR" parent_id="-W5m2KrnzhOu4n_W" correlation_id="rMnsvmZgeICF8nWX" duration=59
[info] event=screens.alerts.alert.fetch.stop span_id="-W5m2KrnzhOu4n_W" parent_id="I9jo4F1BJDrJ8vWG" correlation_id="rMnsvmZgeICF8nWX" duration=60
[info] event=screens.v2.candidate_generator.dup.departures.get_section_data.stop span_id="I9jo4F1BJDrJ8vWG" parent_id="iYqe8eeYivLAsoUI" correlation_id="ieKTBrgWuc2EFYsO" duration=189
[info] event=screens.v2.candidate_generator.dup.departures.get_sections_data.stop span_id="iYqe8eeYivLAsoUI" parent_id="ClDUq0ACUgNPH_N2" correlation_id="ieKTBrgWuc2EFYsO" duration=189
[info] event=screens.v2.candidate_generator.dup.departures_instances.stop request_id="F9yM_aesq1sJfV0AAApE" span_id="ClDUq0ACUgNPH_N2" parent_id="mNf25ySqPZ0tM29t" correlation_id="ZE2s3j5XzDPJpHou" duration=411
[info] Sent 200 in 419ms
```

</details>