### PR TITLE
feat: audio readout for push-button Bus Shelters

### DIFF
--- a/lib/screens/v2/widget_instance/alert.ex
+++ b/lib/screens/v2/widget_instance/alert.ex
@@ -7,6 +7,7 @@ defmodule Screens.V2.WidgetInstance.Alert do
   alias Screens.V2.WidgetInstance
   alias Screens.V2.WidgetInstance.Serializer.RoutePill
   alias ScreensConfig.Screen
+  alias ScreensConfig.V2.{Audio, BusShelter}
 
   defstruct screen: nil,
             alert: nil,
@@ -271,11 +272,12 @@ defmodule Screens.V2.WidgetInstance.Alert do
     end
   end
 
-  def audio_valid_candidate?(%__MODULE__{screen: %Screen{app_id: app_id}})
-      when app_id in ~w[bus_eink_v2 gl_eink_v2]a,
-      do: true
+  def audio_valid_candidate?(%__MODULE__{
+        screen: %Screen{app_params: %BusShelter{audio: %Audio{interval_enabled: true}}}
+      }),
+      do: false
 
-  def audio_valid_candidate?(_instance), do: false
+  def audio_valid_candidate?(_instance), do: true
 
   def audio_view(_instance), do: ScreensWeb.V2.Audio.AlertView
 

--- a/lib/screens/v2/widget_instance/subway_status.ex
+++ b/lib/screens/v2/widget_instance/subway_status.ex
@@ -9,7 +9,7 @@ defmodule Screens.V2.WidgetInstance.SubwayStatus do
   alias Screens.Stops.Subway
   alias Screens.V2.WidgetInstance.SubwayStatus
   alias ScreensConfig.Screen
-  alias ScreensConfig.V2.{BusEink, Footer, GlEink, PreFare}
+  alias ScreensConfig.V2.{Footer, GlEink}
 
   defmodule SubwayStatusAlert do
     @moduledoc false
@@ -87,6 +87,8 @@ defmodule Screens.V2.WidgetInstance.SubwayStatus do
   @green_line_branches ["Green-B", "Green-C", "Green-D", "Green-E"]
 
   defimpl Screens.V2.WidgetInstance do
+    alias ScreensConfig.V2.{Audio, BusShelter}
+
     def priority(_instance), do: [2, 1]
 
     @spec serialize(SubwayStatus.t()) :: SubwayStatus.serialized_response()
@@ -134,11 +136,12 @@ defmodule Screens.V2.WidgetInstance.SubwayStatus do
 
     def audio_sort_key(_instance), do: [2]
 
-    def audio_valid_candidate?(%{screen: %Screen{app_params: %app{}}})
-        when app in [BusEink, GlEink, PreFare],
-        do: true
+    def audio_valid_candidate?(%SubwayStatus{
+          screen: %Screen{app_params: %BusShelter{audio: %Audio{interval_enabled: true}}}
+        }),
+        do: false
 
-    def audio_valid_candidate?(_instance), do: false
+    def audio_valid_candidate?(_instance), do: true
 
     def audio_view(_instance), do: ScreensWeb.V2.Audio.SubwayStatusView
   end

--- a/test/screens/v2/widget_instance/alert_test.exs
+++ b/test/screens/v2/widget_instance/alert_test.exs
@@ -1,6 +1,7 @@
 defmodule Screens.V2.WidgetInstance.AlertTest do
   use ExUnit.Case, async: true
 
+  alias ScreensConfig.V2.Audio
   alias Screens.Alerts.Alert
   alias ScreensConfig.Screen
   alias ScreensConfig.V2.{BusEink, BusShelter, GlEink}
@@ -81,6 +82,18 @@ defmodule Screens.V2.WidgetInstance.AlertTest do
 
   defp put_app_id(widget, app_id) do
     %{widget | screen: %{widget.screen | app_id: app_id}}
