### PR TITLE
chore: Update Dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -55,6 +55,12 @@ updates:
           - "@svgr/webpack"
           - "@types/webpack-env"
           - "*-loader"
+          - "terser*"
+      polyfills:
+        patterns:
+          - "core-js*"
+          - "regenerator-runtime"
+          - "whatwg-fetch"
       moment:
         patterns:
           - "moment*"


### PR DESCRIPTION
Saw an open PR for `terser` and realized that was missing from the existing `webpack` group. Also made a group for the three packages imported by `polyfills.js`.