### PR TITLE
feat: switch alert requests for specific routes to cache

### DIFF
--- a/lib/screens/alerts/alert.ex
+++ b/lib/screens/alerts/alert.ex
@@ -204,6 +204,12 @@ defmodule Screens.Alerts.Alert do
     {:ok, Screens.Alerts.Cache.Filter.filter_by(alerts, filters)}
   end
 
+  def fetch_from_cache_or_empty_list(filters \\ [], get_all_alerts \\ &Cache.all/0) do
+    {:ok, alerts} = fetch_from_cache(filters, get_all_alerts)
+
+    alerts
+  end
+
   defp format_cache_filter({:route_id, route_id}), do: {:routes, [route_id]}
   defp format_cache_filter({:stop_id, stop_id}), do: {:stops, [stop_id]}
   defp format_cache_filter({:route_ids, route_ids}), do: {:routes, route_ids}
@@ -559,7 +565,7 @@ defmodule Screens.Alerts.Alert do
   def by_route_id(route_id, stop_id) do
     {inline_alerts, global_alerts} =
       [route_id: route_id]
-      |> fetch_or_empty_list()
+      |> fetch_from_cache_or_empty_list()
       |> Enum.split_with(&inline?/1)
 
     global_alert = Enum.min_by(global_alerts, &sort_key(&1, stop_id), fn -> nil end)

--- a/lib/screens/alerts/alert.ex
+++ b/lib/screens/alerts/alert.ex
@@ -201,7 +201,7 @@ defmodule Screens.Alerts.Alert do
       |> Enum.reject(&is_nil/1)
       |> Enum.into(%{})
 
-    Screens.Alerts.Cache.Filter.filter_by(alerts, filters)
+    {:ok, Screens.Alerts.Cache.Filter.filter_by(alerts, filters)}
   end
 
   defp format_cache_filter({:route_id, route_id}), do: {:routes, [route_id]}

--- a/lib/screens/v2/candidate_generator/dup/alerts.ex
+++ b/lib/screens/v2/candidate_generator/dup/alerts.ex
@@ -23,7 +23,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Alerts do
         config,
         now \\ DateTime.utc_now(),
         fetch_stop_name_fn \\ &Stop.fetch_stop_name/1,
-        fetch_alerts_fn \\ &Alert.fetch/1,
+        fetch_alerts_fn \\ &Alert.fetch_from_cache/1,
         fetch_location_context_fn \\ &Stop.fetch_location_context/3
       ) do
     # In this function:

--- a/lib/screens/v2/candidate_generator/widgets/reconstructed_alert.ex
+++ b/lib/screens/v2/candidate_generator/widgets/reconstructed_alert.ex
@@ -51,7 +51,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlert do
   def reconstructed_alert_instances(
         %Screen{app_params: %PreFare{} = app_params} = config,
         now \\ DateTime.utc_now(),
-        fetch_alerts_fn \\ &Alert.fetch/1,
+        fetch_alerts_fn \\ &Alert.fetch_from_cache/1,
         fetch_stop_name_fn \\ &Stop.fetch_stop_name/1,
         fetch_location_context_fn \\ &Stop.fetch_location_context/3,
         fetch_subway_platforms_for_stop_fn \\ &Stop.fetch_subway_platforms_for_stop/1

--- a/lib/screens/v2/candidate_generator/widgets/subway_status.ex
+++ b/lib/screens/v2/candidate_generator/widgets/subway_status.ex
@@ -12,18 +12,14 @@ defmodule Screens.V2.CandidateGenerator.Widgets.SubwayStatus do
       ) do
     route_ids = ["Blue", "Orange", "Red", "Green-B", "Green-C", "Green-D", "Green-E"]
 
-    case Screens.Alerts.Alert.fetch(route_ids: route_ids) do
-      {:ok, alerts} ->
-        relevant_alerts =
-          alerts
-          |> Enum.filter(&relevant?(&1, now))
-          |> Enum.map(&append_context(&1, fetch_subway_platforms_for_stop_fn))
+    {:ok, alerts} = Screens.Alerts.Alert.fetch_from_cache(route_ids: route_ids)
 
-        [%SubwayStatus{screen: config, subway_alerts: relevant_alerts}]
+    relevant_alerts =
+      alerts
+      |> Enum.filter(&relevant?(&1, now))
+      |> Enum.map(&append_context(&1, fetch_subway_platforms_for_stop_fn))
 
-      :error ->
-        []
-    end
+    [%SubwayStatus{screen: config, subway_alerts: relevant_alerts}]
   end
 
   def relevant?(alert, now) do

--- a/test/screens/alerts/alert_test.exs
+++ b/test/screens/alerts/alert_test.exs
@@ -179,58 +179,61 @@ defmodule Screens.Alerts.AlertTest do
     end
 
     test "returns all of the alerts", %{alerts: alerts, get_all_alerts: get_all_alerts} do
