### PR TITLE
refactor: remove redundant Sentry-disabling code

### DIFF
--- a/assets/src/components/v2/widget_tree_error_boundary.tsx
+++ b/assets/src/components/v2/widget_tree_error_boundary.tsx
@@ -65,7 +65,7 @@ class WidgetTreeErrorBoundary extends React.Component<Props, State> {
       return;
     }
 
-    if (getDataset().disableSentry) {
+    if (!getDataset().sentry) {
       // Log via the server. (to Splunk, at time of writing.)
       fetch("/v2/api/screen/log_frontend_error", {
         method: "POST",

--- a/assets/src/util/sentry.tsx
+++ b/assets/src/util/sentry.tsx
@@ -21,19 +21,14 @@ const captureException = (ex: unknown, options?: RavenOptions) => {
 
 /**
  * Initializes Sentry if the DSN is defined AND this client is running on
- * a real production screen AND the URL does not contain the disable_sentry param.
+ * a real production screen.
  */
 const initSentry = (appString: string) => {
-  const {
-    sentry: sentryDsn,
-    environmentName: env,
-    disableSentry,
-  } = getDataset();
-  // Note: passing an empty string as the DSN sets up a "no-op SDK" that captures errors and lets you call its methods,
-  // but does not actually log anything to the Sentry service.
+  const { sentry: sentryDsn, environmentName: env } = getDataset();
 
-  if (sentryDsn && isRealScreen() && !disableSentry) {
+  if (sentryDsn && isRealScreen()) {
     Raven.config(sentryDsn, { environment: env }).install();
+
     if (isOFM()) {
       const today = new Date();
       const hour = today.getHours();

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -21,6 +21,10 @@ unless config_env() == :test do
 end
 
 if config_env() == :prod do
+  config :sentry,
+    dsn: System.get_env("SENTRY_DSN"),
+    environment_name: eb_env_name
+
   signs_ui_s3_bucket =
     case eb_env_name do
       "screens-prod" -> "mbta-signs"
@@ -33,19 +37,10 @@ if config_env() == :prod do
     http: [:inet6, port: String.to_integer(System.get_env("PORT") || "4000")],
     secret_key_base: System.get_env("SECRET_KEY_BASE")
 
-  sentry_dsn = System.get_env("SENTRY_DSN")
-
   config :screens,
     environment_name: eb_env_name,
     signs_ui_s3_bucket: signs_ui_s3_bucket,
-    sentry_frontend_dsn: sentry_dsn,
     screenplay_fullstory_org_id: System.get_env("SCREENPLAY_FULLSTORY_ORG_ID")
-
-  if sentry_dsn not in [nil, ""] do
-    config :sentry,
-      dsn: sentry_dsn,
-      environment_name: eb_env_name
-  end
 
   config :screens, ScreensWeb.AuthManager, secret_key: System.get_env("SCREENS_AUTH_SECRET")
 

--- a/lib/screens_web/controllers/screen_controller.ex
+++ b/lib/screens_web/controllers/screen_controller.ex
@@ -79,10 +79,9 @@ defmodule ScreensWeb.ScreenController do
       %Screen{app_id: app_id} ->
         conn
         |> assign(:app_id, app_id)
-        |> assign(:sentry_frontend_dsn, Application.get_env(:screens, :sentry_frontend_dsn))
+        |> assign(:sentry_dsn, if(params["disable_sentry"], do: nil, else: Sentry.get_dsn()))
         |> assign(:is_real_screen, match?(%{"is_real_screen" => "true"}, params))
         |> assign(:requestor, params["requestor"])
-        |> assign(:disable_sentry, params["disable_sentry"])
         |> render("index.html")
 
       nil ->

--- a/lib/screens_web/controllers/v2/screen_controller.ex
+++ b/lib/screens_web/controllers/v2/screen_controller.ex
@@ -139,12 +139,11 @@ defmodule ScreensWeb.V2.ScreenController do
       refresh_rate: refresh_rate,
       audio_readout_interval: Parameters.get_audio_readout_interval(app_id),
       audio_interval_offset_seconds: Parameters.get_audio_interval_offset_seconds(config),
-      sentry_frontend_dsn: Application.get_env(:screens, :sentry_frontend_dsn),
+      sentry_dsn: if(params["disable_sentry"], do: nil, else: Sentry.get_dsn()),
       refresh_rate_offset: calculate_refresh_rate_offset(screen_id, refresh_rate),
       is_real_screen: match?(%{"is_real_screen" => "true"}, params),
       screen_side: screen_side(params),
       requestor: params["requestor"],
-      disable_sentry: params["disable_sentry"],
       rotation_index: rotation_index(params),
       triptych_pane: triptych_pane(params),
       is_pending: false

--- a/lib/screens_web/templates/screen/index.html.eex
+++ b/lib/screens_web/templates/screen/index.html.eex
@@ -4,8 +4,5 @@
   data-environment-name="<%= @environment_name %>"
   data-is-real-screen="<%= @is_real_screen %>"
   data-requestor="<%= @requestor %>"
-  data-disable-sentry="<%= @disable_sentry %>"
-  <%= if record_sentry?() do %>
-    data-sentry="<%= @sentry_frontend_dsn %>"
-  <% end %>
+  data-sentry="<%= @sentry_dsn %>"
 ></div>

--- a/lib/screens_web/templates/v2/screen/index.html.eex
+++ b/lib/screens_web/templates/v2/screen/index.html.eex
@@ -8,11 +8,9 @@
   data-refresh-rate-offset="<%= @refresh_rate_offset %>"
   data-is-real-screen="<%= @is_real_screen %>"
   data-is-pending="<%= @is_pending %>"
+  data-sentry="<%= @sentry_dsn %>"
   <%= if not is_nil(@screen_side) do %>
     data-screen-side="<%= @screen_side %>"
-  <% end %>
-  <%= if record_sentry?() do %>
-    data-sentry="<%= @sentry_frontend_dsn %>"
   <% end %>
   <%= if not is_nil(@rotation_index) do %>
     data-rotation-index="<%= @rotation_index %>"
@@ -24,5 +22,4 @@
     data-screenplay-fullstory-org-id="<%= assigns[:screenplay_fullstory_org_id] %>"
   <% end %>
   data-requestor="<%= @requestor %>"
-  data-disable-sentry="<%= @disable_sentry %>"
 ></div>

--- a/lib/screens_web/views/screen_view.ex
+++ b/lib/screens_web/views/screen_view.ex
@@ -1,5 +1,3 @@
 defmodule ScreensWeb.ScreenView do
   use ScreensWeb, :view
-
-  def record_sentry?, do: Application.get_env(:screens, :record_sentry, false)
 end

--- a/lib/screens_web/views/v2/screen_view.ex
+++ b/lib/screens_web/views/v2/screen_view.ex
@@ -1,5 +1,3 @@
 defmodule ScreensWeb.V2.ScreenView do
   use ScreensWeb, :view
-
-  def record_sentry?, do: Application.get_env(:screens, :record_sentry, false)
 end


### PR DESCRIPTION
Simplifies the multiple overlapping mechanisms for enabling and disabling Sentry, hopefully without changing existing behavior.

* If a `SENTRY_DSN` environment variable is defined, and the Mix env is `prod`, Sentry is enabled on the backend.
* If the above is true _and_ there is not a `disable_sentry` query param in the URL, Sentry is also enabled on the frontend.

There do not appear to be any screens actively using `disable_sentry` at the time of writing, but we'll leave this feature alone for now.