### PR TITLE
feat: Expand route filters to include route_type

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -27,6 +27,7 @@ config :screens,
   blue_bikes_station_status_url: [:no_api_requests_allowed_during_testing],
   blue_bikes_api_client: Screens.BlueBikes.FakeClient,
   stops_to_routes_route_mod: Screens.Routes.Route.Mock,
+  alerts_cache_filter_route_mod: Screens.Routes.Route.Mock,
   dup_headsign_replacements: %{
     "Test 1" => "T1"
   },

--- a/lib/screens/routes/route.ex
+++ b/lib/screens/routes/route.ex
@@ -39,6 +39,7 @@ defmodule Screens.Routes.Route do
   @type color :: name_colors() | :purple | :teal | :yellow
   @type icon :: name_colors() | :bus | :cr | :ferry | :mattapan
 
+  @callback by_id(id()) :: {:ok, t()} | :error
   @spec by_id(id()) :: {:ok, t()} | :error
   def by_id(route_id) do
     case V3Api.get_json("routes/" <> route_id) do

--- a/test/screens/alerts/alert_test.exs
+++ b/test/screens/alerts/alert_test.exs
@@ -202,6 +202,11 @@ defmodule Screens.Alerts.AlertTest do
     end
 
     test "filters by routes", %{get_all_alerts: get_all_alerts} do
+      stub(Route.Mock, :by_id, fn
+        "Z" -> {:ok, %Route{id: "Z", type: :rail}}
+        "Y" -> {:ok, %Route{id: "Y", type: :rail}}
+      end)
+
       assert {:ok, [%Alert{id: "stop: C, route: Z" <> _}, %Alert{id: "stop: D, route: Y/Z" <> _}]} =
                Alert.fetch_from_cache([route_ids: ["Z"]], get_all_alerts)
 
@@ -233,6 +238,8 @@ defmodule Screens.Alerts.AlertTest do
     end
 
     test "filters by route and direction_id", %{get_all_alerts: get_all_alerts} do
+      stub(Route.Mock, :by_id, fn "Z" -> {:ok, %Route{id: "Z", type: :rail}} end)
+
       assert {:ok, [%Alert{id: "stop: D, route: Y/Z, route_type: 2, direction_id: 1"}]} =
                Alert.fetch_from_cache([route_ids: ["Z"], direction_id: 1], get_all_alerts)
     end

--- a/test/screens/alerts/cache/filter_test.exs
+++ b/test/screens/alerts/cache/filter_test.exs
@@ -53,5 +53,17 @@ defmodule Screens.Alerts.Cache.FilterTest do
                %{stop: "place-aport"}
              ] == Filter.build_matchers(%{stops: ["place-aport"]})
     end
+
+    test "expands route filters to include route types" do
+      stub(Route.Mock, :by_id, fn
+        "Blue" -> {:ok, %Route{id: "Blue", type: :subway}}
+        "Green-E" -> {:ok, %Route{id: "Green-E", type: :light_rail}}
+      end)
+
+      assert [
+               %{route: "Blue", route_type: 1},
+               %{route: "Green-E", route_type: 0}
+             ] = Filter.build_matchers(%{routes: ["Blue", "Green-E"]})
+    end
   end
 end


### PR DESCRIPTION
Adds `route_type` filter expansion to the alerts cache matcher building.