### PR TITLE
fix: filter cancelled & skipped departures

### DIFF
--- a/lib/screens/predictions/parser.ex
+++ b/lib/screens/predictions/parser.ex
@@ -1,5 +1,6 @@
 defmodule Screens.Predictions.Parser do
   @moduledoc false
+  alias Screens.Predictions.ScheduleRelationship
 
   def parse_result(%{"data" => data, "included" => included}) do
     included_data = parse_included_data(included)
@@ -46,11 +47,17 @@ defmodule Screens.Predictions.Parser do
         %{"id" => id, "attributes" => attributes, "relationships" => relationships},
         included_data
       ) do
-    %{"arrival_time" => arrival_time_string, "departure_time" => departure_time_string} =
+    %{
+      "arrival_time" => arrival_time_string,
+      "departure_time" => departure_time_string,
+      "schedule_relationship" => schedule_relationship
+    } =
       attributes
 
     arrival_time = parse_time(arrival_time_string)
     departure_time = parse_time(departure_time_string)
+
+    schedule_relationship = ScheduleRelationship.parse(schedule_relationship)
 
     %{
       "route" => %{"data" => %{"id" => route_id}},
@@ -89,7 +96,8 @@ defmodule Screens.Predictions.Parser do
       alerts: alerts,
       arrival_time: arrival_time,
       departure_time: departure_time,
-      track_number: track_number
+      track_number: track_number,
+      schedule_relationship: schedule_relationship
     }
   end
 

--- a/lib/screens/predictions/prediction.ex
+++ b/lib/screens/predictions/prediction.ex
@@ -2,6 +2,7 @@ defmodule Screens.Predictions.Prediction do
   @moduledoc false
 
   alias Screens.Departures.Departure
+  alias Screens.Predictions.ScheduleRelationship
   alias Screens.Vehicles.Vehicle
 
   defstruct id: nil,
@@ -13,7 +14,8 @@ defmodule Screens.Predictions.Prediction do
             arrival_time: nil,
             departure_time: nil,
             stop_headsign: nil,
-            track_number: nil
+            track_number: nil,
+            schedule_relationship: :scheduled
 
   @type t :: %__MODULE__{
           id: String.t(),
@@ -25,7 +27,8 @@ defmodule Screens.Predictions.Prediction do
           arrival_time: DateTime.t() | nil,
           departure_time: DateTime.t() | nil,
           stop_headsign: String.t() | nil,
-          track_number: String.t() | nil
+          track_number: String.t() | nil,
+          schedule_relationship: ScheduleRelationship.t()
         }
 
   @spec fetch(Departure.query_params()) :: {:ok, list(t())} | :error

--- a/lib/screens/predictions/schedule_relationship.ex
+++ b/lib/screens/predictions/schedule_relationship.ex
@@ -1,0 +1,16 @@
+defmodule Screens.Predictions.ScheduleRelationship do
+  @moduledoc """
+  Internal representation of the V3 API Prediction schedule relationship field.
+
+  https://github.com/mbta/api/blob/8de1d89330077a0dcc739cd9123170d5913c11b5/apps/model/lib/model/prediction.ex#L32-L45
+  """
+
+  @type t :: :scheduled | :added | :cancelled | :no_data | :skipped | :unscheduled
+
+  def parse(nil), do: :scheduled
+  def parse("ADDED"), do: :added
+  def parse("CANCELLED"), do: :cancelled
+  def parse("NO_DATA"), do: :no_data
+  def parse("SKIPPED"), do: :skipped
+  def parse("UNSCHEDULED"), do: :unscheduled
+end

--- a/lib/screens/v2/departure/builder.ex
+++ b/lib/screens/v2/departure/builder.ex
@@ -1,6 +1,7 @@
 defmodule Screens.V2.Departure.Builder do
   @moduledoc false
 
+  alias Screens.Departures.Departure
   alias Screens.Predictions.Prediction
   alias Screens.Schedules.Schedule
   alias Screens.Stops.Stop
@@ -119,8 +120,15 @@ defmodule Screens.V2.Departure.Builder do
       end)
       |> Enum.map(fn s -> %Departure{schedule: s} end)
 
-    predicted_departures
-    |> Kernel.++(unpredicted_departures)
+    departures = predicted_departures ++ unpredicted_departures
+
+    departures
+    |> Enum.reject(&cancelled_or_skipped?/1)
     |> Enum.sort_by(&Departure.time/1, DateTime)
   end
