### PR TITLE
perf: reduce API request volume on DUPs

### DIFF
--- a/lib/screens/routes/route.ex
+++ b/lib/screens/routes/route.ex
@@ -59,10 +59,10 @@ defmodule Screens.Routes.Route do
     end
   end
 
-  @doc "Fetches routes that serve the given stop."
-  @spec serving_stop(Stop.id()) :: {:ok, [t()]} | :error
-  def serving_stop(stop_id, get_json_fn \\ &V3Api.get_json/2) do
-    case get_json_fn.("routes", %{"filter[stop]" => stop_id}) do
+  @doc "Fetches routes that serve the given stops."
+  @spec serving_stops([Stop.id()]) :: {:ok, [t()]} | :error
+  def serving_stops(stop_ids, get_json_fn \\ &V3Api.get_json/2) do
+    case get_json_fn.("routes", %{"filter[stop]" => Enum.join(stop_ids, ",")}) do
       {:ok, %{"data" => data}} ->
         {:ok, Enum.map(data, fn route -> Parser.parse_route(route) end)}
 
@@ -72,7 +72,7 @@ defmodule Screens.Routes.Route do
   end
 
   @doc """
-  Similar to `serving_stop` but also determines whether each route has any scheduled service at
+  Similar to `serving_stops` but also determines whether each route has any scheduled service at
   the given stop on the current day. Only route IDs and the `active?` flag are returned.
   """
   @spec serving_stop_with_active(Stop.id()) ::

--- a/lib/screens/v2/candidate_generator/dup/departures.ex
+++ b/lib/screens/v2/candidate_generator/dup/departures.ex
@@ -28,7 +28,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
         fetch_departures_fn \\ &Departure.fetch/2,
         fetch_alerts_fn \\ &Alert.fetch_or_empty_list/1,
         fetch_schedules_fn \\ &Screens.Schedules.Schedule.fetch/2,
-        fetch_routes_serving_stop_fn \\ &Screens.Routes.Route.serving_stop/1,
+        fetch_routes_serving_stops_fn \\ &Screens.Routes.Route.serving_stops/1,
         fetch_vehicles_fn \\ &Screens.Vehicles.Vehicle.by_route_and_direction/2
       ) do
     primary_departures_instances =
@@ -36,7 +36,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
       |> get_sections_data(
         fetch_departures_fn,
         fetch_alerts_fn,
-        fetch_routes_serving_stop_fn,
+        fetch_routes_serving_stops_fn,
         now
       )
       |> sections_data_to_departure_instances(
@@ -64,7 +64,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
       |> get_sections_data(
         fetch_departures_fn,
         fetch_alerts_fn,
-        fetch_routes_serving_stop_fn,
+        fetch_routes_serving_stops_fn,
         now
       )
       |> sections_data_to_departure_instances(
@@ -208,7 +208,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
          sections,
          fetch_departures_fn,
          fetch_alerts_fn,
-         fetch_routes_serving_stop_fn,
+         fetch_routes_serving_stops_fn,
          now
        ) do
     Screens.Telemetry.span(
@@ -222,7 +222,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
             &1,
             fetch_departures_fn,
             fetch_alerts_fn,
-            fetch_routes_serving_stop_fn,
+            fetch_routes_serving_stops_fn,
             now,
             ctx
           ),
@@ -249,7 +249,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
            section,
          fetch_departures_fn,
          fetch_alerts_fn,
-         fetch_routes_serving_stop_fn,
+         fetch_routes_serving_stops_fn,
          now,
          ctx
        ) do
@@ -257,7 +257,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
       [:screens, :v2, :candidate_generator, :dup, :departures, :get_section_data],
       ctx,
       fn ->
-        routes = get_routes_serving_section(params, fetch_routes_serving_stop_fn)
+        routes = get_routes_serving_section(params, fetch_routes_serving_stops_fn)
         # DUP sections will always show no more than one mode.
         # For subway, each route will have its own section.
         # If the stop is served by two different subway/light rail routes, route_ids must be populated for each section
