### PR TITLE
fix: GL Eink departures crash with headway message

### DIFF
--- a/lib/screens/v2/candidate_generator/gl_eink.ex
+++ b/lib/screens/v2/candidate_generator/gl_eink.ex
@@ -229,20 +229,20 @@ defmodule Screens.V2.CandidateGenerator.GlEink do
         :overnight
 
       headway ->
-        {:ok,
-         departures_to_concat ++
-           [
-             %{
-               text: %FreeTextLine{
-                 icon: nil,
-                 text: [
-                   "Trains to #{destination} every",
-                   %{format: :bold, text: "#{headway - 2}-#{headway + 2}"},
-                   "minutes"
-                 ]
-               }
-             }
-           ]}
+        {
+          :ok,
+          departures_to_concat ++
+            [
+              %FreeTextLine{
+                icon: nil,
+                text: [
+                  "Trains to #{destination} every",
+                  %{format: :bold, text: "#{headway - 2}-#{headway + 2}"},
+                  "minutes"
+                ]
+              }
+            ]
+        }
     end
   end
 end


### PR DESCRIPTION
This instance of `%{text: FreeTextLine.t()}` to represent a "notice row" in the departures widget was missed in c6e30f8.