### PR TITLE
fix: inspector showing `NaN` audio interval

### DIFF
--- a/assets/src/apps/v2/bus_shelter.tsx
+++ b/assets/src/apps/v2/bus_shelter.tsx
@@ -106,12 +106,8 @@ const getAudioConfig = (): AudioConfig | null => {
   );
   const audioReadoutInterval = getDatasetValue("audioReadoutInterval");
 
-  if (
-    audioIntervalOffsetSeconds === undefined ||
-    audioReadoutInterval === undefined
-  ) {
+  if (!audioReadoutInterval || audioIntervalOffsetSeconds === undefined)
     return null;
-  }
 
   return {
     intervalOffsetSeconds: parseInt(audioIntervalOffsetSeconds),


### PR DESCRIPTION
When a screen normally capable of periodic audio readouts (Bus Shelter) had them disabled, this was incorrectly loaded as an interval of `NaN` minutes, rather than no interval at all. This basically worked anyway on the screens themselves, but showed up oddly in the Inspector.

<img width="345" alt="Screenshot 2025-01-24 at 5 03 06 PM" src="https://github.com/user-attachments/assets/b218ef29-3f05-4e12-9caf-808f73ab4086" />
