### PR TITLE
Refactors from RDS generation

### DIFF
--- a/lib/screens/alerts/alert.ex
+++ b/lib/screens/alerts/alert.ex
@@ -5,6 +5,7 @@ defmodule Screens.Alerts.Alert do
   alias Screens.Routes.Route
   alias Screens.RouteType
   alias Screens.Stops.Stop
+  alias Screens.Trips.Trip
   alias Screens.V3Api
 
   defstruct id: nil,
@@ -105,7 +106,7 @@ defmodule Screens.Alerts.Alert do
           stop: String.t() | nil,
           route: String.t() | nil,
           route_type: non_neg_integer() | nil,
-          direction_id: 0 | 1 | nil
+          direction_id: Trip.direction() | nil
         }
 
   @type t :: %__MODULE__{

--- a/lib/screens/departures/departure.ex
+++ b/lib/screens/departures/departure.ex
@@ -32,7 +32,7 @@ defmodule Screens.Departures.Departure do
           route: String.t(),
           route_id: String.t(),
           destination: String.t(),
-          direction_id: 0 | 1 | nil,
+          direction_id: Trip.direction(),
           vehicle_status: String.t(),
           alerts: list(:delay | :snow_route | :last_trip),
           stop_type: :first_stop | :last_stop | :mid_route_stop,
@@ -45,7 +45,7 @@ defmodule Screens.Departures.Departure do
   @type query_params :: %{
           optional(:stop_ids) => list(String.t()),
           optional(:route_ids) => list(String.t()),
-          optional(:direction_id) => 0 | 1 | :both,
+          optional(:direction_id) => Trip.direction() | :both,
           optional(:sort) => String.t(),
           optional(:include) => list(String.t()),
           optional(:date) => String.t(),

--- a/lib/screens/route_patterns/route_pattern.ex
+++ b/lib/screens/route_patterns/route_pattern.ex
@@ -4,24 +4,7 @@ defmodule Screens.RoutePatterns.RoutePattern do
   alias Screens.RoutePatterns
   alias Screens.Routes.Route
   alias Screens.Stops.Stop
-  alias Screens.Trips.Trip
   alias Screens.V3Api
-
-  defstruct id: nil,
-            direction_id: nil,
-            typicality: nil,
-            route_id: nil,
-            representative_trip_id: nil
-
-  @type id :: String.t()
-
-  @type t :: %__MODULE__{
-          id: id,
-          direction_id: 0 | 1,
-          typicality: 1 | 2 | 3 | 4,
-          route_id: Route.id(),
-          representative_trip_id: Trip.id()
-        }
 
   def stops_by_route_and_direction(route_id, direction_id) do
     with {:ok, route_patterns} <-

--- a/lib/screens/routes/route.ex
+++ b/lib/screens/routes/route.ex
@@ -189,4 +189,8 @@ defmodule Screens.Routes.Route do
   def icon(%{type: :ferry}), do: :ferry
   def icon(%{type: :rail}), do: :cr
   def icon(_), do: :bus
+
+  @spec name(t()) :: String.t()
+  def name(%__MODULE__{type: :bus, short_name: short_name}), do: short_name
+  def name(%__MODULE__{long_name: long_name}), do: long_name
 end

--- a/lib/screens/schedules/schedule.ex
+++ b/lib/screens/schedules/schedule.ex
@@ -1,6 +1,8 @@
 defmodule Screens.Schedules.Schedule do
   @moduledoc false
+
   alias Screens.Departures.Departure
+  alias Screens.Trips.Trip
 
   defstruct id: nil,
             trip: nil,
@@ -22,7 +24,7 @@ defmodule Screens.Schedules.Schedule do
           departure_time: DateTime.t() | nil,
           stop_headsign: String.t() | nil,
           track_number: String.t() | nil,
-          direction_id: 0 | 1
+          direction_id: Trip.direction()
         }
 
   @spec fetch(Departure.query_params(), String.t() | nil) :: {:ok, list(t())} | :error

--- a/lib/screens/trips/trip.ex
+++ b/lib/screens/trips/trip.ex
@@ -10,10 +10,11 @@ defmodule Screens.Trips.Trip do
             stops: nil
 
   @type id :: String.t()
+  @type direction :: 0 | 1
 
   @type t :: %__MODULE__{
           id: id,
-          direction_id: 0 | 1 | nil,
+          direction_id: direction(),
           headsign: String.t() | nil,
           route_id: String.t() | nil,
           stops: list(Stop.id())

--- a/lib/screens/v2/candidate_generator/dup/departures.ex
+++ b/lib/screens/v2/candidate_generator/dup/departures.ex
@@ -150,7 +150,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
        ) do
     routes_with_live_departures =
       departures
-      |> Enum.map(&{Departure.route_id(&1), Departure.direction_id(&1)})
+      |> Enum.map(&{Departure.route(&1).id, Departure.direction_id(&1)})
       |> Enum.uniq()
 
     # Check if there is any room for overnight rows before running the logic.

--- a/lib/screens/v2/candidate_generator/widgets/departures.ex
+++ b/lib/screens/v2/candidate_generator/widgets/departures.ex
@@ -181,7 +181,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.Departures do
     with {:ok, departures} <- departure_fetch_fn.(fetch_params, fetch_opts) do
       {:ok,
        departures
-       |> Enum.reject(&(Departure.route_type(&1) in disabled_route_types))
+       |> Enum.reject(&(Departure.route(&1).type in disabled_route_types))
        |> filter_departures(filters, now)
        |> make_bidirectional(is_bidirectional)}
     end
@@ -227,7 +227,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.Departures do
   end
 
   defp route_direction(d) do
-    %RouteDirection{route_id: Departure.route_id(d), direction_id: Departure.direction_id(d)}
+    %RouteDirection{route_id: Departure.route(d).id, direction_id: Departure.direction_id(d)}
   end
 
   # "Bidirectional" mode: take only the first departure, and the next departure in the opposite

--- a/lib/screens/v2/departure.ex
+++ b/lib/screens/v2/departure.ex
@@ -141,41 +141,9 @@ defmodule Screens.V2.Departure do
   def id(%__MODULE__{prediction: %Prediction{id: prediction_id}}), do: prediction_id
   def id(%__MODULE__{schedule: %Schedule{id: schedule_id}}), do: schedule_id
 
-  def route_id(%__MODULE__{prediction: %Prediction{route: %Route{id: route_id}}}) do
-    route_id
-  end
-
-  def route_id(%__MODULE__{prediction: nil, schedule: %Schedule{route: %Route{id: route_id}}}) do
-    route_id
-  end
-
-  def route_name(%__MODULE__{
-        prediction: %Prediction{
-          route: %Route{short_name: short_name, long_name: long_name, type: type}
-        }
-      }) do
-    do_route_name(type, short_name, long_name)
-  end
-
-  def route_name(%__MODULE__{
-        prediction: nil,
-        schedule: %Schedule{
-          route: %Route{short_name: short_name, long_name: long_name, type: type}
-        }
-      }) do
-    do_route_name(type, short_name, long_name)
-  end
-
-  def route_type(%__MODULE__{prediction: %Prediction{route: %Route{type: route_type}}}) do
-    route_type
-  end
-
-  def route_type(%__MODULE__{
-        prediction: nil,
-        schedule: %Schedule{route: %Route{type: route_type}}
-      }) do
-    route_type
-  end
+  @spec route(t()) :: Route.t()
+  def route(%__MODULE__{prediction: %Prediction{route: route}}), do: route
+  def route(%__MODULE__{prediction: nil, schedule: %Schedule{route: route}}), do: route
 
   def scheduled_time(%__MODULE__{schedule: s}) when not is_nil(s) do
     select_arrival_time(s)
@@ -183,13 +151,9 @@ defmodule Screens.V2.Departure do
 
   def scheduled_time(_), do: nil
 
-  def stop_id(%__MODULE__{prediction: %Prediction{stop: %Stop{id: stop_id}}}) do
-    stop_id
-  end
-
-  def stop_id(%__MODULE__{prediction: nil, schedule: %Schedule{stop: %Stop{id: stop_id}}}) do
-    stop_id
-  end
+  @spec stop(t()) :: Stop.t()
+  def stop(%__MODULE__{prediction: %Prediction{stop: stop}}), do: stop
+  def stop(%__MODULE__{prediction: nil, schedule: %Schedule{stop: stop}}), do: stop
 
   def stop_type(%__MODULE__{
         prediction: %Prediction{arrival_time: arrival_time, departure_time: departure_time}
@@ -231,13 +195,6 @@ defmodule Screens.V2.Departure do
   end
 
   def vehicle_status(_), do: nil
-
-  defp do_route_name(type, short_name, long_name) do
-    case type do
-      :bus -> short_name
-      _ -> long_name
-    end
-  end
 
   defp crowding_data_relevant?(%Trip{id: trip_trip_id, stops: [first_stop | _]}, %Vehicle{
          current_status: current_status,

--- a/lib/screens/v2/departure.ex
+++ b/lib/screens/v2/departure.ex
@@ -17,7 +17,7 @@ defmodule Screens.V2.Departure do
   defstruct prediction: nil, schedule: nil
 
   @type params :: %{
-          optional(:direction_id) => :both | 0 | 1,
+          optional(:direction_id) => Trip.direction() | :both,
           optional(:route_ids) => [Route.id()],
           optional(:route_type) => nil | :bus | :ferry | :light_rail | :rail | :subway,
           optional(:stop_ids) => [Stop.id()]

--- a/lib/screens/v2/widget_instance/overnight_cr_departures.ex
+++ b/lib/screens/v2/widget_instance/overnight_cr_departures.ex
@@ -6,6 +6,7 @@ defmodule Screens.V2.WidgetInstance.OvernightCRDepartures do
   @moduledoc false
 
   alias Screens.Schedules.Schedule
+  alias Screens.Trips.Trip
   alias Screens.V2.Departure
   alias Screens.V2.WidgetInstance
 
@@ -19,7 +20,7 @@ defmodule Screens.V2.WidgetInstance.OvernightCRDepartures do
   @type t :: %__MODULE__{
           destination: String.t(),
           last_tomorrow_schedule: Schedule.t(),
-          direction_to_destination: 0 | 1,
+          direction_to_destination: Trip.direction(),
           priority: WidgetInstance.priority(),
           now: DateTime.t()
         }

--- a/lib/screens/vehicles/vehicle.ex
+++ b/lib/screens/vehicles/vehicle.ex
@@ -1,6 +1,7 @@
 defmodule Screens.Vehicles.Vehicle do
   @moduledoc false
 
+  alias Screens.Trips.Trip
   alias Screens.Vehicles.Carriage
 
   defstruct id: nil,
@@ -25,7 +26,7 @@ defmodule Screens.Vehicles.Vehicle do
 
   @type t :: %__MODULE__{
           id: String.t(),
-          direction_id: 0 | 1,
+          direction_id: Trip.direction(),
           current_status: current_status,
           trip_id: Screens.Trips.Trip.id() | nil,
           stop_id: Screens.Stops.Stop.id() | nil,

--- a/test/screens/v2/departure_test.exs
+++ b/test/screens/v2/departure_test.exs
@@ -177,54 +177,20 @@ defmodule Screens.V2.DepartureTest do
     end
   end
 
-  describe "route_id/1" do
-    test "returns prediction route_id when present" do
+  describe "route/1" do
+    test "returns prediction route when present" do
       prediction = %Prediction{route: %Route{id: "28"}}
       schedule = %Schedule{route: %Route{id: "1"}}
       departure = %Departure{prediction: prediction, schedule: schedule}
 
-      assert "28" == Departure.route_id(departure)
+      assert %Route{id: "28"} == Departure.route(departure)
     end
 
-    test "returns schedule route_id when no prediction is present" do
+    test "returns schedule route when no prediction is present" do
       schedule = %Schedule{route: %Route{id: "1"}}
       departure = %Departure{prediction: nil, schedule: schedule}
 
-      assert "1" == Departure.route_id(departure)
-    end
-  end
-
-  describe "route_name/1" do
-    test "returns prediction route short_name when present" do
-      prediction = %Prediction{route: %Route{id: "34E", type: :bus, short_name: "214/216"}}
-      schedule = %Schedule{route: %Route{id: "1", short_name: "1"}}
-      departure = %Departure{prediction: prediction, schedule: schedule}
-
-      assert "214/216" == Departure.route_name(departure)
-    end
-
-    test "returns schedule route short_name when no prediction is present" do
-      schedule = %Schedule{route: %Route{id: "34E", type: :bus, short_name: "214/216"}}
-      departure = %Departure{prediction: nil, schedule: schedule}
-
-      assert "214/216" == Departure.route_name(departure)
-    end
-  end
-
-  describe "route_type/1" do
-    test "returns prediction route_type when present" do
-      prediction = %Prediction{route: %Route{type: :rail}}
-      schedule = %Schedule{route: %Route{type: :subway}}
-      departure = %Departure{prediction: prediction, schedule: schedule}
-
-      assert :rail == Departure.route_type(departure)
-    end
-
-    test "returns schedule route_type when no prediction is present" do
-      schedule = %Schedule{route: %Route{type: :subway}}
-      departure = %Departure{prediction: nil, schedule: schedule}
-
-      assert :subway == Departure.route_type(departure)
+      assert %Route{id: "1"} == Departure.route(departure)
     end
   end
 


### PR DESCRIPTION
Implements the updated ["RDS generation" algorithm](https://www.notion.so/mbta-downtown-crossing/Real-time-departure-states-13dddc816adb43e79a3d952c246b08f7?pvs=4#347394ea5da94f4684ef0580783b09bd) and stubs out a `NoDepartures` state for all RDSes. Rather than doing this specifically "from DUP screen configs", the module accepts a `Departures` widget configuration struct, which is common to all screen types (though DUPs are a little odd in that they have two independent instances of this, for the multiple rotations — some glue logic will be needed in the candidate generator to accommodate this).

Currently this is not connected to anything "real" but will shortly be hooked up to the `new_departures` DUP variant as specified in the dependent Asana task.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207992837169561