### PR TITLE
fix: prevent crash on empty list

### DIFF
--- a/lib/screens/v2/widget_instance/reconstructed_alert.ex
+++ b/lib/screens/v2/widget_instance/reconstructed_alert.ex
@@ -144,17 +144,10 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
     list_of_directions_and_routes =
       informed_entities
       |> Enum.map(fn entity -> get_direction_and_route_from_entity(entity, location) end)
-      |> Enum.filter(& &1)
+      |> Enum.reject(&is_nil/1)
       |> Enum.uniq()
 
-    {direction_id, route_id} =
-      if length(list_of_directions_and_routes) == 1 do
-        hd(list_of_directions_and_routes)
-
-        # If there are multiple route ids in that informed entities list, then the alert includes branching
-      else
-        select_direction_and_route(list_of_directions_and_routes)
-      end
+    {direction_id, route_id} = select_direction_and_route(list_of_directions_and_routes)
 
     cond do
       # When the alert is non-directional but the station is at the boundary:
@@ -230,17 +223,12 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
     do: {direction_id, route}
 
   # Select 1 direction + route from this list of directions + routes for multiple branches
-  defp select_direction_and_route(list_of_directions_and_routes) do
-    direction_id =
-      list_of_directions_and_routes
-      |> hd()
-      |> elem(0)
+  defp select_direction_and_route([]), do: {nil, nil}
+  defp select_direction_and_route([direction_and_route]), do: direction_and_route
 
-    case list_of_directions_and_routes do
-      [{direction_id, "Red" <> _} | _] -> {direction_id, "Red"}
-      _ -> {direction_id, "Green-trunk"}
-    end
-  end
+  # If there are multiple route ids in that informed entities list, then the alert includes branching
+  defp select_direction_and_route([{direction_id, "Red" <> _} | _]), do: {direction_id, "Red"}
+  defp select_direction_and_route([{direction_id, _} | _]), do: {direction_id, "Green-trunk"}
 
   defp get_route_pills(t, location \\ nil)
 


### PR DESCRIPTION
Refactors `select_direction_and_route/1` to use pattern mattern more heavily and handle cases when the passed argument is an empty list.

This handles the case when the direction and route for the informed entities of an alert are empty or otherwise filtered down to an empty list (e.g. only contain JFK). Additionally this is perhaps slightly more idiomatic Elixir code.

Fixes [SCREENS-AM](https://mbtace.sentry.io/issues/5591310217/)
