### PR TITLE
fix: show "BRD" only if the vehicle is at the stop

### DIFF
--- a/lib/screens/v2/departure.ex
+++ b/lib/screens/v2/departure.ex
@@ -186,8 +186,6 @@ defmodule Screens.V2.Departure do
     stop_id
   end
 
-  def stop_id(_), do: nil
-
   def stop_type(%__MODULE__{
         prediction: %Prediction{arrival_time: arrival_time, departure_time: departure_time}
       }) do

--- a/lib/screens/v2/departure.ex
+++ b/lib/screens/v2/departure.ex
@@ -186,6 +186,8 @@ defmodule Screens.V2.Departure do
     stop_id
   end
 
+  def stop_id(_), do: nil
+
   def stop_type(%__MODULE__{
         prediction: %Prediction{arrival_time: arrival_time, departure_time: departure_time}
       }) do

--- a/lib/screens/v2/widget_instance/departures.ex
+++ b/lib/screens/v2/widget_instance/departures.ex
@@ -3,6 +3,7 @@ defmodule Screens.V2.WidgetInstance.Departures do
 
   alias Screens.Alerts.Alert
   alias Screens.Departures.Departure
+  alias Screens.Predictions.Prediction
   alias Screens.Routes.Route
   alias Screens.Schedules.Schedule
   alias Screens.Util
@@ -415,8 +416,10 @@ defmodule Screens.V2.WidgetInstance.Departures do
        do: %{time: %{type: :icon, icon: :overnight}}
 
   defp serialize_time(departure, _screen, now) do
+    stop_id = Departure.stop_id(departure)
     departure_time = Departure.time(departure)
     vehicle_status = Departure.vehicle_status(departure)
+    vehicle_stop_id = Prediction.stop_for_vehicle(departure.prediction)
     stop_type = Departure.stop_type(departure)
     route_type = Departure.route_type(departure)
 
@@ -425,7 +428,7 @@ defmodule Screens.V2.WidgetInstance.Departures do
 
     time =
       cond do
-        vehicle_status == :stopped_at and second_diff < 90 ->
+        vehicle_status == :stopped_at and second_diff < 90 and stop_id == vehicle_stop_id ->
           %{type: :text, text: "BRD"}
 
         second_diff < 30 and stop_type == :first_stop ->

--- a/lib/screens/v2/widget_instance/departures.ex
+++ b/lib/screens/v2/widget_instance/departures.ex
@@ -415,6 +415,7 @@ defmodule Screens.V2.WidgetInstance.Departures do
        ),
        do: %{time: %{type: :icon, icon: :overnight}}
 
+  # credo:disable-for-next-line Credo.Check.Refactor.CyclomaticComplexity
   defp serialize_time(departure, _screen, now) do
     stop_id = Departure.stop_id(departure)
     departure_time = Departure.time(departure)

--- a/test/screens/v2/widget_instance/departures_test.exs
+++ b/test/screens/v2/widget_instance/departures_test.exs
@@ -10,6 +10,7 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
   alias Screens.Predictions.Prediction
   alias Screens.Routes.Route
   alias Screens.Schedules.Schedule
+  alias Screens.Stops.Stop
   alias Screens.Trips.Trip
   alias Screens.Vehicles.Vehicle
   alias Screens.V2.{Departure, WidgetInstance}
@@ -542,11 +543,24 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
         prediction: %Prediction{
           departure_time: ~U[2020-01-01T00:01:10Z],
           route: %Route{type: :subway},
-          vehicle: %Vehicle{current_status: :stopped_at}
+          vehicle: %Vehicle{current_status: :stopped_at, stop_id: "stop-b"},
+          stop: %Stop{id: "stop-b"}
         }
       }
 
       assert serialized_boarding ==
