### PR TITLE
use new headway periods

### DIFF
--- a/lib/screens/signs_ui_config/cache.ex
+++ b/lib/screens/signs_ui_config/cache.ex
@@ -9,7 +9,7 @@ defmodule Screens.SignsUiConfig.Cache do
 
   @type table_entry ::
           {{:sign_mode, sign_id :: String.t()}, atom()}
-          | {{:time_ranges, zone_id :: String.t()}, %{off_peak: time_range, peak: time_range}}
+          | {{:time_ranges, zone_id :: String.t()}, %{optional(atom()) => time_range}}
 
   @type time_range :: {low :: integer(), high :: integer()}
 
@@ -17,7 +17,7 @@ defmodule Screens.SignsUiConfig.Cache do
   # Table entries use 2-part tuples as keys, to distinguish sign mode entries from time range entries.
   # They look like:
   # - Sign mode entry: {{:sign_mode, sign_id}, mode}
-  # - Time ranges entry: {{:time_ranges, line_or_trunk}, %{off_peak: {low, high}, peak: {low, high}}}
+  # - Time ranges entry: {{:time_ranges, line_or_trunk}, %{off_peak: {low, high}, peak: {low, high}, saturday: {low, high}, sunday: {low, high}}}
   #
   # To look up the mode that a given sign is in for example, use:
   # [[mode]] = :ets.match(@table, {{:sign_mode, sign_id}, :"$1})

--- a/lib/screens/signs_ui_config/parse.ex
+++ b/lib/screens/signs_ui_config/parse.ex
@@ -12,11 +12,21 @@ defmodule Screens.SignsUiConfig.Parse do
     {sign_modes, time_ranges}
   end
 
-  defp parse_time_ranges(%{"off_peak" => off_peak, "peak" => peak}) do
-    %{off_peak: parse_time_range(off_peak), peak: parse_time_range(peak)}
+  defp parse_time_ranges(map) do
+    for {key, field} <- [
+          off_peak: "off_peak",
+          peak: "peak",
+          saturday: "saturday",
+          sunday: "sunday"
+        ],
+        range = parse_time_range(map[field]),
+        into: %{} do
+      {key, range}
+    end
   end
 
   defp parse_time_range(%{"range_low" => low, "range_high" => high}), do: {low, high}
+  defp parse_time_range(_), do: nil
 
   defp parse_sign_modes(signs) do
     signs

--- a/lib/screens/util.ex
+++ b/lib/screens/util.ex
@@ -8,19 +8,24 @@ defmodule Screens.Util do
     t |> DateTime.truncate(:second) |> DateTime.to_iso8601()
   end
 
-  @spec time_period(DateTime.t()) :: :peak | :off_peak
+  @spec time_period(DateTime.t()) :: :peak | :off_peak | :saturday | :sunday
   def time_period(utc_time) do
     {:ok, dt} = DateTime.shift_zone(utc_time, "America/New_York")
 
-    day_of_week = dt |> DateTime.to_date() |> Date.day_of_week()
-    weekday? = day_of_week in 1..5
+    # Subtract 3 hours, since the service day ends at 3 AM
+    day_of_week = DateTime.add(dt, -3, :hour) |> Date.day_of_week()
 
     t = {dt.hour, dt.minute}
     am_rush? = t >= {7, 0} and t < {9, 0}
     pm_rush? = t >= {16, 0} and t <= {18, 30}
     rush_hour? = am_rush? or pm_rush?
 
-    if(weekday? and rush_hour?, do: :peak, else: :off_peak)
+    case {day_of_week, rush_hour?} do
+      {6, _} -> :saturday
+      {7, _} -> :sunday
+      {_, true} -> :peak
+      {_, false} -> :off_peak
+    end
   end
 
   @doc """

--- a/lib/screens/util.ex
+++ b/lib/screens/util.ex
@@ -13,7 +13,7 @@ defmodule Screens.Util do
     {:ok, dt} = DateTime.shift_zone(utc_time, "America/New_York")
 
     # Subtract 3 hours, since the service day ends at 3 AM
-    day_of_week = DateTime.add(dt, -3, :hour) |> Date.day_of_week()
+    day_of_week = dt |> DateTime.add(-3, :hour) |> Date.day_of_week()
 
     t = {dt.hour, dt.minute}
     am_rush? = t >= {7, 0} and t < {9, 0}

--- a/test/screens/util_test.exs
+++ b/test/screens/util_test.exs
@@ -117,4 +117,12 @@ defmodule Screens.UtilTest do
       assert expected == get_service_date_today(now)
     end
   end
+
+  test "time_period" do
+    tz = "America/New_York"
+    assert DateTime.new!(~D[2020-03-20], ~T[18:00:00], tz) |> time_period() == :peak
+    assert DateTime.new!(~D[2020-03-21], ~T[02:00:00], tz) |> time_period() == :off_peak
+    assert DateTime.new!(~D[2020-03-21], ~T[08:00:00], tz) |> time_period() == :saturday
+    assert DateTime.new!(~D[2020-03-22], ~T[12:00:00], tz) |> time_period() == :sunday
+  end
 end


### PR DESCRIPTION
**Asana task**: [Change Screens to read these new values, handle appropriately](https://app.asana.com/0/1185117109217413/1208512927678682/f)

Description

This changes screens to use the new headway values, as outlined in the ticket. Also changes the parsing method slightly so that it's resilient to missing or unexpected values.