### PR TITLE
fix: Recon error workaround.

### DIFF
--- a/lib/screens/health.ex
+++ b/lib/screens/health.ex
@@ -81,10 +81,20 @@ defmodule Screens.Health do
   defp process_metrics({pid, name, supervisor}) do
     metrics =
       pid
-      |> :recon.info(@process_metrics)
+      |> safe_recon_info(@process_metrics)
       |> Stream.map(fn {metric, value} -> "#{metric}=#{value}" end)
       |> Enum.intersperse(" ")
 
     {name, supervisor, metrics}
+  end
+
+  # work around https://github.com/ferd/recon/issues/95
+  # The issue is closed but is still very much an issue.
+  @spec safe_recon_info(pid(), [atom()]) ::
+          [] | [{:recon.info_type(), [{:recon.info_key(), term()}]}]
+  defp safe_recon_info(pid, metrics) do
+    :recon.info(pid, metrics)
+  rescue
+    FunctionClauseError -> []
   end
 end

--- a/lib/screens/health.ex
+++ b/lib/screens/health.ex
@@ -89,7 +89,6 @@ defmodule Screens.Health do
   end
 
   # work around https://github.com/ferd/recon/issues/95
-  # The issue is closed but is still very much an issue.
   @spec safe_recon_info(pid(), [atom()]) ::
           [] | [{:recon.info_type(), [{:recon.info_key(), term()}]}]
   defp safe_recon_info(pid, metrics) do


### PR DESCRIPTION
In the first PR, I removed this workaround because the author closed Cora's original [issue](https://github.com/ferd/recon/issues/95). This is definitely still an issue. I deployed the health check on Friday and saw the error occur about 60 times. Want to get this workaround in before deploying the check to prod.