### PR TITLE
temp: Force client logging through server

### DIFF
--- a/assets/src/components/v2/screen_page.tsx
+++ b/assets/src/components/v2/screen_page.tsx
@@ -1,7 +1,9 @@
-import React from "react";
+import React, { Fragment } from "react";
 import { useParams } from "react-router-dom";
 import ScreenContainer from "Components/v2/screen_container";
 import { ScreenIDProvider } from "Hooks/v2/use_screen_id";
+import WidgetTreeErrorBoundary from "Components/v2/widget_tree_error_boundary";
+import { isDup } from "Util/outfront";
 
 interface Props {
   id?: string;
@@ -9,9 +11,13 @@ interface Props {
 
 const ScreenPage = ({ id }: Props) => {
   const screenId = id ?? (useParams() as { id: string }).id;
+  const ErrorBoundaryOrFragment = isDup() ? Fragment : WidgetTreeErrorBoundary;
+
   return (
     <ScreenIDProvider id={screenId}>
-      <ScreenContainer id={screenId} />
+      <ErrorBoundaryOrFragment>
+        <ScreenContainer id={screenId} />
+      </ErrorBoundaryOrFragment>
     </ScreenIDProvider>
   );
 };

--- a/assets/src/components/v2/widget_tree_error_boundary.tsx
+++ b/assets/src/components/v2/widget_tree_error_boundary.tsx
@@ -67,7 +67,7 @@ class WidgetTreeErrorBoundary extends React.Component<Props, State> {
 
     if (!getDataset().sentry) {
       // Log via the server. (to Splunk, at time of writing.)
-      fetch("/v2/api/screen/log_frontend_error", {
+      fetch("/v2/api/logging/log_frontend_error", {
         method: "POST",
         headers: {
           "content-type": "application/json",


### PR DESCRIPTION
Client logging through Sentry is not working at the moment. I think this is because the screen is crashing before we add the error boundary. We can keep the current one where it is but also added it a little earlier in hopes that bus e-ink will log something.