### PR TITLE
dev: enable Dependabot for Actions versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,17 @@
 version: 2
 updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "10:00"
+    open-pull-requests-limit: 5
   - package-ecosystem: mix
     directory: "/"
     schedule:
       interval: daily
       time: "10:00"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5
     groups:
       mix-patches:
         patterns:
@@ -17,7 +23,7 @@ updates:
     schedule:
       interval: daily
       time: "10:00"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5
     groups:
       npm-patches:
         patterns:


### PR DESCRIPTION
I noticed some deprecation warnings in CI because we're using old versions of some Actions, which themselves are using old versions of Node. Dependabot can now help us keep these up-to-date.