### PR TITLE
[Bugfix] Make elevator text being plural conditional

### DIFF
--- a/assets/src/components/v2/elevator/elevator_closures_list.tsx
+++ b/assets/src/components/v2/elevator/elevator_closures_list.tsx
@@ -201,7 +201,7 @@ const OutsideClosureList = ({
       {numPages > 1 && (
         <div className="paging-info-container">
           <div className="more-elevators-text">
-            +{numOffsetRows} more elevators
+            +{numOffsetRows} more elevator{numOffsetRows !== 1 ? "s" : ""}
           </div>
           <PagingIndicators numPages={numPages} pageIndex={pageIndex} />
         </div>


### PR DESCRIPTION
**Asana task**: [Bugfix: Elevators should not be plural when only 1](https://app.asana.com/0/1185117109217413/1209061604856912)

Description

- [ ] Tests added?
