### PR TITLE
Initial destinations framework

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -165,6 +165,11 @@ config :screens, Screens.V2.ScreenData,
 
 config :screens, Screens.V2.CandidateGenerator.DupNew, stop_module: Screens.Stops.MockStop
 
+config :screens, Screens.V2.RDS,
+  departure_module: Screens.V2.MockDeparture,
+  route_pattern_module: Screens.RoutePatterns.MockRoutePattern,
+  stop_module: Screens.Stops.MockStop
+
 config :screens, Screens.LastTrip,
   trip_updates_adapter: Screens.LastTrip.TripUpdates.Noop,
   vehicle_positions_adapter: Screens.LastTrip.VehiclePositions.Noop

--- a/lib/screens/departures/departure.ex
+++ b/lib/screens/departures/departure.ex
@@ -336,8 +336,7 @@ defmodule Screens.Departures.Departure do
   end
 
   def do_query_and_parse(%{} = query_params, api_endpoint, parser, extra_params \\ %{}) do
-    default_params = %{sort: "departure_time", include: ~w[route stop trip]}
-
+    default_params = %{sort: "departure_time"}
     all_params = [default_params, query_params, extra_params]
 
     api_query_params =
@@ -348,7 +347,7 @@ defmodule Screens.Departures.Departure do
       |> Enum.into(%{})
 
     case Screens.V3Api.get_json(api_endpoint, api_query_params) do
-      {:ok, result} -> {:ok, parser.parse_result(result)}
+      {:ok, result} -> {:ok, parser.parse(result)}
       _ -> :error
     end
   end

--- a/lib/screens/lines/line.ex
+++ b/lib/screens/lines/line.ex
@@ -1,0 +1,14 @@
+defmodule Screens.Lines.Line do
+  @moduledoc false
+
+  defstruct ~w[id long_name short_name sort_order]a
+
+  @type id :: String.t()
+
+  @type t :: %__MODULE__{
+          id: id(),
+          long_name: String.t(),
+          short_name: String.t(),
+          sort_order: integer()
+        }
+end

--- a/lib/screens/lines/parser.ex
+++ b/lib/screens/lines/parser.ex
@@ -1,0 +1,19 @@
+defmodule Screens.Lines.Parser do
+  @moduledoc false
+
+  def parse_line(%{
+        "id" => id,
+        "attributes" => %{
+          "long_name" => long_name,
+          "short_name" => short_name,
+          "sort_order" => sort_order
+        }
+      }) do
+    %Screens.Lines.Line{
+      id: id,
+      long_name: long_name,
+      short_name: short_name,
+      sort_order: sort_order
+    }
+  end
+end

--- a/lib/screens/predictions/parser.ex
+++ b/lib/screens/predictions/parser.ex
@@ -30,7 +30,7 @@ defmodule Screens.Predictions.Parser do
         },
         included
       ) do
-    trip = included |> Map.fetch!({trip_id, "trip"}) |> Trips.Parser.parse_trip()
+    trip = included |> Map.fetch!({trip_id, "trip"}) |> Trips.Parser.parse_trip(included)
     stop = included |> Map.fetch!({stop_id, "stop"}) |> Stops.Parser.parse_stop()
     route = included |> Map.fetch!({route_id, "route"}) |> Routes.Parser.parse_route(included)
 

--- a/lib/screens/predictions/prediction.ex
+++ b/lib/screens/predictions/prediction.ex
@@ -19,10 +19,10 @@ defmodule Screens.Predictions.Prediction do
 
   @type t :: %__MODULE__{
           id: String.t(),
-          trip: Screens.Trips.Trip.t() | nil,
+          trip: Screens.Trips.Trip.t(),
           stop: Screens.Stops.Stop.t(),
           route: Screens.Routes.Route.t(),
-          vehicle: Screens.Vehicles.Vehicle.t(),
+          vehicle: Screens.Vehicles.Vehicle.t() | nil,
           alerts: list(Screens.Alerts.Alert.t()),
           arrival_time: DateTime.t() | nil,
           departure_time: DateTime.t() | nil,
@@ -38,7 +38,7 @@ defmodule Screens.Predictions.Prediction do
         query_params,
         "predictions",
         Screens.Predictions.Parser,
-        %{include: ~w[route stop trip trip.stops vehicle alerts]}
+        %{include: ~w[alerts route.line stop trip.stops vehicle]}
       )
 
     case predictions do

--- a/lib/screens/predictions/prediction.ex
+++ b/lib/screens/predictions/prediction.ex
@@ -38,7 +38,10 @@ defmodule Screens.Predictions.Prediction do
         query_params,
         "predictions",
         Screens.Predictions.Parser,
-        %{include: ~w[alerts route.line stop trip.stops vehicle]}
+        %{
+          include:
+            ~w[alerts route.line stop trip.route_pattern.representative_trip trip.stops vehicle]
+        }
       )
 
     case predictions do

--- a/lib/screens/route_patterns/parser.ex
+++ b/lib/screens/route_patterns/parser.ex
@@ -33,7 +33,7 @@ defmodule Screens.RoutePatterns.Parser do
       canonical?: canonical?,
       direction_id: direction_id,
       typicality: typicality,
-      route: included |> Map.fetch!({route_id, "route"}) |> Routes.Parser.parse_route(),
+      route: included |> Map.fetch!({route_id, "route"}) |> Routes.Parser.parse_route(included),
       stops:
         included
         |> Map.fetch!({representative_trip_id, "trip"})

--- a/lib/screens/route_patterns/parser.ex
+++ b/lib/screens/route_patterns/parser.ex
@@ -28,25 +28,24 @@ defmodule Screens.RoutePatterns.Parser do
          },
          included
        ) do
+    %{
+      "attributes" => %{"headsign" => headsign},
+      "relationships" => %{"stops" => %{"data" => stop_references}}
+    } = Map.fetch!(included, {representative_trip_id, "trip"})
+
+    stops =
+      Enum.map(stop_references, fn %{"id" => stop_id} ->
+        included |> Map.fetch!({stop_id, "stop"}) |> Stops.Parser.parse_stop()
+      end)
+
     %RoutePattern{
       id: id,
       canonical?: canonical?,
       direction_id: direction_id,
       typicality: typicality,
       route: included |> Map.fetch!({route_id, "route"}) |> Routes.Parser.parse_route(included),
-      stops:
-        included
-        |> Map.fetch!({representative_trip_id, "trip"})
-        |> parse_representative_stops(included)
+      headsign: headsign,
+      stops: stops
     }
-  end
-
-  defp parse_representative_stops(
-         %{"relationships" => %{"stops" => %{"data" => stop_references}}},
-         included
-       ) do
-    Enum.map(stop_references, fn %{"id" => stop_id} ->
-      included |> Map.fetch!({stop_id, "stop"}) |> Stops.Parser.parse_stop()
-    end)
   end
 end

--- a/lib/screens/route_patterns/parser.ex
+++ b/lib/screens/route_patterns/parser.ex
@@ -1,0 +1,52 @@
+defmodule Screens.RoutePatterns.Parser do
+  @moduledoc false
+
+  alias Screens.RoutePatterns.RoutePattern
+  alias Screens.{Routes, Stops}
+
+  def parse(%{"data" => data} = response) do
+    included =
+      response
+      |> Map.get("included", [])
+      |> Map.new(fn %{"id" => id, "type" => type} = resource -> {{id, type}, resource} end)
+
+    Enum.map(data, &parse_route_pattern(&1, included))
+  end
+
+  defp parse_route_pattern(
+         %{
+           "id" => id,
+           "attributes" => %{
+             "canonical" => canonical?,
+             "direction_id" => direction_id,
+             "typicality" => typicality
+           },
+           "relationships" => %{
+             "route" => %{"data" => %{"id" => route_id}},
+             "representative_trip" => %{"data" => %{"id" => representative_trip_id}}
+           }
+         },
+         included
+       ) do
+    %RoutePattern{
+      id: id,
+      canonical?: canonical?,
+      direction_id: direction_id,
+      typicality: typicality,
+      route: included |> Map.fetch!({route_id, "route"}) |> Routes.Parser.parse_route(),
+      stops:
+        included
+        |> Map.fetch!({representative_trip_id, "trip"})
+        |> parse_representative_stops(included)
+    }
+  end
+
+  defp parse_representative_stops(
+         %{"relationships" => %{"stops" => %{"data" => stop_references}}},
+         included
+       ) do
+    Enum.map(stop_references, fn %{"id" => stop_id} ->
+      included |> Map.fetch!({stop_id, "stop"}) |> Stops.Parser.parse_stop()
+    end)
+  end
+end

--- a/lib/screens/route_patterns/route_direction_stops.ex
+++ b/lib/screens/route_patterns/route_direction_stops.ex
@@ -1,4 +1,4 @@
-defmodule Screens.RoutePatterns.Parser do
+defmodule Screens.RoutePatterns.RouteDirectionStops do
   @moduledoc false
 
   require Logger

--- a/lib/screens/route_patterns/route_pattern.ex
+++ b/lib/screens/route_patterns/route_pattern.ex
@@ -42,7 +42,7 @@ defmodule Screens.RoutePatterns.RoutePattern do
       fetch_params
       |> Enum.flat_map(&encode_param/1)
       |> Map.new()
