### PR TITLE
fix: show only active closures on elevator screens

### DIFF
--- a/lib/screens/v2/candidate_generator/elevator/closures.ex
+++ b/lib/screens/v2/candidate_generator/elevator/closures.ex
@@ -62,7 +62,9 @@ defmodule Screens.V2.CandidateGenerator.Elevator.Closures do
         footer_instance
       ) do
     {:ok, alerts} = @alert.fetch_elevator_alerts_with_facilities()
-    closures = Enum.flat_map(alerts, &elevator_closure/1)
+
+    closures =
+      alerts |> Enum.filter(&Alert.happening_now?/1) |> Enum.flat_map(&elevator_closure/1)
 
     case Enum.find(closures, fn %Closure{id: id} -> id == elevator_id end) do
       nil ->


### PR DESCRIPTION
**Asana task**: https://app.asana.com/0/1185117109217413/1209154878642792