### PR TITLE
chore: consolidate error/warning logging

### DIFF
--- a/lib/screens/audio.ex
+++ b/lib/screens/audio.ex
@@ -1,7 +1,7 @@
 defmodule Screens.Audio do
   @moduledoc false
 
-  require Logger
+  alias Screens.Log
 
   @lexicon_names ["mbtalexicon"]
 
@@ -17,24 +17,8 @@ defmodule Screens.Audio do
         {:ok, audio_data}
 
       {:error, error} ->
-        report_error(ssml_string, error, log_meta)
+        Log.error("synthesize_ssml_failed", [error: error, string: ssml_string] ++ log_meta)
         :error
     end
-  end
-
-  defp report_error(ssml_string, error, meta) do
-    Logger.error(
-      "synthesize_ssml_failed string=#{inspect(ssml_string)} error=#{inspect(error)}",
-      meta
-    )
-
-    _ =
-      if meta[:is_screen] do
-        Sentry.capture_message("synthesize_ssml_failed",
-          extra: Enum.into(meta, %{error: error, string: ssml_string})
-        )
-      end
-
-    nil
   end
 end

--- a/lib/screens/cache/engine.ex
+++ b/lib/screens/cache/engine.ex
@@ -51,10 +51,4 @@ defmodule Screens.Cache.Engine do
   Returns the number of milliseconds to wait between each `update_table` call.
   """
   @callback update_interval_ms() :: non_neg_integer
-
-  @doc """
-  Returns the number of minutes to wait before changing the log level
-  for failed `update_table` calls from warning to error.
-  """
-  @callback update_failure_error_log_threshold_minutes() :: non_neg_integer
 end

--- a/lib/screens/config/cache/engine.ex
+++ b/lib/screens/config/cache/engine.ex
@@ -37,9 +37,6 @@ defmodule Screens.Config.Cache.Engine do
   @impl true
   def update_interval_ms, do: 5_000
 
-  @impl true
-  def update_failure_error_log_threshold_minutes, do: 2
-
   @spec config_to_table_entries(Config.t(), DateTime.t() | nil) :: Cache.table_contents()
   defp config_to_table_entries(config, last_deploy_timestamp) do
     screen_entries =

--- a/lib/screens/departures/departure.ex
+++ b/lib/screens/departures/departure.ex
@@ -1,8 +1,7 @@
 defmodule Screens.Departures.Departure do
   @moduledoc false
 
-  require Logger
-
+  alias Screens.Log
   alias Screens.Predictions.Prediction
   alias Screens.Schedules.Schedule
   alias Screens.Trips.Trip
@@ -410,8 +409,10 @@ defmodule Screens.Departures.Departure do
       expected_route_ids = ["64", "120"]
 
       if length(route_ids) > 1 and !Enum.member?(expected_route_ids, route_id) do
-        Logger.warning(
-          "log_unexpected_groups found #{length(route_ids)} predictions on trip #{trip_id} for route #{Enum.at(route_ids, 0)}"
+        Log.warning("log_unexpected_groups",
+          predictions: length(route_ids),
+          route: Enum.at(route_ids, 0),
+          trip: trip_id
         )
       end
     end)

--- a/lib/screens/log.ex
+++ b/lib/screens/log.ex
@@ -6,7 +6,7 @@ defmodule Screens.Log do
   def error(tag, data \\ []), do: log(:error, tag, data)
   def warning(tag, data \\ []), do: log(:warning, tag, data)
 
-  @spec log(:error | :warning, String.t(), Enumerable.t({term(), term()})) :: :ok
+  @spec log(:error | :warning, String.t(), Enumerable.t({String.Chars.t(), term()})) :: :ok
   defp log(level, tag, data) do
     Logger.log(
       level,

--- a/lib/screens/log.ex
+++ b/lib/screens/log.ex
@@ -1,0 +1,20 @@
+defmodule Screens.Log do
+  @moduledoc "Conveniences for logging to Splunk and Sentry."
+
+  require Logger
+
+  def error(tag, data \\ []), do: log(:error, tag, data)
+  def warning(tag, data \\ []), do: log(:warning, tag, data)
+
+  @spec log(:error | :warning, String.t(), Enumerable.t({term(), term()})) :: :ok
+  defp log(level, tag, data) do
+    Logger.log(
+      level,
+      tag <> " " <> Enum.map_join(data, " ", fn {key, value} -> "#{key}=#{inspect(value)}" end)
+    )
+
+    _ = Sentry.capture_message(tag, extra: Map.new(data), level: level, result: :none)
+
+    :ok
+  end
+end

--- a/lib/screens/route_patterns/route_direction_stops.ex
+++ b/lib/screens/route_patterns/route_direction_stops.ex
@@ -3,8 +3,8 @@ defmodule Screens.RoutePatterns.RouteDirectionStops do
 
   alias Screens.Log
 
-  def parse_result(%{"data" => data, "included" => included}, route_id) do
-    included_data = parse_included_data(included)
+  def parse_result(%{"data" => data} = response, route_id) do
+    included_data = response |> Map.get("included", []) |> parse_included_data()
     parse_data(data, included_data, route_id)
   end
 

--- a/lib/screens/route_patterns/route_direction_stops.ex
+++ b/lib/screens/route_patterns/route_direction_stops.ex
@@ -1,16 +1,11 @@
 defmodule Screens.RoutePatterns.RouteDirectionStops do
   @moduledoc false
 
-  require Logger
+  alias Screens.Log
 
   def parse_result(%{"data" => data, "included" => included}, route_id) do
     included_data = parse_included_data(included)
     parse_data(data, included_data, route_id)
-  end
-
-  def parse_result(_, _) do
-    Logger.warning("Unrecognized format of route_pattern data.")
-    :error
   end
 
   defp parse_included_data(data) do
@@ -62,17 +57,16 @@ defmodule Screens.RoutePatterns.RouteDirectionStops do
          },
          included_data
        ) do
-    # The only way this function output an empty array is if the trip data has an empty stop list
-    # This happens occasionally in dev-green
     parsed =
       included_data
       |> Map.get({"trip", trip_id})
       |> Enum.map(fn stop_id -> Map.get(included_data, {"stop", stop_id}) end)
 
     case parsed do
-      # If `trip` is present, but the stop array is empty, there's a problem with the trip in the API
       [] ->
-        Logger.warning("Trip data doesn't contain stop ids. trip_id: #{trip_id}")
+        # Happens sometimes in API dev (only?). If a trip has no stops, there is something wrong
+        # with the data.
+        Log.warning("route_pattern_empty_stops", trip_id: trip_id)
         :error
 
       _ ->

--- a/lib/screens/signs_ui_config/cache/engine.ex
+++ b/lib/screens/signs_ui_config/cache/engine.ex
@@ -23,7 +23,4 @@ defmodule Screens.SignsUiConfig.Cache.Engine do
 
   @impl true
   def update_interval_ms, do: 60_000
-
-  @impl true
-  def update_failure_error_log_threshold_minutes, do: 2
 end

--- a/lib/screens/v2/candidate_generator/dup/alerts.ex
+++ b/lib/screens/v2/candidate_generator/dup/alerts.ex
@@ -5,6 +5,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Alerts do
 
   alias Screens.Alerts.Alert
   alias Screens.LocationContext
+  alias Screens.Log
   alias Screens.Routes.Route
   alias Screens.Stops.Stop
   alias Screens.V2.LocalizedAlert
@@ -159,14 +160,13 @@ defmodule Screens.V2.CandidateGenerator.Dup.Alerts do
       alert.effect in [:shuttle, :suspension] and
         Enum.any?(alert.informed_entities, &(&1.direction_id in 0..1))
 
-    _ =
-      if directional do
-        Sentry.capture_message(
-          "DUP logic encountered a directional shuttle or suspension alert. Discarding.",
-          level: "warning",
-          extra: %{alert_id: alert.id, alert_effect: alert.effect}
-        )
-      end
+    if directional do
+      Log.warning(
+        "dup_discarding_directional_alert",
+        alert_id: alert.id,
+        alert_effect: alert.effect
+      )
+    end
 
     directional
   end

--- a/lib/screens/v2/candidate_generator/dup/departures.ex
+++ b/lib/screens/v2/candidate_generator/dup/departures.ex
@@ -4,6 +4,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
   require Logger
 
   alias Screens.Alerts.Alert
+  alias Screens.Log
   alias Screens.Routes.Route
   alias Screens.Util
   alias Screens.V2.CandidateGenerator.Widgets
@@ -534,11 +535,12 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
          _first_schedule_tomorrow,
          route_id,
          direction_id,
-         now
+         _now
        )
        when is_nil(first_schedule_today) or is_nil(last_schedule_today) do
-    Logger.info(
-      "[get_overnight_schedules_for_section] No schedules for today found. route_id=#{route_id} direction_id=#{direction_id} now=#{now}"
+    Log.warning("dup_overnight_no_first_last_schedule",
+      route_id: route_id,
+      direction_id: direction_id
     )
 
     nil
@@ -577,8 +579,9 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
        ) do
     cond do
       DateTime.compare(now, first_schedule_tomorrow.departure_time) == :gt ->
-        Logger.warning(
-          "[get_overnight_schedules_for_section] now is after first_schedule_tomorrow. route_id=#{route_id} direction_id=#{direction_id} now=#{now}"
+        Log.warning("dup_overnight_after_first_schedule",
+          route_id: route_id,
+          direction_id: direction_id
         )
 
         nil

--- a/lib/screens/v2/candidate_generator/elevator/closures.ex
+++ b/lib/screens/v2/candidate_generator/elevator/closures.ex
@@ -1,9 +1,8 @@
 defmodule Screens.V2.CandidateGenerator.Elevator.Closures do
   @moduledoc false
 
-  require Logger
-
   alias Screens.Alerts.{Alert, InformedEntity}
+  alias Screens.Log
   alias Screens.Routes.Route
   alias Screens.Stops.Stop
   alias Screens.V2.WidgetInstance
@@ -82,7 +81,7 @@ defmodule Screens.V2.CandidateGenerator.Elevator.Closures do
         []
 
       {:error, error} ->
-        Logger.error("[elevator_status_instances] #{inspect(error)}")
+        Log.error("elevator_closures_error", error: error)
         []
     end
   end
@@ -191,11 +190,7 @@ defmodule Screens.V2.CandidateGenerator.Elevator.Closures do
     if data = @elevator_redundancy_data[informed_facility_id] do
       data["nearby_redundancy?"]
     else
-      _ =
-        Sentry.capture_message(
-          "Elevator #{informed_facility_id} does not exist in redundancy data"
-        )
-
+      Log.warning("elevator_redundancy_not_found", facility_id: informed_facility_id)
       false
     end
   end

--- a/lib/screens/v2/location_context.ex
+++ b/lib/screens/v2/location_context.ex
@@ -1,8 +1,7 @@
 defmodule Screens.LocationContext do
   @moduledoc false
 
-  require Logger
-
+  alias Screens.Log
   alias Screens.RoutePatterns.RoutePattern
   alias Screens.Routes.Route
   alias Screens.RouteType
@@ -66,10 +65,7 @@ defmodule Screens.LocationContext do
           }
         else
           :error ->
-            Logger.error(
-              "[location_context fetch error] Failed to get location context for an alert: stop_id=#{stop_id}"
-            )
-
+            Log.error("location_context_fetch_error", stop_id: stop_id)
             :error
         end
       end

--- a/lib/screens/v2/widget_instance/audio_only/alerts_intro.ex
+++ b/lib/screens/v2/widget_instance/audio_only/alerts_intro.ex
@@ -3,11 +3,10 @@ defmodule Screens.V2.WidgetInstance.AudioOnly.AlertsIntro do
   An audio-only widget that introduces the section of the readout describing service alerts.
   """
 
