### PR TITLE
Add log to catch nil CR schedule.

### DIFF
--- a/lib/screens/v2/widget_instance/cr_departures.ex
+++ b/lib/screens/v2/widget_instance/cr_departures.ex
@@ -133,14 +133,19 @@ defmodule Screens.V2.WidgetInstance.CRDepartures do
          } = departure,
          now
        ) do
-    if is_nil(schedule) do
-      Logger.error("[cr_departures serialize_time] schedule is nil: #{inspect(departure)}")
-    end
-
     {:ok, scheduled_departure_time} =
-      %Departure{schedule: schedule}
-      |> Departure.time()
-      |> DateTime.shift_zone("America/New_York")
+      try do
+        %Departure{schedule: schedule}
+        |> Departure.time()
+        |> DateTime.shift_zone("America/New_York")
+      rescue
+        ex ->
+          Logger.error(
+            "[cr_departures serialize_time] Could not get schedule time: #{inspect(departure)}"
+          )
+
+          reraise ex, __STACKTRACE__
+      end
 
     cond do
       is_nil(prediction) ->

--- a/lib/screens/v2/widget_instance/cr_departures.ex
+++ b/lib/screens/v2/widget_instance/cr_departures.ex
@@ -1,6 +1,7 @@
 defmodule Screens.V2.WidgetInstance.CRDepartures do
   @moduledoc false
 
+  require Logger
   alias Screens.Predictions.Prediction
   alias Screens.Stops.Stop
   alias Screens.V2.Departure
@@ -132,6 +133,10 @@ defmodule Screens.V2.WidgetInstance.CRDepartures do
          } = departure,
          now
        ) do
+    if is_nil(schedule) do
+      Logger.error("[cr_departures serialize_time] schedule is nil: #{inspect(departure)}")
+    end
+
     {:ok, scheduled_departure_time} =
       %Departure{schedule: schedule}
       |> Departure.time()


### PR DESCRIPTION
**Asana task**: ad-hoc

Every once in a while, the Porter Pre-Fare screen crashes with the following error 
```
7c59130100be ** (FunctionClauseError) no function clause matching in Screens.V2.Departure.select_arrival_time/1

7c59130100be (screens 0.1.0) lib/screens/v2/departure.ex:255: Screens.V2.Departure.select_arrival_time(nil)
```

If I'm following the code correctly, this only happens when `schedule == nil`. This should not happen though, so I think this is a data problem. Before suggesting something is wrong, I want to try to catch the departure data when it happens next. 

- [ ] Tests added?
