### PR TITLE
fix: Allow line wrapping on flex zone alerts.

### DIFF
--- a/lib/screens/v2/widget_instance/reconstructed_alert.ex
+++ b/lib/screens/v2/widget_instance/reconstructed_alert.ex
@@ -410,7 +410,9 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
     %{
       issue: "No trains",
       remedy: "Seek alternate route",
-      location: %{text: ["No #{route_id} Line trains " | format_endpoint_string(endpoints)]},
+      location: %{
+        text: ["No #{route_id} Line trains " | format_endpoint_string(endpoints, true)]
+      },
       endpoints: endpoints,
       cause: format_cause(cause),
       routes: get_route_pills(t),
@@ -437,7 +439,8 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
       remedy: "Use shuttle bus",
       location: %{
         text: [
-          "Shuttle buses replace #{route_id} Line trains " | format_endpoint_string(endpoints)
+          "Shuttle buses replace #{route_id} Line trains "
+          | format_endpoint_string(endpoints, true)
         ]
       },
       endpoints: endpoints,
@@ -546,7 +549,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
       if location in [:downstream, :upstream] do
         {"No trains", nil}
       else
-        endpoint_text = format_endpoint_string(endpoints)
+        endpoint_text = format_endpoint_string(endpoints, true)
 
         location_text =
           if is_nil(endpoint_text),
@@ -609,7 +612,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
       if location in [:downstream, :upstream] do
         {"No trains", nil, "Shuttle buses available"}
       else
-        endpoint_text = format_endpoint_string(endpoints)
+        endpoint_text = format_endpoint_string(endpoints, true)
 
         location_text =
           if is_nil(endpoint_text), do: nil, else: %{text: ["Shuttle buses " | endpoint_text]}
@@ -1173,19 +1176,31 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
     includes_glx and not includes_west_of_copley
   end
 
-  def format_endpoint_string(nil), do: nil
+  @spec format_endpoint_string(nil | {String.t(), String.t()}) ::
+          nil | list(FreeText.t()) | String.t()
+  def format_endpoint_string(stations, prevent_line_wrap \\ false)
 
-  def format_endpoint_string({station, station}) do
-    ["at ", %{text: station, format: :nowrap}]
+  def format_endpoint_string(nil, _), do: nil
+
+  def format_endpoint_string({station, station}, prevent_line_wrap) do
+    if prevent_line_wrap do
+      ["at ", %{text: station, format: :nowrap}]
+    else
+      "at #{station}"
+    end
   end
 
-  def format_endpoint_string({min_station, max_station}) do
-    [
-      "between ",
-      %{text: min_station, format: :nowrap},
-      " and ",
-      %{text: max_station, format: :nowrap}
-    ]
+  def format_endpoint_string({min_station, max_station}, prevent_line_wrap) do
+    if prevent_line_wrap do
+      [
+        "between ",
+        %{text: min_station, format: :nowrap},
+        " and ",
+        %{text: max_station, format: :nowrap}
+      ]
+    else
+      "between #{min_station} and #{max_station}"
+    end
   end
 
   def serialize(widget, log_fn \\ &Logger.warning/1)

--- a/test/screens/v2/widget_instance/reconstructed_alert_test.exs
+++ b/test/screens/v2/widget_instance/reconstructed_alert_test.exs
@@ -1466,7 +1466,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
 
       expected = %{
         issue: %{text: ["No ", %{format: :nowrap, text: "Oak Grove"}, " trains"]},
-        location: ["at ", %{format: :nowrap, text: "Wellington"}],
+        location: "at Wellington",
         cause: "",
         routes: [%{color: :orange, text: "ORANGE LINE", type: :text}],
         effect: :suspension,
@@ -1490,12 +1490,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
 
       expected = %{
         issue: "No trains",
-        location: [
-          "between ",
-          %{format: :nowrap, text: "Wellington"},
-          " and ",
-          %{format: :nowrap, text: "Assembly"}
-        ],
+        location: "between Wellington and Assembly",
         cause: "",
         routes: [%{color: :orange, text: "ORANGE LINE", type: :text}],
         effect: :suspension,
@@ -1519,12 +1514,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
 
       expected = %{
         issue: %{text: ["No ", %{format: :nowrap, text: "Oak Grove"}, " trains"]},
-        location: [
-          "between ",
-          %{format: :nowrap, text: "Wellington"},
-          " and ",
-          %{format: :nowrap, text: "Assembly"}
-        ],
+        location: "between Wellington and Assembly",
         cause: "",
         routes: [%{color: :orange, text: "ORANGE LINE", type: :text}],
         effect: :suspension,
@@ -1547,7 +1537,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
 
       expected = %{
         issue: "No Oak Grove trains",
-        location: ["at ", %{format: :nowrap, text: "Wellington"}],
+        location: "at Wellington",
         cause: "",
         routes: [%{color: :orange, text: "ORANGE LINE", type: :text}],
         effect: :shuttle,
@@ -1744,12 +1734,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
 
       expected = %{
         issue: "No trains",
-        location: [
-          "between ",
-          %{format: :nowrap, text: "North Station"},
-          " and ",
-          %{format: :nowrap, text: "Science Park/West End"}
-        ],
+        location: "between North Station and Science Park/West End",
         cause: "",
         routes: [%{color: :green, text: "GREEN LINE", type: :text}],
         effect: :shuttle,
@@ -2125,12 +2110,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
 
       expected = %{
         issue: "No trains",
-        location: [
-          "between ",
-          %{format: :nowrap, text: "Airport"},
-          " and ",
-          %{format: :nowrap, text: "Orient Heights"}
-        ],
+        location: "between Airport and Orient Heights",
         cause: "",
         routes: [%{color: :blue, text: "BLUE LINE", type: :text}],
         effect: :shuttle,
@@ -2237,12 +2217,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
 
       expected = %{
         issue: "No trains",
-        location: [
-          "between ",
-          %{format: :nowrap, text: "Arlington"},
-          " and ",
-          %{format: :nowrap, text: "Park Street"}
-        ],
+        location: "between Arlington and Park Street",
         cause: "",
         routes: [%{color: :green, text: "GREEN LINE", type: :text}],
         effect: :suspension,
@@ -2289,12 +2264,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
 
       expected = %{
         issue: "No trains",
-        location: [
-          "between ",
-          %{format: :nowrap, text: "Brigham Circle"},
-          " and ",
-          %{format: :nowrap, text: "Museum of Fine Arts"}
-        ],
+        location: "between Brigham Circle and Museum of Fine Arts",
         cause: "",
         routes: [%{color: :green, text: "GREEN LINE", type: :text, branches: ["E"]}],
         effect: :suspension,
@@ -2342,12 +2312,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
 
       expected = %{
         issue: "No trains",
-        location: [
-          "between ",
-          %{format: :nowrap, text: "Ball Square"},
-          " and ",
-          %{format: :nowrap, text: "Gilman Square"}
-        ],
+        location: "between Ball Square and Gilman Square",
         cause: "",
         routes: [%{color: :green, text: "GREEN LINE", type: :text, branches: ["E"]}],
         effect: :suspension,
@@ -2701,12 +2666,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
       # Flexzone test
       expected = %{
         issue: "No trains",
-        location: [
-          "between ",
-          %{format: :nowrap, text: "North Station"},
-          " and ",
-          %{format: :nowrap, text: "Back Bay"}
-        ],
+        location: "between North Station and Back Bay",
         cause: "",
         routes: [%{color: :orange, text: "ORANGE LINE", type: :text}],
         effect: :suspension,


### PR DESCRIPTION
**Asana task**: ad-hoc

When I reviewed #2068, I didn't think about flex zone alerts. Because of the limited space on those, we should allow station names to wrap. Tweaked function a bit so that it returns a string for flex zone alerts.

- [x] Tests added?
