### PR TITLE
chore: Add dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,6 @@ updates:
     open-pull-requests-limit: 10
     groups:
       mix-patches:
-        applies-to: version-updates
         patterns:
           - "*"
         update-types:
@@ -21,35 +20,29 @@ updates:
     open-pull-requests-limit: 10
     groups:
       npm-patches:
-        applies-to: version-updates
         patterns:
           - "*"
         update-types:
           - "patch"
       eslint:
-        applies-to: version-updates
         patterns:
           - "eslint*"
           - "@typescript-eslint*"
           - "@eslint*"
       react:
-        applies-to: version-updates
         patterns:
           - "react*"
           - "@types/react*"
       testing-tools:
-        applies-to: version-updates
         patterns:
           - "ts-jest"
           - "jest*"
           - "@jest*"
       babel:
-        applies-to: version-updates
         patterns:
           - "babel*"
           - "@babel*"
       webpack:
-        applies-to: version-updates
         patterns:
           - "webpack*"
           - "*webpack-plugin"
@@ -57,6 +50,5 @@ updates:
           - "@types/webpack-env"
           - "*-loader"
       moment:
-        applies-to: version-updates
         patterns:
           - "moment*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,62 @@
 version: 2
 updates:
-- package-ecosystem: mix
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "10:00"
-  open-pull-requests-limit: 10
-- package-ecosystem: npm
-  directory: "/assets"
-  schedule:
-    interval: daily
-    time: "10:00"
-  open-pull-requests-limit: 10
+  - package-ecosystem: mix
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "10:00"
+    open-pull-requests-limit: 10
+    groups:
+      mix-patches:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+  - package-ecosystem: npm
+    directory: "/assets"
+    schedule:
+      interval: daily
+      time: "10:00"
+    open-pull-requests-limit: 10
+    groups:
+      npm-patches:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+      eslint:
+        applies-to: version-updates
+        patterns:
+          - "eslint*"
+          - "@typescript-eslint*"
+          - "@eslint*"
+      react:
+        applies-to: version-updates
+        patterns:
+          - "react*"
+          - "@types/react*"
+      testing-tools:
+        applies-to: version-updates
+        patterns:
+          - "ts-jest"
+          - "jest*"
+          - "@jest*"
+      babel:
+        applies-to: version-updates
+        patterns:
+          - "babel*"
+          - "@babel*"
+      webpack:
+        applies-to: version-updates
+        patterns:
+          - "webpack*"
+          - "*webpack-plugin"
+          - "@svgr/webpack"
+          - "@types/webpack-env"
+          - "*-loader"
+      moment:
+        applies-to: version-updates
+        patterns:
+          - "moment*"


### PR DESCRIPTION
I want to try out Dependabot's `groups` option so we can reduce the number of PRs it opens. Feel free to call out groups that should be added or groups I added that don't look right.