### PR TITLE
fix: Only match v2 screen IDs in v2 controller

### DIFF
--- a/lib/screens_web/controllers/v2/screen_controller.ex
+++ b/lib/screens_web/controllers/v2/screen_controller.ex
@@ -83,7 +83,7 @@ defmodule ScreensWeb.V2.ScreenController do
 
     config = Cache.screen(screen_id)
 
-    if is_struct(config, Screen) do
+    if match?(%Screen{app_id: app_id} when app_id in @recognized_app_ids, config) do
       assigns = get_assigns(params, screen_id, config)
 
       conn


### PR DESCRIPTION
This PR addresses [this](https://mbtace.sentry.io/issues/5758610323/events/1f7281300b7c4299b88dd720971a38fd/) Sentry error. When screen ID is opened with the v2 URL, we don't check that the ID is a v2 screen. This causes v1 IDs to throw a cryptic error when we calculate refresh rates. We should instead return a 404. We could also redirect to the v1 controller but that seems a little heavy handed. 