+  alias Screens.Log
   alias Screens.V2.WidgetInstance
   alias Screens.V2.WidgetInstance.{ReconstructedAlert, SubwayStatus}
   alias ScreensConfig.Screen
-
-  require Logger
 
   @type t :: %__MODULE__{
           screen: Screen.t(),
@@ -38,14 +37,11 @@ defmodule Screens.V2.WidgetInstance.AudioOnly.AlertsIntro do
 
     case first_service_alert_index do
       nil ->
-        Logger.warning("Failed to find a service alert widget in the audio readout queue")
+        Log.warning("alerts_intro_widget_not_found")
         [0]
 
       0 ->
-        Logger.warning(
-          "Unexpectedly found a service alert widget at the start of the audio readout queue"
-        )
-
+        Log.warning("alerts_intro_widget_at_queue_start")
         [0]
 
       i ->

--- a/lib/screens/v2/widget_instance/audio_only/alerts_outro.ex
+++ b/lib/screens/v2/widget_instance/audio_only/alerts_outro.ex
@@ -3,11 +3,10 @@ defmodule Screens.V2.WidgetInstance.AudioOnly.AlertsOutro do
   An audio-only widget that follows the section of the readout describing alerts.
   """
 
+  alias Screens.Log
   alias Screens.V2.WidgetInstance
   alias Screens.V2.WidgetInstance.ReconstructedAlert
   alias ScreensConfig.Screen
-
-  require Logger
 
   @type t :: %__MODULE__{
           screen: Screen.t(),
@@ -35,7 +34,7 @@ defmodule Screens.V2.WidgetInstance.AudioOnly.AlertsOutro do
 
     case last_alert_widget do
       nil ->
-        Logger.warning("Failed to find an alert widget in the audio readout queue")
+        Log.warning("alerts_outro_widget_not_found")
         [100]
 
       widget ->

--- a/lib/screens/v2/widget_instance/audio_only/content_summary.ex
+++ b/lib/screens/v2/widget_instance/audio_only/content_summary.ex
@@ -3,8 +3,7 @@ defmodule Screens.V2.WidgetInstance.AudioOnly.ContentSummary do
   An audio-only widget that summarizes what's about to be read out.
   """
 
-  require Logger
-
+  alias Screens.Log
   alias Screens.V2.WidgetInstance
   alias Screens.V2.WidgetInstance.{BlueBikes, NormalHeader, ShuttleBusInfo}
   alias ScreensConfig.Screen
@@ -36,7 +35,7 @@ defmodule Screens.V2.WidgetInstance.AudioOnly.ContentSummary do
     # Attempt to find a header widget and place this widget immediately after it
     case Enum.find(t.widgets_snapshot, &match?(%NormalHeader{}, &1)) do
       nil ->
-        Logger.warning("Failed to find a header widget in the audio readout queue")
+        Log.warning("content_summary_header_not_found")
         [0]
 
       header ->

--- a/lib/screens/v2/widget_instance/cr_departures.ex
+++ b/lib/screens/v2/widget_instance/cr_departures.ex
@@ -1,7 +1,7 @@
 defmodule Screens.V2.WidgetInstance.CRDepartures do
   @moduledoc false
 
-  require Logger
+  alias Screens.Log
   alias Screens.Predictions.Prediction
   alias Screens.Stops.Stop
   alias Screens.V2.Departure
@@ -135,10 +135,7 @@ defmodule Screens.V2.WidgetInstance.CRDepartures do
        ) do
     {:ok, scheduled_departure_time} =
       if is_nil(schedule) do
