### PR TITLE
temp: Force bottom filler for Mercury screens.

### DIFF
--- a/lib/screens/v2/widget_instance/bottom_screen_filler.ex
+++ b/lib/screens/v2/widget_instance/bottom_screen_filler.ex
@@ -17,6 +17,7 @@ defmodule Screens.V2.WidgetInstance.BottomScreenFiller do
 
   @type t :: %__MODULE__{screen: Screen.t()}
 
+  def priority(%__MODULE__{screen: %Screen{vendor: :mercury}}), do: [0]
   def priority(_instance), do: [10]
   def serialize(_instance), do: %{}
   def slot_names(_instance), do: [:full_body_bottom_screen]


### PR DESCRIPTION
See [this thread](https://mbta.slack.com/archives/G012H4G4U06/p1733323450195799) for context.

Tl;dr: Our Mercury screens have a burn-in problem. Mercury has requested we use a static image on the bottom panel. They will then turn off the panel until the issue is resolved.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208994786336825