### PR TITLE
tweak: Suppress Alewife platform closure alert.

### DIFF
--- a/lib/screens/v2/widget_instance/reconstructed_alert.ex
+++ b/lib/screens/v2/widget_instance/reconstructed_alert.ex
@@ -1270,7 +1270,9 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
   def alert_ids(%__MODULE__{} = t), do: [t.alert.id]
 
   def valid_candidate?(%__MODULE__{} = t) do
-    t.alert.id not in ["197140", "580015"]
+    test_alert_ids = ["197140"]
+    prod_alert_ids = ["580015"]
+    t.alert.id not in (test_alert_ids ++ prod_alert_ids)
   end
 
   defimpl Screens.V2.WidgetInstance do

--- a/lib/screens/v2/widget_instance/reconstructed_alert.ex
+++ b/lib/screens/v2/widget_instance/reconstructed_alert.ex
@@ -1270,11 +1270,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
   def alert_ids(%__MODULE__{} = t), do: [t.alert.id]
 
   def valid_candidate?(%__MODULE__{} = t) do
-    suppressed =
-      t.alert.id in ["549108", "555079", "555080"] and
-        t.location_context.home_stop === "place-gover"
-
-    not suppressed
+    t.alert.id not in ["197140", "580015"]
   end
 
   defimpl Screens.V2.WidgetInstance do


### PR DESCRIPTION
**Asana task**: ad-hoc

The Alewife platform is being bypassed this weekend. The alert was created using a new Alerts UI feature that the Pre-Fare screens cannot handle yet. We will use a static image in its place.

Note: the scenario we are testing here is suppressing the above alert and letting another shuttle alert render normally. There is a flex zone alert bug keeping this branch from displaying the alert properly. That is being resolved in #2094.

- [ ] Tests added?
