### PR TITLE
refactor: remove unused `shows_alerts?` code

### DIFF
--- a/lib/screens/v2/screen_data/parameters.ex
+++ b/lib/screens/v2/screen_data/parameters.ex
@@ -38,9 +38,6 @@ defmodule Screens.V2.ScreenData.Parameters do
     triptych_v2: 0
   }
 
-  # This list should contain IDs of any apps that __do not__ show any widget that implements `Screens.V2.AlertsWidget`.
-  @apps_that_do_not_show_alerts [:triptych_v2]
-
   @spec get_candidate_generator(ScreensConfig.Screen.t() | atom()) :: candidate_generator()
   def get_candidate_generator(%ScreensConfig.Screen{app_id: app_id}) do
     get_candidate_generator(app_id)
@@ -66,18 +63,6 @@ defmodule Screens.V2.ScreenData.Parameters do
 
   def get_audio_readout_interval(app_id) do
     Map.get(@app_id_to_audio_readout_interval, app_id)
-  end
-
-  @doc """
-  Returns true for screen types that can show any widget that implements `Screens.V2.AlertsWidget`.
-  """
-  @spec shows_alerts?(ScreensConfig.Screen.t() | atom()) :: boolean()
-  def shows_alerts?(%ScreensConfig.Screen{app_id: app_id}) do
-    shows_alerts?(app_id)
-  end
-
-  def shows_alerts?(app_id) do
-    app_id not in @apps_that_do_not_show_alerts
   end
 
   @spec get_audio_interval_offset_seconds(ScreensConfig.Screen.t()) :: pos_integer()


### PR DESCRIPTION
This is now an unused duplicate of logic that was moved into `ScreensConfig.Screen.shows_alerts?`.