### PR TITLE
fix: missing CR route abbreviation for Foxboro

### DIFF
--- a/lib/screens/v2/widget_instance/serializer/route_pill.ex
+++ b/lib/screens/v2/widget_instance/serializer/route_pill.ex
@@ -1,6 +1,8 @@
 defmodule Screens.V2.WidgetInstance.Serializer.RoutePill do
   @moduledoc false
 
+  require Logger
+
   alias Screens.Routes.Route
   alias Screens.RouteType
 
@@ -37,18 +39,19 @@ defmodule Screens.V2.WidgetInstance.Serializer.RoutePill do
   @type icon :: :bus | :light_rail | :rail | :boat
 
   @cr_line_abbreviations %{
-    "Haverhill" => "HVL",
-    "Newburyport" => "NBP",
-    "Lowell" => "LWL",
-    "Fitchburg" => "FBG",
-    "Worcester" => "WOR",
-    "Needham" => "NDM",
-    "Franklin" => "FRK",
-    "Providence" => "PVD",
     "Fairmount" => "FMT",
-    "Middleborough" => "MID",
+    "Fitchburg" => "FBG",
+    "Foxboro" => "FOX",
+    "Franklin" => "FRK",
+    "Greenbush" => "GRB",
+    "Haverhill" => "HVL",
     "Kingston" => "KNG",
-    "Greenbush" => "GRB"
+    "Lowell" => "LWL",
+    "Middleborough" => "MID",
+    "Needham" => "NDM",
+    "Newburyport" => "NBP",
+    "Providence" => "PVD",
+    "Worcester" => "WOR"
   }
 
   @special_bus_route_names %{
@@ -201,7 +204,13 @@ defmodule Screens.V2.WidgetInstance.Serializer.RoutePill do
   defp do_serialize("Blue", _), do: %{type: :text, text: "BL"}
 
   defp do_serialize("CR-" <> line, opts) do
-    base = %{route_abbrev: Map.fetch!(@cr_line_abbreviations, line)}
+    abbreviation =
+      Map.get_lazy(@cr_line_abbreviations, line, fn ->
+        Logger.warning("missing route pill abbreviation for CR-" <> line)
+        nil
+      end)
+
+    base = %{route_abbrev: abbreviation}
 
     if track_number = opts[:track_number],
       do: Map.merge(base, %{type: :text, text: "TR#{track_number}"}),

--- a/test/screens/v2/widget_instance/serializer/route_pill_test.exs
+++ b/test/screens/v2/widget_instance/serializer/route_pill_test.exs
@@ -1,6 +1,7 @@
 defmodule Screens.V2.WidgetInstance.Serializer.RoutePillTest do
   use ExUnit.Case, async: true
 
+  import ExUnit.CaptureLog
   import Screens.V2.WidgetInstance.Serializer.RoutePill
 
   describe "serialize_for_departure/4" do
@@ -12,6 +13,16 @@ defmodule Screens.V2.WidgetInstance.Serializer.RoutePillTest do
     test "Returns track number with route abbreviation for CR when not nil" do
       assert %{type: :text, text: "TR3", color: :purple, route_abbrev: "FMT"} ==
                serialize_for_departure("CR-Fairmount", "", :rail, 3)
+    end
+
+    test "Returns no abbreviation and logs a warning for an unknown CR route" do
+      logs =
+        capture_log([level: :warning], fn ->
+          assert %{type: :icon, icon: :rail, color: :purple, route_abbrev: nil} ==
+                   serialize_for_departure("CR-Foobar", "", :rail, nil)
+        end)
+
+      assert logs =~ "missing route pill abbreviation for CR-Foobar"
     end
 
     test "Returns boat icon if route type is :ferry" do


### PR DESCRIPTION
This also changes the logic to omit the abbreviation and log a warning instead of crashing when it encounters a Commuter Rail route we haven't heard of, since the fallback of showing a CR icon is reasonable and this issue should not prevent the whole screen/section from working.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207678749880387