+               Departures.serialize_times_with_crowding([departure], screen, now)
+
+      departure = %Departure{
+        prediction: %Prediction{
+          departure_time: ~U[2020-01-01T00:01:10Z],
+          route: %Route{type: :subway},
+          vehicle: %Vehicle{current_status: :stopped_at, stop_id: "stop-a"},
+          stop: %Stop{id: "stop-b"}
+        }
+      }
+
+      assert serialized_boarding !=
                Departures.serialize_times_with_crowding([departure], screen, now)
 
       departure = %Departure{

--- a/test/screens/v2/widget_instance/departures_test.exs
+++ b/test/screens/v2/widget_instance/departures_test.exs
@@ -117,7 +117,7 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
                   type: :subway,
                   long_name: "Orange Line"
                 },
-                stop: %Screens.Stops.Stop{id: "70015", name: "Back Bay"},
+                stop: %Stop{id: "70015", name: "Back Bay"},
                 stop_headsign: "Oak Grove"
               )
           }
@@ -567,7 +567,8 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
         prediction: %Prediction{
           departure_time: ~U[2020-01-01T00:02:10Z],
           route: %Route{type: :subway},
-          vehicle: %Vehicle{current_status: :stopped_at}
+          vehicle: %Vehicle{current_status: :stopped_at},
+          stop: %Stop{}
         }
       }
 
@@ -578,7 +579,8 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
         prediction: %Prediction{
           departure_time: ~U[2020-01-01T00:02:10Z],
           route: %Route{type: :subway},
-          vehicle: %Vehicle{current_status: :in_transit_to}
+          vehicle: %Vehicle{current_status: :in_transit_to},
+          stop: %Stop{}
         }
       }
 
@@ -594,7 +596,8 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
         prediction: %Prediction{
           arrival_time: nil,
           departure_time: ~U[2020-01-01T00:00:10Z],
-          route: %Route{type: :subway}
+          route: %Route{type: :subway},
+          stop: %Stop{}
         }
       }
 
@@ -605,7 +608,8 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
         prediction: %Prediction{
           arrival_time: nil,
           departure_time: ~U[2020-01-01T00:00:40Z],
-          route: %Route{type: :subway}
+          route: %Route{type: :subway},
+          stop: %Stop{}
         }
       }
 
@@ -616,7 +620,8 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
         prediction: %Prediction{
           arrival_time: ~U[2020-01-01T00:00:10Z],
           departure_time: ~U[2020-01-01T00:00:10Z],
-          route: %Route{type: :subway}
+          route: %Route{type: :subway},
+          stop: %Stop{}
         }
       }
 
@@ -632,7 +637,8 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
         prediction: %Prediction{
           arrival_time: ~U[2020-01-01T00:00:10Z],
           departure_time: ~U[2020-01-01T00:00:10Z],
-          route: %Route{type: :subway}
+          route: %Route{type: :subway},
+          stop: %Stop{}
         }
       }
 
@@ -643,7 +649,8 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
         prediction: %Prediction{
           arrival_time: ~U[2020-01-01T00:00:40Z],
           departure_time: ~U[2020-01-01T00:00:40Z],
-          route: %Route{type: :subway}
+          route: %Route{type: :subway},
+          stop: %Stop{}
         }
       }
 
@@ -697,7 +704,8 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
         prediction: %Prediction{
           arrival_time: ~U[2020-01-01T00:20:00Z],
           departure_time: ~U[2020-01-01T00:20:00Z],
-          route: %Route{type: :subway}
+          route: %Route{type: :subway},
+          stop: %Stop{}
         }
       }
 
@@ -708,7 +716,8 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
         prediction: %Prediction{
           arrival_time: ~U[2020-01-01T00:20:00Z],
           departure_time: ~U[2020-01-01T00:20:00Z],
-          route: %Route{type: :rail}
+          route: %Route{type: :rail},
+          stop: %Stop{}
         }
       }
 
@@ -719,7 +728,8 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
         prediction: %Prediction{
           arrival_time: ~U[2020-01-01T00:20:00Z],
           departure_time: ~U[2020-01-01T00:20:00Z],
-          route: %Route{type: :bus}
+          route: %Route{type: :bus},
+          stop: %Stop{}
         }
       }
 
