### PR TITLE
fix: handle unscheduled commuter rail departures

### DIFF
--- a/lib/screens/v2/departure.ex
+++ b/lib/screens/v2/departure.ex
@@ -45,9 +45,14 @@ defmodule Screens.V2.Departure do
     end
   end
 
-  def fetch_predictions_and_schedules(params, now) do
-    with {:ok, predictions} <- Prediction.fetch(params),
-         {:ok, schedules} <- Schedule.fetch(params) do
+  def fetch_predictions_and_schedules(
+        params,
+        now,
+        fetch_predictions_fn \\ &Prediction.fetch/1,
+        fetch_schedules_fn \\ &Schedule.fetch/1
+      ) do
+    with {:ok, predictions} <- fetch_predictions_fn.(params),
+         {:ok, schedules} <- fetch_schedules_fn.(params) do
       relevant_predictions = Builder.get_relevant_departures(predictions, now)
       relevant_schedules = Builder.get_relevant_departures(schedules, now)
 

--- a/test/screens/v2/widget_instance/cr_departures_test.exs
+++ b/test/screens/v2/widget_instance/cr_departures_test.exs
@@ -4,9 +4,9 @@ defmodule Screens.V2.WidgetInstance.CRDeparturesTest do
   # alias Screens.Alerts.Alert
   # alias Screens.Config.Dup.Override.FreeTextLine
   # alias Screens.Config.Screen
+  alias Screens.Schedules.Schedule
   alias Screens.Predictions.Prediction
   # alias Screens.Routes.Route
-  # alias Screens.Schedules.Schedule
   alias Screens.Trips.Trip
   # alias Screens.Vehicles.Vehicle
   alias Screens.V2.{Departure, WidgetInstance}
@@ -50,6 +50,86 @@ defmodule Screens.V2.WidgetInstance.CRDeparturesTest do
 
       assert %{headsign: "Beth Israel", station_service_list: []} ==
                CRDeparturesWidget.serialize_headsign(departure, "Somewhere")
+    end
+  end
+
+  describe "serialize_departure/5" do
+    test "serializes a departure with a schedule and a prediction" do
+      now = ~U[2024-08-28 18:08:30.883227Z]
+
+      departure = %Departure{
+        schedule: %Schedule{
+          id: "schedule-1",
+          trip: %Trip{id: "trip-1", headsign: "Somewhere"},
+          arrival_time: DateTime.add(now, 5, :minute),
+          departure_time: DateTime.add(now, 7, :minute)
+        },
+        prediction: %Prediction{
+          id: "prediction-1",
+          trip: %Trip{id: "trip-1", headsign: "Somewhere"},
+          arrival_time: DateTime.add(now, 5, :minute),
+          departure_time: DateTime.add(now, 7, :minute)
+        }
+      }
+
+      assert %{
+               prediction_or_schedule_id: "prediction-1"
+             } =
+               CRDeparturesWidget.serialize_departure(
+                 departure,
+                 "Somewhere",
+                 %{},
+                 "place-smwhr",
+                 now
+               )
+    end
+
+    test "serializes a departure with only a schedule" do
+      now = ~U[2024-08-28 18:08:30.883227Z]
+
+      departure = %Departure{
+        schedule: %Schedule{
+          id: "schedule-1",
+          trip: %Trip{id: "trip-1", headsign: "Somewhere"},
+          arrival_time: DateTime.add(now, 5, :minute),
+          departure_time: DateTime.add(now, 7, :minute)
+        }
+      }
+
+      assert %{
+               prediction_or_schedule_id: "schedule-1"
+             } =
+               CRDeparturesWidget.serialize_departure(
+                 departure,
+                 "Somewhere",
+                 %{},
+                 "place-smwhr",
+                 now
+               )
+    end
+
+    test "serializes a departure with only a prediction" do
+      now = ~U[2024-08-28 18:08:30.883227Z]
+
+      departure = %Departure{
+        prediction: %Prediction{
+          id: "prediction-1",
+          trip: %Trip{id: "trip-1", headsign: "Somewhere"},
+          arrival_time: DateTime.add(now, 5, :minute),
+          departure_time: DateTime.add(now, 7, :minute)
+        }
+      }
+
+      assert %{
+               prediction_or_schedule_id: "prediction-1"
+             } =
+               CRDeparturesWidget.serialize_departure(
+                 departure,
+                 "Somewhere",
+                 %{},
+                 "place-smwhr",
+                 now
+               )
     end
   end
 


### PR DESCRIPTION
The commuter rail departures widget made the assumption that there would never be a departure that had a prediction but no matching schedule. We have observed that this isn't always the case.

Adds handling of a `nil` schedule to the commuter rail departures widget. The only thing relying on a present schedule in `serialize_departure/5` was calculating if a departure was delayed. If there is no schedule we do not flag the departure as delayed; otherwise, the delayed calculation remains unchanged.

**Asana task**: [[Screens 🐞] Fix Departure prediction/schedule merging](https://app.asana.com/0/1185117109217413/1207953256080348/f)

> [!NOTE]
> The associated ticket references an issue with filtering out past schedules before merging them with predictions into departures. To verify that this is not actually the case I have added tests verifying that past schedules are still merged with their matching predictions. 