-      assert alerts == Alert.fetch_from_cache([], get_all_alerts)
+      assert {:ok, alerts} == Alert.fetch_from_cache([], get_all_alerts)
     end
 
     test "filters by stops", %{get_all_alerts: get_all_alerts} do
-      assert [%Alert{id: "stop: A" <> _}] =
+      assert {:ok, [%Alert{id: "stop: A" <> _}]} =
                Alert.fetch_from_cache([stop_id: "A"], get_all_alerts)
 
-      assert [%Alert{id: "stop: B" <> _}] =
+      assert {:ok, [%Alert{id: "stop: B" <> _}]} =
                Alert.fetch_from_cache([stop_ids: ["B"]], get_all_alerts)
 
-      assert [%Alert{id: "stop: A" <> _}, %Alert{id: "stop: B" <> _}] =
+      assert {:ok, [%Alert{id: "stop: A" <> _}, %Alert{id: "stop: B" <> _}]} =
                Alert.fetch_from_cache([stop_ids: ["A", "B"]], get_all_alerts)
     end
 
     test "filters by routes", %{get_all_alerts: get_all_alerts} do
-      assert [%Alert{id: "stop: C, route: Z" <> _}, %Alert{id: "stop: D, route: Y/Z" <> _}] =
+      assert {:ok, [%Alert{id: "stop: C, route: Z" <> _}, %Alert{id: "stop: D, route: Y/Z" <> _}]} =
                Alert.fetch_from_cache([route_ids: ["Z"]], get_all_alerts)
 
-      assert [%Alert{id: "stop: D, route: Y/Z" <> _}] =
+      assert {:ok, [%Alert{id: "stop: D, route: Y/Z" <> _}]} =
                Alert.fetch_from_cache([route_ids: ["Y"]], get_all_alerts)
     end
 
     test "filters by route_type", %{get_all_alerts: get_all_alerts} do
-      assert [
-               %Alert{id: "stop: C, route: Z, route_type: 2" <> _},
-               %Alert{id: "stop: D, route: Y/Z, route_type: 2" <> _}
-             ] =
+      assert {:ok,
+              [
+                %Alert{id: "stop: C, route: Z, route_type: 2" <> _},
+                %Alert{id: "stop: D, route: Y/Z, route_type: 2" <> _}
+              ]} =
                Alert.fetch_from_cache([route_type: :rail], get_all_alerts)
 
-      assert [
-               %Alert{id: "stop: C, route: Z, route_type: 2" <> _},
-               %Alert{id: "stop: D, route: Y/Z, route_type: 2" <> _}
-             ] =
+      assert {:ok,
+              [
+                %Alert{id: "stop: C, route: Z, route_type: 2" <> _},
+                %Alert{id: "stop: D, route: Y/Z, route_type: 2" <> _}
+              ]} =
                Alert.fetch_from_cache([route_type: 2], get_all_alerts)
 
-      assert [
-               %Alert{id: "stop: A, route_type: 3" <> _},
-               %Alert{id: "stop: B, route_type: 3" <> _}
-             ] =
+      assert {:ok,
+              [
+                %Alert{id: "stop: A, route_type: 3" <> _},
+                %Alert{id: "stop: B, route_type: 3" <> _}
+              ]} =
                Alert.fetch_from_cache([route_types: [:bus]], get_all_alerts)
     end
 
     test "filters by route and direction_id", %{get_all_alerts: get_all_alerts} do
-      assert [%Alert{id: "stop: D, route: Y/Z, route_type: 2, direction_id: 1"}] =
+      assert {:ok, [%Alert{id: "stop: D, route: Y/Z, route_type: 2, direction_id: 1"}]} =
                Alert.fetch_from_cache([route_ids: ["Z"], direction_id: 1], get_all_alerts)
     end
 
     test "filters by activities when passed", %{get_all_alerts: get_all_alerts} do
-      assert [%Alert{id: "USING_WHEELCHAIR"}] =
+      assert {:ok, [%Alert{id: "USING_WHEELCHAIR"}]} =
                Alert.fetch_from_cache([activities: ["USING_WHEELCHAIR"]], get_all_alerts)
 
-      assert [%Alert{id: "stop: C, route: Z" <> _}] =
+      assert {:ok, [%Alert{id: "stop: C, route: Z" <> _}]} =
                Alert.fetch_from_cache([activities: ["EXIT", "DOES_NOT_EXIST"]], get_all_alerts)
     end
   end


### PR DESCRIPTION
Replaces calls to `Alert.fetch/1` and `Alert.fetch_or_empty_list/1` that only filter on `route_id` with calls to `Alert.fetch_from_cache/1` and `Alert.fetch_from_cache_or_empty_list/1` respectively.