-        Logger.error(
-          "[cr_departures serialize_time] Could not get schedule time: #{inspect(departure)}"
-        )
-
+        Log.error("cr_departures_no_scheduled_time", departure: departure)
         {:ok, nil}
       else
         %Departure{schedule: schedule}

--- a/lib/screens/v2/widget_instance/dup_alert.ex
+++ b/lib/screens/v2/widget_instance/dup_alert.ex
@@ -5,11 +5,10 @@ defmodule Screens.V2.WidgetInstance.DupAlert do
 
   alias Screens.Alerts.Alert
   alias Screens.LocationContext
+  alias Screens.Log
   alias Screens.V2.LocalizedAlert
   alias Screens.V2.WidgetInstance.DupAlert.Serialize
   alias ScreensConfig.Screen
-
-  require Logger
 
   @enforce_keys [
     :screen,
@@ -139,7 +138,7 @@ defmodule Screens.V2.WidgetInstance.DupAlert do
                                [effect, location, layout_zero] =
                                  Enum.map(
                                    [effect, location, layout_zero],
-                                   &String.to_existing_atom/1
+                                   &String.to_atom/1
                                  )
 
                                [affected_line_count, primary_section_count] =
@@ -226,7 +225,8 @@ defmodule Screens.V2.WidgetInstance.DupAlert do
   # we generate DUP alert widgets for, but in case one slips through, we
   # should know about it!
   defp log_layout_mismatch(t, delay_severity) do
-    log_fields =
+    Log.warning(
+      "dup_alert_no_matching_layout",
       t
       |> get_layout_parameters()
       |> Map.merge(%{
@@ -235,10 +235,6 @@ defmodule Screens.V2.WidgetInstance.DupAlert do
         alert_id: t.alert.id,
         stop_id: t.screen.app_params.alerts.stop_id
       })
-
-    Logger.warning(
-      "[DUP alert no matching layout] " <>
-        Enum.map_join(log_fields, " ", fn {label, value} -> "#{label}=#{value}" end)
     )
   end
 

--- a/lib/screens/v2/widget_instance/serializer/route_pill.ex
+++ b/lib/screens/v2/widget_instance/serializer/route_pill.ex
@@ -1,8 +1,7 @@
 defmodule Screens.V2.WidgetInstance.Serializer.RoutePill do
   @moduledoc false
 
-  require Logger
-
+  alias Screens.Log
   alias Screens.Routes.Route
   alias Screens.RouteType
 
@@ -208,7 +207,7 @@ defmodule Screens.V2.WidgetInstance.Serializer.RoutePill do
   defp do_serialize("CR-" <> line, opts) do
     abbreviation =
       Map.get_lazy(@cr_line_abbreviations, line, fn ->
-        Logger.warning("missing route pill abbreviation for CR-" <> line)
+        Log.warning("missing_route_pill_abbreviation", line: line)
         nil
       end)
 

--- a/lib/screens_web/controllers/v2/screen_controller.ex
+++ b/lib/screens_web/controllers/v2/screen_controller.ex
@@ -2,6 +2,7 @@ defmodule ScreensWeb.V2.ScreenController do
   use ScreensWeb, :controller
 
   alias Screens.Config.Cache
+  alias Screens.Log
   alias Screens.V2.ScreenData.Parameters
   alias ScreensConfig.Screen
 
@@ -151,10 +152,7 @@ defmodule ScreensWeb.V2.ScreenController do
         widget(conn, %{"app_id" => app_id, "widget" => widget_data})
 
       {:error, _} ->
-        _ =
-          Sentry.capture_message(
-            "[screen_controller widget] invalid widget JSON in query params for app_id: #{app_id}"
-          )
+        Log.error("invalid_widget_json", app_id: app_id, source: :query)
 
         conn
         |> put_status(:bad_request)
@@ -177,11 +175,7 @@ defmodule ScreensWeb.V2.ScreenController do
 
   def widget(conn, %{"app_id" => app_id}) do
     app_id = String.to_existing_atom(app_id)
-
-    _ =
-      Sentry.capture_message(
-        "[screen_controller widget] missing widget JSON in request body for app_id: #{app_id}"
-      )
+    Log.error("invalid_widget_json", app_id: app_id, source: :body)
 
     conn
     |> put_status(:bad_request)

--- a/test/screens/v2/widget_instance/audio_only/alerts_intro_test.exs
+++ b/test/screens/v2/widget_instance/audio_only/alerts_intro_test.exs
@@ -106,11 +106,7 @@ defmodule Screens.V2.WidgetInstance.AudioOnly.AlertsIntroTest do
       {result, log} = with_log(fn -> AlertsIntro.audio_sort_key(widget, audio_sort_key_fn) end)
 
       assert [0] == result
-
-      assert String.contains?(
-               log,
-               "Failed to find a service alert widget in the audio readout queue"
-             )
+      assert log =~ "alerts_intro_widget_not_found"
     end
 
     test "logs a warning and returns [0] if service alert widget is first in the readout queue",
@@ -118,11 +114,7 @@ defmodule Screens.V2.WidgetInstance.AudioOnly.AlertsIntroTest do
       {result, log} = with_log(fn -> AlertsIntro.audio_sort_key(widget, audio_sort_key_fn) end)
 
       assert [0] == result
-
-      assert String.contains?(
-               log,
-               "Unexpectedly found a service alert widget at the start of the audio readout queue"
-             )
+      assert log =~ "alerts_intro_widget_at_queue_start"
     end
   end
 

--- a/test/screens/v2/widget_instance/audio_only/alerts_outro_test.exs
+++ b/test/screens/v2/widget_instance/audio_only/alerts_outro_test.exs
@@ -92,11 +92,7 @@ defmodule Screens.V2.WidgetInstance.AudioOnly.AlertsOutroTest do
       {result, log} = with_log(fn -> AlertsOutro.audio_sort_key(widget, audio_sort_key_fn) end)
 
       assert [100] == result
-
-      assert String.contains?(
-               log,
-               "Failed to find an alert widget in the audio readout queue"
-             )
+      assert log =~ "alerts_outro_widget_not_found"
     end
   end
 

--- a/test/screens/v2/widget_instance/audio_only/content_summary_test.exs
+++ b/test/screens/v2/widget_instance/audio_only/content_summary_test.exs
@@ -107,7 +107,7 @@ defmodule Screens.V2.WidgetInstance.AudioOnly.ContentSummaryTest do
       {result, log} = with_log(fn -> WidgetInstance.audio_sort_key(widget) end)
 
       assert [0] == result
-      assert String.contains?(log, "Failed to find a header widget in the audio readout queue")
+      assert log =~ "content_summary_header_not_found"
     end
   end
 

--- a/test/screens/v2/widget_instance/cr_departures_test.exs
+++ b/test/screens/v2/widget_instance/cr_departures_test.exs
@@ -127,7 +127,7 @@ defmodule Screens.V2.WidgetInstance.CRDeparturesTest do
           )
         end)
 
