### PR TITLE
feat: cache stops to routes for use in alerts cache filter expansion

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -485,6 +485,8 @@ config :screens, Screens.ScreenApiResponseCache,
   gc_interval: :timer.hours(1),
   allocated_memory: 250_000_000
 
+config :screens, Screens.Stops.StopsToRoutes, adapter: Nebulex.Adapters.Local
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{Mix.env()}.exs"

--- a/config/test.exs
+++ b/config/test.exs
@@ -26,7 +26,7 @@ config :screens,
   blue_bikes_station_information_url: [:no_api_requests_allowed_during_testing],
   blue_bikes_station_status_url: [:no_api_requests_allowed_during_testing],
   blue_bikes_api_client: Screens.BlueBikes.FakeClient,
-  alerts_cache_filter_route_mod: Screens.Routes.Route.Mock,
+  stops_to_routes_route_mod: Screens.Routes.Route.Mock,
   dup_headsign_replacements: %{
     "Test 1" => "T1"
   },
@@ -161,3 +161,5 @@ config :screens, :screens_by_alert,
   screens_by_alert_ttl_seconds: 2,
   screens_last_updated_ttl_seconds: 2,
   screens_ttl_seconds: 1
+
+config :screens, Screens.Stops.StopsToRoutes, adapter: Nebulex.Adapters.Nil

--- a/lib/screens/alerts/cache/filter.ex
+++ b/lib/screens/alerts/cache/filter.ex
@@ -2,12 +2,7 @@ defmodule Screens.Alerts.Cache.Filter do
   @moduledoc """
   Logic to apply filters to a list of `Screens.Alerts.Alert` structs.
   """
-
-  @route_mod Application.compile_env(
-               :screens,
-               :alerts_cache_filter_route_mod,
-               Screens.Routes.Route
-             )
+  alias Screens.Stops.StopsToRoutes
 
   @default_activities ~w[BOARD EXIT RIDE]
 
@@ -92,15 +87,10 @@ defmodule Screens.Alerts.Cache.Filter do
   end
 
   defp build_matcher({:stops, values}, acc) when is_list(values) do
-    routes =
-      values
-      |> Enum.flat_map(fn stop_id ->
-        {:ok, routes} = @route_mod.serving_stop(stop_id)
-        routes
-      end)
+    route_ids = StopsToRoutes.stops_to_routes(values)
 
     route_matchers =
-      for %{id: route_id} <- routes,
+      for route_id <- route_ids,
           stop_id <- [nil | values] do
         %{route: route_id, stop: stop_id}
       end

--- a/lib/screens/application.ex
+++ b/lib/screens/application.ex
@@ -37,7 +37,8 @@ defmodule Screens.Application do
       Screens.OlCrowding.DynamicSupervisor,
       {Screens.OlCrowding.Agent, %{}},
       {Screens.ScreenApiResponseCache, []},
-      Screens.Streams.Alerts
+      Screens.Streams.Alerts,
+      Screens.Stops.StopsToRoutes
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html

--- a/lib/screens/stops/stops_to_routes.ex
+++ b/lib/screens/stops/stops_to_routes.ex
@@ -1,0 +1,57 @@
+defmodule Screens.Stops.StopsToRoutes do
+  @moduledoc """
+  Cache of stop ids to route ids. Information for stop ids missing from the
+  cache is fetched automatically from the V3 API when requested.
+  """
+  use Nebulex.Cache,
+    otp_app: :screens,
+    adapter: Nebulex.Adapters.Local
+
+  @base_ttl :timer.hours(1)
+
+  @spec stops_to_routes([stop_id :: String.t()]) :: [route_id :: String.t()]
+  def stops_to_routes(stop_ids) do
+    from_cache = get_all(stop_ids)
+    missing_stop_ids = stop_ids -- Map.keys(from_cache)
+
+    from_api =
+      if Enum.empty?(missing_stop_ids) do
+        %{}
+      else
+        from_api =
+          for stop_id <- missing_stop_ids, into: %{} do
+            {:ok, routes} = fetch_routes_for_stops(stop_id)
+            route_ids = Enum.map(routes, & &1.id)
+
+            {stop_id, route_ids}
+          end
+
+        put_all(from_api, ttl: ttl())
+
+        from_api
+      end
+
+    [from_cache, from_api]
+    |> Enum.map(&ungroup_values/1)
+    |> Enum.concat()
+    |> Enum.uniq()
+  end
+
+  defp fetch_routes_for_stops(stop_ids) do
+    stop_impl = Application.get_env(:screens, :stops_to_routes_stop_mod, Screens.Stops.Stop)
+    stop_impl.fetch_routes_for_stops(stop_ids)
+  end
+
+  defp ungroup_values(map) do
+    map
+    |> Map.values()
+    |> List.flatten()
+    |> Enum.uniq()
+  end
+
+  # Set random TTLs from 1hr to 1.5hrs to alleviate the thundering herd problem
+  defp ttl do
+    additional_minutes = :rand.uniform(30)
+    @base_ttl + :timer.minutes(additional_minutes)
+  end
+end


### PR DESCRIPTION
Adds a Nebulex cache for stops -> routes. Uses that cache from `Screens.Alerts.Cache.Filter` to make the alerts cache snappy again