@@ -730,7 +740,8 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
         prediction: %Prediction{
           arrival_time: ~U[2020-01-01T00:20:00Z],
           departure_time: ~U[2020-01-01T00:20:00Z],
-          route: %Route{type: :ferry}
+          route: %Route{type: :ferry},
+          stop: %Stop{}
         }
       }
 
@@ -759,7 +770,8 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
         prediction: %Prediction{
           arrival_time: ~U[2020-01-01T05:20:00Z],
           departure_time: ~U[2020-01-01T05:20:00Z],
-          route: %Route{type: :subway}
+          route: %Route{type: :subway},
+          stop: %Stop{}
         }
       }
 
@@ -774,12 +786,14 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
         prediction: %Prediction{
           arrival_time: ~U[2020-01-01T02:20:00Z],
           departure_time: ~U[2020-01-01T02:20:00Z],
-          route: %Route{type: :rail}
+          route: %Route{type: :rail},
+          stop: %Stop{}
         },
         schedule: %Schedule{
           arrival_time: ~U[2020-01-01T02:15:00Z],
           departure_time: ~U[2020-01-01T02:15:00Z],
-          route: %Route{type: :rail}
+          route: %Route{type: :rail},
+          stop: %Stop{}
         }
       }
 
@@ -807,12 +821,14 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
         prediction: %Prediction{
           arrival_time: ~U[2020-01-01T02:20:00Z],
           departure_time: ~U[2020-01-01T02:20:00Z],
-          route: %Route{type: :rail}
+          route: %Route{type: :rail},
+          stop: %Stop{}
         },
         schedule: %Schedule{
           arrival_time: ~U[2020-01-01T02:20:00Z],
           departure_time: ~U[2020-01-01T02:20:00Z],
-          route: %Route{type: :rail}
+          route: %Route{type: :rail},
+          stop: %Stop{}
         }
       }
 
@@ -827,12 +843,14 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
         prediction: %Prediction{
           arrival_time: ~U[2020-01-01T02:20:00Z],
           departure_time: ~U[2020-01-01T02:20:00Z],
-          route: %Route{type: :bus}
+          route: %Route{type: :bus},
+          stop: %Stop{}
         },
         schedule: %Schedule{
           arrival_time: ~U[2020-01-01T02:15:00Z],
           departure_time: ~U[2020-01-01T02:15:00Z],
-          route: %Route{type: :bus}
+          route: %Route{type: :bus},
+          stop: %Stop{}
         }
       }
 
@@ -847,12 +865,14 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
         prediction: %Prediction{
           arrival_time: ~U[2020-01-01T00:00:10Z],
           departure_time: ~U[2020-01-01T00:00:10Z],
-          route: %Route{type: :rail}
+          route: %Route{type: :rail},
+          stop: %Stop{}
         },
         schedule: %Schedule{
           arrival_time: ~U[2020-01-01T00:05:00Z],
           departure_time: ~U[2020-01-01T00:05:00Z],
-          route: %Route{type: :rail}
+          route: %Route{type: :rail},
+          stop: %Stop{}
         }
       }
 
@@ -868,7 +888,8 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
         prediction: %Prediction{
           arrival_time: ~U[2020-01-01T02:20:00Z],
           departure_time: ~U[2020-01-01T02:20:00Z],
-          route: %Route{type: :rail}
+          route: %Route{type: :rail},
+          stop: %Stop{}
         }
       }
 


### PR DESCRIPTION
compares the vehicle's stop to the prediction's stop and only shows "BRD" if they match. this prevents "BRD" from showing when stops are very close to each other (such that a prediction is within the "BRD" window) and a vehicle is boarding at the previous stop

**Asana task**: [Fix "BRD" when vehicle is boarding at a previous stop](https://app.asana.com/0/1185117109217422/1207697513391322/f)

Description

- [x] Tests added