-      assert log =~ "Could not get schedule time"
+      assert log =~ "cr_departures_no_scheduled_time"
       assert %{prediction_or_schedule_id: "prediction-1"} = result
     end
   end

--- a/test/screens/v2/widget_instance/serializer/route_pill_test.exs
+++ b/test/screens/v2/widget_instance/serializer/route_pill_test.exs
@@ -22,7 +22,7 @@ defmodule Screens.V2.WidgetInstance.Serializer.RoutePillTest do
                    serialize_for_departure("CR-Foobar", "", :rail, nil)
         end)
 
-      assert logs =~ "missing route pill abbreviation for CR-Foobar"
+      assert logs =~ ~s(missing_route_pill_abbreviation line="Foobar")
     end
 
     test "Returns boat icon if route type is :ferry" do


### PR DESCRIPTION
Various modules were "manually" implementing the `key=value` log format we use for Splunk searchability, and most errors or warnings were only being logged rather than reported to Sentry (where they are easier to organize and we can be proactively notified about them). This change consolidates all existing errors/warnings into a shared function that logs to both `Logger` and Sentry.

* Sentry reports are also sent asynchronously, so they don't hold up returning a value to a client.

* All errors/warnings are given a unique underscored identifier rather than a free-text message, which improves Splunk ergonomics.

Existing logging at `info` level and below is not changed, but would be a logical next step.