### PR TITLE
Support Mercury bus e-ink screens

### DIFF
--- a/assets/src/components/admin/inspector.tsx
+++ b/assets/src/components/admin/inspector.tsx
@@ -31,6 +31,7 @@ const SCREEN_TYPES = new Set([
 ]);
 
 const AUDIO_SCREEN_TYPES = new Set([
+  "bus_eink_v2",
   "bus_shelter_v2",
   "busway_v2",
   "gl_eink_v2",

--- a/lib/screens/v2/screen_data/parameters.ex
+++ b/lib/screens/v2/screen_data/parameters.ex
@@ -11,6 +11,7 @@ defmodule Screens.V2.ScreenData.Parameters do
 
   @static_params %{
     bus_eink_v2: %Static{
+      audio_active_time: @all_times,
       candidate_generator: CandidateGenerator.BusEink,
       refresh_rate: 30
     },

--- a/lib/screens/v2/widget_instance/alert.ex
+++ b/lib/screens/v2/widget_instance/alert.ex
@@ -271,7 +271,10 @@ defmodule Screens.V2.WidgetInstance.Alert do
     end
   end
 
-  def audio_valid_candidate?(%__MODULE__{screen: %Screen{app_id: :gl_eink_v2}}), do: true
+  def audio_valid_candidate?(%__MODULE__{screen: %Screen{app_id: app_id}})
+      when app_id in ~w[bus_eink_v2 gl_eink_v2]a,
+      do: true
+
   def audio_valid_candidate?(_instance), do: false
 
   def audio_view(_instance), do: ScreensWeb.V2.Audio.AlertView

--- a/lib/screens/v2/widget_instance/normal_header.ex
+++ b/lib/screens/v2/widget_instance/normal_header.ex
@@ -20,13 +20,7 @@ defmodule Screens.V2.WidgetInstance.NormalHeader do
 
   # Mercury adds their own time so we omit the time in the response.
   # https://app.asana.com/0/1185117109217413/1206070378353406/f
-  def serialize(
-        %__MODULE__{
-          screen: %Screen{vendor: :mercury, app_id: :gl_eink_v2},
-          icon: icon,
-          text: text
-        } = t
-      ) do
+  def serialize(%__MODULE__{screen: %Screen{vendor: :mercury}, icon: icon, text: text} = t) do
     %{icon: icon, text: text, show_to: showing_destination?(t)}
   end
 

--- a/lib/screens/v2/widget_instance/subway_status.ex
+++ b/lib/screens/v2/widget_instance/subway_status.ex
@@ -9,7 +9,7 @@ defmodule Screens.V2.WidgetInstance.SubwayStatus do
   alias Screens.Stops.Stop
   alias Screens.V2.WidgetInstance.SubwayStatus
   alias ScreensConfig.Screen
-  alias ScreensConfig.V2.{Footer, GlEink, PreFare}
+  alias ScreensConfig.V2.{BusEink, Footer, GlEink, PreFare}
 
   defmodule SubwayStatusAlert do
     @moduledoc false
@@ -135,7 +135,7 @@ defmodule Screens.V2.WidgetInstance.SubwayStatus do
     def audio_sort_key(_instance), do: [2]
 
     def audio_valid_candidate?(%{screen: %Screen{app_params: %app{}}})
-        when app in [PreFare, GlEink],
+        when app in [BusEink, GlEink, PreFare],
         do: true
 
     def audio_valid_candidate?(_instance), do: false

--- a/lib/screens_web/controllers/v2/screen_api_controller.ex
+++ b/lib/screens_web/controllers/v2/screen_api_controller.ex
@@ -102,7 +102,7 @@ defmodule ScreensWeb.V2.ScreenApiController do
   end
 
   # Add extra fields used by the Mercury E-ink client
-  defp put_extra_fields(response, screen_id, %Screen{app_id: :gl_eink_v2}) do
+  defp put_extra_fields(response, screen_id, %Screen{vendor: :mercury}) do
     response
     # Used to enable audio readout without additional network requests
     # https://app.asana.com/0/1176097567827729/1205748798471858/f

--- a/test/screens/v2/widget_instance/alert_test.exs
+++ b/test/screens/v2/widget_instance/alert_test.exs
@@ -633,12 +633,12 @@ defmodule Screens.V2.WidgetInstance.AlertTest do
   end
 
   describe "audio_valid_candidate?/1" do
-    test "returns true for gl_eink_v2", %{widget: widget} do
+    test "returns true for eink screen types", %{widget: widget} do
       assert AlertWidget.audio_valid_candidate?(widget)
     end
 
-    test "returns false for screen types != gl_eink_v2", %{widget: widget} do
-      widget = %{widget | screen: %Screen{widget.screen | app_id: :bus_eink_v2}}
+    test "returns false for non-eink screen types", %{widget: widget} do
+      widget = %{widget | screen: %Screen{widget.screen | app_id: :bus_shelter_v2}}
       refute AlertWidget.audio_valid_candidate?(widget)
     end
   end

--- a/test/screens/v2/widget_instance/normal_header_test.exs
+++ b/test/screens/v2/widget_instance/normal_header_test.exs
@@ -20,7 +20,6 @@ defmodule Screens.V2.WidgetInstance.NormalHeaderTest do
       mercury_eink_instance: %WidgetInstance.NormalHeader{
         screen:
           struct(ScreensConfig.Screen, %{
-            app_id: :gl_eink_v2,
             vendor: :mercury,
             app_params: struct(GlEink, %{header: struct(Header.Destination)})
           }),
@@ -38,7 +37,7 @@ defmodule Screens.V2.WidgetInstance.NormalHeaderTest do
   end
 
   describe "serialize/1" do
-    test "does not return time if vendor is Mercury and app is GlEink", %{
+    test "does not return time if vendor is Mercury", %{
       mercury_eink_instance: instance
     } do
       assert %{


### PR DESCRIPTION
We'll soon be setting up our first Bus E-ink screen provided by Mercury. This requires a couple of changes:

* In places we previously had logic to include extra "Mercury fields" when the screen type was `gl_eink`, we should instead key on the `vendor` field.
* Since this new screen will have an audio readout button similar to GL E-ink, the Bus E-ink screen type now needs to support audio.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208343202037657