@@ -634,16 +634,13 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
 
   defp get_routes_serving_section(
          %{route_ids: route_ids, stop_ids: stop_ids},
-         fetch_routes_serving_stop_fn
+         fetch_routes_serving_stops_fn
        ) do
     routes =
-      stop_ids
-      |> Enum.map(&fetch_routes_serving_stop_fn.(&1))
-      |> Enum.flat_map(fn
+      case fetch_routes_serving_stops_fn.(stop_ids) do
         {:ok, routes} -> routes
         :error -> []
-      end)
-      |> Enum.uniq()
+      end
 
     if route_ids == [] do
       routes

--- a/lib/screens/v2/candidate_generator/pre_fare.ex
+++ b/lib/screens/v2/candidate_generator/pre_fare.ex
@@ -93,10 +93,10 @@ defmodule Screens.V2.CandidateGenerator.PreFare do
   def audio_only_instances(
         widgets,
         config,
-        routes_serving_stop_fn \\ &Route.serving_stop/1
+        routes_serving_stops_fn \\ &Route.serving_stops/1
       ) do
     [
-      fn -> content_summary_instances(widgets, config, routes_serving_stop_fn) end,
+      fn -> content_summary_instances(widgets, config, routes_serving_stops_fn) end,
       fn -> alerts_intro_instances(widgets, config) end,
       fn -> alerts_outro_instances(widgets, config) end
     ]
@@ -133,9 +133,9 @@ defmodule Screens.V2.CandidateGenerator.PreFare do
     [%ShuttleBusInfoWidget{screen: config, now: now}]
   end
 
-  defp content_summary_instances(widgets, config, routes_serving_stop_fn) do
-    config.app_params.content_summary.parent_station_id
-    |> routes_serving_stop_fn.()
+  defp content_summary_instances(widgets, config, routes_serving_stops_fn) do
+    [config.app_params.content_summary.parent_station_id]
+    |> routes_serving_stops_fn.()
     |> case do
       {:ok, routes_at_station} ->
         subway_lines_at_station =

--- a/lib/screens/v2/candidate_generator/widgets/elevator_closures.ex
+++ b/lib/screens/v2/candidate_generator/widgets/elevator_closures.ex
@@ -67,7 +67,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ElevatorClosures do
   end
 
   defp routes_serving_stop(stop_id) do
-    case Route.serving_stop(stop_id) do
+    case Route.serving_stops([stop_id]) do
       {:ok, routes} -> routes
       :error -> []
     end

--- a/test/screens/v2/candidate_generator/dup/departures_test.exs
+++ b/test/screens/v2/candidate_generator/dup/departures_test.exs
@@ -250,13 +250,20 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
 
     fetch_vehicles_fn = fn _, _ -> [struct(Vehicle)] end
 
-    fetch_routes_serving_stop_fn = fn
-      "Boat" -> {:ok, [%{id: "Ferry", type: :ferry}]}
-      "place-A" -> {:ok, [%{id: "Orange", type: :subway}, %{id: "Green", type: :light_rail}]}
-      "bus-A" -> {:ok, [%{id: "Bus A", type: :bus}]}
-      "bus-B" -> {:ok, [%{id: "Bus B", type: :bus}]}
-      "place-overnight" -> {:ok, [%{id: "Red", type: :subway}]}
-      _ -> {:ok, [%{id: "test", type: :test}]}
+    fetch_routes_serving_stops_fn = fn stop_ids ->
+      {
+        :ok,
+        stop_ids
+        |> Enum.flat_map(fn
+          "Boat" -> [%{id: "Ferry", type: :ferry}]
+          "place-A" -> [%{id: "Orange", type: :subway}, %{id: "Green", type: :light_rail}]
+          "bus-A" -> [%{id: "Bus A", type: :bus}]
+          "bus-B" -> [%{id: "Bus B", type: :bus}]
+          "place-overnight" -> [%{id: "Red", type: :subway}]
+          _ -> [%{id: "test", type: :test}]
+        end)
+        |> Enum.uniq()
+      }
     end
 
     %{
@@ -264,7 +271,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
       fetch_departures_fn: fetch_departures_fn,
       fetch_alerts_fn: fetch_alerts_fn,
       fetch_schedules_fn: fetch_schedules_fn,
-      fetch_routes_serving_stop_fn: fetch_routes_serving_stop_fn,
+      fetch_routes_serving_stops_fn: fetch_routes_serving_stops_fn,
       fetch_vehicles_fn: fetch_vehicles_fn
     }
   end
