### PR TITLE
fix: move v3 api url into config/runtime.exs

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -73,7 +73,6 @@ config :screens,
   triptych_player_s3_bucket: "mbta-ctd-config",
   triptych_player_fetcher: Screens.TriptychPlayer.Fetch.S3,
   last_deploy_fetcher: Screens.Util.LastDeploy.S3Fetch,
-  default_api_v3_url: "https://api-v3.mbta.com/",
   blue_bikes_api_client: Screens.BlueBikes.Client,
   blue_bikes_station_information_url:
     "https://gbfs.bluebikes.com/gbfs/en/station_information.json",

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -14,8 +14,6 @@ config :screens, ScreensWeb.Endpoint,
   watchers: [npx: ["exit_on_eof", "npm run watch", cd: "assets"]]
 
 config :screens,
-  default_api_v3_url: System.get_env("API_V3_URL", "https://api-v3.mbta.com/"),
-  api_v3_key: System.get_env("API_V3_KEY"),
   config_fetcher: Screens.Config.Fetch.Local,
   pending_config_fetcher: Screens.PendingConfig.Fetch.Local,
   triptych_player_fetcher: Screens.TriptychPlayer.Fetch.Local,

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -4,6 +4,22 @@
 # remember to add this file to your .gitignore.
 import Config
 
+eb_env_name = System.get_env("ENVIRONMENT_NAME")
+
+api_v3_url =
+  case eb_env_name do
+    "screens-prod" -> "https://api-v3.mbta.com/"
+    "screens-dev" -> "https://api-dev.mbtace.com/"
+    "screens-dev-green" -> "https://api-dev-green.mbtace.com/"
+    _ -> System.get_env("API_V3_URL", "https://api-v3.mbta.com/")
+  end
+
+unless config_env() == :test do
+  config :screens,
+    api_v3_url: api_v3_url,
+    api_v3_key: System.get_env("API_V3_KEY")
+end
+
 if config_env() == :prod do
   # make sure ExAWS.SecretsManager and its dependencies are available
   {:ok, _} = Application.ensure_all_started(:httpoison)
@@ -11,8 +27,6 @@ if config_env() == :prod do
   {:ok, _} = Application.ensure_all_started(:hackney)
   {:ok, _} = Application.ensure_all_started(:ex_aws)
   {:ok, _} = Application.ensure_all_started(:ex_aws_secretsmanager)
-
-  eb_env_name = System.get_env("ENVIRONMENT_NAME")
 
   secret_key_base =
     (eb_env_name <> "-secret-key-base")
@@ -47,6 +61,7 @@ if config_env() == :prod do
   sentry_dsn = System.get_env("SENTRY_DSN")
 
   config :screens,
+    api_v3_url: api_v3_url,
     api_v3_key: api_v3_key,
     environment_name: eb_env_name,
     signs_ui_s3_bucket: signs_ui_s3_bucket,

--- a/config/test.exs
+++ b/config/test.exs
@@ -22,7 +22,7 @@ config :screens,
   #
   # To write testable functions: pass request-firing functions as arguments. Default value can be the "normal" fetch function,
   # and then during tests, we can pass a stubbed version
-  default_api_v3_url: [:no_api_requests_allowed_during_testing],
+  api_v3_url: [:no_api_requests_allowed_during_testing],
   blue_bikes_station_information_url: [:no_api_requests_allowed_during_testing],
   blue_bikes_station_status_url: [:no_api_requests_allowed_during_testing],
   blue_bikes_api_client: Screens.BlueBikes.FakeClient,

--- a/lib/screens/streams/alerts.ex
+++ b/lib/screens/streams/alerts.ex
@@ -23,7 +23,7 @@ defmodule Screens.Streams.Alerts do
   defp children(:test), do: []
 
   defp children(_env) do
-    api_url = Application.get_env(:screens, :default_api_v3_url)
+    api_url = Application.get_env(:screens, :api_v3_url)
     api_key = Application.get_env(:screens, :api_v3_key)
 
     url =

--- a/lib/screens/v3_api.ex
+++ b/lib/screens/v3_api.ex
@@ -113,18 +113,7 @@ defmodule Screens.V3Api do
   end
 
   defp base_url do
-    :screens
-    |> Application.get_env(:environment_name)
-    |> base_url_for_environment()
-  end
-
-  defp base_url_for_environment(environment_name) do
-    case environment_name do
-      "screens-prod" -> "https://api-v3.mbta.com/"
-      "screens-dev" -> "https://api-dev.mbtace.com/"
-      "screens-dev-green" -> "https://api-dev-green.mbtace.com/"
-      _ -> Application.get_env(:screens, :default_api_v3_url)
-    end
+    Application.get_env(:screens, :api_v3_url)
   end
 
   defp api_key_headers(nil), do: []


### PR DESCRIPTION
The base url for the v3 api was previously calculated in `Screens.V3Api` based on the environment name (or fell back to :default_api_v3_url). This value is needed in more places than `Screens.V3Api` now (`Screens.Streams.Alerts` specifically) so `:default_api_v3_url` has been replaced with `:v3_api_url` and is set in `config/runtime.exs`.
