### PR TITLE
feat: in-memory Alert storage

### DIFF
--- a/lib/screens/alerts/cache.ex
+++ b/lib/screens/alerts/cache.ex
@@ -1,0 +1,77 @@
+defmodule Screens.Alerts.Cache do
+  @moduledoc """
+  GenStage Consumer of Alert server sent event data
+  """
+  use GenStage
+
+  require Logger
+
+  alias Screens.Alerts
+  alias ServerSentEventStage.Event
+
+  def start_link(opts) do
+    {name, init_arg} = Keyword.pop(opts, :name, __MODULE__)
+    GenStage.start_link(__MODULE__, init_arg, name: name)
+  end
+
+  @impl true
+  def init(init_arg) do
+    state = %{}
+    subscribe_to = Keyword.get(init_arg, :subscribe_to, [Screens.Streams.Alerts.Producer])
+    {:consumer, state, subscribe_to: subscribe_to}
+  end
+
+  @impl true
+  def handle_events(events, _from, state) do
+    state =
+      for event <- events, reduce: state do
+        state ->
+          case decode_data(event) do
+            :error -> state
+            %Event{} = event -> apply_event(event, state)
+          end
+      end
+
+    {:noreply, [], state}
+  end
+
+  @impl true
+  def handle_call(:all, _from, state) do
+    {:reply, Map.values(state), [], state}
+  end
+
+  def all(pid \\ __MODULE__) do
+    GenStage.call(pid, :all)
+  end
+
+  defp apply_event(%Event{event: "reset", data: data}, _state) do
+    data
+    |> Enum.map(fn data ->
+      alert = Alerts.Parser.parse_alert(data)
+      {alert.id, alert}
+    end)
+    |> Map.new()
+  end
+
+  defp apply_event(%Event{event: event, data: alert}, state) when event in ~w[add update] do
+    alert = Alerts.Parser.parse_alert(alert)
+
+    Map.put_new(state, alert.id, alert)
+  end
+
+  defp apply_event(%Event{event: "remove", data: %{"id" => id}}, state) do
+    Map.delete(state, id)
+  end
+
+  defp apply_event(event, state) do
+    Logger.warning(fn -> "Unknown event: #{inspect(event)}" end)
+    state
+  end
+
+  defp decode_data(%Event{data: encoded} = event) do
+    case Jason.decode(encoded) do
+      {:ok, decoded} -> %{event | data: decoded}
+      _ -> :error
+    end
+  end
+end

--- a/lib/screens/application.ex
+++ b/lib/screens/application.ex
@@ -36,7 +36,8 @@ defmodule Screens.Application do
       {Screens.ScreensByAlert.SelfRefreshRunner, name: Screens.ScreensByAlert.SelfRefreshRunner},
       Screens.OlCrowding.DynamicSupervisor,
       {Screens.OlCrowding.Agent, %{}},
-      {Screens.ScreenApiResponseCache, []}
+      {Screens.ScreenApiResponseCache, []},
+      Screens.Streams
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html

--- a/lib/screens/streams.ex
+++ b/lib/screens/streams.ex
@@ -1,0 +1,24 @@
+defmodule Screens.Streams do
+  @moduledoc """
+  `Supervisor` for all V3 API server sent event streams `GenStage` pipelines.
+
+  Each child should be an entire `GenStage` pipeline in its own `Supervisor`
+  using the `:rest_for_one` strategy. This allows a crashed stages to be
+  restarted in their subscription order.
+  """
+  use Supervisor
+
+  def start_link(opts) do
+    {name, init_arg} = Keyword.pop(opts, :name, __MODULE__)
+    Supervisor.start_link(__MODULE__, init_arg, name: name)
+  end
+
+  @impl true
+  def init(_init_arg) do
+    children = [
+      Screens.Streams.Alerts
+    ]
+
+    Supervisor.init(children, strategy: :one_for_one)
+  end
+end

--- a/lib/screens/streams/alerts.ex
+++ b/lib/screens/streams/alerts.ex
@@ -1,0 +1,46 @@
+defmodule Screens.Streams.Alerts do
+  @moduledoc """
+  Supervisor for streamed producer and consumer(s) of Alerts data from the
+  V3 API
+  """
+  use Supervisor
+
+  @dialyzer {:nowarn_function, children: 1}
+  @env Mix.env()
+
+  def start_link(opts) do
+    {name, init_arg} = Keyword.pop(opts, :name, __MODULE__)
+    Supervisor.start_link(__MODULE__, init_arg, name: name)
+  end
+
+  @impl true
+  def init(_init_arg) do
+    children()
+    |> Supervisor.init(strategy: :rest_for_one)
+  end
+
+  defp children(env \\ @env)
+  defp children(:test), do: []
+
+  defp children(_env) do
+    api_url = Application.get_env(:screens, :default_api_v3_url)
+    api_key = Application.get_env(:screens, :api_v3_key)
+
+    url =
+      api_url
+      |> URI.merge("/alerts")
+      |> URI.to_string()
+
+    producer = {
+      ServerSentEventStage,
+      name: Screens.Streams.Alerts.Producer, url: url, headers: [{"x-api-key", api_key}]
+    }
+
+    consumer = {
+      Screens.Alerts.Cache,
+      name: Screens.Alerts.Cache, subscribe_to: [Screens.Streams.Alerts.Producer]
+    }
+
+    [producer, consumer]
+  end
+end


### PR DESCRIPTION
Uses ServerSentEventStage to implement a simple in-memory store of the current alerts from the V3 API.

[Server Sent Events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events) are parsed into `Screens.Alerts.Alert` structs and stored in a `Map` which is kept in the process state of the `GenStage` consumer.

> [!NOTE]  
> This implementation is limited to serial access because the data is kept in process state. This is a known limitation. I'd like to keep this as-is knowing that I will come back through and swap this for a more parallelizable implementation after filtering logic (#2119) is solid.