### PR TITLE
fix: guard against inspector code crashing screens

### DIFF
--- a/assets/src/components/admin/inspector.tsx
+++ b/assets/src/components/admin/inspector.tsx
@@ -11,7 +11,12 @@ import { useHistory, useLocation } from "react-router-dom";
 import AdminForm from "./admin_form";
 
 import { doSubmit, type Config, type Screen } from "Util/admin";
-import { type Message, sendMessage, useReceiveMessage } from "Util/inspector";
+import {
+  type Message,
+  INSPECTOR_FRAME_NAME,
+  sendMessage,
+  useReceiveMessage,
+} from "Util/inspector";
 
 type ScreenWithId = { id: string; config: Screen };
 
@@ -90,6 +95,7 @@ const Inspector: ComponentType = () => {
 
       <div className="viewer__screen">
         <iframe
+          name={INSPECTOR_FRAME_NAME}
           onLoad={adjustFrame}
           ref={frameRef}
           src={

--- a/assets/src/components/admin/inspector.tsx
+++ b/assets/src/components/admin/inspector.tsx
@@ -291,7 +291,7 @@ const DataControls: ComponentType<{
         <input
           type="checkbox"
           checked={isRefreshEnabled}
-          onClick={() => setIsRefreshEnabled(!isRefreshEnabled)}
+          onChange={() => setIsRefreshEnabled(!isRefreshEnabled)}
         />
         Enable refresh interval
       </label>

--- a/assets/src/hooks/v2/use_api_response.tsx
+++ b/assets/src/hooks/v2/use_api_response.tsx
@@ -2,7 +2,7 @@ import { WidgetData } from "Components/v2/widget";
 import useDriftlessInterval from "Hooks/use_driftless_interval";
 import React, { useEffect, useMemo, useState } from "react";
 import { getDatasetValue } from "Util/dataset";
-import { sendMessage, useReceiveMessage } from "Util/inspector";
+import { sendToInspector, useReceiveFromInspector } from "Util/inspector";
 import { isDup, isOFM, isTriptych, getTriptychPane } from "Util/outfront";
 import { getScreenSide, isRealScreen } from "Util/util";
 import * as SentryLogger from "Util/sentry";
@@ -244,16 +244,13 @@ const useInspectorControls = (
   fetchData: () => void,
   lastSuccess: number | null,
 ): void => {
-  useReceiveMessage((message) => {
+  useReceiveFromInspector((message) => {
     if (message.type == "refresh_data") fetchData();
   });
 
   useEffect(() => {
     if (lastSuccess) {
-      sendMessage(window.parent, {
-        type: "data_refreshed",
-        timestamp: lastSuccess,
-      });
+      sendToInspector({ type: "data_refreshed", timestamp: lastSuccess });
     }
   }, [lastSuccess]);
 };

--- a/assets/src/hooks/v2/use_refresh_rate.ts
+++ b/assets/src/hooks/v2/use_refresh_rate.ts
@@ -1,7 +1,7 @@
 import _ from "lodash";
 import { useMemo, useState } from "react";
 import { fetchDatasetValue, getDatasetValue } from "Util/dataset";
-import { useReceiveMessage } from "Util/inspector";
+import { useReceiveFromInspector } from "Util/inspector";
 import { isOFM } from "Util/outfront";
 import { useScreenID } from "./use_screen_id";
 
@@ -40,7 +40,7 @@ const useRefreshRate = (): RefreshRateConfig => {
 const useInspectorOverride = (): number | null => {
   const [override, setOverride] = useState<number | null>(null);
 
-  useReceiveMessage((message) => {
+  useReceiveFromInspector((message) => {
     if (message.type == "set_refresh_rate") setOverride(message.ms);
   });
 


### PR DESCRIPTION
On real Bus E-ink screens we saw a mysterious "[DOM Exception 12](https://mbtace.sentry.io/issues/5760152862/)" crash that seemed to be caused by the inspector changes. Though the message sending and listening should have already been a no-op when the screen is not "framed", this adds a check for whether the screen is "framed" by the inspector specifically, and otherwise doesn't even attempt to send/listen. This should sidestep any issues with e.g. a screen vendor rendering our pages inside a frame.

Deployed to dev to test on Jon's physical screen, and confirmed that this fixed the "blank screen" issue it was having since the previous dev deploy, presumably as a result of this DOM Exception 12.