### PR TITLE
Admin dashboard routing improvements

### DIFF
--- a/assets/src/apps/admin.tsx
+++ b/assets/src/apps/admin.tsx
@@ -2,7 +2,12 @@ require("../../css/admin.scss");
 
 import React, { ComponentType } from "react";
 import ReactDOM from "react-dom";
-import { HashRouter as Router, NavLink, Route, Switch } from "react-router-dom";
+import {
+  BrowserRouter as Router,
+  NavLink,
+  Route,
+  Switch,
+} from "react-router-dom";
 import weakKey from "weak-key";
 
 import {
@@ -43,7 +48,7 @@ const routes: [string, string, ComponentType][][] = [
 
 const App = (): JSX.Element => {
   return (
-    <Router>
+    <Router basename="/admin">
       <div className="admin-navbar">
         {routes.map((group) => (
           <div key={weakKey(group)} className="admin-navbar__group">

--- a/lib/screens_web/auth_manager/pipeline.ex
+++ b/lib/screens_web/auth_manager/pipeline.ex
@@ -6,7 +6,19 @@ defmodule ScreensWeb.AuthManager.Pipeline do
     error_handler: ScreensWeb.AuthManager.ErrorHandler,
     module: ScreensWeb.AuthManager
 
+  plug :fetch_session
+  plug :save_previous_path
   plug(Guardian.Plug.VerifySession, claims: %{"typ" => "access"})
   plug(Guardian.Plug.VerifyHeader, claims: %{"typ" => "access"})
   plug(Guardian.Plug.LoadResource, allow_blank: true)
+
+  def save_previous_path(
+        %Plug.Conn{query_string: query_string, request_path: request_path} = conn,
+        _opts
+      ) do
+    Plug.Conn.put_session(conn, :previous_path, path_with_qs(request_path, query_string))
+  end
+
+  defp path_with_qs(path, ""), do: path
+  defp path_with_qs(path, query), do: "#{path}?#{query}"
 end

--- a/lib/screens_web/controllers/auth_controller.ex
+++ b/lib/screens_web/controllers/auth_controller.ex
@@ -20,14 +20,17 @@ defmodule ScreensWeb.AuthController do
     roles =
       get_in(auth.extra.raw_info.userinfo, ["resource_access", keycloak_client_id, "roles"]) || []
 
+    redirect_to = Plug.Conn.get_session(conn, :previous_path, ~p"/admin")
+
     conn
+    |> Plug.Conn.delete_session(:previous_path)
     |> Guardian.Plug.sign_in(
       ScreensWeb.AuthManager,
       username,
       %{roles: roles},
       ttl: {expiration - current_time, :seconds}
     )
-    |> redirect(to: ScreensWeb.Router.Helpers.admin_path(conn, :index))
+    |> redirect(to: redirect_to)
   end
 
   def callback(

--- a/lib/screens_web/router.ex
+++ b/lib/screens_web/router.ex
@@ -56,7 +56,7 @@ defmodule ScreensWeb.Router do
     pipe_through [:redirect_prod_http, :browser, :auth, :ensure_auth, :ensure_screens_group]
 
     live_dashboard "/dashboard", metrics: ScreensWeb.Telemetry
-    get("/", AdminController, :index)
+    get("/*_", AdminController, :index)
   end
 
   scope "/api/admin", ScreensWeb do

--- a/test/screens_web/controllers/auth_controller_test.exs
+++ b/test/screens_web/controllers/auth_controller_test.exs
@@ -28,7 +28,7 @@ defmodule ScreensWeb.Controllers.AuthControllerTest do
 
       response = html_response(conn, 302)
 
-      assert response =~ ScreensWeb.Router.Helpers.admin_path(conn, :index)
+      assert response =~ ~p"/admin"
       assert Guardian.Plug.current_claims(conn)["roles"] == ["screens-admin"]
     end
 


### PR DESCRIPTION
Updates the admin dash to use "real" routing instead of hash-based, and the admin authentication pipeline to preserve the originally requested path. With these changes, it's now possible to link directly to a specific admin page and for that link to work even if you need to authenticate.

The "previous path" implementation is mostly swiped from Screenplay. Thanks, Screenplay. [Thcreenplay](https://en.wikiquote.org/wiki/Look_Around_You#Water).