### PR TITLE
fix: Map marker cords

### DIFF
--- a/assets/src/components/v2/elevator/current_elevator_closed.tsx
+++ b/assets/src/components/v2/elevator/current_elevator_closed.tsx
@@ -21,7 +21,7 @@ type Coordinates = {
 
 const PulsatingDot = ({ x, y }: Coordinates) => {
   return (
-    <div className="marker-container" style={{ top: x, left: y }}>
+    <div className="marker-container" style={{ left: x, top: y }}>
       <CurrentLocationBackground className="marker-background" />
       <CurrentLocationMarker className="marker" />
     </div>


### PR DESCRIPTION
Betsy pointed out that coordinates from Figma weren't matching up exactly in our code. I then realized I mapped `top` and `left` wrong 😅. Flipped them so coordinates work as expected.