### PR TITLE
dev: fix Phoenix assets watcher not exiting

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -51,6 +51,7 @@
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-jest": "^28.5.0",
         "eslint-plugin-react": "^7.34.1",
+        "exit_on_eof": "^1.0.4",
         "file-loader": "^6.2.0",
         "fishery": "^2.2.2",
         "globals": "^15.1.0",
@@ -7834,6 +7835,15 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/exit_on_eof": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/exit_on_eof/-/exit_on_eof-1.0.4.tgz",
+      "integrity": "sha512-CSDQmFtqoJJOokiZUdMcAh1f8GnltH4aLPbc11jRrWnR1MC/FPXICaKEsirSL/hJ5Wuo+7H7V8+OW6PD1aniuA==",
+      "dev": true,
+      "bin": {
+        "exit_on_eof": "index.js"
       }
     },
     "node_modules/expand-brackets": {

--- a/assets/package.json
+++ b/assets/package.json
@@ -63,6 +63,7 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-jest": "^28.5.0",
     "eslint-plugin-react": "^7.34.1",
+    "exit_on_eof": "^1.0.4",
     "file-loader": "^6.2.0",
     "fishery": "^2.2.2",
     "globals": "^15.1.0",

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -11,7 +11,7 @@ config :screens, ScreensWeb.Endpoint,
   debug_errors: true,
   code_reloader: true,
   check_origin: false,
-  watchers: [npm: ["run", "watch", cd: "assets"]]
+  watchers: [npx: ["exit_on_eof", "npm run watch", cd: "assets"]]
 
 config :screens,
   default_api_v3_url: System.get_env("API_V3_URL", "https://api-v3.mbta.com/"),


### PR DESCRIPTION
Phoenix expects watcher processes to exit when it sends an EOF to their stdin, but tools like Webpack and `tsc` don't have this behavior by default and will keep running in the background, piling up over time. [`exit_on_eof`](https://github.com/ntilwalli/exit_on_eof?tab=readme-ov-file) is a package developed specifically to bridge this gap.

(Webpack actually has a `--watch-options-stdin` flag for this, but since `tsc` lacks such an option, we would need to use the package anyway.)