-      |> Map.put("include", Enum.join(~w[route representative_trip.stops], ","))
+      |> Map.put("include", Enum.join(~w[route.line representative_trip.stops], ","))
 
     case get_json_fn.("route_patterns", encoded_params) do
       {:ok, response} ->

--- a/lib/screens/route_patterns/route_pattern.ex
+++ b/lib/screens/route_patterns/route_pattern.ex
@@ -1,11 +1,13 @@
 defmodule Screens.RoutePatterns.RoutePattern do
   @moduledoc false
 
-  alias Screens.RoutePatterns
+  alias Screens.RoutePatterns.RouteDirectionStops
   alias Screens.Routes.Route
   alias Screens.Stops.Stop
+  alias Screens.Trips.Trip
   alias Screens.V3Api
 
+  @spec stops_by_route_and_direction(Route.id(), Trip.direction()) :: {:ok, [Stop.t()]} | :error
   def stops_by_route_and_direction(route_id, direction_id) do
     with {:ok, route_patterns} <-
            V3Api.get_json("route_patterns", %{
@@ -15,7 +17,7 @@ defmodule Screens.RoutePatterns.RoutePattern do
              "include" => "representative_trip.stops"
            }),
          parsed_result when parsed_result != :error <-
-           RoutePatterns.Parser.parse_result(route_patterns, route_id) do
+           RouteDirectionStops.parse_result(route_patterns, route_id) do
       {:ok, parsed_result}
     else
       _ -> :error

--- a/lib/screens/route_patterns/route_pattern.ex
+++ b/lib/screens/route_patterns/route_pattern.ex
@@ -8,7 +8,7 @@ defmodule Screens.RoutePatterns.RoutePattern do
   alias Screens.Trips.Trip
   alias Screens.V3Api
 
-  defstruct ~w[id canonical? direction_id typicality route stops]a
+  defstruct ~w[id canonical? direction_id typicality route headsign stops]a
 
   @type id :: String.t()
   @type typicality :: 1 | 2 | 3 | 4 | 5
@@ -19,6 +19,7 @@ defmodule Screens.RoutePatterns.RoutePattern do
           direction_id: Trip.direction(),
           typicality: typicality(),
           route: Route.t(),
+          headsign: String.t(),
           stops: [Stop.t()]
         }
 

--- a/lib/screens/route_patterns/route_pattern.ex
+++ b/lib/screens/route_patterns/route_pattern.ex
@@ -1,11 +1,71 @@
 defmodule Screens.RoutePatterns.RoutePattern do
   @moduledoc false
 
-  alias Screens.RoutePatterns.RouteDirectionStops
+  alias Screens.RoutePatterns.{Parser, RouteDirectionStops}
   alias Screens.Routes.Route
+  alias Screens.RouteType
   alias Screens.Stops.Stop
   alias Screens.Trips.Trip
   alias Screens.V3Api
+
+  defstruct ~w[id canonical? direction_id typicality route stops]a
+
+  @type id :: String.t()
+  @type typicality :: 1 | 2 | 3 | 4 | 5
+
+  @type t :: %__MODULE__{
+          id: id(),
+          canonical?: boolean(),
+          direction_id: Trip.direction(),
+          typicality: typicality(),
+          route: Route.t(),
+          stops: [Stop.t()]
+        }
+
+  @type params :: %{
+          optional(:canonical?) => boolean(),
+          optional(:date) => Date.t(),
+          optional(:direction_id) => Trip.direction() | :both,
+          optional(:ids) => [id()],
+          optional(:route_ids) => [Route.id()],
+          optional(:route_type) => RouteType.t(),
+          optional(:stop_ids) => [Stop.id()],
+          optional(:typicality) => typicality()
+        }
+
+  @callback fetch(params()) :: {:ok, [t()]} | :error
+  def fetch(params, get_json_fn \\ &V3Api.get_json/2) do
+    # The API doesn't currently have some of these filters built-in
+    {filter_params, fetch_params} = Map.split(params, ~w[route_type typicality]a)
+
+    encoded_params =
+      fetch_params
+      |> Enum.flat_map(&encode_param/1)
+      |> Map.new()
+      |> Map.put("include", Enum.join(~w[route representative_trip.stops], ","))
+
+    case get_json_fn.("route_patterns", encoded_params) do
+      {:ok, response} ->
+        {:ok, Enum.reduce(filter_params, Parser.parse(response), &apply_filter/2)}
+
+      _ ->
+        :error
+    end
+  end
+
+  defp apply_filter({:route_type, type}, patterns),
+    do: Enum.filter(patterns, &(&1.route.type == type))
+
+  defp apply_filter({:typicality, typicality}, patterns),
+    do: Enum.filter(patterns, &(&1.typicality == typicality))
+
+  defp encode_param({:ids, ids}), do: [{"filter[id]", Enum.join(ids, ",")}]
+  defp encode_param({:route_ids, ids}), do: [{"filter[route]", Enum.join(ids, ",")}]
+  defp encode_param({:direction_id, :both}), do: []
+  defp encode_param({:direction_id, id}), do: [{"filter[direction_id]", to_string(id)}]
+  defp encode_param({:stop_ids, ids}), do: [{"filter[stop]", Enum.join(ids, ",")}]
+  defp encode_param({:canonical?, canonical?}), do: [{"filter[canonical]", to_string(canonical?)}]
+  defp encode_param({:date, date}), do: [{"filter[date]", Date.to_iso8601(date)}]
 
   @spec stops_by_route_and_direction(Route.id(), Trip.direction()) :: {:ok, [Stop.t()]} | :error
   def stops_by_route_and_direction(route_id, direction_id) do

--- a/lib/screens/routes/parser.ex
+++ b/lib/screens/routes/parser.ex
@@ -1,21 +1,37 @@
 defmodule Screens.Routes.Parser do
   @moduledoc false
 
-  def parse_route(%{
-        "id" => id,
-        "attributes" => %{
-          "short_name" => short_name,
-          "long_name" => long_name,
-          "direction_destinations" => direction_destinations,
-          "type" => route_type
-        }
-      }) do
-    %Screens.Routes.Route{
+  alias Screens.{Lines, Routes, RouteType}
+
+  def parse(%{"data" => data} = response) do
+    included =
+      response
+      |> Map.get("included", [])
+      |> Map.new(fn %{"id" => id, "type" => type} = resource -> {{id, type}, resource} end)
+
+    Enum.map(data, &parse_route(&1, included))
+  end
+
+  def parse_route(
+        %{
+          "id" => id,
+          "attributes" => %{
+            "short_name" => short_name,
+            "long_name" => long_name,
+            "direction_destinations" => direction_destinations,
+            "type" => route_type
+          },
+          "relationships" => %{"line" => %{"data" => %{"id" => line_id}}}
+        },
+        included
+      ) do
+    %Routes.Route{
       id: id,
       short_name: short_name,
       long_name: long_name,
       direction_destinations: direction_destinations,
-      type: Screens.RouteType.from_id(route_type)
+      type: RouteType.from_id(route_type),
+      line: included |> Map.fetch!({line_id, "line"}) |> Lines.Parser.parse_line()
     }
   end
 end

--- a/lib/screens/schedules/parser.ex
+++ b/lib/screens/schedules/parser.ex
@@ -30,7 +30,7 @@ defmodule Screens.Schedules.Parser do
          },
          included
        ) do
-    trip = included |> Map.fetch!({trip_id, "trip"}) |> Trips.Parser.parse_trip()
+    trip = included |> Map.fetch!({trip_id, "trip"}) |> Trips.Parser.parse_trip(included)
     stop = included |> Map.fetch!({stop_id, "stop"}) |> Stops.Parser.parse_stop()
     route = included |> Map.fetch!({route_id, "route"}) |> Routes.Parser.parse_route(included)
 

--- a/lib/screens/schedules/schedule.ex
+++ b/lib/screens/schedules/schedule.ex
@@ -17,7 +17,7 @@ defmodule Screens.Schedules.Schedule do
 
   @type t :: %__MODULE__{
           id: String.t(),
-          trip: Screens.Trips.Trip.t() | nil,
+          trip: Screens.Trips.Trip.t(),
           stop: Screens.Stops.Stop.t(),
           route: Screens.Routes.Route.t(),
           arrival_time: DateTime.t() | nil,
@@ -36,7 +36,7 @@ defmodule Screens.Schedules.Schedule do
         query_params,
         "schedules",
         Screens.Schedules.Parser,
-        extra_params
+        Map.put(extra_params, :include, ~w[route.line stop trip.stops])
       )
 
     case schedules do

--- a/lib/screens/schedules/schedule.ex
+++ b/lib/screens/schedules/schedule.ex
@@ -36,7 +36,11 @@ defmodule Screens.Schedules.Schedule do
         query_params,
         "schedules",
         Screens.Schedules.Parser,
-        Map.put(extra_params, :include, ~w[route.line stop trip.stops])
+        Map.put(
+          extra_params,
+          :include,
+          ~w[route.line stop trip.route_pattern.representative_trip trip.stops]
+        )
       )
 
     case schedules do

--- a/lib/screens/stops/parser.ex
+++ b/lib/screens/stops/parser.ex
@@ -5,6 +5,7 @@ defmodule Screens.Stops.Parser do
         "id" => id,
         "attributes" => %{
           "name" => name,
+          "location_type" => location_type,
           "platform_code" => platform_code,
           "platform_name" => platform_name
         }