@@ -275,7 +282,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
       fetch_departures_fn: fetch_departures_fn,
       fetch_alerts_fn: fetch_alerts_fn,
       fetch_schedules_fn: fetch_schedules_fn,
-      fetch_routes_serving_stop_fn: fetch_routes_serving_stop_fn,
+      fetch_routes_serving_stops_fn: fetch_routes_serving_stops_fn,
       fetch_vehicles_fn: fetch_vehicles_fn
     } do
       config =
@@ -441,7 +448,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
           fetch_departures_fn,
           fetch_alerts_fn,
           fetch_schedules_fn,
-          fetch_routes_serving_stop_fn,
+          fetch_routes_serving_stops_fn,
           fetch_vehicles_fn
         )
 
@@ -453,7 +460,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
       fetch_departures_fn: fetch_departures_fn,
       fetch_alerts_fn: fetch_alerts_fn,
       fetch_schedules_fn: fetch_schedules_fn,
-      fetch_routes_serving_stop_fn: fetch_routes_serving_stop_fn,
+      fetch_routes_serving_stops_fn: fetch_routes_serving_stops_fn,
       fetch_vehicles_fn: fetch_vehicles_fn
     } do
       config =
@@ -624,7 +631,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
           fetch_departures_fn,
           fetch_alerts_fn,
           fetch_schedules_fn,
-          fetch_routes_serving_stop_fn,
+          fetch_routes_serving_stops_fn,
           fetch_vehicles_fn
         )
 
@@ -636,7 +643,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
       fetch_departures_fn: fetch_departures_fn,
       fetch_alerts_fn: fetch_alerts_fn,
       fetch_schedules_fn: fetch_schedules_fn,
-      fetch_routes_serving_stop_fn: fetch_routes_serving_stop_fn,
+      fetch_routes_serving_stops_fn: fetch_routes_serving_stops_fn,
       fetch_vehicles_fn: fetch_vehicles_fn
     } do
       config =
@@ -810,7 +817,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
           fetch_departures_fn,
           fetch_alerts_fn,
           fetch_schedules_fn,
-          fetch_routes_serving_stop_fn,
+          fetch_routes_serving_stops_fn,
           fetch_vehicles_fn
         )
 
@@ -822,7 +829,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
       fetch_departures_fn: fetch_departures_fn,
       fetch_alerts_fn: fetch_alerts_fn,
       fetch_schedules_fn: fetch_schedules_fn,
-      fetch_routes_serving_stop_fn: fetch_routes_serving_stop_fn,
+      fetch_routes_serving_stops_fn: fetch_routes_serving_stops_fn,
       fetch_vehicles_fn: fetch_vehicles_fn
     } do
       config =
@@ -914,7 +921,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
           fetch_departures_fn,
           fetch_alerts_fn,
           fetch_schedules_fn,
-          fetch_routes_serving_stop_fn,
+          fetch_routes_serving_stops_fn,
           fetch_vehicles_fn
         )
 
@@ -926,7 +933,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
       fetch_departures_fn: fetch_departures_fn,
       fetch_alerts_fn: fetch_alerts_fn,
       fetch_schedules_fn: fetch_schedules_fn,
-      fetch_routes_serving_stop_fn: fetch_routes_serving_stop_fn,
+      fetch_routes_serving_stops_fn: fetch_routes_serving_stops_fn,
       fetch_vehicles_fn: fetch_vehicles_fn
     } do
       config =
@@ -1108,7 +1115,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
           fetch_departures_fn,
           fetch_alerts_fn,
           fetch_schedules_fn,
-          fetch_routes_serving_stop_fn,
+          fetch_routes_serving_stops_fn,
           fetch_vehicles_fn
         )
 
