### PR TITLE
fix: Filter out predictions w/ arrival_time but no departure_time.

### DIFF
--- a/lib/screens/v2/departure/builder.ex
+++ b/lib/screens/v2/departure/builder.ex
@@ -17,6 +17,7 @@ defmodule Screens.V2.Departure.Builder do
   def get_relevant_departures(predictions_or_schedules, now \\ DateTime.utc_now()) do
     predictions_or_schedules
     |> Stream.reject(&in_past_or_nil_time?(&1, now))
+    |> Stream.reject(&prediction_has_no_departure_time?/1)
     |> Stream.reject(&multi_route_duplicate?/1)
     |> Stream.reject(&vehicle_already_departed?/1)
     |> choose_earliest_arrival_per_trip()
@@ -57,6 +58,12 @@ defmodule Screens.V2.Departure.Builder do
   end
 
   defp vehicle_already_departed?(_), do: false
+
+  defp prediction_has_no_departure_time?(%Schedule{}), do: false
+
+  defp prediction_has_no_departure_time?(prediction) do
+    prediction.arrival_time != nil and prediction.departure_time == nil
+  end
 
   defp choose_earliest_arrival_per_trip(predictions_or_schedules) do
     {departures_without_trip, departures_with_trip} =

--- a/test/screens/v2/departure/builder_test.exs
+++ b/test/screens/v2/departure/builder_test.exs
@@ -12,6 +12,28 @@ defmodule Screens.V2.Departure.BuilderTest do
 
   describe "get_relevant_departures/1" do
     test "filters out departures with both arrival_time and departure_time nil" do
+      d1 = %Prediction{
+        id: "departure",
+        arrival_time: nil,
+        departure_time: ~U[2020-02-01T01:00:00Z]
+      }
+
+      d2 = %Prediction{
+        id: "both",
+        arrival_time: ~U[2020-02-01T01:00:00Z],
+        departure_time: ~U[2020-02-01T01:00:00Z]
+      }
+
+      d3 = %Prediction{id: "neither", arrival_time: nil, departure_time: nil}
+      departures = [d1, d2, d3]
+
+      now = ~U[2020-01-01T01:00:00Z]
+
+      assert MapSet.new([d1, d2]) ==
+               MapSet.new(Builder.get_relevant_departures(departures, now))
+    end
+
+    test "filters out departures with an arrival_time but no departure_time" do
       d1 = %Prediction{id: "arrival", arrival_time: ~U[2020-02-01T01:00:00Z], departure_time: nil}
 
       d2 = %Prediction{
@@ -26,12 +48,11 @@ defmodule Screens.V2.Departure.BuilderTest do
         departure_time: ~U[2020-02-01T01:00:00Z]
       }
 
-      d4 = %Prediction{id: "neither", arrival_time: nil, departure_time: nil}
-      departures = [d1, d2, d3, d4]
+      departures = [d1, d2, d3]
 
       now = ~U[2020-01-01T01:00:00Z]
 
-      assert MapSet.new([d1, d2, d3]) ==
+      assert MapSet.new([d2, d3]) ==
                MapSet.new(Builder.get_relevant_departures(departures, now))
     end
 


### PR DESCRIPTION
This PR adds additional filtering to predictions returned from the API. When a prediction has an `arrival_time` but no `departure_time`, it is an API best practice to filter it out. 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208058010923825