@@ -12,6 +13,7 @@ defmodule Screens.Stops.Parser do
     %Screens.Stops.Stop{
       id: id,
       name: name,
+      location_type: location_type,
       platform_code: platform_code,
       platform_name: platform_name
     }

--- a/lib/screens/trips/trip.ex
+++ b/lib/screens/trips/trip.ex
@@ -3,11 +3,7 @@ defmodule Screens.Trips.Trip do
 
   alias Screens.Stops.Stop
 
-  defstruct id: "",
-            direction_id: nil,
-            headsign: nil,
-            route_id: nil,
-            stops: nil
+  defstruct ~w[id direction_id headsign pattern_headsign route_id stops]a
 
   @type id :: String.t()
   @type direction :: 0 | 1
@@ -15,8 +11,15 @@ defmodule Screens.Trips.Trip do
   @type t :: %__MODULE__{
           id: id,
           direction_id: direction(),
-          headsign: String.t() | nil,
+          headsign: String.t(),
+          pattern_headsign: String.t() | nil,
           route_id: String.t() | nil,
           stops: list(Stop.id()) | nil
         }
+
+  @spec representative_headsign(t()) :: String.t()
+  def representative_headsign(%__MODULE__{pattern_headsign: headsign}) when not is_nil(headsign),
+    do: headsign
+
+  def representative_headsign(%__MODULE__{headsign: headsign}), do: headsign
 end

--- a/lib/screens/trips/trip.ex
+++ b/lib/screens/trips/trip.ex
@@ -17,6 +17,6 @@ defmodule Screens.Trips.Trip do
           direction_id: direction(),
           headsign: String.t() | nil,
           route_id: String.t() | nil,
-          stops: list(Stop.id())
+          stops: list(Stop.id()) | nil
         }
 end

--- a/lib/screens/v2/candidate_generator/dup/departures.ex
+++ b/lib/screens/v2/candidate_generator/dup/departures.ex
@@ -28,7 +28,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
         fetch_departures_fn \\ &Departure.fetch/2,
         fetch_alerts_fn \\ &Alert.fetch_or_empty_list/1,
         fetch_schedules_fn \\ &Screens.Schedules.Schedule.fetch/2,
-        fetch_routes_serving_stops_fn \\ &Screens.Routes.Route.serving_stops/1,
+        fetch_routes_fn \\ &Screens.Routes.Route.fetch/1,
         fetch_vehicles_fn \\ &Screens.Vehicles.Vehicle.by_route_and_direction/2
       ) do
     primary_departures_instances =
@@ -36,7 +36,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
       |> get_sections_data(
         fetch_departures_fn,
         fetch_alerts_fn,
-        fetch_routes_serving_stops_fn,
+        fetch_routes_fn,
         now
       )
       |> sections_data_to_departure_instances(
@@ -64,7 +64,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
       |> get_sections_data(
         fetch_departures_fn,
         fetch_alerts_fn,
-        fetch_routes_serving_stops_fn,
+        fetch_routes_fn,
         now
       )
       |> sections_data_to_departure_instances(
@@ -209,7 +209,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
          sections,
          fetch_departures_fn,
          fetch_alerts_fn,
-         fetch_routes_serving_stops_fn,
+         fetch_routes_fn,
          now
        ) do
     Screens.Telemetry.span(
@@ -223,7 +223,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
             &1,
             fetch_departures_fn,
             fetch_alerts_fn,
-            fetch_routes_serving_stops_fn,
+            fetch_routes_fn,
             now,
             ctx
           ),
@@ -250,7 +250,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
            section,
          fetch_departures_fn,
          fetch_alerts_fn,
-         fetch_routes_serving_stops_fn,
+         fetch_routes_fn,
          now,
          ctx
        ) do
@@ -258,7 +258,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
       [:screens, :v2, :candidate_generator, :dup, :departures, :get_section_data],
       ctx,
       fn ->
-        routes = get_routes_serving_section(params, fetch_routes_serving_stops_fn)
+        routes = get_routes_serving_section(params, fetch_routes_fn)
         # DUP sections will always show no more than one mode.
         # For subway, each route will have its own section.
         # If the stop is served by two different subway/light rail routes, route_ids must be populated for each section
@@ -635,10 +635,10 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
 
   defp get_routes_serving_section(
          %{route_ids: route_ids, stop_ids: stop_ids},
-         fetch_routes_serving_stops_fn
+         fetch_routes_fn
        ) do
     routes =
-      case fetch_routes_serving_stops_fn.(stop_ids) do
+      case fetch_routes_fn.(%{stop_ids: stop_ids}) do
         {:ok, routes} -> routes
         :error -> []
       end

--- a/lib/screens/v2/candidate_generator/pre_fare.ex
+++ b/lib/screens/v2/candidate_generator/pre_fare.ex
@@ -92,10 +92,10 @@ defmodule Screens.V2.CandidateGenerator.PreFare do
   def audio_only_instances(
         widgets,
         config,
-        routes_serving_stops_fn \\ &Route.serving_stops/1
+        routes_fetch_fn \\ &Route.fetch/1
       ) do
     [
-      fn -> content_summary_instances(widgets, config, routes_serving_stops_fn) end,
+      fn -> content_summary_instances(widgets, config, routes_fetch_fn) end,
       fn -> alerts_intro_instances(widgets, config) end,
       fn -> alerts_outro_instances(widgets, config) end
     ]
@@ -132,9 +132,9 @@ defmodule Screens.V2.CandidateGenerator.PreFare do
     [%ShuttleBusInfoWidget{screen: config, now: now}]
   end
 
-  defp content_summary_instances(widgets, config, routes_serving_stops_fn) do
-    [config.app_params.content_summary.parent_station_id]
-    |> routes_serving_stops_fn.()
+  defp content_summary_instances(widgets, config, routes_fetch_fn) do
+    %{stop_id: config.app_params.content_summary.parent_station_id}
+    |> routes_fetch_fn.()
     |> case do
       {:ok, routes_at_station} ->
         subway_lines_at_station =

--- a/lib/screens/v2/candidate_generator/widgets/elevator_closures.ex
+++ b/lib/screens/v2/candidate_generator/widgets/elevator_closures.ex
@@ -67,7 +67,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ElevatorClosures do
   end
 
   defp routes_serving_stop(stop_id) do
-    case Route.serving_stops([stop_id]) do
+    case Route.fetch(%{stop_id: stop_id}) do
       {:ok, routes} -> routes
       :error -> []
     end

--- a/lib/screens/v2/departure.ex
+++ b/lib/screens/v2/departure.ex
@@ -141,6 +141,13 @@ defmodule Screens.V2.Departure do
   def id(%__MODULE__{prediction: %Prediction{id: prediction_id}}), do: prediction_id
   def id(%__MODULE__{schedule: %Schedule{id: schedule_id}}), do: schedule_id
 
+  @spec representative_headsign(t()) :: String.t() | nil
+  def representative_headsign(%__MODULE__{prediction: %Prediction{trip: trip}}),
+    do: Trip.representative_headsign(trip)
+
+  def representative_headsign(%__MODULE__{schedule: %Schedule{trip: trip}}),
+    do: Trip.representative_headsign(trip)
+
   @spec route(t()) :: Route.t()
   def route(%__MODULE__{prediction: %Prediction{route: route}}), do: route
   def route(%__MODULE__{prediction: nil, schedule: %Schedule{route: route}}), do: route

--- a/lib/screens/v2/departure.ex
+++ b/lib/screens/v2/departure.ex
@@ -32,7 +32,7 @@ defmodule Screens.V2.Departure do
 
   @type fetch :: (params(), opts() -> result())
 
-  @spec fetch(params(), opts()) :: result()
+  @callback fetch(params(), opts()) :: result()
   def fetch(params, opts \\ []) do
     # This is equivalent to an argument with a default value, so it's fine
     # credo:disable-for-next-line Screens.Checks.UntestableDateTime