@@ -1119,7 +1126,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
       config: config,
       fetch_departures_fn: fetch_departures_fn,
       fetch_schedules_fn: fetch_schedules_fn,
-      fetch_routes_serving_stop_fn: fetch_routes_serving_stop_fn,
+      fetch_routes_serving_stops_fn: fetch_routes_serving_stops_fn,
       fetch_vehicles_fn: fetch_vehicles_fn
     } do
       config =
@@ -1196,7 +1203,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
           fetch_departures_fn,
           fetch_alerts_fn,
           fetch_schedules_fn,
-          fetch_routes_serving_stop_fn,
+          fetch_routes_serving_stops_fn,
           fetch_vehicles_fn
         )
 
@@ -1207,7 +1214,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
       config: config,
       fetch_departures_fn: fetch_departures_fn,
       fetch_schedules_fn: fetch_schedules_fn,
-      fetch_routes_serving_stop_fn: fetch_routes_serving_stop_fn,
+      fetch_routes_serving_stops_fn: fetch_routes_serving_stops_fn,
       fetch_vehicles_fn: fetch_vehicles_fn
     } do
       config =
@@ -1408,7 +1415,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
           fetch_departures_fn,
           fetch_alerts_fn,
           fetch_schedules_fn,
-          fetch_routes_serving_stop_fn,
+          fetch_routes_serving_stops_fn,
           fetch_vehicles_fn
         )
 
@@ -1419,7 +1426,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
       config: config,
       fetch_departures_fn: fetch_departures_fn,
       fetch_schedules_fn: fetch_schedules_fn,
-      fetch_routes_serving_stop_fn: fetch_routes_serving_stop_fn,
+      fetch_routes_serving_stops_fn: fetch_routes_serving_stops_fn,
       fetch_vehicles_fn: fetch_vehicles_fn
     } do
       config =
@@ -1571,7 +1578,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
           fetch_departures_fn,
           fetch_alerts_fn,
           fetch_schedules_fn,
-          fetch_routes_serving_stop_fn,
+          fetch_routes_serving_stops_fn,
           fetch_vehicles_fn
         )
 
@@ -1582,7 +1589,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
       config: config,
       fetch_departures_fn: fetch_departures_fn,
       fetch_schedules_fn: fetch_schedules_fn,
-      fetch_routes_serving_stop_fn: fetch_routes_serving_stop_fn,
+      fetch_routes_serving_stops_fn: fetch_routes_serving_stops_fn,
       fetch_vehicles_fn: fetch_vehicles_fn
     } do
       config =
@@ -1687,7 +1694,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
           fetch_departures_fn,
           fetch_alerts_fn,
           fetch_schedules_fn,
-          fetch_routes_serving_stop_fn,
+          fetch_routes_serving_stops_fn,
           fetch_vehicles_fn
         )
 
@@ -1698,7 +1705,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
       config: config,
       fetch_departures_fn: fetch_departures_fn,
       fetch_alerts_fn: fetch_alerts_fn,
-      fetch_routes_serving_stop_fn: fetch_routes_serving_stop_fn,
+      fetch_routes_serving_stops_fn: fetch_routes_serving_stops_fn,
       fetch_schedules_fn: fetch_schedules_fn,
       fetch_vehicles_fn: fetch_vehicles_fn
     } do
@@ -1815,7 +1822,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
           fetch_departures_fn,
           fetch_alerts_fn,
           fetch_schedules_fn,
-          fetch_routes_serving_stop_fn,
+          fetch_routes_serving_stops_fn,
           fetch_vehicles_fn
         )
 
@@ -1827,7 +1834,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
       fetch_departures_fn: fetch_departures_fn,
       fetch_alerts_fn: fetch_alerts_fn,
       fetch_schedules_fn: fetch_schedules_fn,
-      fetch_routes_serving_stop_fn: fetch_routes_serving_stop_fn,
+      fetch_routes_serving_stops_fn: fetch_routes_serving_stops_fn,
       fetch_vehicles_fn: fetch_vehicles_fn
     } do
       config =
@@ -1858,7 +1865,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
           fetch_departures_fn,
           fetch_alerts_fn,
           fetch_schedules_fn,
