### PR TITLE
[Bugfix] Fix padding and locations of dividing lines for elevator closures

### DIFF
--- a/assets/css/v2/elevator/elevator_closures_list.scss
+++ b/assets/css/v2/elevator/elevator_closures_list.scss
@@ -65,7 +65,7 @@
 
           &:not(.current-station) {
             &::after,
-            &:first-child::before {
+            &.first-row-on-page::before {
               position: absolute;
               left: 0;
               width: calc(100% - 48px);

--- a/assets/css/v2/elevator/elevator_closures_list.scss
+++ b/assets/css/v2/elevator/elevator_closures_list.scss
@@ -68,7 +68,7 @@
             &:first-child::before {
               position: absolute;
               left: 0;
-              width: 100%;
+              width: calc(100% - 48px);
               height: 2px;
               margin: 0 24px;
               content: "";

--- a/assets/src/components/v2/elevator/elevator_closures_list.tsx
+++ b/assets/src/components/v2/elevator/elevator_closures_list.tsx
@@ -17,14 +17,15 @@ import AccessibilityAlert from "Images/svgr_bundled/accessibility-alert.svg";
 interface ClosureRowProps {
   station: StationWithClosures;
   isCurrentStation: boolean;
+  isFirstRowOnPage: boolean;
 }
 
 const ClosureRow = ({
   station: { id, name, closures, route_icons, summary },
-  isCurrentStation,
+  isCurrentStation, isFirstRowOnPage
 }: ClosureRowProps) => {
   return (
-    <div className={cx("closure-row", { "current-station": isCurrentStation })}>
+    <div className={cx("closure-row", { "current-station": isCurrentStation, "first-row-on-page": isFirstRowOnPage })}>
       <div className="closure-row__name-and-pills">
         {isCurrentStation ? (
           <div className="closure-row__station-name">At this station</div>
@@ -122,16 +123,16 @@ const OutsideClosureList = ({
 
   // Each index represents a page number and each value represents the number of
   // rows on the corresponding page index.
-  const [rowCounts, setRowCounts] = useState<number[]>([]);
+  const [rowCountsPerPage, setRowCountsPerPage] = useState<number[]>([]);
 
-  const numPages = Object.keys(rowCounts).length;
+  const numPages = Object.keys(rowCountsPerPage).length;
   const pageIndex = useClientPaging({ numPages, onFinish, lastUpdate });
 
-  const numOffsetRows = Object.keys(rowCounts).reduce((acc, key) => {
+  const numOffsetRows = Object.keys(rowCountsPerPage).reduce((acc, key) => {
     if (parseInt(key) === pageIndex) {
       return acc;
     } else {
-      return acc + rowCounts[key];
+      return acc + rowCountsPerPage[key];
     }
   }, 0);
 
@@ -148,8 +149,14 @@ const OutsideClosureList = ({
       rowCounts.push(offsets.filter((o) => o === uo).length);
     });
 
-    setRowCounts(rowCounts);
+    setRowCountsPerPage(rowCounts);
   }, [stations]);
+
+  // Track which closure row will be at the top of each page to apply special styling
+  let firstRowsOnPages = [0]
+  for (let i = 0; i < rowCountsPerPage.length - 1; i++) {
+    firstRowsOnPages.push(firstRowsOnPages[i] + rowCountsPerPage[i])
+  }
 
   return (
     <div className="closures-list">
@@ -173,11 +180,12 @@ const OutsideClosureList = ({
             }
             ref={ref}
           >
-            {sortedStations.map((station) => (
+            {sortedStations.map((station, index) => (
               <ClosureRow
                 station={station}
                 isCurrentStation={station.id == stationId}
                 key={station.id}
+                isFirstRowOnPage={firstRowsOnPages.includes(index)}
               />
             ))}
           </div>

--- a/assets/src/components/v2/elevator/elevator_closures_list.tsx
+++ b/assets/src/components/v2/elevator/elevator_closures_list.tsx
@@ -22,10 +22,16 @@ interface ClosureRowProps {
 
 const ClosureRow = ({
   station: { id, name, closures, route_icons, summary },
-  isCurrentStation, isFirstRowOnPage
+  isCurrentStation,
+  isFirstRowOnPage,
 }: ClosureRowProps) => {
   return (
-    <div className={cx("closure-row", { "current-station": isCurrentStation, "first-row-on-page": isFirstRowOnPage })}>
+    <div
+      className={cx("closure-row", {
+        "current-station": isCurrentStation,
+        "first-row-on-page": isFirstRowOnPage,
+      })}
+    >
       <div className="closure-row__name-and-pills">
         {isCurrentStation ? (
           <div className="closure-row__station-name">At this station</div>
@@ -153,9 +159,9 @@ const OutsideClosureList = ({
   }, [stations]);
 
   // Track which closure row will be at the top of each page to apply special styling
-  let firstRowsOnPages = [0]
+  const firstRowsOnPages = [0];
   for (let i = 0; i < rowCountsPerPage.length - 1; i++) {
-    firstRowsOnPages.push(firstRowsOnPages[i] + rowCountsPerPage[i])
+    firstRowsOnPages.push(firstRowsOnPages[i] + rowCountsPerPage[i]);
   }
 
   return (


### PR DESCRIPTION
**Asana task**: [Dividing Line Margin Issue on Elevator Screens](https://app.asana.com/0/1185117109217422/1209001244550628)

### Description
Fixes two issues with elevator closures separating lines on elevator screens, shown in the images below:
-  Padding: The dividing line for elevator closures had width set to 100%, which caused it to overflow to the right and appear on proceeding pages.
- Beyond the first page, there was no top line between the header and the closures.

<img width="400" alt="image" src="https://github.com/user-attachments/assets/9df6f7c9-644c-43cf-bd3d-c68873f3430d" />

<img width="401" alt="image" src="https://github.com/user-attachments/assets/3fa94c0b-98d5-4aa7-af1c-e22aa531919c" />

- [ ] Tests added?


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209061601128473