--- a/lib/screens/v2/rds.ex
+++ b/lib/screens/v2/rds.ex
@@ -1,0 +1,107 @@
+defmodule Screens.V2.RDS do
+  @moduledoc """
+  Real-time Destination State. Represents a "destination" a rider could reach (ordinarily or
+  currently) by taking a line from a stop, and the "state" of that destination, in the form of
+  departure countdowns, a headway estimate, a message that service has ended for the day, etc.
+
+  Conceptually, screen configuration is translated into a set of "destinations", each of which is
+  assigned a "state", containing all the data required to present it. These can then be translated
+  into widgets by screen-specific code.
+  """
+
+  alias Screens.Lines.Line
+  alias Screens.RoutePatterns.RoutePattern
+  alias Screens.Routes.Route
+  alias Screens.Stops.Stop
+  alias Screens.V2.Departure
+
+  alias ScreensConfig.V2.Departures
+  alias ScreensConfig.V2.Departures.{Query, Section}
+
+  alias __MODULE__.NoDepartures
+
+  @type t :: %__MODULE__{
+          stop: Stop.t(),
+          line: Line.t(),
+          headsign: String.t(),
+          state: NoDepartures.t()
+        }
+  @enforce_keys ~w[stop line headsign state]a
+  defstruct @enforce_keys
+
+  defmodule NoDepartures do
+    @moduledoc """
+    The fallback state, presented as a headway or "no departures" message. A destination is in
+    this state when A) displaying departures has been manually disabled for the relevant transit
+    mode, or B) there simply aren't any upcoming departures we want to display, and as far as we
+    can tell this is "normal"/expected.
+    """
+    @type t :: %__MODULE__{}
+    defstruct []
+  end
+
+  @departure Application.compile_env(:screens, [__MODULE__, :departure_module], Departure)
+
+  @route_pattern Application.compile_env(
+                   :screens,
+                   [__MODULE__, :route_pattern_module],
+                   RoutePattern
+                 )
+
+  @stop Application.compile_env(:screens, [__MODULE__, :stop_module], Stop)
+
+  @max_departure_minutes 90
+
+  @doc """
+  Generates destinations from departures widget configuration.
+
+  Produces a list of destinations for each configured `Section`, in the same order the sections
+  occur in the config.
+
+  ⚠️ Enforces that every section's query contains at least one ID in `stop_ids`.
+  """
+  @spec get(Departures.t()) :: [[t()]]
+  @spec get(Departures.t(), DateTime.t()) :: [[t()]]
+  def get(%Departures{sections: sections}, now \\ DateTime.utc_now()),
+    do: Enum.map(sections, &from_section(&1, now))
+
+  defp from_section(
+         %Section{query: %Query{params: %Query.Params{stop_ids: stop_ids} = params}},
+         now
+       )
+       when stop_ids != [] do
+    {:ok, child_stops} = @stop.fetch_child_stops(stop_ids)
+    {:ok, typical_patterns} = params |> Map.put(:typicality, 1) |> @route_pattern.fetch()
+    {:ok, departures} = @departure.fetch(params, include_schedules: true, now: now)
+
+    (tuples_from_departures(departures, now) ++
+       tuples_from_patterns(typical_patterns, child_stops))
+    |> Enum.uniq()
+    |> Enum.map(fn {stop, line, headsign} ->
+      %__MODULE__{stop: stop, line: line, headsign: headsign, state: %NoDepartures{}}
+    end)
+  end
+
+  defp tuples_from_departures(departures, now) do
+    departures
+    |> Enum.reject(fn d ->
+      DateTime.diff(Departure.time(d), now, :minute) > @max_departure_minutes
+    end)
+    |> Enum.map(fn d ->
+      {Departure.stop(d), Departure.route(d).line, Departure.representative_headsign(d)}
+    end)
+  end
+
+  defp tuples_from_patterns(route_patterns, child_stops) do
+    stop_ids = child_stops |> List.flatten() |> Enum.map(& &1.id) |> MapSet.new()
+
+    Enum.flat_map(
+      route_patterns,
+      fn %RoutePattern{headsign: headsign, route: %Route{line: line}, stops: stops} ->
+        stops
+        |> Enum.filter(&(&1.id in stop_ids))
+        |> Enum.map(fn stop -> {stop, line, headsign} end)
+      end
+    )
+  end
+end

--- a/test/screens/route_patterns/route_pattern_test.exs
+++ b/test/screens/route_patterns/route_pattern_test.exs
@@ -97,6 +97,7 @@ defmodule Screens.RoutePatterns.RoutePatternTest do
                   "type" => "stop",
                   "attributes" => %{
                     "name" => "Wonderland",
+                    "location_type" => 0,
                     "platform_code" => "1",
                     "platform_name" => "Bowdoin"
                   }
@@ -106,6 +107,7 @@ defmodule Screens.RoutePatterns.RoutePatternTest do
                   "type" => "stop",
                   "attributes" => %{
                     "name" => "Orient Heights",
+                    "location_type" => 0,
                     "platform_code" => nil,
                     "platform_name" => "Bowdoin"
                   }
@@ -115,6 +117,7 @@ defmodule Screens.RoutePatterns.RoutePatternTest do
                   "type" => "stop",
                   "attributes" => %{
                     "name" => "Bowdoin",
+                    "location_type" => 0,
                     "platform_code" => nil,
                     "platform_name" => "Exit Only"
                   }
@@ -143,6 +146,7 @@ defmodule Screens.RoutePatterns.RoutePatternTest do
       bowdoin = %Stop{
         id: "70838",
         name: "Bowdoin",
+        location_type: 0,
         platform_code: nil,
         platform_name: "Exit Only"
       }
@@ -150,6 +154,7 @@ defmodule Screens.RoutePatterns.RoutePatternTest do
       orient_heights = %Stop{
         id: "70051",
         name: "Orient Heights",
+        location_type: 0,
         platform_code: nil,
         platform_name: "Bowdoin"
       }
@@ -157,6 +162,7 @@ defmodule Screens.RoutePatterns.RoutePatternTest do
       wonderland = %Stop{
         id: "70059",
         name: "Wonderland",
+        location_type: 0,
         platform_code: "1",
         platform_name: "Bowdoin"
       }

--- a/test/screens/route_patterns/route_pattern_test.exs
+++ b/test/screens/route_patterns/route_pattern_test.exs
@@ -1,6 +1,7 @@
 defmodule Screens.RoutePatterns.RoutePatternTest do
   use ExUnit.Case, async: true
 
+  alias Screens.Lines.Line
   alias Screens.RoutePatterns.RoutePattern
   alias Screens.Routes.Route
   alias Screens.Stops.Stop
@@ -8,7 +9,7 @@ defmodule Screens.RoutePatterns.RoutePatternTest do
   describe "fetch/2" do
     test "fetches and parses route patterns" do
       get_json_fn =
-        fn "route_patterns", %{"include" => "route,representative_trip.stops"} ->
+        fn "route_patterns", %{"include" => "route.line,representative_trip.stops"} ->
           {
             :ok,
             %{
@@ -51,6 +52,18 @@ defmodule Screens.RoutePatterns.RoutePatternTest do
                     "long_name" => "Blue Line",
                     "short_name" => "",
                     "type" => 1
+                  },
+                  "relationships" => %{
+                    "line" => %{"data" => %{"id" => "line-Blue", "type" => "line"}}
+                  }
+                },
+                %{
+                  "id" => "line-Blue",
+                  "type" => "line",
+                  "attributes" => %{
+                    "long_name" => "Blue Line",
+                    "short_name" => "",
+                    "sort_order" => 0
                   }
                 },
                 %{
@@ -109,12 +122,20 @@ defmodule Screens.RoutePatterns.RoutePatternTest do
           }
         end
 