+
+  defp cancelled_or_skipped?(%Departure{prediction: %Prediction{schedule_relationship: sr}}),
+    do: sr in [:cancelled, :skipped]
+
+  defp cancelled_or_skipped?(_), do: false
 end

--- a/test/screens/predictions/schedule_relationship_test.exs
+++ b/test/screens/predictions/schedule_relationship_test.exs
@@ -1,0 +1,30 @@
+defmodule Screens.Predictions.ScheduleRelationshipTest do
+  alias Screens.Predictions.ScheduleRelationship
+  use ExUnit.Case, async: true
+
+  describe "parse/1" do
+    test "parses nil to :scheduled" do
+      assert :scheduled == ScheduleRelationship.parse(nil)
+    end
+
+    test "parses \"ADDED\" to :added" do
+      assert :added == ScheduleRelationship.parse("ADDED")
+    end
+
+    test "parses \"CANCELLED\" to :cancelled" do
+      assert :cancelled == ScheduleRelationship.parse("CANCELLED")
+    end
+
+    test "parses \"NO_DATA\" to :no_data" do
+      assert :no_data == ScheduleRelationship.parse("NO_DATA")
+    end
+
+    test "parses \"SKIPPED\" to :skipped" do
+      assert :skipped == ScheduleRelationship.parse("SKIPPED")
+    end
+
+    test "parses \"UNSCHEDULED\" to :unscheduled" do
+      assert :unscheduled == ScheduleRelationship.parse("UNSCHEDULED")
+    end
+  end
+end

--- a/test/screens/v2/departure/builder_test.exs
+++ b/test/screens/v2/departure/builder_test.exs
@@ -275,5 +275,49 @@ defmodule Screens.V2.Departure.BuilderTest do
       assert expected ==
                Builder.merge_predictions_and_schedules(predictions, schedules, schedules)
     end
+
+    test "filters out departures that have been marked cancelled" do
+      p1 = %Prediction{id: "p1", departure_time: ~U[2020-02-01T00:00:00Z], trip: %Trip{id: "t7"}}
+
+      p2 = %Prediction{
+        id: "p2",
+        departure_time: ~U[2020-02-01T01:00:00Z],
+        trip: %Trip{id: "t3"},
+        schedule_relationship: :cancelled
+      }
+
+      predictions = [p1, p2]
+
+      s1 = %Schedule{id: "s1", departure_time: ~U[2020-02-01T01:01:00Z], trip: %Trip{id: "t3"}}
+      s2 = %Schedule{id: "s2", departure_time: ~U[2020-02-01T00:01:00Z], trip: %Trip{id: "t7"}}
+      schedules = [s1, s2]
+
+      expected = [%Departure{prediction: p1, schedule: s2}]
+
+      assert expected ==
+               Builder.merge_predictions_and_schedules(predictions, schedules, schedules)
+    end
+
+    test "filters out departures that have been marked skipped" do
+      p1 = %Prediction{id: "p1", departure_time: ~U[2020-02-01T00:00:00Z], trip: %Trip{id: "t7"}}
+
+      p2 = %Prediction{
+        id: "p2",
+        departure_time: ~U[2020-02-01T01:00:00Z],
+        trip: %Trip{id: "t3"},
+        schedule_relationship: :skipped
+      }
+
+      predictions = [p1, p2]
+
+      s1 = %Schedule{id: "s1", departure_time: ~U[2020-02-01T01:01:00Z], trip: %Trip{id: "t3"}}
+      s2 = %Schedule{id: "s2", departure_time: ~U[2020-02-01T00:01:00Z], trip: %Trip{id: "t7"}}
+      schedules = [s1, s2]
+
+      expected = [%Departure{prediction: p1, schedule: s2}]
+
+      assert expected ==
+               Builder.merge_predictions_and_schedules(predictions, schedules, schedules)
+    end
   end
 end


### PR DESCRIPTION
Parses the `schedule_relationship` field for `Predictions` and uses that data to remove departures with a SKIPPED or CANCELLED schedule relationship when merging `Prediction`s and `Schedule`s.

Some Predictions now have a SKIPPED schedule relationship **AND** arrival/departure times (indicating what time the vehicle is predicted to pass through the stop). These Predictions need to be filtered out when we fetch departures. Previously these didn't have times so our other filtering logic would remove them.

For completeness we are also filtering out Predictions with a CANCELLED schedule relationship.

**Asana task**: [Filter out cancelled/skipped departures on Screens](https://app.asana.com/0/1185117109217413/1207498013010848/f)
