### PR TITLE
refactor: remove separate Hackney pool for ExAws

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -35,10 +35,6 @@ config :phoenix, :format_encoders,
 # Use Jason for JSON parsing in ExAws
 config :ex_aws, json_codec: Jason
 
-config :ex_aws, :hackney_opts,
-  recv_timeout: 30_000,
-  pool: :ex_aws_pool
-
 config :elixir, :time_zone_database, Tzdata.TimeZoneDatabase
 
 config :hackney, mod_metrics: :hackney_telemetry

--- a/lib/screens/application.ex
+++ b/lib/screens/application.ex
@@ -13,7 +13,6 @@ defmodule Screens.Application do
       Screens.Telemetry,
       {Screens.Cache.Owner, engine_module: Screens.Config.Cache.Engine},
       {Screens.Cache.Owner, engine_module: Screens.SignsUiConfig.Cache.Engine},
-      :hackney_pool.child_spec(:ex_aws_pool, []),
       :hackney_pool.child_spec(:api_v3_pool, max_connections: 100),
       # Task supervisor for ScreensByAlert async updates
       {Task.Supervisor, name: Screens.ScreensByAlert.Memcache.TaskSupervisor},


### PR DESCRIPTION
Though this is unlikely to be causing any issues, it also seems very unnecessary. Over the past 30 days we've seen at most 2 concurrent connections out of a possible 50 in this pool (and 1 out of 50 for the default pool, which ExAws will use after this change). This aligns with how often we'd expect to be calling AWS APIs during normal operations.

Relevant Splunk query: `index=screens-prod-application hackney_pool | timechart max(in_use_count) by pool`