### PR TITLE
feat: Elevator evergreen content

### DIFF
--- a/assets/css/elevator_v2.scss
+++ b/assets/css/elevator_v2.scss
@@ -9,6 +9,12 @@
 @import "v2/elevator/footer";
 @import "v2/lcd_common/route_pill";
 
+.evergreen-content-image__container,
+.evergreen-content-image__image {
+  width: 100%;
+  height: 100%;
+}
+
 body {
   margin: 0;
   font-family: Inter;

--- a/lib/screens/v2/candidate_generator/elevator.ex
+++ b/lib/screens/v2/candidate_generator/elevator.ex
@@ -31,8 +31,12 @@ defmodule Screens.V2.CandidateGenerator.Elevator do
         elevator_closure_instances_fn \\ &ElevatorClosures.elevator_status_instances/1,
         evergreen_content_instances_fn \\ &Evergreen.evergreen_content_instances/2
       ) do
-    [header_instance(config, now), footer_instance(config)] ++
-      elevator_closure_instances_fn.(config) ++ evergreen_content_instances_fn.(config, now)
+    Enum.concat([
+      header_instance(config, now),
+      footer_instance(config),
+      elevator_closure_instances_fn.(config),
+      evergreen_content_instances_fn.(config, now)
+    ])
   end
 
   def audio_only_instances(_widgets, _config), do: []

--- a/lib/screens/v2/candidate_generator/elevator.ex
+++ b/lib/screens/v2/candidate_generator/elevator.ex
@@ -3,6 +3,7 @@ defmodule Screens.V2.CandidateGenerator.Elevator do
 
   alias Screens.V2.CandidateGenerator
   alias Screens.V2.CandidateGenerator.Elevator.Closures, as: ElevatorClosures
+  alias Screens.V2.CandidateGenerator.Widgets.Evergreen
   alias Screens.V2.Template.Builder
   alias Screens.V2.WidgetInstance.{Footer, NormalHeader}
   alias ScreensConfig.Screen
@@ -27,10 +28,11 @@ defmodule Screens.V2.CandidateGenerator.Elevator do
   def candidate_instances(
         config,
         now \\ DateTime.utc_now(),
-        elevator_closure_instances_fn \\ &ElevatorClosures.elevator_status_instances/1
+        elevator_closure_instances_fn \\ &ElevatorClosures.elevator_status_instances/1,
+        evergreen_content_instances_fn \\ &Evergreen.evergreen_content_instances/2
       ) do
     [header_instance(config, now), footer_instance(config)] ++
-      elevator_closure_instances_fn.(config)
+      elevator_closure_instances_fn.(config) ++ evergreen_content_instances_fn.(config, now)
   end
 
   def audio_only_instances(_widgets, _config), do: []

--- a/lib/screens/v2/candidate_generator/widgets/evergreen.ex
+++ b/lib/screens/v2/candidate_generator/widgets/evergreen.ex
@@ -5,13 +5,13 @@ defmodule Screens.V2.CandidateGenerator.Widgets.Evergreen do
   alias Screens.V2.WidgetInstance.EvergreenContent
   alias ScreensConfig.Screen
   alias ScreensConfig.V2.EvergreenContentItem
-  alias ScreensConfig.V2.{BusEink, BusShelter, Dup, GlEink, PreFare}
+  alias ScreensConfig.V2.{BusEink, BusShelter, Dup, Elevator, GlEink, PreFare}
 
   def evergreen_content_instances(
         %Screen{app_params: %app{evergreen_content: evergreen_content}} = config,
         now \\ DateTime.utc_now()
       )
-      when app in [BusEink, BusShelter, Dup, GlEink, PreFare] do
+      when app in [BusEink, BusShelter, Dup, Elevator, GlEink, PreFare] do
     Enum.map(evergreen_content, &evergreen_content_instance(&1, config, now))
   end
 


### PR DESCRIPTION
Adds evergreen content support on elevator screens. Assuming `Screens.Util.Assets.s3_asset_url/1` points at the `screens-dev-green` bucket, you can use the following config to test:

```json
{
  "ELE-101": {
    "disabled": false,
    "name": "",
    "app_id": "elevator_v2",
    "app_params": {
      "evergreen_content": [
        {
          "priority": [0],
          "slot_names": ["header"],
          "asset_path": "images/elevator/header_test.png",
          "schedule": [
            {
              "start_dt": null,
              "end_dt": null
            }
          ],
          "text_for_audio": null,
          "audio_priority": null
        },
        {
          "priority": [0],
          "slot_names": ["main_content"],
          "asset_path": "images/elevator/main_content_test.png",
          "schedule": [
            {
              "start_dt": null,
              "end_dt": null
            }
          ],
          "text_for_audio": null,
          "audio_priority": null
        },
        {
          "priority": [0],
          "slot_names": ["footer"],
          "asset_path": "images/elevator/footer_test.png",
          "schedule": [
            {
              "start_dt": null,
              "end_dt": null
            }
          ],
          "text_for_audio": null,
          "audio_priority": null
        }
      ],
      "elevator_id": "842",
      "alternate_direction_text": "Alternate direction text goes here. This is the largest body text class. Use this for shorter sets of directions. Add up to 6 lines at this size",
      "accessible_path_image_url": "images/elevator/maps/forest-hills-map.png",
      "accessible_path_direction_arrow": "e",
      "accessible_path_image_here_coordinates": {
        "x": 151,
        "y": 182
      }
    },
    "device_id": "",
    "hidden_from_screenplay": false,
    "refresh_if_loaded_before": null,
    "tags": [],
    "vendor": "mimo"
  }
}
```

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208310396563613