### PR TITLE
refactor: elevator closure header/footer handling

### DIFF
--- a/lib/screens/v2/candidate_generator/elevator.ex
+++ b/lib/screens/v2/candidate_generator/elevator.ex
@@ -5,12 +5,15 @@ defmodule Screens.V2.CandidateGenerator.Elevator do
   alias Screens.V2.CandidateGenerator.Elevator.Closures, as: ElevatorClosures
   alias Screens.V2.CandidateGenerator.Widgets.Evergreen
   alias Screens.V2.Template.Builder
-  alias Screens.V2.WidgetInstance.{Footer, NormalHeader}
-  alias ScreensConfig.Screen
-  alias ScreensConfig.V2.Elevator
 
   @behaviour CandidateGenerator
 
+  @instance_fns [
+    &ElevatorClosures.elevator_status_instances/2,
+    &Evergreen.evergreen_content_instances/2
+  ]
+
+  @impl true
   def screen_template do
     {
       :screen,
@@ -26,29 +29,11 @@ defmodule Screens.V2.CandidateGenerator.Elevator do
     |> Builder.build_template()
   end
 
-  def candidate_instances(
-        config,
-        now \\ DateTime.utc_now(),
-        elevator_closure_instances_fn \\ &ElevatorClosures.elevator_status_instances/3,
-        evergreen_content_instances_fn \\ &Evergreen.evergreen_content_instances/2
-      ) do
-    Enum.concat([
-      elevator_closure_instances_fn.(
-        config,
-        header_instance(config, now),
-        footer_instance(config)
-      ),
-      evergreen_content_instances_fn.(config, now)
-    ])
+  @impl true
+  def candidate_instances(config, now \\ DateTime.utc_now(), instance_fns \\ @instance_fns) do
+    instance_fns |> Enum.map(& &1.(config, now)) |> Enum.concat()
   end
 
+  @impl true
   def audio_only_instances(_widgets, _config), do: []
-
-  defp header_instance(%Screen{app_params: %Elevator{elevator_id: elevator_id}} = config, now) do
-    %NormalHeader{text: "Elevator #{elevator_id}", screen: config, time: now}
-  end
-
-  defp footer_instance(config) do
-    %Footer{screen: config}
-  end
 end

--- a/test/screens/v2/candidate_generator/elevator_test.exs
+++ b/test/screens/v2/candidate_generator/elevator_test.exs
@@ -3,7 +3,6 @@ defmodule Screens.V2.CandidateGenerator.ElevatorTest do
 
   alias ScreensConfig.{Screen, V2}
   alias Screens.V2.CandidateGenerator.Elevator
-  alias Screens.V2.WidgetInstance.{Footer, NormalHeader}
 
   setup do
     config = %Screen{
@@ -31,31 +30,16 @@ defmodule Screens.V2.CandidateGenerator.ElevatorTest do
     end
   end
 
-  describe "candidate_instances/4" do
-    test "returns expected header and footer", %{config: config} do
+  describe "candidate_instances/3" do
+    test "calls instance generator functions and combines the results", %{config: config} do
       now = ~U[2020-04-06T10:00:00Z]
 
-      expected_header = %NormalHeader{
-        screen: config,
-        icon: nil,
-        text: "Elevator 1",
-        time: now
-      }
+      instance_fns = [
+        fn ^config, ^now -> ~w[one two]a end,
+        fn ^config, ^now -> ~w[three]a end
+      ]
 
-      expected_footer = %Footer{screen: config}
-      elevator_closure_instances_fn = fn _, _, _ -> [expected_header, expected_footer] end
-      evergreen_content_instances_fn = fn _, _ -> [] end
-
-      actual_instances =
-        Elevator.candidate_instances(
-          config,
-          now,
-          elevator_closure_instances_fn,
-          evergreen_content_instances_fn
-        )
-
-      assert expected_header in actual_instances
-      assert expected_footer in actual_instances
+      assert Elevator.candidate_instances(config, now, instance_fns) == ~w[one two three]a
     end
   end
 end


### PR DESCRIPTION
Some refactoring on the way to future elevator closures.

* Rather than the main Elevator screen candidate generator creating the header and footer widgets and the Closures generator "modifying" them with variants as appropriate, now the Closures generator alone is responsible. This somewhat simplifies the implementation and testing on both ends.

* Tests for the Closures generator were more verbose and testing more than they strictly needed to be (for example, that the correct header and footer were present in every case). These are now cut down to only the relevant and unique details.