+  end
+
+  defp put_bus_shelter_params(widget, params) do
+    %{
+      widget
+      | screen: %{
+          widget.screen
+          | app_id: :bus_shelter_v2,
+            app_params:
+              struct!(%BusShelter{header: nil, footer: nil, alerts: nil, departures: nil}, params)
+        }
+    }
   end
 
   defp put_effect(widget, effect) do
@@ -632,13 +645,18 @@ defmodule Screens.V2.WidgetInstance.AlertTest do
   end
 
   describe "audio_valid_candidate?/1" do
-    test "returns true for eink screen types", %{widget: widget} do
+    test "returns false for bus shelter screens with periodic audio", %{widget: widget} do
+      widget = put_bus_shelter_params(widget, audio: %Audio{interval_enabled: true})
+      refute AlertWidget.audio_valid_candidate?(widget)
+    end
+
+    test "returns true for bus shelter screens without periodic audio", %{widget: widget} do
+      widget = put_bus_shelter_params(widget, audio: %Audio{interval_enabled: false})
       assert AlertWidget.audio_valid_candidate?(widget)
     end
 
-    test "returns false for non-eink screen types", %{widget: widget} do
-      widget = %{widget | screen: %Screen{widget.screen | app_id: :bus_shelter_v2}}
-      refute AlertWidget.audio_valid_candidate?(widget)
+    test "returns true for other screen types", %{widget: widget} do
+      assert AlertWidget.audio_valid_candidate?(widget)
     end
   end
 

--- a/test/screens/v2/widget_instance/subway_status_test.exs
+++ b/test/screens/v2/widget_instance/subway_status_test.exs
@@ -1,9 +1,10 @@
 defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
   use ExUnit.Case, async: true
 
+  alias ScreensConfig.V2.Audio
   alias Screens.Alerts.Alert
   alias ScreensConfig.Screen
-  alias ScreensConfig.V2.{BusShelter, Departures, PreFare}
+  alias ScreensConfig.V2.BusShelter
   alias Screens.V2.WidgetInstance
   alias Screens.V2.WidgetInstance.SubwayStatus
 
@@ -1732,39 +1733,34 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
   end
 
   describe "audio_valid_candidate?/1" do
-    test "returns true for PreFare" do
+    test "returns false for bus shelter screens with periodic audio" do
       instance = %SubwayStatus{
-        screen: %Screen{
-          app_params: struct(PreFare),
-          vendor: nil,
-          device_id: nil,
-          name: nil,
-          app_id: nil
-        }
+        screen:
+          struct(Screen,
+            app_id: :bus_shelter_v2,
+            app_params: struct(BusShelter, audio: %Audio{interval_enabled: true})
+          )
+      }
+
+      refute WidgetInstance.audio_valid_candidate?(instance)
+    end
+
+    test "returns true for bus shelter screens without periodic audio" do
+      instance = %SubwayStatus{
+        screen:
+          struct(Screen,
+            app_id: :bus_shelter_v2,
+            app_params: struct(BusShelter, audio: %Audio{interval_enabled: false})
+          )
       }
 
       assert WidgetInstance.audio_valid_candidate?(instance)
     end
 
-    test "returns false for BusShelter" do
-      instance = %SubwayStatus{
-        screen: %Screen{
-          app_params: %BusShelter{
-            departures: %Departures{
-              sections: []
-            },
-            header: nil,
-            footer: nil,
-            alerts: nil
-          },
-          vendor: nil,
-          device_id: nil,
-          name: nil,
-          app_id: nil
-        }
-      }
+    test "returns true for other screen types" do
+      instance = %SubwayStatus{screen: struct(Screen, app_id: :pre_fare_v2)}
 
-      refute WidgetInstance.audio_valid_candidate?(instance)
+      assert WidgetInstance.audio_valid_candidate?(instance)
     end
   end
 


### PR DESCRIPTION
For Bus Shelter screens that use push-button audio (i.e. do not have a periodic audio readout), the Alert and Subway Status widgets should be included in the readout.

**Asana task**: https://app.asana.com/0/1185117109217413/1208591545042715/f