### PR TITLE
chore: suppress alert 590467 on pre-fare screens

### DIFF
--- a/lib/screens/v2/widget_instance/reconstructed_alert.ex
+++ b/lib/screens/v2/widget_instance/reconstructed_alert.ex
@@ -1313,10 +1313,10 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
 
   def alert_ids(%__MODULE__{} = t), do: [t.alert.id]
 
-  def valid_candidate?(%__MODULE__{} = t) do
-    test_alert_ids = ["197140"]
-    prod_alert_ids = ["580015"]
-    t.alert.id not in (test_alert_ids ++ prod_alert_ids)
+  @suppressed_alert_ids ~w[590467]
+
+  def valid_candidate?(%__MODULE__{alert: %{id: alert_id}}) do
+    alert_id not in @suppressed_alert_ids
   end
 
   defimpl Screens.V2.WidgetInstance do

--- a/test/screens/v2/widget_instance/reconstructed_alert_test.exs
+++ b/test/screens/v2/widget_instance/reconstructed_alert_test.exs
@@ -103,6 +103,10 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
     %{widget | alert: %{widget.alert | header: header}}
   end
 
+  defp put_alert_id(widget, id) do
+    %{widget | alert: %{widget.alert | id: id}}
+  end
+
   defp put_severity(widget, severity) do
     %{widget | alert: %{widget.alert | severity: severity}}
   end
@@ -3170,6 +3174,23 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
                  %{alert_widget | is_full_screen: false},
                  &fake_log/1
                )
+    end
+  end
+
+  describe "valid_candidate?/1" do
+    test "returns true", %{widget: widget} do
+      assert WidgetInstance.valid_candidate?(widget)
+    end
+
+    suppressed_alerts = ~w[590467]
+
+    for alert_id <- suppressed_alerts do
+      @tag alert_id: alert_id
+      test "returns false for alert ##{alert_id}", %{widget: widget, alert_id: alert_id} do
+        refute widget
+               |> put_alert_id(alert_id)
+               |> WidgetInstance.valid_candidate?()
+      end
     end
   end
 end


### PR DESCRIPTION
Alert #590467 represents suspension of red line service on the Braintree branch with shuttles connecting at Ashmont instead of JFK/UMass. Because of this abnormal shuttle pattern, the generated line maps will not be accurate. Evergreen content will be used to display the correct information to riders.

**Asana task**: [Custom graphics during Braintree Branch diversion](https://app.asana.com/0/1185117109217422/1208136071296475/f)

- [x] Tests added?