-          fetch_routes_serving_stop_fn,
+          fetch_routes_serving_stops_fn,
           fetch_vehicles_fn
         )
 
@@ -1872,7 +1879,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
            config: config,
            fetch_departures_fn: fetch_departures_fn,
            fetch_alerts_fn: fetch_alerts_fn,
-           fetch_routes_serving_stop_fn: fetch_routes_serving_stop_fn,
+           fetch_routes_serving_stops_fn: fetch_routes_serving_stops_fn,
            fetch_vehicles_fn: fetch_vehicles_fn
          } do
       config =
@@ -2000,7 +2007,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
           fetch_departures_fn,
           fetch_alerts_fn,
           fetch_schedules_fn,
-          fetch_routes_serving_stop_fn,
+          fetch_routes_serving_stops_fn,
           fetch_vehicles_fn
         )
 
@@ -2012,7 +2019,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
            config: config,
            fetch_departures_fn: fetch_departures_fn,
            fetch_alerts_fn: fetch_alerts_fn,
-           fetch_routes_serving_stop_fn: fetch_routes_serving_stop_fn,
+           fetch_routes_serving_stops_fn: fetch_routes_serving_stops_fn,
            fetch_vehicles_fn: fetch_vehicles_fn
          } do
       config =
@@ -2133,7 +2140,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
           fetch_departures_fn,
           fetch_alerts_fn,
           fetch_schedules_fn,
-          fetch_routes_serving_stop_fn,
+          fetch_routes_serving_stops_fn,
           fetch_vehicles_fn
         )
 
@@ -2146,7 +2153,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
            config: config,
            fetch_departures_fn: fetch_departures_fn,
            fetch_alerts_fn: fetch_alerts_fn,
-           fetch_routes_serving_stop_fn: fetch_routes_serving_stop_fn,
+           fetch_routes_serving_stops_fn: fetch_routes_serving_stops_fn,
            fetch_vehicles_fn: fetch_vehicles_fn
          } do
       config =
@@ -2212,7 +2219,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
           fetch_departures_fn,
           fetch_alerts_fn,
           fetch_schedules_fn,
-          fetch_routes_serving_stop_fn,
+          fetch_routes_serving_stops_fn,
           fetch_vehicles_fn
         )
 
@@ -2224,7 +2231,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
            config: config,
            fetch_departures_fn: fetch_departures_fn,
            fetch_alerts_fn: fetch_alerts_fn,
-           fetch_routes_serving_stop_fn: fetch_routes_serving_stop_fn,
+           fetch_routes_serving_stops_fn: fetch_routes_serving_stops_fn,
            fetch_vehicles_fn: fetch_vehicles_fn
          } do
       config =
@@ -2283,7 +2290,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
           fetch_departures_fn,
           fetch_alerts_fn,
           fetch_schedules_fn,
-          fetch_routes_serving_stop_fn,
+          fetch_routes_serving_stops_fn,
           fetch_vehicles_fn
         )
 
@@ -2295,7 +2302,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
            config: config,
            fetch_departures_fn: fetch_departures_fn,
            fetch_alerts_fn: fetch_alerts_fn,
-           fetch_routes_serving_stop_fn: fetch_routes_serving_stop_fn,
+           fetch_routes_serving_stops_fn: fetch_routes_serving_stops_fn,
            fetch_vehicles_fn: fetch_vehicles_fn
          } do
       config =
@@ -2392,7 +2399,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
           fetch_departures_fn,
           fetch_alerts_fn,
           fetch_schedules_fn,
-          fetch_routes_serving_stop_fn,
+          fetch_routes_serving_stops_fn,
           fetch_vehicles_fn
         )
 
@@ -2404,7 +2411,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
            config: config,
            fetch_departures_fn: fetch_departures_fn,
            fetch_alerts_fn: fetch_alerts_fn,
-           fetch_routes_serving_stop_fn: fetch_routes_serving_stop_fn,
+           fetch_routes_serving_stops_fn: fetch_routes_serving_stops_fn,
            fetch_vehicles_fn: fetch_vehicles_fn
          } do
       config =
