### PR TITLE
feat: abbreviate v2 departure destinations

### DIFF
--- a/assets/src/components/v2/departures/destination.tsx
+++ b/assets/src/components/v2/departures/destination.tsx
@@ -1,5 +1,10 @@
 import React, { ComponentType } from "react";
 
+const abbreviate = (headsign: string): string => {
+  if (headsign === "Government Center") return "Government Ctr";
+  return headsign;
+};
+
 type Destination = {
   headsign: string;
   variation?: string;
@@ -8,7 +13,9 @@ type Destination = {
 const Destination: ComponentType<Destination> = ({ headsign, variation }) => {
   return (
     <div className="departure-destination">
-      <div className="departure-destination__headsign">{headsign}</div>
+      <div className="departure-destination__headsign">
+        {abbreviate(headsign)}
+      </div>
       {variation && (
         <div className="departure-destination__variation">{variation}</div>
       )}


### PR DESCRIPTION
In general we're okay with the overflow behavior of destinations being ellipsized ("..."), but in the specific case of Government Center as a Green Line destination, we already have a standard abbreviation we use in other places (such as `NormalHeader`), and this would otherwise be rendered as "Government Cen..." on Sectional screens. Per Dave/Betsy review, we should just add this specific abbreviation for now, and revisit the larger topic of abbreviation consistency and thoroughness later.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207678749880384