### PR TITLE
fix: always use API_V3_URL environment variable

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -4,23 +4,15 @@
 # remember to add this file to your .gitignore.
 import Config
 
-eb_env_name = System.get_env("ENVIRONMENT_NAME")
-
-api_v3_url =
-  case eb_env_name do
-    "screens-prod" -> "https://api-v3.mbta.com/"
-    "screens-dev" -> "https://api-dev.mbtace.com/"
-    "screens-dev-green" -> "https://api-dev-green.mbtace.com/"
-    _ -> System.get_env("API_V3_URL", "https://api-v3.mbta.com/")
-  end
-
 unless config_env() == :test do
   config :screens,
-    api_v3_url: api_v3_url,
+    api_v3_url: System.get_env("API_V3_URL", "https://api-v3.mbta.com/"),
     api_v3_key: System.get_env("API_V3_KEY")
 end
 
 if config_env() == :prod do
+  eb_env_name = System.get_env("ENVIRONMENT_NAME")
+
   config :sentry,
     dsn: System.get_env("SENTRY_DSN"),
     environment_name: eb_env_name


### PR DESCRIPTION
Our ECS tasks all set a `API_V3_URL` pointing to the desired V3 API environment but we were ignoring that value and instead deriving the V3 API URL based on `ENVIRONMENT_NAME`. This is confusing.

With this change the URL used for the V3 API is always fetched from the environment as `API_V3_URL` (unless `MIX_ENV=test`).

This has the added benefit of picking up the changes in https://github.com/mbta/devops/pull/2122

**Asana task**: [Point screens-dev-green at api-dev-blue](https://app.asana.com/0/1185117109217413/1207488840910528/f)