### PR TITLE
feat: admin screen inspector

### DIFF
--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -84,6 +84,12 @@
   width: 240px;
 }
 
+.admin-table__inspector-link {
+  color: unset;
+  text-decoration: none;
+  border-bottom: 1px dotted;
+}
+
 .admin-modal__background {
   position: fixed;
   top: 0;

--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -1,3 +1,5 @@
+@import "admin/viewer";
+
 #app {
   font-family: sans-serif;
   font-size: 14px;
@@ -19,6 +21,7 @@
 
 .admin-navbar__group {
   display: flex;
+  align-items: center;
 
   &:not(:first-child) {
     padding-left: 1em;

--- a/assets/css/admin/viewer.scss
+++ b/assets/css/admin/viewer.scss
@@ -1,0 +1,74 @@
+.viewer {
+  display: flex;
+  gap: 0.5em;
+  align-items: stretch;
+}
+
+.viewer__controls {
+  display: flex;
+  flex: 0 0 24em;
+  flex-direction: column;
+  gap: 1.5em;
+  padding: 1em;
+  background-color: #eee;
+
+  h1 {
+    margin: 0;
+  }
+
+  fieldset {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5em;
+    align-items: start;
+
+    & > div {
+      display: flex;
+      flex-direction: row;
+      gap: 0.5em;
+      align-items: center;
+    }
+  }
+
+  legend {
+    color: #666;
+  }
+
+  select {
+    max-width: 22em;
+  }
+}
+
+.viewer__modal {
+  width: 80%;
+  max-width: 1024px;
+
+  &__close-button {
+    float: right;
+  }
+
+  &__ssml {
+    font-family: monospace;
+    white-space: preserve;
+  }
+
+  .admin-form {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5em;
+  }
+
+  .admin__textarea {
+    width: 100%;
+    height: 80vh;
+  }
+}
+
+.viewer__screen {
+  flex: 1 1 auto;
+
+  iframe {
+    width: 100%;
+    border: 0;
+  }
+}

--- a/assets/src/apps/admin.tsx
+++ b/assets/src/apps/admin.tsx
@@ -25,8 +25,10 @@ import AdminScreenConfigForm from "Components/admin/admin_screen_config_form";
 import AdminTriptychPlayerForm from "Components/admin/admin_triptych_player_form";
 import ImageManager from "Components/admin/admin_image_manager";
 import Devops from "Components/admin/devops";
+import Inspector from "Components/admin/inspector";
 
 const routes: [string, string, ComponentType][][] = [
+  [["inspector", "🔍", Inspector]],
   [["", "All Screens", AllScreensTable]],
   [
     ["bus-eink-v2-screens", "Bus E-ink", BusEinkV2ScreensTable],

--- a/assets/src/components/admin/admin_cells.tsx
+++ b/assets/src/components/admin/admin_cells.tsx
@@ -1,4 +1,5 @@
 import React, { useRef, useMemo, useEffect } from "react";
+import { Link } from "react-router-dom";
 import _ from "lodash";
 
 import { gatherSelectOptions } from "Util/admin";
@@ -168,6 +169,18 @@ const IndeterminateCheckbox = ({ indeterminate, ...rest }) => {
   );
 };
 
+const InspectorLink = ({ value }) => {
+  return (
+    <Link
+      to={`/inspector?id=${value}`}
+      className="admin-table__inspector-link"
+      title="🔍 View in Inspector"
+    >
+      {value}
+    </Link>
+  );
+};
+
 export {
   EditableCell,
   EditableList,
@@ -176,4 +189,5 @@ export {
   EditableCheckbox,
   EditableTextarea,
   IndeterminateCheckbox,
+  InspectorLink,
 };

--- a/assets/src/components/admin/admin_form.tsx
+++ b/assets/src/components/admin/admin_form.tsx
@@ -93,7 +93,7 @@ const AdminForm = ({ fetchConfig, validatePath, confirmPath }): JSX.Element => {
   }, []);
 
   return (
-    <div>
+    <div className="admin-form">
       <textarea
         ref={configRef}
         id="config"

--- a/assets/src/components/admin/admin_tables.tsx
+++ b/assets/src/components/admin/admin_tables.tsx
@@ -14,6 +14,7 @@ import {
   EditableSelect,
   EditableCheckbox,
   EditableTextarea,
+  InspectorLink,
 } from "Components/admin/admin_cells";
 
 import {
@@ -42,6 +43,7 @@ const AllScreensTable = (): JSX.Element => {
     {
       Header: "Screen ID",
       accessor: "id",
+      Cell: InspectorLink,
       Filter: DefaultColumnFilter,
       FormCell: FormStaticCell,
     },
@@ -115,7 +117,12 @@ const AllScreensTable = (): JSX.Element => {
 
 const SolariScreensTable = (): JSX.Element => {
   const columns = [
-    { Header: "Screen ID", accessor: "id", Filter: DefaultColumnFilter },
+    {
+      Header: "Screen ID",
+      accessor: "id",
+      Cell: InspectorLink,
+      Filter: DefaultColumnFilter,
+    },
     {
       Header: "Station Name",
       accessor: buildAppParamAccessor("station_name"),
@@ -182,7 +189,12 @@ const SolariScreensTable = (): JSX.Element => {
 
 const DupV2ScreensTable = (): JSX.Element => {
   const columns = [
-    { Header: "Screen ID", accessor: "id", Filter: DefaultColumnFilter },
+    {
+      Header: "Screen ID",
+      accessor: "id",
+      Cell: InspectorLink,
+      Filter: DefaultColumnFilter,
+    },
     {
       Header: "Header",
       accessor: buildAppParamAccessor("header"),
@@ -235,6 +247,7 @@ const v2Columns = [
   {
     Header: "Screen ID",
     accessor: "id",
+    Cell: InspectorLink,
     Filter: DefaultColumnFilter,
     FormCell: FormStaticCell,
   },
@@ -282,6 +295,7 @@ const v2Columns = [
 const screenIDColumn = {
   Header: "Screen ID",
   accessor: "id",
+  Cell: InspectorLink,
   Filter: DefaultColumnFilter,
   FormCell: FormStaticCell,
 };
@@ -515,6 +529,7 @@ const BuswayV2ScreensTable = (): JSX.Element => {
     {
       Header: "Screen ID",
       accessor: "id",
+      Cell: InspectorLink,
       Filter: DefaultColumnFilter,
       FormCell: FormStaticCell,
     },

--- a/assets/src/components/admin/inspector.tsx
+++ b/assets/src/components/admin/inspector.tsx
@@ -1,0 +1,428 @@
+import React, {
+  type ComponentType,
+  type RefObject,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+import { useHistory, useLocation } from "react-router-dom";
+
+import AdminForm from "./admin_form";
+
+import { doSubmit, type Config, type Screen } from "Util/admin";
+import { type Message, sendMessage, useReceiveMessage } from "Util/inspector";
+
+type ScreenWithId = { id: string; config: Screen };
+
+const SCREEN_TYPES = new Set([
+  "bus_eink_v2",
+  "bus_shelter_v2",
+  "busway_v2",
+  "dup_v2",
+  "gl_eink_v2",
+  "pre_fare_v2",
+]);
+
+const AUDIO_SCREEN_TYPES = new Set([
+  "bus_shelter_v2",
+  "busway_v2",
+  "gl_eink_v2",
+  "pre_fare_v2",
+]);
+
+const Inspector: ComponentType = () => {
+  const [config, setConfig] = useState<Config | null>(null);
+
+  useEffect(() => {
+    fetch("/api/admin")
+      .then((result) => result.json())
+      .then((json) => JSON.parse(json.config))
+      .then((config) => setConfig(config))
+      .catch(() => alert("Failed to load config!"));
+  }, []);
+
+  const { search } = useLocation();
+  const screenId = new URLSearchParams(search).get("id");
+  const screen: ScreenWithId | null =
+    config && screenId
+      ? { id: screenId, config: config.screens[screenId] }
+      : null;
+
+  const [isSimulation, setIsSimulation] = useState(false);
+
+  const frameRef = useRef<HTMLIFrameElement>(null);
+
+  const sendToFrame = (message: Message) => {
+    const frameWindow = frameRef.current?.contentWindow;
+    frameWindow && sendMessage(frameWindow, message);
+  };
+
+  const [zoom, setZoom] = useState(1.0);
+  const adjustFrame = () => adjustScreenFrame(frameRef, isSimulation, zoom);
+  useLayoutEffect(adjustFrame, [zoom]);
+
+  return (
+    <div className="viewer">
+      <div className="viewer__controls">
+        <h1>Inspector</h1>
+
+        {config && (
+          <>
+            <ScreenSelector
+              config={config}
+              screen={screen}
+              isSimulation={isSimulation}
+              setIsSimulation={setIsSimulation}
+            />
+
+            {screen && (
+              <>
+                <ConfigControls screen={screen} />
+                <ViewControls zoom={zoom} setZoom={setZoom} />
+                <DataControls sendToFrame={sendToFrame} />
+                <AudioControls config={config} screen={screen} />
+              </>
+            )}
+          </>
+        )}
+      </div>
+
+      <div className="viewer__screen">
+        <iframe
+          onLoad={adjustFrame}
+          ref={frameRef}
+          src={
+            screen
+              ? new URL(
+                  `/v2/screen/${screen.id}${isSimulation ? "/simulation" : ""}`,
+                  location.origin,
+                ).toString()
+              : "about:blank"
+          }
+        ></iframe>
+      </div>
+    </div>
+  );
+};
+
+const ScreenSelector: ComponentType<{
+  config: Config;
+  screen: ScreenWithId | null;
+  isSimulation: boolean;
+  setIsSimulation: (value: boolean) => void;
+}> = ({ config, screen, isSimulation, setIsSimulation }) => {
+  const history = useHistory();
+  const { pathname, search } = useLocation();
+
+  const navigateToScreen = (id) => {
+    const params = new URLSearchParams(search);
+    params.set("id", id);
+    history.push({ pathname, search: params.toString() });
+  };
+
+  const screensByType: Record<string, ScreenWithId[]> = Object.entries(
+    config.screens,
+  )
+    .filter(([, { app_id }]) => SCREEN_TYPES.has(app_id))
+    .sort(([idA], [idB]) => idA.localeCompare(idB))
+    .reduce((groups, [id, config]) => {
+      groups[config.app_id] ||= [];
+      groups[config.app_id].push({ id, config });
+      return groups;
+    }, {});
+
+  return (
+    <fieldset>
+      <legend>Screen</legend>
+
+      <select
+        value={screen?.id}
+        onChange={(event) => navigateToScreen(event.target.value)}
+      >
+        <option></option>
+        {Object.keys(screensByType).map((type) => (
+          <optgroup label={type} key={type}>
+            {screensByType[type].map(({ id, config: { name } }) => (
+              <option value={id} key={id}>
+                {id}
+                {name ? ` · ${name}` : ""}
+              </option>
+            ))}
+          </optgroup>
+        ))}
+      </select>
+
+      <label>
+        <input
+          type="checkbox"
+          checked={isSimulation}
+          onChange={() => setIsSimulation(!isSimulation)}
+        />
+        Screenplay Simulation
+      </label>
+    </fieldset>
+  );
+};
+
+const ConfigControls: ComponentType<{ screen: ScreenWithId }> = ({
+  screen,
+}) => {
+  const [editableConfig, setEditableConfig] = useState<Screen | null>(null);
+  const [isRequestingReload, setIsRequestingReload] = useState(false);
+  const dialogRef = useRef<HTMLDialogElement>(null);
+
+  return (
+    <fieldset>
+      <legend>Configuration</legend>
+
+      <div>
+        <button
+          onClick={() => {
+            setEditableConfig(screen.config);
+            dialogRef.current?.showModal();
+          }}
+        >
+          Edit Config
+        </button>
+
+        <button
+          disabled={isRequestingReload}
+          onClick={() => {
+            setIsRequestingReload(true);
+            doSubmit("/api/admin/refresh", { screen_ids: [screen.id] })
+              .then(() => alert("Scheduled a reload for this screen."))
+              .finally(() => setIsRequestingReload(false));
+          }}
+        >
+          Schedule Page Reload
+        </button>
+      </div>
+
+      <dialog className="viewer__modal" ref={dialogRef}>
+        <button
+          className="viewer__modal__close-button"
+          onClick={() => {
+            dialogRef.current?.close();
+            setEditableConfig(null);
+          }}
+        >
+          × Cancel
+        </button>
+
+        <p>
+          ⚠️ <b>Warning:</b> This will update the live config for this screen.
+        </p>
+
+        {editableConfig && (
+          <AdminForm
+            fetchConfig={async () => editableConfig}
+            validatePath={`/api/admin/screens/validate/${screen.id}`}
+            confirmPath={`/api/admin/screens/confirm/${screen.id}`}
+          />
+        )}
+      </dialog>
+    </fieldset>
+  );
+};
+
+const ViewControls: ComponentType<{
+  zoom: number;
+  setZoom: (zoom: number) => void;
+}> = ({ zoom, setZoom }) => {
+  return (
+    <fieldset>
+      <legend>View</legend>
+
+      <div>
+        <button disabled={zoom <= 0.25} onClick={() => setZoom(zoom - 0.25)}>
+          ➖
+        </button>
+        <button onClick={() => setZoom(zoom + 0.25)}>➕</button>
+        <button onClick={() => setZoom(1.0)}>Reset</button>
+        <div>({zoom}x)</div>
+      </div>
+    </fieldset>
+  );
+};
+
+const DataControls: ComponentType<{
+  sendToFrame: (message: Message) => void;
+}> = ({ sendToFrame }) => {
+  const [dataTimestamp, setDataTimestamp] = useState<number | null>(null);
+  const [dataSecondsOld, setDataSecondsOld] = useState<number | null>(null);
+  const [isRefreshEnabled, setIsRefreshEnabled] = useState(true);
+
+  useReceiveMessage((message) => {
+    if (message.type == "data_refreshed") {
+      setDataTimestamp(message.timestamp);
+      setDataSecondsOld(0);
+    }
+  });
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setDataSecondsOld(
+        dataTimestamp ? Math.round((Date.now() - dataTimestamp) / 1000) : null,
+      );
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [dataTimestamp]);
+
+  useEffect(() => {
+    sendToFrame({ type: "set_refresh_rate", ms: isRefreshEnabled ? null : 0 });
+  }, [isRefreshEnabled]);
+
+  return (
+    <fieldset>
+      <legend>Data</legend>
+
+      <div>
+        <button onClick={() => sendToFrame({ type: "refresh_data" })}>
+          Refresh
+        </button>
+
+        {isRefreshEnabled && dataSecondsOld != null && (
+          <span>⏱️ {dataSecondsOld} seconds ago</span>
+        )}
+      </div>
+
+      <label>
+        <input
+          type="checkbox"
+          checked={isRefreshEnabled}
+          onClick={() => setIsRefreshEnabled(!isRefreshEnabled)}
+        />
+        Enable refresh interval
+      </label>
+    </fieldset>
+  );
+};
+
+const AudioControls: ComponentType<{
+  config: Config;
+  screen: ScreenWithId;
+}> = ({ config, screen }) => {
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [ssml, setSSML] = useState<string | null>(null);
+  const dialogRef = useRef<HTMLDialogElement>(null);
+
+  useEffect(
+    () => (ssml ? dialogRef.current?.showModal() : dialogRef.current?.close()),
+    [dialogRef, ssml],
+  );
+
+  let audioPath: string | null = null;
+  let v1ScreenId: string | null = null;
+
+  if (AUDIO_SCREEN_TYPES.has(screen.config.app_id)) {
+    // Temporarily special-case Busway screens while V2 doesn't support audio
+    // yet, in a way that aligns with how they're configured in reality (using
+    // the audio endpoint of a corresponding V1 screen).
+    if (screen.config.app_id == "busway_v2") {
+      const maybeV1Id = screen.id.replace(/-V2$/, "");
+
+      if (maybeV1Id != screen.id && config.screens[maybeV1Id]) {
+        audioPath = `/audio/${maybeV1Id}`;
+        v1ScreenId = maybeV1Id;
+      }
+    } else {
+      audioPath = `/v2/audio/${screen.id}`;
+    }
+  }
+
+  return (
+    <fieldset>
+      <legend>Audio</legend>
+
+      {audioPath ? (
+        <>
+          <div>
+            <button
+              onClick={() => {
+                setSSML("Loading...");
+                fetch(`${audioPath}/debug`)
+                  .then((result) => result.text())
+                  .then((text) => setSSML(text))
+                  .catch(() => alert("Failed to fetch SSML!"));
+              }}
+            >
+              Show SSML
+            </button>
+
+            <button onClick={() => setIsPlaying(!isPlaying)}>
+              {isPlaying ? "⏹️ Stop Audio" : "▶️ Play Audio"}
+            </button>
+          </div>
+
+          {v1ScreenId && (
+            <div>
+              <span>
+                (from v1 screen <code>{v1ScreenId}</code>)
+              </span>
+            </div>
+          )}
+
+          <dialog className="viewer__modal" ref={dialogRef}>
+            <button
+              className="viewer__modal__close-button"
+              onClick={() => setSSML(null)}
+            >
+              × Close
+            </button>
+            <div className="viewer__modal__ssml">{ssml}</div>
+          </dialog>
+
+          {isPlaying && (
+            <audio
+              autoPlay={true}
+              onEnded={() => setIsPlaying(false)}
+              src={`${audioPath}/readout.mp3`}
+            />
+          )}
+        </>
+      ) : (
+        <div>Not supported on this screen</div>
+      )}
+    </fieldset>
+  );
+};
+
+const adjustScreenFrame = (
+  ref: RefObject<HTMLIFrameElement>,
+  isSimulation: boolean,
+  zoom: number,
+) => {
+  if (ref.current?.contentWindow) {
+    const doc = ref.current.contentWindow.document;
+    let style = doc.getElementById("viewer-injected-style");
+
+    if (!style) {
+      style = doc.createElement("style");
+      style.id = "viewer-injected-style";
+      doc.head.appendChild(style);
+    }
+
+    const className = isSimulation
+      ? "simulation-screen-scrolling-container"
+      : "screen-container";
+
+    style.innerHTML = `
+      .screen-container {
+        margin: unset;
+      }
+      .simulation-screen-centering-container {
+        justify-content: unset;
+      }
+      .${className} {
+        transform: scale(${zoom});
+        transform-origin: top left;
+      }
+    `;
+
+    ref.current.height = doc.body.scrollHeight.toString();
+    ref.current.width = doc.body.scrollWidth.toString();
+  }
+};
+
+export default Inspector;

--- a/assets/src/hooks/v2/use_api_response.tsx
+++ b/assets/src/hooks/v2/use_api_response.tsx
@@ -2,6 +2,7 @@ import { WidgetData } from "Components/v2/widget";
 import useDriftlessInterval from "Hooks/use_driftless_interval";
 import React, { useEffect, useMemo, useState } from "react";
 import { getDatasetValue } from "Util/dataset";
+import { sendMessage, useReceiveMessage } from "Util/inspector";
 import { isDup, isOFM, isTriptych, getTriptychPane } from "Util/outfront";
 import { getScreenSide, isRealScreen } from "Util/util";
 import * as SentryLogger from "Util/sentry";
@@ -234,7 +235,27 @@ const useBaseApiResponse = ({
     refreshRateOffsetMs,
   );
 
+  useInspectorControls(fetchData, lastSuccess);
+
   return { apiResponse, requestCount, lastSuccess };
+};
+
+const useInspectorControls = (
+  fetchData: () => void,
+  lastSuccess: number | null,
+): void => {
+  useReceiveMessage((message) => {
+    if (message.type == "refresh_data") fetchData();
+  });
+
+  useEffect(() => {
+    if (lastSuccess) {
+      sendMessage(window.parent, {
+        type: "data_refreshed",
+        timestamp: lastSuccess,
+      });
+    }
+  }, [lastSuccess]);
 };
 
 const useApiResponse = ({ id }) =>

--- a/assets/src/util/admin.tsx
+++ b/assets/src/util/admin.tsx
@@ -1,5 +1,24 @@
 import getCsrfToken from "Util/csrf";
 
+type JSONArray = Array<JSON>;
+type JSONObject = { [key: string]: JSON };
+type JSON = null | string | number | boolean | JSONArray | JSONObject;
+
+export type Config = {
+  screens: { [id: string]: Screen };
+  devops: { disabled_modes: string[] };
+};
+
+export type Screen = {
+  app_id: string;
+  app_params: JSONObject;
+  device_id: string | null;
+  disabled: boolean;
+  hidden_from_screenplay: boolean;
+  name: string;
+  vendor: string;
+};
+
 const gatherSelectOptions = (rows, columnId) => {
   const options = rows.map((row) => row.values[columnId]);
   const uniqueOptions = new Set(options);

--- a/assets/src/util/inspector.ts
+++ b/assets/src/util/inspector.ts
@@ -1,0 +1,27 @@
+import { useEffect } from "react";
+
+/**
+ * Defines a protocol the "Inspector" admin UI can use to communicate with
+ * iframe'd screens. Limit usage of these functions to this specific purpose;
+ * components _within_ a screen have many better options (props, contexts, etc.)
+ * for communicating with each other.
+ */
+
+export type Message =
+  | { type: "data_refreshed"; timestamp: number }
+  | { type: "refresh_data" }
+  | { type: "set_refresh_rate"; ms: number | null };
+
+const sendMessage = (window: Window, message: Message) =>
+  window.postMessage(message, { targetOrigin: location.origin });
+
+const useReceiveMessage = (handler: (message: Message) => void) =>
+  useEffect(() => {
+    const listener = ({ data, origin }) =>
+      origin == location.origin && handler(data);
+
+    window.addEventListener("message", listener);
+    return () => window.removeEventListener("message", listener);
+  });
+
+export { sendMessage, useReceiveMessage };

--- a/lib/screens_web/router.ex
+++ b/lib/screens_web/router.ex
@@ -64,7 +64,9 @@ defmodule ScreensWeb.Router do
 
     get "/", AdminApiController, :index
     post "/screens/validate", AdminApiController, :validate
+    post "/screens/validate/:id", AdminApiController, :validate
     post "/screens/confirm", AdminApiController, :confirm
+    post "/screens/confirm/:id", AdminApiController, :confirm
     post "/refresh", AdminApiController, :refresh
     post "/devops", AdminApiController, :devops
     get "/image_filenames", AdminApiController, :image_filenames


### PR DESCRIPTION
Presenting a ~~proof that I should not be left unsupervised~~ new Screens admin tool: the **Inspector**.

This is, I promise, pursuant to [Set up parallel running of new DUP logic](https://app.asana.com/0/1185117109217413/1207992837169564). The train of thought went something like this:

* Rather than hunting down and typing in DUP screen IDs and query params, it'd be nice to have a little tool that lets you select any screen you want, display it, and flip between the code paths. That should only take a couple days to build, it'll just expand the scope of this task a little bit.
* Okay, neither "base" screen pages nor Screenplay simulations are very readable without zooming them out/in... we should be able to resize the screen.
* And we'll probably want a way to reload the screen data immediately when we switch code paths.
  * Oh, and it'd be nice if we could suspend the automatic data updates. Hate when I'm fiddling with something in the web inspector and the DOM keeps changing out from under me.
* Repeat for a few more "it'd be nice if we had this" things which are increasingly unrelated to DUP departures logic.
* Hey, where'd that week go?

Feature creep aside, I'm hoping folks agree this is a useful tool in general and a decent "attractor" for developer/admin features that might otherwise be screen page query params or other less-friendly mechanisms. I know I'd personally use it a lot for debugging in preference to the "raw" screen pages. Of course, if you don't agree, please say so 🙂 Considering this wasn't explicitly planned at any point, I'm very willing to rework it if there are concerns.

If it's not clear: the implementation of the "DUP logic switch" within this framework would be extremely similar to the existing Refresh button in the Data section. Instead of signaling the data hook to perform a refresh, it would signal to update a bit of internal state to use a different URL for fetching the data. The screen data API controller would then pick up on this and from there the approach would be identical to the originally-proposed one.

[Preview on dev-green](https://screens-dev-green.mbtace.com/admin/inspector?id=MUL-114-V2).

<img width="1289" alt="Screenshot 2024-08-26 at 1 36 53 PM" src="https://github.com/user-attachments/assets/f0277ea1-fda2-47d9-9154-35d39a80f98b">

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208138805469601