### PR TITLE
fix: error reporting on speech synthesis failures

### DIFF
--- a/lib/screens_web/controllers/audio_controller.ex
+++ b/lib/screens_web/controllers/audio_controller.ex
@@ -37,7 +37,8 @@ defmodule ScreensWeb.AudioController do
            Screens.ScreenData.by_screen_id(screen_id, is_screen, check_disabled: true),
          template_assigns <- Screens.Audio.from_api_data(data, screen_id),
          ssml <- render_ssml(template_assigns),
-         {:ok, audio_data} <- Screens.Audio.synthesize(ssml, is_screen, "ssml") do
+         {:ok, audio_data} <-
+           Screens.Audio.synthesize(ssml, "ssml", screen_id: screen_id, is_screen: is_screen) do
       send_audio(conn, {:binary, audio_data}, disposition)
     else
       _ -> send_fallback_audio(conn, is_screen, screen_id, disposition)

--- a/lib/screens_web/controllers/v2/audio_controller.ex
+++ b/lib/screens_web/controllers/v2/audio_controller.ex
@@ -48,7 +48,7 @@ defmodule ScreensWeb.V2.AudioController do
   end
 
   def text_to_speech(conn, %{"text" => text}) do
-    case Screens.Audio.synthesize(text, false, "text") do
+    case Screens.Audio.synthesize(text, "text", is_screen: false) do
       {:ok, audio_data} ->
         send_download(conn, {:binary, audio_data}, filename: "readout.mp3", disposition: :inline)
 
@@ -60,7 +60,7 @@ defmodule ScreensWeb.V2.AudioController do
   defp readout(conn, screen_id, real_screen?, disposition) do
     screen_id
     |> fetch_ssml()
-    |> Screens.Audio.synthesize(real_screen?, "ssml")
+    |> Screens.Audio.synthesize("ssml", screen_id: screen_id, is_screen: real_screen?)
     |> case do
       {:ok, audio_data} ->
         send_download(conn, {:binary, audio_data},


### PR DESCRIPTION
Over the weekend, we hit a "maximum text length exceeded" error when trying to synthesize audio for a pre-fare ([Sentry](https://mbtace.sentry.io/issues/5728118365/)). Unfortunately we don't know exactly what the text was, because A) the code to log the error itself contained an error, and B) even if it had worked, we weren't logging the input text. Also, we probably wouldn't know it had happened at all, since this report would have only gone to the logs and not to Sentry.

This fixes the string interpolation in the logging, adds some needed context, and adds a Sentry report so we'll be notified when this happens again.

The [current audio readout](https://screens.mbta.com/v2/audio/PRE-110/debug) for this pre-fare is indeed rather close to the [limit](https://docs.aws.amazon.com/polly/latest/dg/limits.html#limits-synthesizespeech) of 3,000 "billed characters" (exclusive of characters in SSML tags). I'll create a task for us to look into splitting up our speech somehow or cutting down on the number of characters.