### PR TITLE
feat: takeover layout for elevator screens

### DIFF
--- a/assets/src/apps/v2/elevator.tsx
+++ b/assets/src/apps/v2/elevator.tsx
@@ -10,6 +10,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
 import NormalScreen from "Components/v2/elevator/normal_screen";
+import TakeoverScreen from "Components/v2/takeover_screen";
 import EvergreenContent from "Components/v2/evergreen_content";
 import ScreenPage from "Components/v2/screen_page";
 import { MappingContext } from "Components/v2/widget";
@@ -22,6 +23,7 @@ import NormalHeader from "Components/v2/normal_header";
 
 const TYPE_TO_COMPONENT = {
   normal: NormalScreen,
+  takeover: TakeoverScreen,
   elevator_closures_list: ElevatorClosuresList,
   current_elevator_closed: CurrentElevatorClosed,
   evergreen_content: EvergreenContent,

--- a/lib/screens/v2/candidate_generator/elevator.ex
+++ b/lib/screens/v2/candidate_generator/elevator.ex
@@ -19,7 +19,8 @@ defmodule Screens.V2.CandidateGenerator.Elevator do
           :header,
           :main_content,
           :footer
-        ]
+        ],
+        takeover: [:full_screen]
       }
     }
     |> Builder.build_template()

--- a/test/screens/v2/candidate_generator/elevator_test.exs
+++ b/test/screens/v2/candidate_generator/elevator_test.exs
@@ -25,7 +25,8 @@ defmodule Screens.V2.CandidateGenerator.ElevatorTest do
     test "returns template" do
       assert {:screen,
               %{
-                normal: [:header, :main_content, :footer]
+                normal: [:header, :main_content, :footer],
+                takeover: [:full_screen]
               }} == Elevator.screen_template()
     end
   end


### PR DESCRIPTION
This allows evergreen content to be configured to replace the whole screen, including the header and footer.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209001244550623