### PR TITLE
chore: add :verify_on_exit! to tests using Mox

### DIFF
--- a/test/screens/alerts/alert_test.exs
+++ b/test/screens/alerts/alert_test.exs
@@ -6,6 +6,8 @@ defmodule Screens.Alerts.AlertTest do
   alias Screens.Alerts.Alert
   alias Screens.Routes.Route
 
+  setup :verify_on_exit!
+
   defp alert_json(id) do
     %{
       "id" => id,

--- a/test/screens/alerts/cache/filter_test.exs
+++ b/test/screens/alerts/cache/filter_test.exs
@@ -6,6 +6,8 @@ defmodule Screens.Alerts.Cache.FilterTest do
   alias Screens.Alerts.Cache.Filter
   alias Screens.Routes.Route
 
+  setup :verify_on_exit!
+
   describe "build_matchers/1" do
     test "passes through empty filters" do
       assert [] == Filter.build_matchers(%{})


### PR DESCRIPTION
Adds `:verify_on_exit!` setup calls to tests using Mox to prevent any missed mock functional call expectations later on.

As suggested by @digitalcora https://github.com/mbta/screens/pull/2145#discussion_r1722188841


