### PR TITLE
revert: no-wrap station names in prefare alerts

### DIFF
--- a/assets/src/components/v2/pre_fare_single_screen_alert.tsx
+++ b/assets/src/components/v2/pre_fare_single_screen_alert.tsx
@@ -6,8 +6,6 @@ import DisruptionDiagram, {
 } from "./disruption_diagram/disruption_diagram";
 import { classWithModifier, classWithModifiers, formatCause } from "Util/util";
 
-import FreeText, { type FreeTextType } from "./free_text";
-
 import ClockIcon from "Images/svgr_bundled/clock-negative.svg";
 import NoServiceIcon from "Images/svgr_bundled/no-service.svg";
 import InfoIcon from "Images/svgr_bundled/info.svg";
@@ -15,28 +13,9 @@ import ISAIcon from "Images/svgr_bundled/isa.svg";
 import WalkingIcon from "Images/svgr_bundled/nearby.svg";
 import ShuttleBusIcon from "Images/svgr_bundled/bus.svg";
 
-type StringOrFreeText = string | FreeTextType | Array<string | FreeTextType>;
-
-const Text = ({ children: text }: { children?: StringOrFreeText | null }) => {
-  if (text == null) return null;
-
-  if (typeof text === "string") return <span>{text}</span>;
-  if (Array.isArray(text)) {
-    return (
-      <>
-        {text.map((el, i) => (
-          <Text key={i}>{el}</Text>
-        ))}
-      </>
-    );
-  }
-
-  return <FreeText lines={text} />;
-};
-
 interface PreFareSingleScreenAlertProps {
-  issue: StringOrFreeText;
-  location: StringOrFreeText;
+  issue: string;
+  location: string;
   cause: string;
   remedy: string;
   remedy_bold?: string;
@@ -55,10 +34,10 @@ interface EnrichedRoute {
 }
 
 interface StandardLayoutProps {
-  issue: StringOrFreeText;
+  issue: string;
   remedy: string;
   effect: string;
-  location: StringOrFreeText | null;
+  location: string | null;
   disruptionDiagram?: DisruptionDiagramData;
 }
 
@@ -183,7 +162,7 @@ const MultiLineLayout: React.ComponentType<MultiLineLayoutProps> = ({
 };
 
 interface FallbackLayoutProps {
-  issue: StringOrFreeText;
+  issue: string;
   remedy: string;
   remedyBold?: string;
   effect: string;
@@ -213,11 +192,7 @@ const FallbackLayout: React.ComponentType<FallbackLayoutProps> = ({
   return (
     <div className="alert-card__fallback">
       {icon}
-      {issue && (
-        <div className="alert-card__fallback__issue-text">
-          <Text>{issue}</Text>
-        </div>
-      )}
+      {issue && <div className="alert-card__fallback__issue-text">{issue}</div>}
       {remedy && (
         <div
           className={classWithModifier(
@@ -239,8 +214,8 @@ const FallbackLayout: React.ComponentType<FallbackLayoutProps> = ({
 };
 
 interface StandardIssueSectionProps {
-  issue: StringOrFreeText;
-  location: StringOrFreeText | null;
+  issue: string;
+  location: string | null;
   contentTextSize: string;
 }
 
@@ -258,12 +233,10 @@ const StandardIssueSection: React.ComponentType<StandardIssueSectionProps> = ({
           contentTextSize,
         )}
       >
-        <Text>{issue}</Text>
+        {issue}
       </div>
       {location && (
-        <div className="alert-card__issue__location">
-          <Text>{location}</Text>
-        </div>
+        <div className="alert-card__issue__location">{location}</div>
       )}
     </div>
   </div>
@@ -280,10 +253,8 @@ const DownstreamIssueSection: React.ComponentType<
     <div
       className={classWithModifier("alert-card__content-block__text", "medium")}
     >
-      No trains <span style={{ fontWeight: 500 }}>between</span>{" "}
-      <span className="free-text__string--nowrap">{endpoints[0]}</span>{" "}
-      <span style={{ fontWeight: 500 }}>&</span>{" "}
-      <span className="free-text__string--nowrap">{endpoints[1]}</span>
+      No trains <span style={{ fontWeight: 500 }}>between</span> {endpoints[0]}{" "}
+      <span style={{ fontWeight: 500 }}>&</span> {endpoints[1]}
     </div>
   </div>
 );

--- a/lib/screens_web/views/v2/audio/reconstructed_alert_single_screen_view.ex
+++ b/lib/screens_web/views/v2/audio/reconstructed_alert_single_screen_view.ex
@@ -3,7 +3,6 @@ defmodule ScreensWeb.V2.Audio.ReconstructedAlertSingleScreenView do
 
   alias Screens.Alerts.Alert
   alias Screens.Util
-  alias ScreensConfig.V2.FreeTextLine
 
   def render("_widget.ssml", alert) do
     ~E|<p><%= render_banner(alert) %><%= render_alert(alert) %></p>|
@@ -45,7 +44,7 @@ defmodule ScreensWeb.V2.Audio.ReconstructedAlertSingleScreenView do
           issue: issue
         } = alert
       ) do
-    ~E|<%= issue_to_string(issue) %><%= render_cause(alert.cause) %>.|
+    ~E|<%= issue %><%= render_cause(alert.cause) %>.|
   end
 
   # Downstream closure
@@ -90,7 +89,7 @@ defmodule ScreensWeb.V2.Audio.ReconstructedAlertSingleScreenView do
         endpoints: {left_endpoint, right_endpoint},
         cause: cause
       }) do
-    ~E|There are <%= issue_to_string(issue) %>. Please use the shuttle bus. Shuttle buses are replacing <%= get_line_name(route_svg_names) %> trains between <%= left_endpoint %> and <%= right_endpoint %><%= render_cause(cause) %>. All shuttle buses are accessible.|
+    ~E|There are <%= issue %>. Please use the shuttle bus. Shuttle buses are replacing <%= get_line_name(route_svg_names) %> trains between <%= left_endpoint %> and <%= right_endpoint %><%= render_cause(cause) %>. All shuttle buses are accessible.|
   end
 
   # Boundary suspension
@@ -102,7 +101,7 @@ defmodule ScreensWeb.V2.Audio.ReconstructedAlertSingleScreenView do
         endpoints: {left_endpoint, right_endpoint},
         cause: cause
       }) do
-    ~E|There are <%= issue_to_string(issue) %>. Please seek an alternate route. Please note that there are no <%= get_line_name(route_svg_names) %> trains between <%= left_endpoint %> and <%= right_endpoint %><%= render_cause(cause) %>.|
+    ~E|There are <%= issue %>. Please seek an alternate route. Please note that there are no <%= get_line_name(route_svg_names) %> trains between <%= left_endpoint %> and <%= right_endpoint %><%= render_cause(cause) %>.|
   end
 
   # Closure here - three cases
@@ -221,11 +220,4 @@ defmodule ScreensWeb.V2.Audio.ReconstructedAlertSingleScreenView do
 
   defp render_cause(nil), do: nil
   defp render_cause(cause), do: " #{Alert.get_cause_string(cause)}"
-
-  defp issue_to_string(%{text: _} = issue) do
-    issue_free_text = struct(FreeTextLine, issue)
-    FreeTextLine.to_plaintext(issue_free_text)
-  end
-
-  defp issue_to_string(issue), do: issue
 end

--- a/test/screens/v2/widget_instance/reconstructed_alert_test.exs
+++ b/test/screens/v2/widget_instance/reconstructed_alert_test.exs
@@ -536,16 +536,8 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
         |> put_is_full_screen(true)
 
       expected = %{
-        issue: %{text: ["No trains to ", %{format: :nowrap, text: "Forest Hills"}]},
-        location: %{
-          text: [
-            "No Orange Line trains ",
-            "between ",
-            %{format: :nowrap, text: "Malden Center"},
-            " and ",
-            %{format: :nowrap, text: "Wellington"}
-          ]
-        },
+        issue: "No trains to Forest Hills",
+        location: "No Orange Line trains between Malden Center and Wellington",
         cause: nil,
         effect: :suspension,
         remedy: "Seek alternate route",
@@ -584,16 +576,8 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
         |> put_is_full_screen(true)
 
       expected = %{
-        issue: %{text: ["No trains to ", %{format: :nowrap, text: "Forest Hills"}]},
-        location: %{
-          text: [
-            "Shuttle buses ",
-            "between ",
-            %{format: :nowrap, text: "Wellington"},
-            " and ",
-            %{format: :nowrap, text: "Assembly"}
-          ]
-        },
+        issue: "No trains to Forest Hills",
+        location: "Shuttle buses between Wellington and Assembly",
         cause: nil,
         effect: :shuttle,
         remedy: "Use shuttle bus",
@@ -671,16 +655,8 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
         |> put_is_full_screen(true)
 
       expected = %{
-        issue: %{text: ["No trains to ", %{format: :nowrap, text: "Forest Hills"}]},
-        location: %{
-          text: [
-            "No Orange Line trains ",
-            "between ",
-            %{format: :nowrap, text: "Wellington"},
-            " and ",
-            %{format: :nowrap, text: "Assembly"}
-          ]
-        },
+        issue: "No trains to Forest Hills",
+        location: "No Orange Line trains between Wellington and Assembly",
         cause: :construction,
         effect: :suspension,
         remedy: "Seek alternate route",
@@ -720,15 +696,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
 
       expected = %{
         issue: "No trains",
-        location: %{
-          text: [
-            "No Orange Line trains ",
-            "between ",
-            %{format: :nowrap, text: "Oak Grove"},
-            " and ",
-            %{format: :nowrap, text: "Malden Center"}
-          ]
-        },
+        location: "No Orange Line trains between Oak Grove and Malden Center",
         cause: nil,
         effect: :suspension,
         remedy: "Seek alternate route",
@@ -766,15 +734,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
 
       expected = %{
         issue: "No trains",
-        location: %{
-          text: [
-            "Shuttle buses replace Orange Line trains ",
-            "between ",
-            %{format: :nowrap, text: "Oak Grove"},
-            " and ",
-            %{format: :nowrap, text: "Malden Center"}
-          ]
-        },
+        location: "Shuttle buses replace Orange Line trains between Oak Grove and Malden Center",
         cause: nil,
         effect: :shuttle,
         remedy: "Use shuttle bus",
@@ -814,16 +774,8 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
         |> put_is_full_screen(true)
 
       expected = %{
-        issue: %{text: ["No trains to ", %{format: :nowrap, text: "Oak Grove"}]},
-        location: %{
-          text: [
-            "No Orange Line trains ",
-            "between ",
-            %{format: :nowrap, text: "Oak Grove"},
-            " and ",
-            %{format: :nowrap, text: "Malden Center"}
-          ]
-        },
+        issue: "No trains to Oak Grove",
+        location: "No Orange Line trains between Oak Grove and Malden Center",
         cause: nil,
         routes: [%{route_id: "Orange", svg_name: "ol"}],
         effect: :suspension,
@@ -861,16 +813,8 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
         |> put_is_full_screen(true)
 
       expected = %{
-        issue: %{text: ["No trains to ", %{format: :nowrap, text: "Oak Grove"}]},
-        location: %{
-          text: [
-            "Shuttle buses ",
-            "between ",
-            %{format: :nowrap, text: "Oak Grove"},
-            " and ",
-            %{format: :nowrap, text: "Malden Center"}
-          ]
-        },
+        issue: "No trains to Oak Grove",
+        location: "Shuttle buses between Oak Grove and Malden Center",
         cause: nil,
         routes: [%{route_id: "Orange", svg_name: "ol"}],
         effect: :shuttle,
@@ -1159,15 +1103,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
         endpoints: {"Haymarket", "Chinatown"},
         is_transfer_station: true,
         issue: "No Orange Line trains",
-        location: %{
-          text: [
-            "No Orange Line trains ",
-            "between ",
-            %{format: :nowrap, text: "Haymarket"},
-            " and ",
-            %{format: :nowrap, text: "Chinatown"}
-          ]
-        },
+        location: "No Orange Line trains between Haymarket and Chinatown",
         region: :here,
         remedy: "Seek alternate route",
         routes: [%{route_id: "Orange", svg_name: "ol"}],
@@ -1207,15 +1143,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
         issue: "No Orange Line trains",
         remedy: "Use shuttle bus",
         cause: nil,
-        location: %{
-          text: [
-            "Shuttle buses ",
-            "between ",
-            %{format: :nowrap, text: "State"},
-            " and ",
-            %{format: :nowrap, text: "Chinatown"}
-          ]
-        },
+        location: "Shuttle buses between State and Chinatown",
         routes: [%{route_id: "Orange", svg_name: "ol"}],
         effect: :shuttle,
         updated_at: "Friday, 5:00 am",
@@ -1334,7 +1262,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
         |> put_cause(:unknown)
 
       expected = %{
-        issue: %{text: ["No ", %{format: :nowrap, text: "Alewife"}, " trains"]},
+        issue: "No Alewife trains",
         location: "",
         cause: "",
         routes: [%{color: :red, text: "RED LINE", type: :text}],
@@ -1358,7 +1286,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
         |> put_cause(:unknown)
 
       expected = %{
-        issue: %{text: ["No ", %{format: :nowrap, text: "Alewife"}, " trains"]},
+        issue: "No Alewife trains",
         location: "",
         cause: "",
         routes: [%{color: :red, text: "RED LINE", type: :text}],
@@ -1409,9 +1337,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
         |> put_severity(10)
 
       expected = %{
-        issue: %{
-          text: [%{format: :nowrap, text: "Alewife"}, " trains may be delayed over 60 minutes"]
-        },
+        issue: "Alewife trains may be delayed over 60 minutes",
         location: "",
         cause: "",
         routes: [%{color: :red, text: "RED LINE", type: :text}],
@@ -1436,9 +1362,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
         |> put_severity(10)
 
       expected = %{
-        issue: %{
-          text: [%{format: :nowrap, text: "Alewife"}, " trains may be delayed over 60 minutes"]
-        },
+        issue: "Alewife trains may be delayed over 60 minutes",
         location: "",
         cause: "due to construction",
         routes: [%{color: :red, text: "RED LINE", type: :text}],
@@ -1465,7 +1389,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
         |> put_cause(:unknown)
 
       expected = %{
-        issue: %{text: ["No ", %{format: :nowrap, text: "Oak Grove"}, " trains"]},
+        issue: "No Oak Grove trains",
         location: "at Wellington",
         cause: "",
         routes: [%{color: :orange, text: "ORANGE LINE", type: :text}],
@@ -1513,7 +1437,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
         |> put_cause(:unknown)
 
       expected = %{
-        issue: %{text: ["No ", %{format: :nowrap, text: "Oak Grove"}, " trains"]},
+        issue: "No Oak Grove trains",
         location: "between Wellington and Assembly",
         cause: "",
         routes: [%{color: :orange, text: "ORANGE LINE", type: :text}],
@@ -1560,7 +1484,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
         |> put_informed_stations(["Wellington"])
 
       expected = %{
-        issue: %{text: ["Trains will bypass ", %{format: :nowrap, text: "Wellington"}]},
+        issue: "Trains will bypass Wellington",
         location: "",
         cause: "",
         routes: [
@@ -1610,7 +1534,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
         |> put_informed_stations(["Wellington"])
 
       expected = %{
-        issue: %{text: ["Trains will bypass ", %{text: "Wellington", format: :nowrap}]},
+        issue: "Trains will bypass Wellington",
         location: "",
         cause: "due to construction",
         routes: [
@@ -3057,7 +2981,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
 
       # Flexzone test
       expected = %{
-        issue: %{text: ["No ", %{text: "North Station & North", format: :nowrap}, " trains"]},
+        issue: "No North Station & North trains",
         location: "",
         cause: "",
         routes: [%{color: :green, text: "GREEN LINE", type: :text}],


### PR DESCRIPTION
This reverts commits 19125d8, 9ffd4b4, and 5aff537, pending investigation on how we can accomplish this without causing overflow when a destination is too long to fit on one line.

See discussion on: https://app.asana.com/0/1185117109217422/1207688110481364