@@ -2452,7 +2459,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
           fetch_departures_fn,
           fetch_alerts_fn,
           fetch_schedules_fn,
-          fetch_routes_serving_stop_fn,
+          fetch_routes_serving_stops_fn,
           fetch_vehicles_fn
         )
 
@@ -2463,7 +2470,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
          %{
            config: config,
            fetch_departures_fn: fetch_departures_fn,
-           fetch_routes_serving_stop_fn: fetch_routes_serving_stop_fn
+           fetch_routes_serving_stops_fn: fetch_routes_serving_stops_fn
          } do
       config =
         config
@@ -2534,7 +2541,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
           fetch_departures_fn,
           fetch_alerts_fn,
           fetch_schedules_fn,
-          fetch_routes_serving_stop_fn,
+          fetch_routes_serving_stops_fn,
           fetch_vehicles_fn
         )
 

--- a/test/screens/v2/candidate_generator/pre_fare_test.exs
+++ b/test/screens/v2/candidate_generator/pre_fare_test.exs
@@ -119,7 +119,7 @@ defmodule Screens.V2.CandidateGenerator.PreFareTest do
          %{config: config} do
       widgets = []
 
-      routes_serving_stop_fn = fn "place-foo" ->
+      routes_serving_stops_fn = fn ["place-foo"] ->
         {:ok, [%{id: "Red"}, %{id: "Green-B"}, %{id: "Green-C"}, %{id: "Blue"}]}
       end
 
@@ -132,7 +132,7 @@ defmodule Screens.V2.CandidateGenerator.PreFareTest do
       assert expected_content_summary in PreFare.audio_only_instances(
                widgets,
                config,
-               routes_serving_stop_fn
+               routes_serving_stops_fn
              )
     end
 
@@ -142,10 +142,10 @@ defmodule Screens.V2.CandidateGenerator.PreFareTest do
          } do
       widgets = []
 
-      routes_serving_stop_fn = fn "place-foo" -> :error end
+      routes_serving_stops_fn = fn ["place-foo"] -> :error end
 
       refute Enum.any?(
-               PreFare.audio_only_instances(widgets, config, routes_serving_stop_fn),
+               PreFare.audio_only_instances(widgets, config, routes_serving_stops_fn),
                &match?(%ContentSummary{}, &1)
              )
     end
@@ -153,10 +153,10 @@ defmodule Screens.V2.CandidateGenerator.PreFareTest do
     test "always returns list containing alerts intro", %{config: config} do
       widgets = []
 
-      routes_serving_stop_fn = fn "place-foo" -> {:ok, []} end
+      routes_serving_stops_fn = fn ["place-foo"] -> {:ok, []} end
 
       assert Enum.any?(
-               PreFare.audio_only_instances(widgets, config, routes_serving_stop_fn),
+               PreFare.audio_only_instances(widgets, config, routes_serving_stops_fn),
                &match?(%AlertsIntro{}, &1)
              )
     end
@@ -164,10 +164,10 @@ defmodule Screens.V2.CandidateGenerator.PreFareTest do
     test "always returns list containing alerts outro", %{config: config} do
       widgets = []
 
-      routes_serving_stop_fn = fn "place-foo" -> {:ok, []} end
+      routes_serving_stops_fn = fn ["place-foo"] -> {:ok, []} end
 
       assert Enum.any?(
-               PreFare.audio_only_instances(widgets, config, routes_serving_stop_fn),
+               PreFare.audio_only_instances(widgets, config, routes_serving_stops_fn),
                &match?(%AlertsOutro{}, &1)
              )
     end


### PR DESCRIPTION
Previously DUPs made one routes-serving-stop API request for every stop ID configured for every section. This may be inefficient given the API supports filtering by many stop IDs in one request, and suspiciously, DUPs configured with more stop IDs seem to encounter the "Failed to get section data" timeout [more often](https://mbtace.sentry.io/issues/5545381601/tags/url/?environment=screens-prod&project=6061747&statsPeriod=14d).

This enhances our routes-serving-stop fetching to support more than one stop ID, and passes in the entire list of stop IDs for each DUP section.