### PR TITLE
Add CSS for elevator takeover

### DIFF
--- a/assets/css/elevator_v2.scss
+++ b/assets/css/elevator_v2.scss
@@ -12,6 +12,7 @@
 @import "v2/elevator/footer";
 @import "v2/lcd_common/route_pill";
 @import "v2/arrow";
+@import "v2/elevator/screen/takeover";
 
 .evergreen-content-image__container,
 .evergreen-content-image__image {

--- a/assets/css/v2/elevator/screen/takeover.scss
+++ b/assets/css/v2/elevator/screen/takeover.scss
@@ -1,0 +1,14 @@
+.screen-takeover {
+  position: relative;
+  width: 1080px;
+  margin-right: auto;
+  margin-left: auto;
+}
+
+.screen-takeover__full-screen {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 1080px;
+  height: 1920px;
+}


### PR DESCRIPTION
Ad-hoc

Betsy called out two issues seen with elevator screens showing evergreen content [in slack](https://mbta.slack.com/archives/C039ARUM48H/p1736361819704629), one of them being that the screen was appearing very small.

I'm not sure if I have the explanation down quite right, but I think this was happening because we were missing the appropriate CSS classes for elevator screen takeovers and so the typical down-scaling that we do to size screens appropriately into Screenplay was being applied to the screen's dimensions and not the takeover container's dimensions.
