### PR TITLE
fix: incorrect environment name for Image Manager

### DIFF
--- a/lib/screens/image.ex
+++ b/lib/screens/image.ex
@@ -95,7 +95,7 @@ defmodule Screens.Image do
   end
 
   defp psa_images_prefix do
-    Application.get_env(:screens, :environment_name, "dev") <> "/images/psa/"
+    Application.get_env(:screens, :environment_name, "screens-dev") <> "/images/psa/"
   end
 
   defp get_s3_path(filename), do: psa_images_prefix() <> filename


### PR DESCRIPTION
In local development, the Image Manager defaults to using the `dev` environment's S3 bucket — except that the environment name should have been `screens-dev`, so this did not work.