+      blue_line = %Line{
+        id: "line-Blue",
+        short_name: "",
+        long_name: "Blue Line",
+        sort_order: 0
+      }
+
       blue_route = %Route{
         id: "Blue",
         short_name: "",
         long_name: "Blue Line",
         direction_destinations: ["Bowdoin", "Wonderland"],
-        type: :subway
+        type: :subway,
+        line: blue_line
       }
 
       bowdoin = %Stop{
@@ -162,7 +183,7 @@ defmodule Screens.RoutePatterns.RoutePatternTest do
 
     test "filters by route type or typicality" do
       get_json_fn =
-        fn "route_patterns", %{"include" => "route,representative_trip.stops"} ->
+        fn "route_patterns", %{"include" => "route.line,representative_trip.stops"} ->
           {
             :ok,
             %{
@@ -205,6 +226,18 @@ defmodule Screens.RoutePatterns.RoutePatternTest do
                     "long_name" => "Blue Line",
                     "short_name" => "",
                     "type" => 1
+                  },
+                  "relationships" => %{
+                    "line" => %{"data" => %{"id" => "line-Blue", "type" => "line"}}
+                  }
+                },
+                %{
+                  "id" => "line-Blue",
+                  "type" => "line",
+                  "attributes" => %{
+                    "long_name" => "Blue Line",
+                    "short_name" => "",
+                    "sort_order" => 0
                   }
                 },
                 %{
@@ -215,6 +248,18 @@ defmodule Screens.RoutePatterns.RoutePatternTest do
                     "long_name" => "Harvard Square - Nubian Station",
                     "short_name" => "1",
                     "type" => 3
+                  },
+                  "relationships" => %{
+                    "line" => %{"data" => %{"id" => "line-1", "type" => "line"}}
+                  }
+                },
+                %{
+                  "id" => "line-1",
+                  "type" => "line",
+                  "attributes" => %{
+                    "long_name" => "Harvard - Nubian",
+                    "short_name" => "1",
+                    "sort_order" => 1
                   }
                 },
                 %{

--- a/test/screens/route_patterns/route_pattern_test.exs
+++ b/test/screens/route_patterns/route_pattern_test.exs
@@ -69,6 +69,7 @@ defmodule Screens.RoutePatterns.RoutePatternTest do
                 %{
                   "id" => "canonical-Blue-C1-0",
                   "type" => "trip",
+                  "attributes" => %{"headsign" => "Bowdoin"},
                   "relationships" => %{
                     "stops" => %{
                       "data" => [
@@ -81,6 +82,7 @@ defmodule Screens.RoutePatterns.RoutePatternTest do
                 %{
                   "id" => "65198154",
                   "type" => "trip",
+                  "attributes" => %{"headsign" => "Bowdoin"},
                   "relationships" => %{
                     "stops" => %{
                       "data" => [
@@ -166,6 +168,7 @@ defmodule Screens.RoutePatterns.RoutePatternTest do
           direction_id: 0,
           typicality: 1,
           route: blue_route,
+          headsign: "Bowdoin",
           stops: [wonderland, bowdoin]
         },
         %RoutePattern{
@@ -174,6 +177,7 @@ defmodule Screens.RoutePatterns.RoutePatternTest do
           direction_id: 0,
           typicality: 3,
           route: blue_route,
+          headsign: "Bowdoin",
           stops: [orient_heights, bowdoin]
         }
       ]
@@ -265,11 +269,13 @@ defmodule Screens.RoutePatterns.RoutePatternTest do
                 %{
                   "id" => "trip-blue",
                   "type" => "trip",
+                  "attributes" => %{"headsign" => "Bowdoin"},
                   "relationships" => %{"stops" => %{"data" => []}}
                 },
                 %{
                   "id" => "trip-bus-1",
                   "type" => "trip",
+                  "attributes" => %{"headsign" => "Nubian"},
                   "relationships" => %{"stops" => %{"data" => []}}
                 }
               ]

--- a/test/screens/route_patterns/route_pattern_test.exs
+++ b/test/screens/route_patterns/route_pattern_test.exs
@@ -1,7 +1,244 @@
 defmodule Screens.RoutePatterns.RoutePatternTest do
   use ExUnit.Case, async: true
 
-  import Screens.RoutePatterns.RoutePattern
+  alias Screens.RoutePatterns.RoutePattern
+  alias Screens.Routes.Route
+  alias Screens.Stops.Stop
+
+  describe "fetch/2" do
+    test "fetches and parses route patterns" do
+      get_json_fn =
+        fn "route_patterns", %{"include" => "route,representative_trip.stops"} ->
+          {
+            :ok,
+            %{
+              "data" => [
+                %{
+                  "id" => "Blue-6-0",
+                  "attributes" => %{
+                    "canonical" => true,
+                    "direction_id" => 0,
+                    "typicality" => 1
+                  },
+                  "relationships" => %{
+                    "representative_trip" => %{
+                      "data" => %{"id" => "canonical-Blue-C1-0", "type" => "trip"}
+                    },
+                    "route" => %{"data" => %{"id" => "Blue", "type" => "route"}}
+                  }
+                },
+                %{
+                  "id" => "Blue-8-0",
+                  "attributes" => %{
+                    "canonical" => false,
+                    "direction_id" => 0,
+                    "typicality" => 3
+                  },
+                  "relationships" => %{
+                    "representative_trip" => %{
+                      "data" => %{"id" => "65198154", "type" => "trip"}
+                    },
+                    "route" => %{"data" => %{"id" => "Blue", "type" => "route"}}
+                  }
+                }
+              ],
+              "included" => [
+                %{
+                  "id" => "Blue",
+                  "type" => "route",
+                  "attributes" => %{
+                    "direction_destinations" => ["Bowdoin", "Wonderland"],
+                    "long_name" => "Blue Line",
+                    "short_name" => "",
+                    "type" => 1
+                  }
+                },
+                %{
+                  "id" => "canonical-Blue-C1-0",
+                  "type" => "trip",
+                  "relationships" => %{
+                    "stops" => %{
+                      "data" => [
+                        %{"id" => "70059", "type" => "stop"},
+                        %{"id" => "70838", "type" => "stop"}
+                      ]
+                    }
+                  }
+                },
+                %{
+                  "id" => "65198154",
+                  "type" => "trip",
+                  "relationships" => %{
+                    "stops" => %{
+                      "data" => [
+                        %{"id" => "70051", "type" => "stop"},
+                        %{"id" => "70838", "type" => "stop"}
+                      ]
+                    }
+                  }
+                },
+                %{
+                  "id" => "70059",
+                  "type" => "stop",
+                  "attributes" => %{
+                    "name" => "Wonderland",
+                    "platform_code" => "1",
+                    "platform_name" => "Bowdoin"
+                  }
+                },
+                %{
+                  "id" => "70051",
+                  "type" => "stop",
+                  "attributes" => %{
+                    "name" => "Orient Heights",
+                    "platform_code" => nil,
+                    "platform_name" => "Bowdoin"
+                  }
+                },
+                %{
+                  "id" => "70838",
+                  "type" => "stop",
+                  "attributes" => %{
+                    "name" => "Bowdoin",
+                    "platform_code" => nil,
+                    "platform_name" => "Exit Only"
+                  }
+                }
+              ]
+            }
+          }
+        end
+
+      blue_route = %Route{
+        id: "Blue",
+        short_name: "",
+        long_name: "Blue Line",
+        direction_destinations: ["Bowdoin", "Wonderland"],
+        type: :subway
+      }
+
+      bowdoin = %Stop{
+        id: "70838",
+        name: "Bowdoin",
+        platform_code: nil,
+        platform_name: "Exit Only"
+      }
+
+      orient_heights = %Stop{
+        id: "70051",
+        name: "Orient Heights",
+        platform_code: nil,
+        platform_name: "Bowdoin"
+      }
+
+      wonderland = %Stop{
+        id: "70059",
+        name: "Wonderland",
+        platform_code: "1",
+        platform_name: "Bowdoin"
+      }
+
+      expected = [
+        %RoutePattern{
+          id: "Blue-6-0",
+          canonical?: true,
+          direction_id: 0,
+          typicality: 1,
+          route: blue_route,
+          stops: [wonderland, bowdoin]
+        },
+        %RoutePattern{
+          id: "Blue-8-0",
+          canonical?: false,
+          direction_id: 0,
+          typicality: 3,
+          route: blue_route,
+          stops: [orient_heights, bowdoin]
+        }
+      ]
+
+      assert {:ok, expected} == RoutePattern.fetch(%{}, get_json_fn)
+    end
+
+    test "filters by route type or typicality" do
+      get_json_fn =
+        fn "route_patterns", %{"include" => "route,representative_trip.stops"} ->
+          {
+            :ok,
+            %{
+              "data" => [
+                %{
+                  "id" => "rp-blue",
+                  "attributes" => %{
+                    "canonical" => true,
+                    "direction_id" => 0,
+                    "typicality" => 1
+                  },
+                  "relationships" => %{
+                    "representative_trip" => %{
+                      "data" => %{"id" => "trip-blue", "type" => "trip"}
+                    },
+                    "route" => %{"data" => %{"id" => "Blue", "type" => "route"}}
+                  }
+                },
+                %{
+                  "id" => "rp-bus-1",
+                  "attributes" => %{
+                    "canonical" => false,
+                    "direction_id" => 0,
+                    "typicality" => 3
+                  },
+                  "relationships" => %{
+                    "representative_trip" => %{
+                      "data" => %{"id" => "trip-bus-1", "type" => "trip"}
+                    },
+                    "route" => %{"data" => %{"id" => "1", "type" => "route"}}
+                  }
+                }
+              ],
+              "included" => [
+                %{
+                  "id" => "Blue",
+                  "type" => "route",
+                  "attributes" => %{
+                    "direction_destinations" => ["Bowdoin", "Wonderland"],
+                    "long_name" => "Blue Line",
+                    "short_name" => "",
+                    "type" => 1
+                  }
+                },
+                %{
+                  "id" => "1",
+                  "type" => "route",
+                  "attributes" => %{
+                    "direction_destinations" => ["Harvard Square", "Nubian Station"],
+                    "long_name" => "Harvard Square - Nubian Station",
+                    "short_name" => "1",
+                    "type" => 3
+                  }
+                },
+                %{
+                  "id" => "trip-blue",
+                  "type" => "trip",
+                  "relationships" => %{"stops" => %{"data" => []}}
+                },
+                %{
+                  "id" => "trip-bus-1",
+                  "type" => "trip",
+                  "relationships" => %{"stops" => %{"data" => []}}
+                }
+              ]
+            }
+          }
+        end
+
+      assert {:ok, [%RoutePattern{id: "rp-bus-1"}]} =
+               RoutePattern.fetch(%{route_type: :bus}, get_json_fn)
+
+      assert {:ok, [%RoutePattern{id: "rp-blue"}]} =
+               RoutePattern.fetch(%{typicality: 1}, get_json_fn)
+    end
+  end
 
   describe "fetch_tagged_stop_sequences_through_stop/2" do
     test "returns {:ok, sequences} if fetch function returns {:ok, data}" do
@@ -44,7 +281,7 @@ defmodule Screens.RoutePatterns.RoutePatternTest do
       expected_stop_sequences = %{"route1" => [~w[1 2 3], ~w[3 2 1]], "route2" => [~w[5 6 7]]}
 
       assert {:ok, expected_stop_sequences} ==
-               fetch_tagged_stop_sequences_through_stop(stop_id, [], get_json_fn)
+               RoutePattern.fetch_tagged_stop_sequences_through_stop(stop_id, [], get_json_fn)
     end
 
     test "returns :error if fetch function returns :error" do
@@ -52,7 +289,8 @@ defmodule Screens.RoutePatterns.RoutePatternTest do
 
       get_json_fn = fn _, _ -> :error end
 
-      assert :error == fetch_tagged_stop_sequences_through_stop(stop_id, [], get_json_fn)
+      assert :error ==
+               RoutePattern.fetch_tagged_stop_sequences_through_stop(stop_id, [], get_json_fn)
     end
 
     test "returns filtered list if route_filters is provided" do
@@ -82,7 +320,11 @@ defmodule Screens.RoutePatterns.RoutePatternTest do
       expected_stop_sequences = %{"Orange" => [~w[5 6 7]]}
 
       assert {:ok, expected_stop_sequences} ==
-               fetch_tagged_stop_sequences_through_stop(stop_id, route_filters, get_json_fn)
+               RoutePattern.fetch_tagged_stop_sequences_through_stop(
+                 stop_id,
+                 route_filters,
+                 get_json_fn
+               )
     end
   end
 end

--- a/test/screens/routes/route_test.exs
+++ b/test/screens/routes/route_test.exs
@@ -3,27 +3,47 @@ defmodule Screens.Routes.RouteTest do
 
   import Screens.Routes.Route
 
-  defp route_json(id) do
+  defp response(ids) do
     %{
-      "id" => id,
-      "attributes" => %{
-        "short_name" => nil,
-        "long_name" => nil,
-        "direction_destinations" => nil,
-        "type" => 1
-      }
+      "data" =>
+        Enum.map(
+          ids,
+          &%{
+            "id" => &1,
+            "attributes" => %{
+              "short_name" => nil,
+              "long_name" => nil,
+              "direction_destinations" => nil,
+              "type" => 1
+            },
+            "relationships" => %{"line" => %{"data" => %{"id" => "line-#{&1}", "type" => "line"}}}
+          }
+        ),
+      "included" =>
+        Enum.map(
+          ids,
+          &%{
+            "id" => "line-#{&1}",
+            "type" => "line",
+            "attributes" => %{
+              "short_name" => nil,
+              "long_name" => nil,
+              "sort_order" => 0
+            }
+          }
+        )
     }
   end
 
   describe "fetch/1" do
     test "sets an ID filter" do
-      get_json_fn = fn _, %{"filter[id]" => "1,2,3"} -> {:ok, %{"data" => [route_json("2")]}} end
+      get_json_fn = fn _, %{"filter[id]" => "1,2,3"} -> {:ok, response(~w[2])} end
 
       assert {:ok, [%{id: "2"}]} = fetch(%{ids: ["1", "2", "3"]}, get_json_fn)
     end
 
     test "sets a limit param" do
-      get_json_fn = fn _, %{"page[limit]" => "1"} -> {:ok, %{"data" => [route_json("ABC")]}} end
+      get_json_fn = fn _, %{"page[limit]" => "1"} -> {:ok, response(~w[ABC])} end
 
       assert {:ok, [%{id: "ABC"}]} = fetch(%{limit: 1}, get_json_fn)
     end
@@ -31,8 +51,8 @@ defmodule Screens.Routes.RouteTest do
 
   describe "serving_stop_with_active/3" do
     setup do
-      active_routes = [route_json("22"), route_json("44")]
-      all_routes = [route_json("22"), route_json("29"), route_json("44")]
+      active_routes = response(~w[22 44])
+      all_routes = response(~w[22 29 44])
 
       stop_id = "1265"
       now = ~U[2021-01-01T00:00:00Z]
@@ -44,22 +64,19 @@ defmodule Screens.Routes.RouteTest do
         now: now,
         get_json_fn: fn
           _, %{"filter[stop]" => ^stop_id, "filter[date]" => ^today_iso8601} ->
-            {:ok, %{"data" => active_routes}}
+            {:ok, active_routes}
 
           _, %{"filter[stop]" => ^stop_id} ->
-            {:ok, %{"data" => all_routes}}
+            {:ok, all_routes}
         end,
-        fetch_routes_fn: fn
-          _, _, :subway -> {:ok, []}
-          _, _, _ -> {:ok, [route_json("22"), route_json("29"), route_json("44")]}
-        end,
+        fetch_routes_fn: fn _, _, _ -> {:ok, []} end,
         x_get_json_fn1: fn
           _, %{"filter[stop]" => ^stop_id, "filter[date]" => ^today_iso8601} -> :error
-          _, %{"filter[stop]" => ^stop_id} -> {:ok, %{"data" => all_routes}}
+          _, %{"filter[stop]" => ^stop_id} -> {:ok, all_routes}
         end,
         x_get_json_fn2: fn
           _, %{"filter[stop]" => ^stop_id, "filter[date]" => ^today_iso8601} ->
-            {:ok, %{"data" => active_routes}}
+            {:ok, active_routes}
 
           _, %{"filter[stop]" => ^stop_id} ->
             :error

--- a/test/screens/stops/stop_test.exs
+++ b/test/screens/stops/stop_test.exs
@@ -1,0 +1,55 @@
+defmodule Screens.Stops.StopTest do
+  use ExUnit.Case, async: true
+
+  alias Screens.Stops.Stop
+
+  describe "fetch_child_stops/2" do
+    test "fetches the child stops of the provided stop IDs" do
+      stop_attributes = %{
+        "name" => "test",
+        "location_type" => 0,
+        "platform_code" => "",
+        "platform_name" => ""
+      }
+
+      get_json_fn =
+        fn "stops", %{"filter[id]" => "sX,s1,p1,p2", "include" => "child_stops"} ->
+          {
+            :ok,
+            %{
+              "data" => [
+                # suppose sX doesn't exist
+                %{
+                  "id" => "s1",
+                  "attributes" => stop_attributes,
+                  "relationships" => %{"child_stops" => %{"data" => []}}
+                },
+                %{
+                  "id" => "p1",
+                  "attributes" => Map.put(stop_attributes, "location_type", 1),
+                  "relationships" => %{
+                    "child_stops" => %{"data" => [%{"id" => "c1"}, %{"id" => "c2"}]}
+                  }
+                },
+                %{
+                  "id" => "p2",
+                  "attributes" => Map.put(stop_attributes, "location_type", 1),
+                  "relationships" => %{
+                    "child_stops" => %{"data" => [%{"id" => "c3"}]}
+                  }
+                }
+              ],
+              "included" => [
+                %{"id" => "c1", "attributes" => stop_attributes},
+                %{"id" => "c2", "attributes" => stop_attributes},
+                %{"id" => "c3", "attributes" => stop_attributes}
+              ]
+            }
+          }
+        end
+
+      assert {:ok, [[], [%Stop{id: "s1"}], [%Stop{id: "c1"}, %Stop{id: "c2"}], [%Stop{id: "c3"}]]} =
+               Stop.fetch_child_stops(~w[sX s1 p1 p2], get_json_fn)
+    end
+  end
+end

--- a/test/screens/v2/candidate_generator/dup/departures_test.exs
+++ b/test/screens/v2/candidate_generator/dup/departures_test.exs
@@ -250,7 +250,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
 
     fetch_vehicles_fn = fn _, _ -> [struct(Vehicle)] end
 
-    fetch_routes_serving_stops_fn = fn stop_ids ->
+    fetch_routes_fn = fn %{stop_ids: stop_ids} ->
       {
         :ok,
         stop_ids
@@ -271,7 +271,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
       fetch_departures_fn: fetch_departures_fn,
       fetch_alerts_fn: fetch_alerts_fn,
       fetch_schedules_fn: fetch_schedules_fn,
-      fetch_routes_serving_stops_fn: fetch_routes_serving_stops_fn,
+      fetch_routes_fn: fetch_routes_fn,
       fetch_vehicles_fn: fetch_vehicles_fn
     }
   end
@@ -282,7 +282,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
       fetch_departures_fn: fetch_departures_fn,
       fetch_alerts_fn: fetch_alerts_fn,
       fetch_schedules_fn: fetch_schedules_fn,
-      fetch_routes_serving_stops_fn: fetch_routes_serving_stops_fn,
+      fetch_routes_fn: fetch_routes_fn,
       fetch_vehicles_fn: fetch_vehicles_fn
     } do
       config =
@@ -451,7 +451,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
           fetch_departures_fn,
           fetch_alerts_fn,
           fetch_schedules_fn,
-          fetch_routes_serving_stops_fn,
+          fetch_routes_fn,
           fetch_vehicles_fn
         )
 
@@ -463,7 +463,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
       fetch_departures_fn: fetch_departures_fn,
       fetch_alerts_fn: fetch_alerts_fn,
       fetch_schedules_fn: fetch_schedules_fn,
-      fetch_routes_serving_stops_fn: fetch_routes_serving_stops_fn,
+      fetch_routes_fn: fetch_routes_fn,
       fetch_vehicles_fn: fetch_vehicles_fn
     } do
       config =
@@ -637,7 +637,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
           fetch_departures_fn,
           fetch_alerts_fn,
           fetch_schedules_fn,
-          fetch_routes_serving_stops_fn,
+          fetch_routes_fn,
           fetch_vehicles_fn
         )
 
@@ -649,7 +649,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
       fetch_departures_fn: fetch_departures_fn,
       fetch_alerts_fn: fetch_alerts_fn,
       fetch_schedules_fn: fetch_schedules_fn,
-      fetch_routes_serving_stops_fn: fetch_routes_serving_stops_fn,
+      fetch_routes_fn: fetch_routes_fn,
       fetch_vehicles_fn: fetch_vehicles_fn
     } do
       config =
@@ -826,7 +826,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
           fetch_departures_fn,
           fetch_alerts_fn,
           fetch_schedules_fn,
-          fetch_routes_serving_stops_fn,
+          fetch_routes_fn,
           fetch_vehicles_fn
         )
 
