### PR TITLE
refactor: namespace GL E-ink headways module

### DIFF
--- a/lib/screens/stops/stop.ex
+++ b/lib/screens/stops/stop.ex
@@ -282,17 +282,6 @@ defmodule Screens.Stops.Stop do
     end)
   end
 
-  def fetch_parent_stop_id(stop_id) do
-    case Screens.V3Api.get_json("stops/" <> stop_id, %{"include" => "parent_station"}) do
-      {:ok, %{"included" => [included_data]}} ->
-        %{"id" => parent_station_id} = included_data
-        parent_station_id
-
-      _ ->
-        nil
-    end
-  end
-
   def fetch_subway_platforms_for_stop(stop_id) do
     case Screens.V3Api.get_json("stops/" <> stop_id, %{"include" => "child_stops"}) do
       {:ok, %{"included" => child_stop_data}} ->

--- a/lib/screens/v2/candidate_generator/gl_eink.ex
+++ b/lib/screens/v2/candidate_generator/gl_eink.ex
@@ -224,7 +224,7 @@ defmodule Screens.V2.CandidateGenerator.GlEink do
   defp format_headway(route_id, stop_id, direction_id, departures_to_concat \\ []) do
     destination = fetch_destination(route_id, direction_id)
 
-    case Screens.Headways.by_route_id(route_id, stop_id, direction_id, nil) do
+    case __MODULE__.Headways.by_route_id(route_id, stop_id, direction_id, nil) do
       nil ->
         :overnight
 

--- a/lib/screens/v2/candidate_generator/gl_eink/headways.ex
+++ b/lib/screens/v2/candidate_generator/gl_eink/headways.ex
@@ -1,4 +1,4 @@
-defmodule Screens.Headways do
+defmodule Screens.V2.CandidateGenerator.GlEink.Headways do
   @moduledoc false
 
   alias Screens.Schedules.Schedule


### PR DESCRIPTION
This frees up the base `Headways` module name for use by a new system based on the OIO-controlled headway values in Signs UI. The plan is for this to eventually be used by all screen types, including GL E-ink, as part of the new "destinations" logic.