### PR TITLE
refactor: new V3 API caching approach

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -471,13 +471,26 @@ config :screens, :screens_by_alert,
   screens_last_updated_ttl_seconds: 3600,
   screens_ttl_seconds: 40
 
-config :screens, Screens.ScreenApiResponseCache,
-  gc_interval: :timer.hours(1),
-  allocated_memory: 250_000_000
-
 config :screens, Screens.LastTrip,
   trip_updates_adapter: Screens.LastTrip.TripUpdates.GTFS,
   vehicle_positions_adapter: Screens.LastTrip.VehiclePositions.GTFS
+
+# Memory limits for V3 API response caches are based on ETS table memory usage measurements in a
+# deployed environment. To avoid thrashing and overloading the HTTP connection pool, these can and
+# should be tweaked as the V3 API usage patterns and requirements of the app change over time.
+
+config :screens, Screens.V3Api.Cache.Realtime,
+  allocated_memory: 50 * 1024 * 1024,
+  gc_cleanup_min_timeout: :timer.seconds(5),
+  gc_interval: :timer.seconds(30),
+  stats: true,
+  telemetry_prefix: ~w[screens v3_api cache]a
+
+config :screens, Screens.V3Api.Cache.Static,
+  allocated_memory: 150 * 1024 * 1024,
+  gc_interval: :timer.hours(1),
+  stats: true,
+  telemetry_prefix: ~w[screens v3_api cache]a
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/lib/screens/application.ex
+++ b/lib/screens/application.ex
@@ -10,10 +10,9 @@ defmodule Screens.Application do
 
     # List all child processes to be supervised
     children = [
-      Screens.Telemetry,
       {Screens.Cache.Owner, engine_module: Screens.Config.Cache.Engine},
       {Screens.Cache.Owner, engine_module: Screens.SignsUiConfig.Cache.Engine},
-      :hackney_pool.child_spec(:api_v3_pool, max_connections: 100),
+      :hackney_pool.child_spec(:api_v3_pool, max_connections: 50),
       # Task supervisor for ScreensByAlert async updates
       {Task.Supervisor, name: Screens.ScreensByAlert.Memcache.TaskSupervisor},
       # ScreensByAlert server process
@@ -24,8 +23,10 @@ defmodule Screens.Application do
       {Screens.ScreensByAlert.SelfRefreshRunner, name: Screens.ScreensByAlert.SelfRefreshRunner},
       # Task supervisor for parallel running of candidate generator variants
       {Task.Supervisor, name: Screens.V2.ScreenData.ParallelRunSupervisor},
-      {Screens.ScreenApiResponseCache, []},
+      Screens.V3Api.Cache.Realtime,
+      Screens.V3Api.Cache.Static,
       Screens.LastTrip,
+      Screens.Telemetry,
       {Phoenix.PubSub, name: ScreensWeb.PubSub},
       ScreensWeb.Endpoint,
       Screens.Health

--- a/lib/screens/screen_api_response_cache.ex
+++ b/lib/screens/screen_api_response_cache.ex
@@ -1,7 +1,0 @@
-defmodule Screens.ScreenApiResponseCache do
-  @moduledoc """
-  Cache used to reduce the number of duplicate API calls.
-  """
-
-  use Nebulex.Cache, otp_app: :screens, adapter: Nebulex.Adapters.Local
-end

--- a/lib/screens/v3_api/cache.ex
+++ b/lib/screens/v3_api/cache.ex
@@ -1,0 +1,60 @@
+defmodule Screens.V3Api.Cache do
+  @moduledoc """
+  Cache used to speed up or eliminate HTTP calls to the V3 API.
+
+  Cached API responses are categorized as either "fresh" or "stale". When a response was cached
+  recently enough that we think reusing it without checking the API at all is acceptable, it is
+  "fresh". Else it is "stale" and we should check before reusing it (using If-Modified-Since).
+  """
+
+  defmodule Realtime do
+    @moduledoc "Caches data derived from GTFS-RT, which becomes stale very quickly."
+    use Nebulex.Cache, otp_app: :screens, adapter: Nebulex.Adapters.Local
+
+    def unconditional_ttl, do: :timer.seconds(3)
+  end
+
+  defmodule Static do
+    @moduledoc "Caches data derived from static GTFS, which becomes stale relatively slowly."
+    use Nebulex.Cache, otp_app: :screens, adapter: Nebulex.Adapters.Local
+
+    def unconditional_ttl, do: :timer.minutes(30)
+  end
+
+  @realtime_resources ~w[alert prediction vehicle]
+
+  @type key :: {path :: String.t(), params :: map()}
+  @type result :: {:fresh, term()} | {:stale, term()} | nil
+
+  @doc "Get a response from the cache."
+  @spec get(key()) :: result()
+  @spec get(key(), now :: DateTime.t()) :: result()
+  def get(key, now \\ DateTime.utc_now()) do
+    case cache_for(key).get(key) do
+      {stale_at, value} ->
+        if DateTime.before?(now, stale_at), do: {:fresh, value}, else: {:stale, value}
+
+      nil ->
+        nil
+    end
+  end
+
+  @doc "Put a response in the cache."
+  @spec put(key(), term()) :: :ok
+  @spec put(key(), term(), now :: DateTime.t()) :: :ok
+  def put(key, value, now \\ DateTime.utc_now()) do
+    cache = cache_for(key)
+    stale_at = DateTime.add(now, cache.unconditional_ttl(), :millisecond)
+    cache.put(key, {stale_at, value})
+  end
+
+  # Imperfectly check whether a request could return any data derived from GTFS-RT, and assign
+  # it to the appropriate cache. Should err on the side of over-categorizing data as `Realtime`,
+  # since we give static data a very long unconditional TTL.
+  defp cache_for({path, params}) do
+    if String.contains?(path, @realtime_resources) or
+         params |> Map.get("include", "") |> String.contains?(@realtime_resources),
+       do: Realtime,
+       else: Static
+  end
+end

--- a/test/screens/v3_api/cache_test.exs
+++ b/test/screens/v3_api/cache_test.exs
@@ -1,0 +1,57 @@
+defmodule Screens.V3Api.CacheTest do
+  use ExUnit.Case, async: true
+
+  alias Screens.V3Api.Cache
+
+  setup do
+    # Since these use the real cache, add a unique value to each test's parameters to avoid
+    # collisions with other tests.
+    {:ok, now: DateTime.utc_now(), params: %{_unique: inspect(make_ref())}}
+  end
+
+  defp put_and_get_after(key, value, now, amount, unit) do
+    Cache.put(key, value, now)
+    Cache.get(key, DateTime.add(now, amount, unit))
+  end
+
+  test "gets nil for nonexistent keys", %{params: params} do
+    assert Cache.get({"routes", params}) == nil
+  end
+
+  test "uses path and params as the cache key", %{params: params} do
+    params1 = Map.put(params, :x, 1)
+    params2 = Map.put(params, :x, 2)
+    Cache.put({"one", params1}, "valA")
+    Cache.put({"one", params2}, "valB")
+    Cache.put({"two", params1}, "valC")
+    Cache.put({"two", params2}, "valD")
+
+    assert {_, "valA"} = Cache.get({"one", params1})
+    assert {_, "valB"} = Cache.get({"one", params2})
+    assert {_, "valC"} = Cache.get({"two", params1})
+    assert {_, "valD"} = Cache.get({"two", params2})
+  end
+
+  test "gets fresh static data", %{now: now, params: params} do
+    assert {:fresh, "fs1"} = put_and_get_after({"routes", params}, "fs1", now, 15, :minute)
+  end
+
+  test "gets fresh realtime data", %{now: now, params: params} do
+    assert {:fresh, "fr1"} = put_and_get_after({"alerts", params}, "fr1", now, 2, :second)
+  end
+
+  test "gets stale static data", %{now: now, params: params} do
+    assert {:stale, "ss1"} = put_and_get_after({"routes", params}, "ss1", now, 2, :hour)
+  end
+
+  test "gets stale realtime data", %{now: now, params: params} do
+    assert {:stale, "sr1"} = put_and_get_after({"alerts", params}, "sr1", now, 10, :second)
+  end
+
+  test "determines cache based on include param", %{now: now, params: params} do
+    assert {:fresh, "resp1"} = put_and_get_after({"trips", params}, "resp1", now, 10, :second)
+
+    rt_params = Map.put(params, "include", "shape,predictions,route_pattern.route")
+    assert {:stale, "resp2"} = put_and_get_after({"trips", rt_params}, "resp2", now, 10, :second)
+  end
+end


### PR DESCRIPTION
Investigating high memory usage in production suggested the V3 API connection pool was a major factor: each open connection consumes about 5MB, and with a pool size of 100, the pool could consume close to 500MB during peak usage, which is half the memory allotted to our instances. Add the 250MB limit on our API response cache and it becomes clear how we could start cutting things close.

Reducing the pool size would be an obvious step to take; but then we _do_ use all of those 100 connections (and still want more!) during peak times. If we could reduce the number of concurrent connections we need, then we could also reduce the pool size without impacting screen performance/stability.

To that end, this change:

* Reduces the V3 API connection pool size to 50 (the default). This should give us ~250MB of overhead.

* Splits API response caching into `Static` and `Realtime` buckets, based on which resources are included in the request, each with its own memory limit and GC settings. The static cache gets 150MB and the realtime cache 50MB, leaving some overhead from the ~250MB previously allotted to the shared cache. (Keeping in mind caches may exceed their memory limit for up to `gc_cleanup_min_timeout`, which defaults to 10 seconds.)

* Adds a layer of "unconditional" response caching: for a period after a response is cached (different for static vs. realtime), it is served from the cache without making an HTTP call to check whether it is outdated. Experimentally this allows ~25% of realtime data requests, and 80-99% of static data requests (depending on time of day), to be served without checking out an HTTP connection at all. This is what theoretically allows reducing the connection pool size without harming performance.

* Adds telemetry for cache statistics.

**Asana task**: https://app.asana.com/0/1185117109217413/1208614347699410