@@ -838,7 +838,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
       fetch_departures_fn: fetch_departures_fn,
       fetch_alerts_fn: fetch_alerts_fn,
       fetch_schedules_fn: fetch_schedules_fn,
-      fetch_routes_serving_stops_fn: fetch_routes_serving_stops_fn,
+      fetch_routes_fn: fetch_routes_fn,
       fetch_vehicles_fn: fetch_vehicles_fn
     } do
       config =
@@ -933,7 +933,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
           fetch_departures_fn,
           fetch_alerts_fn,
           fetch_schedules_fn,
-          fetch_routes_serving_stops_fn,
+          fetch_routes_fn,
           fetch_vehicles_fn
         )
 
@@ -945,7 +945,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
       fetch_departures_fn: fetch_departures_fn,
       fetch_alerts_fn: fetch_alerts_fn,
       fetch_schedules_fn: fetch_schedules_fn,
-      fetch_routes_serving_stops_fn: fetch_routes_serving_stops_fn,
+      fetch_routes_fn: fetch_routes_fn,
       fetch_vehicles_fn: fetch_vehicles_fn
     } do
       config =
@@ -1130,7 +1130,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
           fetch_departures_fn,
           fetch_alerts_fn,
           fetch_schedules_fn,
-          fetch_routes_serving_stops_fn,
+          fetch_routes_fn,
           fetch_vehicles_fn
         )
 
