### PR TITLE
fix: inconsistent departure sorting

### DIFF
--- a/test/screens/v2/departure/builder_test.exs
+++ b/test/screens/v2/departure/builder_test.exs
@@ -161,6 +161,26 @@ defmodule Screens.V2.Departure.BuilderTest do
       assert MapSet.new([d1, d4, d5, d6]) ==
                MapSet.new(Builder.get_relevant_departures(departures, now))
     end
+
+    test "sorts departures by arrival time if present, departure time if not" do
+      # arrives earlier, departs later
+      d1 = %Schedule{
+        id: "1",
+        arrival_time: ~U[2020-02-01T00:00:01Z],
+        departure_time: ~U[2020-02-01T00:00:05Z]
+      }
+
+      # arrives later, departs earlier
+      d2 = %Schedule{
+        id: "2",
+        arrival_time: ~U[2020-02-01T00:00:02Z],
+        departure_time: ~U[2020-02-01T00:00:03Z]
+      }
+
+      now = ~U[2020-01-01T00:00:00Z]
+
+      assert [d1, d2] == Builder.get_relevant_departures([d2, d1], now)
+    end
   end
 
   describe "merge_predictions_and_schedules/2" do


### PR DESCRIPTION
When displaying departures, we show the arrival time if there is one, and the departure time if not. When fetching departures, however, we were sorting by departure time if there was one, and arrival time if not (unless also fetching scheduled stop times, in which case sorting used the same logic as displaying!). This created some situations where departures would appear "out of order".


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207678749880386