### PR TITLE
Minor inspector fixes

### DIFF
--- a/assets/src/components/admin/inspector.tsx
+++ b/assets/src/components/admin/inspector.tsx
@@ -382,7 +382,9 @@ const DataControls: ComponentType<{
 };
 
 const AudioControls: ComponentType<{ screen: ScreenWithId }> = ({ screen }) => {
-  const [isPlaying, setIsPlaying] = useState(false);
+  // To bypass browser caching, we add a meaningless query param to the URL of
+  // the <audio> element, based on the timestamp the Play button was clicked.
+  const [playingAt, setPlayingAt] = useState<Date | null>(null);
   const [ssml, setSSML] = useState<string | null>(null);
   const dialogRef = useRef<HTMLDialogElement>(null);
 
@@ -414,9 +416,13 @@ const AudioControls: ComponentType<{ screen: ScreenWithId }> = ({ screen }) => {
               Show SSML
             </button>
 
-            <button onClick={() => setIsPlaying(!isPlaying)}>
-              {isPlaying ? "⏹️ Stop Audio" : "▶️ Play Audio"}
-            </button>
+            {playingAt ? (
+              <button onClick={() => setPlayingAt(null)}>⏹️ Stop Audio</button>
+            ) : (
+              <button onClick={() => setPlayingAt(new Date())}>
+                ▶️ Play Audio
+              </button>
+            )}
           </div>
 
           <dialog className="viewer__modal" ref={dialogRef}>
@@ -429,11 +435,11 @@ const AudioControls: ComponentType<{ screen: ScreenWithId }> = ({ screen }) => {
             <div className="viewer__modal__ssml">{ssml}</div>
           </dialog>
 
-          {isPlaying && (
+          {playingAt && (
             <audio
               autoPlay={true}
-              onEnded={() => setIsPlaying(false)}
-              src={`${audioPath}/readout.mp3`}
+              onEnded={() => setPlayingAt(null)}
+              src={`${audioPath}/readout.mp3?at=${playingAt.getTime()}`}
             />
           )}
         </>

--- a/assets/src/components/admin/inspector.tsx
+++ b/assets/src/components/admin/inspector.tsx
@@ -164,6 +164,10 @@ const ScreenSelector: ComponentType<{
       return groups;
     }, {});
 
+  const selectEntries: [string, ScreenWithId[]][] = Object.entries(
+    screensByType,
+  ).sort(([typeA], [typeB]) => typeA.localeCompare(typeB));
+
   return (
     <fieldset>
       <legend>Screen</legend>
@@ -173,9 +177,9 @@ const ScreenSelector: ComponentType<{
         onChange={(event) => navigateToScreen(event.target.value)}
       >
         <option></option>
-        {Object.keys(screensByType).map((type) => (
+        {selectEntries.map(([type, screens]) => (
           <optgroup label={type} key={type}>
-            {screensByType[type].map(({ id, config: { name } }) => (
+            {screens.map(({ id, config: { name } }) => (
               <option value={id} key={id}>
                 {id}
                 {name ? ` · ${name}` : ""}


### PR DESCRIPTION
Some things I noticed while testing Bus E-ink audio.

* Sort screen type groups in the screen selector (`bus_eink_v2` comes before `dup_v2`, etc.)
* Ensure the audio button always plays "fresh" audio (browser was caching it for subsequent plays)