### PR TITLE
chore: Update fallback text to link to elevators endpoint

### DIFF
--- a/lib/screens/v2/candidate_generator/elevator/closures.ex
+++ b/lib/screens/v2/candidate_generator/elevator/closures.ex
@@ -52,7 +52,7 @@ defmodule Screens.V2.CandidateGenerator.Elevator.Closures do
   @route injected(Route)
   @stop injected(Stop)
 
-  @fallback_summary "Visit mbta.com/alerts for more info"
+  @fallback_summary "Visit mbta.com/elevators for more info"
 
   @spec elevator_status_instances(Screen.t(), NormalHeader.t(), Footer.t()) ::
           list(WidgetInstance.t())

--- a/priv/elevators.json
+++ b/priv/elevators.json
@@ -43,7 +43,7 @@
     "redundancy": null
   },
   "986": {
-    "summary": "Visit mbta.com/alerts for more info.",
+    "summary": "Visit mbta.com/elevators for more info.",
     "alternate_ids": [
       "896"
     ],
@@ -224,7 +224,7 @@
     "redundancy": 1
   },
   "971": {
-    "summary": "Visit mbta.com/alerts for more info.",
+    "summary": "Visit mbta.com/elevators for more info.",
     "alternate_ids": [
       "972",
       "948",
@@ -305,7 +305,7 @@
     "redundancy": 3
   },
   "896": {
-    "summary": "Visit mbta.com/alerts for more info.",
+    "summary": "Visit mbta.com/elevators for more info.",
     "alternate_ids": [
       "810",
       "805",
@@ -378,7 +378,7 @@
     "redundancy": 2
   },
   "910": {
-    "summary": "Visit mbta.com/alerts for more info.",
+    "summary": "Visit mbta.com/elevators for more info.",
     "alternate_ids": [
       "911",
       "905",
@@ -548,7 +548,7 @@
     "redundancy": 3
   },
   "944": {
-    "summary": "Visit mbta.com/alerts for more info.",
+    "summary": "Visit mbta.com/elevators for more info.",
     "alternate_ids": [
       "945",
       "911",
@@ -1109,7 +1109,7 @@
     "redundancy": 3
   },
   "831": {
-    "summary": "Visit mbta.com/alerts for more info.",
+    "summary": "Visit mbta.com/elevators for more info.",
     "alternate_ids": [
       "830",
       "880",
@@ -1301,7 +1301,7 @@
     "redundancy": 2
   },
   "830": {
-    "summary": "Visit mbta.com/alerts for more info.",
+    "summary": "Visit mbta.com/elevators for more info.",
     "alternate_ids": [
       "831",
       "880",
@@ -1635,7 +1635,7 @@
     "redundancy": 2
   },
   "934": {
-    "summary": "Visit mbta.com/alerts for more info.",
+    "summary": "Visit mbta.com/elevators for more info.",
     "alternate_ids": [
       "935",
       "901",
@@ -1665,7 +1665,7 @@
     "redundancy": 2
   },
   "977": {
-    "summary": "Visit mbta.com/alerts for more info.",
+    "summary": "Visit mbta.com/elevators for more info.",
     "alternate_ids": [
       "976",
       "962",

--- a/test/screens/v2/candidate_generator/elevator/closures_test.exs
+++ b/test/screens/v2/candidate_generator/elevator/closures_test.exs
@@ -169,7 +169,7 @@ defmodule Screens.V2.CandidateGenerator.Elevator.ClosuresTest do
                        %Closure{id: "facility-test-1", name: "Test 1"},
                        %Closure{id: "facility-test-2", name: "Test 2"}
                      ],
-                     summary: "Visit mbta.com/alerts for more info"
+                     summary: "Visit mbta.com/elevators for more info"
                    }
                  ]
                },
@@ -405,7 +405,7 @@ defmodule Screens.V2.CandidateGenerator.Elevator.ClosuresTest do
                    %ElevatorClosuresList.Station{
                      id: "place-3",
                      closures: [%Closure{id: "3"}],
-                     summary: "Visit mbta.com/alerts for more info"
+                     summary: "Visit mbta.com/elevators for more info"
                    }
                  ]
                },


### PR DESCRIPTION
Today when checking out the elevator screens at Forest Hills, we noticed that the fallback text for elevator screen instructions did not reference the updated link.

 Image with updated link below.

<img width="408" alt="image" src="https://github.com/user-attachments/assets/80c70654-84aa-45d6-b402-30ad0df44b88" />

- [ ] Tests added?