@@ -1141,7 +1141,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
       config: config,
       fetch_departures_fn: fetch_departures_fn,
       fetch_schedules_fn: fetch_schedules_fn,
-      fetch_routes_serving_stops_fn: fetch_routes_serving_stops_fn,
+      fetch_routes_fn: fetch_routes_fn,
       fetch_vehicles_fn: fetch_vehicles_fn
     } do
       config =
@@ -1221,7 +1221,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
           fetch_departures_fn,
           fetch_alerts_fn,
           fetch_schedules_fn,
-          fetch_routes_serving_stops_fn,
+          fetch_routes_fn,
           fetch_vehicles_fn
         )
 
@@ -1232,7 +1232,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
       config: config,
       fetch_departures_fn: fetch_departures_fn,
       fetch_schedules_fn: fetch_schedules_fn,
-      fetch_routes_serving_stops_fn: fetch_routes_serving_stops_fn,
+      fetch_routes_fn: fetch_routes_fn,
       fetch_vehicles_fn: fetch_vehicles_fn
     } do
       config =
@@ -1436,7 +1436,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
           fetch_departures_fn,
           fetch_alerts_fn,
           fetch_schedules_fn,
-          fetch_routes_serving_stops_fn,
+          fetch_routes_fn,
           fetch_vehicles_fn
         )
 
@@ -1447,7 +1447,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
       config: config,
       fetch_departures_fn: fetch_departures_fn,
       fetch_schedules_fn: fetch_schedules_fn,
-      fetch_routes_serving_stops_fn: fetch_routes_serving_stops_fn,
+      fetch_routes_fn: fetch_routes_fn,
       fetch_vehicles_fn: fetch_vehicles_fn
     } do
       config =
@@ -1602,7 +1602,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
           fetch_departures_fn,
           fetch_alerts_fn,
           fetch_schedules_fn,
-          fetch_routes_serving_stops_fn,
+          fetch_routes_fn,
           fetch_vehicles_fn
         )
 
@@ -1613,7 +1613,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
       config: config,
       fetch_departures_fn: fetch_departures_fn,
       fetch_schedules_fn: fetch_schedules_fn,
-      fetch_routes_serving_stops_fn: fetch_routes_serving_stops_fn,
+      fetch_routes_fn: fetch_routes_fn,
       fetch_vehicles_fn: fetch_vehicles_fn
     } do
       config =
@@ -1721,7 +1721,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
           fetch_departures_fn,
           fetch_alerts_fn,
           fetch_schedules_fn,
-          fetch_routes_serving_stops_fn,
+          fetch_routes_fn,
           fetch_vehicles_fn
         )
 
@@ -1732,7 +1732,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
       config: config,
       fetch_departures_fn: fetch_departures_fn,
       fetch_alerts_fn: fetch_alerts_fn,
-      fetch_routes_serving_stops_fn: fetch_routes_serving_stops_fn,
+      fetch_routes_fn: fetch_routes_fn,
       fetch_schedules_fn: fetch_schedules_fn,
       fetch_vehicles_fn: fetch_vehicles_fn
     } do
@@ -1852,7 +1852,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
           fetch_departures_fn,
           fetch_alerts_fn,
           fetch_schedules_fn,
-          fetch_routes_serving_stops_fn,
+          fetch_routes_fn,
           fetch_vehicles_fn
         )
 
@@ -1864,7 +1864,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
       fetch_departures_fn: fetch_departures_fn,
       fetch_alerts_fn: fetch_alerts_fn,
       fetch_schedules_fn: fetch_schedules_fn,
-      fetch_routes_serving_stops_fn: fetch_routes_serving_stops_fn,
+      fetch_routes_fn: fetch_routes_fn,
       fetch_vehicles_fn: fetch_vehicles_fn
     } do
       config =
@@ -1895,7 +1895,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
           fetch_departures_fn,
           fetch_alerts_fn,
           fetch_schedules_fn,
-          fetch_routes_serving_stops_fn,
+          fetch_routes_fn,
           fetch_vehicles_fn
         )
 
@@ -1909,7 +1909,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
            config: config,
            fetch_departures_fn: fetch_departures_fn,
            fetch_alerts_fn: fetch_alerts_fn,
-           fetch_routes_serving_stops_fn: fetch_routes_serving_stops_fn,
+           fetch_routes_fn: fetch_routes_fn,
            fetch_vehicles_fn: fetch_vehicles_fn
          } do
       config =
@@ -2040,7 +2040,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
           fetch_departures_fn,
           fetch_alerts_fn,
           fetch_schedules_fn,
-          fetch_routes_serving_stops_fn,
+          fetch_routes_fn,
           fetch_vehicles_fn
         )
 
@@ -2052,7 +2052,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
            config: config,
            fetch_departures_fn: fetch_departures_fn,
            fetch_alerts_fn: fetch_alerts_fn,
-           fetch_routes_serving_stops_fn: fetch_routes_serving_stops_fn,
+           fetch_routes_fn: fetch_routes_fn,
            fetch_vehicles_fn: fetch_vehicles_fn
          } do
       config =
@@ -2176,7 +2176,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
           fetch_departures_fn,
           fetch_alerts_fn,
           fetch_schedules_fn,
-          fetch_routes_serving_stops_fn,
+          fetch_routes_fn,
           fetch_vehicles_fn
         )
 
@@ -2189,7 +2189,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
            config: config,
            fetch_departures_fn: fetch_departures_fn,
            fetch_alerts_fn: fetch_alerts_fn,
-           fetch_routes_serving_stops_fn: fetch_routes_serving_stops_fn,
+           fetch_routes_fn: fetch_routes_fn,
            fetch_vehicles_fn: fetch_vehicles_fn
          } do
       config =
@@ -2258,7 +2258,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
           fetch_departures_fn,
           fetch_alerts_fn,
           fetch_schedules_fn,
-          fetch_routes_serving_stops_fn,
+          fetch_routes_fn,
           fetch_vehicles_fn
         )
 
@@ -2270,7 +2270,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
            config: config,
            fetch_departures_fn: fetch_departures_fn,
            fetch_alerts_fn: fetch_alerts_fn,
-           fetch_routes_serving_stops_fn: fetch_routes_serving_stops_fn,
+           fetch_routes_fn: fetch_routes_fn,
            fetch_vehicles_fn: fetch_vehicles_fn
          } do
       config =
@@ -2332,7 +2332,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
           fetch_departures_fn,
           fetch_alerts_fn,
           fetch_schedules_fn,
-          fetch_routes_serving_stops_fn,
+          fetch_routes_fn,
           fetch_vehicles_fn
         )
 
@@ -2344,7 +2344,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
            config: config,
            fetch_departures_fn: fetch_departures_fn,
            fetch_alerts_fn: fetch_alerts_fn,
-           fetch_routes_serving_stops_fn: fetch_routes_serving_stops_fn,
+           fetch_routes_fn: fetch_routes_fn,
            fetch_vehicles_fn: fetch_vehicles_fn
          } do
       config =
@@ -2443,7 +2443,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
           fetch_departures_fn,
           fetch_alerts_fn,
           fetch_schedules_fn,
-          fetch_routes_serving_stops_fn,
+          fetch_routes_fn,
           fetch_vehicles_fn
         )
 
@@ -2455,7 +2455,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
            config: config,
            fetch_departures_fn: fetch_departures_fn,
            fetch_alerts_fn: fetch_alerts_fn,
-           fetch_routes_serving_stops_fn: fetch_routes_serving_stops_fn,
+           fetch_routes_fn: fetch_routes_fn,
            fetch_vehicles_fn: fetch_vehicles_fn
          } do
       config =
@@ -2503,7 +2503,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
           fetch_departures_fn,
           fetch_alerts_fn,
           fetch_schedules_fn,
-          fetch_routes_serving_stops_fn,
+          fetch_routes_fn,
           fetch_vehicles_fn
         )
 
@@ -2514,7 +2514,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
          %{
            config: config,
            fetch_departures_fn: fetch_departures_fn,
-           fetch_routes_serving_stops_fn: fetch_routes_serving_stops_fn
+           fetch_routes_fn: fetch_routes_fn
          } do
       config =
         config
