### PR TITLE
fix: Incorrect types for TimeRepresentation

### DIFF
--- a/assets/src/components/v2/cr_departures/cr_departure_time.tsx
+++ b/assets/src/components/v2/cr_departures/cr_departure_time.tsx
@@ -4,20 +4,20 @@ import { TimeRepresentation } from "Util/time_representation";
 import LiveDataSvg from "Images/svgr_bundled/live-data-small.svg";
 
 const baseDepartureTime = (time: TimeRepresentation): JSX.Element | null => {
-  if (time.type === "TEXT") {
+  if (time.type === "text") {
     return (
       <div className="base-departure-time">
         <span className="base-departure-time__text">{time.text}</span>
       </div>
     );
-  } else if (time.type === "MINUTES") {
+  } else if (time.type === "minutes") {
     return (
       <div className="base-departure-time">
         <span className="base-departure-time__minutes">{time.minutes}</span>
         <span className="base-departure-time__minutes-label">m</span>
       </div>
     );
-  } else if (time.type === "TIMESTAMP") {
+  } else if (time.type === "timestamp") {
     return (
       <div className="base-departure-time">
         <span className="base-departure-time__timestamp">{time.timestamp}</span>

--- a/assets/src/util/time_representation.tsx
+++ b/assets/src/util/time_representation.tsx
@@ -4,20 +4,20 @@ import "moment-timezone";
 moment.tz.setDefault("America/New_York");
 
 export type TimeRepresentation =
-  | { type: "TEXT"; text: string }
-  | { type: "MINUTES"; minutes: number }
-  | { type: "TIMESTAMP"; timestamp: string; ampm: string };
+  | { type: "text"; text: string }
+  | { type: "minutes"; minutes: number }
+  | { type: "timestamp"; timestamp: string; ampm: string };
 
 export const timeRepresentationsEqual = (rep1, rep2) => {
   if (!rep1 || !rep2) {
     return false;
   } else if (rep1.type !== rep2.type) {
     return false;
-  } else if (rep1.type === "TIMESTAMP") {
+  } else if (rep1.type === "timestamp") {
     return rep1.ampm === rep2.ampm && rep1.timestamp === rep2.timestamp;
-  } else if (rep1.type === "MINUTES") {
+  } else if (rep1.type === "minutes") {
     return rep1.minutes === rep2.minutes;
-  } else if (rep1.type === "TEXT") {
+  } else if (rep1.type === "text") {
     return rep1.text === rep2.text;
   }
 
@@ -39,25 +39,25 @@ export const standardTimeRepresentation = (
 
   if (!forceTimestamp) {
     if (vehicleStatus === "stopped_at" && secondDifference <= 90) {
-      return { type: "TEXT", text: "BRD" };
+      return { type: "text", text: "BRD" };
     }
 
     if (secondDifference <= 30) {
       if (stopType === "first_stop") {
-        return { type: "TEXT", text: "BRD" };
+        return { type: "text", text: "BRD" };
       }
-      return { type: "TEXT", text: "ARR" };
+      return { type: "text", text: "ARR" };
     }
 
     if (minuteDifference < 60 && !noMinutes) {
-      return { type: "MINUTES", minutes: minuteDifference };
+      return { type: "minutes", minutes: minuteDifference };
     }
   }
 
   const timestamp = departureTime.format("h:mm");
   const ampm = departureTime.format("A");
   return {
-    type: "TIMESTAMP",
+    type: "timestamp",
     timestamp,
     ampm,
   };
@@ -73,14 +73,14 @@ export const einkTimeRepresentation = (
   const minuteDifference = Math.round(secondDifference / 60);
 
   if (secondDifference < 60) {
-    return { type: "TEXT", text: "Now" };
+    return { type: "text", text: "Now" };
   } else if (minuteDifference < 60) {
-    return { type: "MINUTES", minutes: minuteDifference };
+    return { type: "minutes", minutes: minuteDifference };
   } else {
     const timestamp = departureTime.format("h:mm");
     const ampm = departureTime.format("A");
     return {
-      type: "TIMESTAMP",
+      type: "timestamp",
       timestamp,
       ampm,
     };


### PR DESCRIPTION
The `type` value we send to the client is always a lowercase atom converted to a string. For some reason, the client code was looking for an uppercase version of each value. This was causing the `div` that holds the time to be empty.

Before:
![Screenshot 2024-11-04 at 8 17 49 AM](https://github.com/user-attachments/assets/afd3aa19-994d-4704-84fa-4d634b1c4b21)


After:
![Screenshot 2024-11-04 at 8 33 53 AM](https://github.com/user-attachments/assets/76ff6829-fa02-44d8-8996-c5a16fde9023)


