### PR TITLE
chore: remove bespoke routes-at-stop retry logic

### DIFF
--- a/lib/screens/routes/route.ex
+++ b/lib/screens/routes/route.ex
@@ -1,8 +1,6 @@
 defmodule Screens.Routes.Route do
   @moduledoc false
 
-  require Logger
-
   alias Screens.Routes.Parser
   alias Screens.RouteType
   alias Screens.Stops.Stop
@@ -63,24 +61,8 @@ defmodule Screens.Routes.Route do
 
   @doc "Fetches routes that serve the given stop."
   @spec serving_stop(Stop.id()) :: {:ok, [t()]} | :error
-  def serving_stop(
-        stop_id,
-        get_json_fn \\ &V3Api.get_json/2,
-        attempts_left \\ 3
-      )
-
-  def serving_stop(_stop_id, _get_json_fn, 0), do: :error
-
-  def serving_stop(
-        stop_id,
-        get_json_fn,
-        attempts_left
-      ) do
+  def serving_stop(stop_id, get_json_fn \\ &V3Api.get_json/2) do
     case get_json_fn.("routes", %{"filter[stop]" => stop_id}) do
-      {:ok, %{"data" => []}, _} ->
-        Logger.warning("Route.serving_stop empty_retry attempts_left=#{attempts_left - 1}")
-        serving_stop(stop_id, get_json_fn, attempts_left - 1)
-
       {:ok, %{"data" => data}} ->
         {:ok, Enum.map(data, fn route -> Parser.parse_route(route) end)}
 


### PR DESCRIPTION
Some time ago (36f9f83) we changed this specific data fetching function so it "doesn't trust" the V3 API if it says there are no routes serving a stop, and tries again up to 3 times.

Some more-recent time ago (297c302), as part of a refactor of this function, we added a warning when a retry occurs, so we'd get some idea whether this logic was still useful.

One month later, we have not logged this warning in any deployed environment, so it seems safe to remove.