@@ -2585,7 +2585,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
           fetch_departures_fn,
           fetch_alerts_fn,
           fetch_schedules_fn,
-          fetch_routes_serving_stops_fn,
+          fetch_routes_fn,
           fetch_vehicles_fn
         )
 

--- a/test/screens/v2/candidate_generator/pre_fare_test.exs
+++ b/test/screens/v2/candidate_generator/pre_fare_test.exs
@@ -119,7 +119,7 @@ defmodule Screens.V2.CandidateGenerator.PreFareTest do
          %{config: config} do
       widgets = []
 
-      routes_serving_stops_fn = fn ["place-foo"] ->
+      routes_fetch_fn = fn %{stop_id: "place-foo"} ->
         {:ok, [%{id: "Red"}, %{id: "Green-B"}, %{id: "Green-C"}, %{id: "Blue"}]}
       end
 
@@ -132,7 +132,7 @@ defmodule Screens.V2.CandidateGenerator.PreFareTest do
       assert expected_content_summary in PreFare.audio_only_instances(
                widgets,
                config,
-               routes_serving_stops_fn
+               routes_fetch_fn
              )
     end
 
@@ -142,10 +142,10 @@ defmodule Screens.V2.CandidateGenerator.PreFareTest do
          } do
       widgets = []
 
-      routes_serving_stops_fn = fn ["place-foo"] -> :error end
+      routes_fetch_fn = fn %{stop_id: "place-foo"} -> :error end
 
       refute Enum.any?(
-               PreFare.audio_only_instances(widgets, config, routes_serving_stops_fn),
+               PreFare.audio_only_instances(widgets, config, routes_fetch_fn),
                &match?(%ContentSummary{}, &1)
              )
     end
@@ -153,10 +153,10 @@ defmodule Screens.V2.CandidateGenerator.PreFareTest do
     test "always returns list containing alerts intro", %{config: config} do
       widgets = []
 
-      routes_serving_stops_fn = fn ["place-foo"] -> {:ok, []} end
+      routes_fetch_fn = fn %{stop_id: "place-foo"} -> {:ok, []} end
 
       assert Enum.any?(
-               PreFare.audio_only_instances(widgets, config, routes_serving_stops_fn),
+               PreFare.audio_only_instances(widgets, config, routes_fetch_fn),
                &match?(%AlertsIntro{}, &1)
              )
     end
@@ -164,10 +164,10 @@ defmodule Screens.V2.CandidateGenerator.PreFareTest do
     test "always returns list containing alerts outro", %{config: config} do
       widgets = []
 
-      routes_serving_stops_fn = fn ["place-foo"] -> {:ok, []} end
+      routes_fetch_fn = fn %{stop_id: "place-foo"} -> {:ok, []} end
 
       assert Enum.any?(
-               PreFare.audio_only_instances(widgets, config, routes_serving_stops_fn),
+               PreFare.audio_only_instances(widgets, config, routes_fetch_fn),
                &match?(%AlertsOutro{}, &1)
              )
     end

--- a/test/screens/v2/rds_test.exs
+++ b/test/screens/v2/rds_test.exs
@@ -1,0 +1,142 @@
+defmodule Screens.V2.RDSTest do
+  use ExUnit.Case, async: true
+
+  alias Screens.Lines.Line
+  alias Screens.Predictions.Prediction
+  alias Screens.RoutePatterns.{MockRoutePattern, RoutePattern}
+  alias Screens.Routes.Route
+  alias Screens.Schedules.Schedule
+  alias Screens.Stops.{MockStop, Stop}
+  alias Screens.Trips.Trip
+  alias Screens.V2.{Departure, MockDeparture}
+  alias Screens.V2.RDS
+  alias ScreensConfig.V2.Departures
+  alias ScreensConfig.V2.Departures.{Query, Section}
+
+  import Mox
+  setup :verify_on_exit!
+
+  describe "get/1" do
+    setup do
+      stub(MockDeparture, :fetch, fn _, _ -> {:ok, []} end)
+      stub(MockRoutePattern, :fetch, fn _ -> {:ok, []} end)
+      stub(MockStop, :fetch_child_stops, fn ids -> {:ok, Enum.map(ids, &[%Stop{id: &1}])} end)
+      :ok
+    end
+
+    defp no_departures(stop_id, line_id, headsign) do
+      %RDS{
+        stop: %Stop{id: stop_id},
+        line: %Line{id: line_id},
+        headsign: headsign,
+        state: %RDS.NoDepartures{}
+      }
+    end
+
+    test "creates destinations from typical route patterns" do
+      stop_ids = ~w[s0 s1]
+
+      expect(MockStop, :fetch_child_stops, fn ^stop_ids ->
+        {:ok, [[%Stop{id: "sA"}, %Stop{id: "sB"}], [%Stop{id: "sC"}]]}
+      end)
+
+      expect(MockRoutePattern, :fetch, fn %{route_type: :bus, stop_ids: ^stop_ids, typicality: 1} ->
+        {:ok,
+         [
+           %RoutePattern{
+             id: "A",
+             headsign: "hA",
+             route: %Route{id: "r1", line: %Line{id: "l1"}},
+             stops: [%Stop{id: "sA"}, %Stop{id: "otherX"}]
+           },
+           %RoutePattern{
+             id: "B",
+             headsign: "hB",
+             route: %Route{id: "r2", line: %Line{id: "l2"}},
+             stops: [%Stop{id: "otherY"}, %Stop{id: "sB"}]
+           },
+           %RoutePattern{
+             id: "C",
+             headsign: "hC",
+             route: %Route{id: "r2", line: %Line{id: "l2"}},
+             stops: [%Stop{id: "sC"}, %Stop{id: "otherZ"}]
+           }
+         ]}
+      end)
+
+      departures = %Departures{
+        sections: [
+          %Section{query: %Query{params: %Query.Params{route_type: :bus, stop_ids: stop_ids}}}
+        ]
+      }
+
+      assert RDS.get(departures) == [
+               [
+                 no_departures("sA", "l1", "hA"),
+                 no_departures("sB", "l2", "hB"),
+                 no_departures("sC", "l2", "hC")
+               ]
+             ]
+    end
+
+    test "creates destinations from upcoming predicted and scheduled departures" do
+      now = ~U[2024-10-11 12:00:00Z]
+
+      expect(MockDeparture, :fetch, fn
+        %{direction_id: 0, route_type: :bus, stop_ids: ["s0"]},
+        [include_schedules: true, now: ^now] ->
+          {
+            :ok,
+            [
+              %Departure{
+                prediction: %Prediction{
+                  departure_time: ~U[2024-10-11 12:30:00Z],
+                  route: %Route{id: "r1", line: %Line{id: "l1"}},
+                  stop: %Stop{id: "s1"},
+                  trip: %Trip{headsign: "other1", pattern_headsign: "h1"}
+                },
+                schedule: nil
+              },
+              %Departure{
+                prediction: nil,
+                schedule: %Schedule{
+                  departure_time: ~U[2024-10-11 13:15:00Z],
+                  route: %Route{id: "r2", line: %Line{id: "l2"}},
+                  stop: %Stop{id: "s2"},
+                  trip: %Trip{headsign: "other2", pattern_headsign: "h2"}
+                }
+              },
+              %Departure{
+                prediction: %Prediction{
+                  # further in the future than the cutoff
+                  departure_time: ~U[2024-10-11 14:00:00Z],
+                  route: %Route{id: "r3", line: %Line{id: "l3"}},
+                  stop: %Stop{id: "s3"},
+                  trip: %Trip{headsign: "other3", pattern_headsign: "h3"}
+                },
+                schedule: nil
+              }
+            ]
+          }
+      end)
+
+      departures = %Departures{
+        sections: [
+          %Section{
+            query: %Query{
+              params: %Query.Params{
+                direction_id: 0,
+                route_type: :bus,
+                stop_ids: ["s0"]
+              }
+            }
+          }
+        ]
+      }
+
+      assert RDS.get(departures, now) == [
+               [no_departures("s1", "l1", "h1"), no_departures("s2", "l2", "h2")]
+             ]
+    end
+  end
+end

--- a/test/support/mocks.ex
+++ b/test/support/mocks.ex
@@ -1,3 +1,5 @@
 Mox.defmock(Screens.Config.MockCache, for: Screens.Config.Cache)
+Mox.defmock(Screens.RoutePatterns.MockRoutePattern, for: Screens.RoutePatterns.RoutePattern)
 Mox.defmock(Screens.Stops.MockStop, for: Screens.Stops.Stop)
+Mox.defmock(Screens.V2.MockDeparture, for: Screens.V2.Departure)
 Mox.defmock(Screens.V2.ScreenData.MockParameters, for: Screens.V2.ScreenData.Parameters)


### PR DESCRIPTION
This adds a module which generates "destinations" from screen configs, the first step in the proposed [real-time destinations](https://www.notion.so/mbta-downtown-crossing/Real-time-destination-states-114f5d8d11ea8077b79cef05225e5725) logic. Both "permanent" (from typical route patterns) and "live" (from upcoming departures) destinations are generated. Initially there is only one possible state for a destination, `NoDepartures`. Following tasks will add more states and wire these into the `DupNew` screen variant.

This required a lot of refactoring and expansion of how we fetch data. Individual commit messages have the explanations of this. 📝

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207992837169561