### PR TITLE
[Bufix] Elevator closure page indicators overlap when more than 2

### DIFF
--- a/assets/css/elevator_v2.scss
+++ b/assets/css/elevator_v2.scss
@@ -61,9 +61,9 @@ body {
 .paging-indicators {
   display: flex;
   align-items: center;
-  margin-right: 66px;
+  margin-right: 39px;
 
-  .paging-indicator:first-child:not(:only-child) {
+  .paging-indicator {
     margin-right: 27px;
   }
 }


### PR DESCRIPTION
**Asana task**: [Various small front-end issues on elevator screens](https://app.asana.com/0/1208877354406742/1209001244550628/f)

This fixes the bug where more than 2 pages of elevator screens would cause the page indicator dots to overlap. There was another bug pointed out where the bottom of the dots would be cut off, but I've been unable to replicate after th efix done in [this PR](https://github.com/mbta/screens/pull/2372).


<img width="405" alt="image" src="https://github.com/user-attachments/assets/a224a017-4940-47f3-841a-dbcb99929a86" />
<img width="408" alt="image" src="https://github.com/user-attachments/assets/f955df9a-e021-4dd2-9c96-a9b3f756827c" />

