### PR TITLE
fix: keep `inline_alerts` field for compatibility

### DIFF
--- a/lib/screens/v2/widget_instance/departures.ex
+++ b/lib/screens/v2/widget_instance/departures.ex
@@ -328,7 +328,9 @@ defmodule Screens.V2.WidgetInstance.Departures do
       type: :departure_row,
       route: serialize_route(departures, route_pill_serializer),
       headsign: serialize_headsign(departures, screen),
-      times_with_crowding: serialize_times_with_crowding(departures, screen, now)
+      times_with_crowding: serialize_times_with_crowding(departures, screen, now),
+      # Temporarily retained for compatibility with deployed clients that expect this field
+      inline_alerts: []
     }
   end
 

--- a/test/screens/v2/departure_test.exs
+++ b/test/screens/v2/departure_test.exs
@@ -1,7 +1,6 @@
 defmodule Screens.V2.DepartureTest do
   use ExUnit.Case, async: true
 
-  alias Screens.Alerts.Alert
   alias Screens.Routes.Route
   alias Screens.Predictions.Prediction
   alias Screens.Schedules.Schedule

--- a/test/screens/v2/widget_instance/departures_test.exs
+++ b/test/screens/v2/widget_instance/departures_test.exs
@@ -1,7 +1,6 @@
 defmodule Screens.V2.WidgetInstance.DeparturesTest do
   use ExUnit.Case, async: true
 
-  alias Screens.Alerts.Alert
   alias ScreensConfig.V2.Departures.Header
   alias ScreensConfig.V2.Departures.Layout
   alias ScreensConfig.V2.FreeTextLine


### PR DESCRIPTION
Currently deployed client code (in particular DUPs, which have to be updated manually by sending a new package to our vendor) requires this field to be present or it will crash.