### PR TITLE
refactor: parse elevator entering redundancy

### DIFF
--- a/lib/screens/v2/candidate_generator/elevator/closures.ex
+++ b/lib/screens/v2/candidate_generator/elevator/closures.ex
@@ -174,7 +174,9 @@ defmodule Screens.V2.CandidateGenerator.Elevator.Closures do
 
   # If any of a closed elevator's alternates are also closed, it's always relevant.
   defp relevant_closure?(
-         %Closure{elevator: %Elevator{alternate_ids: alternate_ids, redundancy: redundancy}},
+         %Closure{
+           elevator: %Elevator{alternate_ids: alternate_ids, exiting_redundancy: redundancy}
+         },
          _home_station_id,
          closures
        ) do
@@ -182,7 +184,11 @@ defmodule Screens.V2.CandidateGenerator.Elevator.Closures do
   end
 
   defp backup_route_summary(
-         [%Closure{elevator: %Elevator{alternate_ids: alternate_ids, redundancy: redundancy}}],
+         [
+           %Closure{
+             elevator: %Elevator{alternate_ids: alternate_ids, exiting_redundancy: redundancy}
+           }
+         ],
          closures
        ) do
     # If any of a closed elevator's alternates are also closed, the normal summary may not be

--- a/priv/elevators.json
+++ b/priv/elevators.json
@@ -1,23 +1,27 @@
 {
   "918": {
+    "exiting": "2",
+    "entering": "2",
     "summary": "Accessible route available",
     "alternate_ids": [
       "901",
       "927",
       "919"
-    ],
-    "redundancy": 2
+    ]
   },
   "925": {
+    "exiting": "2",
+    "entering": "2",
     "summary": "Accessible route available",
     "alternate_ids": [
       "913",
       "914",
       "915"
-    ],
-    "redundancy": 2
+    ]
   },
   "804": {
+    "exiting": "2",
+    "entering": "2",
     "summary": "Accessible route available",
     "alternate_ids": [
       "892",
@@ -25,56 +29,63 @@
       "978",
       "812",
       "823"
-    ],
-    "redundancy": 2
+    ]
   },
   "958": {
+    "exiting": "3A",
+    "entering": "3A",
     "summary": "Exit at Shawmut. Take an Alewife train back to Fields Corner.",
     "alternate_ids": [
       "953",
       "964",
       "957"
-    ],
-    "redundancy": 3
+    ]
   },
   "780": {
+    "exiting": "",
+    "entering": "?",
     "summary": "Request assistance from conductor.",
-    "alternate_ids": [],
-    "redundancy": null
+    "alternate_ids": []
   },
   "986": {
+    "exiting": "3BC",
+    "entering": "3D",
     "summary": "Visit mbta.com/elevators for more info.",
     "alternate_ids": [
       "896"
-    ],
-    "redundancy": 3
+    ]
   },
   "921": {
+    "exiting": "3A",
+    "entering": "3A",
     "summary": "Exit at Copley. Take a Heath St train back to Prudential.",
     "alternate_ids": [
       "920",
       "917",
       "977",
       "976"
-    ],
-    "redundancy": 3
+    ]
   },
   "725": {
+    "exiting": "",
+    "entering": "?",
     "summary": "Request assistance from conductor.",
     "alternate_ids": [
       "727"
-    ],
-    "redundancy": null
+    ]
   },
   "816": {
+    "exiting": "3B",
+    "entering": "3B",
     "summary": "Exit at Harvard. Request shuttle bus back to Davis.",
     "alternate_ids": [
       "821",
       "973"
-    ],
-    "redundancy": 3
+    ]
   },
   "866": {
+    "exiting": "3A",
+    "entering": "3A",
     "summary": "Exit at Harvard. Take an Ashmont/Braintree train back to Kendall/MIT.",
     "alternate_ids": [
       "863",
@@ -82,216 +93,242 @@
       "973",
       "951",
       "952"
-    ],
-    "redundancy": 3
+    ]
   },
   "996": {
+    "exiting": "1",
+    "entering": "1",
     "summary": "N/A",
     "alternate_ids": [
       "997"
-    ],
-    "redundancy": 1
+    ]
   },
   "744": {
+    "exiting": "2",
+    "entering": "2",
     "summary": "Accessible route available",
     "alternate_ids": [
       "800",
       "945"
-    ],
-    "redundancy": 2
+    ]
   },
   "710": {
+    "exiting": "2",
+    "entering": "2",
     "summary": "Accessible route available",
     "alternate_ids": [
       "701",
       "702",
       "703"
-    ],
-    "redundancy": 2
+    ]
   },
   "842": {
+    "exiting": "2A",
+    "entering": "2A",
     "summary": "Accessible route available",
     "alternate_ids": [
       "724"
-    ],
-    "redundancy": 2
+    ]
   },
   "899": {
+    "exiting": "2",
+    "entering": "2",
     "summary": "Accessible route available",
     "alternate_ids": [
       "900"
-    ],
-    "redundancy": 2
+    ]
   },
   "856": {
+    "exiting": "3D",
+    "entering": "3D",
     "summary": "Exit at Ruggles or Forest Hills. Take the Orange Line to Back Bay.",
     "alternate_ids": [
       "849",
       "850",
       "841",
       "842"
-    ],
-    "redundancy": 3
+    ]
   },
   "879": {
+    "exiting": "3A",
+    "entering": "3A",
     "summary": "Exit at JFK/UMass. Take an Alewife train back to Andrew.",
     "alternate_ids": [
       "880",
       "872"
-    ],
-    "redundancy": 3
+    ]
   },
   "901": {
+    "exiting": "2",
+    "entering": "2",
     "summary": "Accessible route available",
     "alternate_ids": [
       "918",
       "927",
       "919"
-    ],
-    "redundancy": 2
+    ]
   },
   "922": {
+    "exiting": "3A",
+    "entering": "3",
     "summary": "Exit at Tufts Medical Center. Take an Oak Grove train back to Chinatown.",
     "alternate_ids": [
       "876",
       "857",
       "858",
       "859"
-    ],
-    "redundancy": 3
+    ]
   },
   "945": {
+    "exiting": "3B",
+    "entering": "3B",
     "summary": "Exit at Oak Grove. Request shuttle bus back to Malden Center.",
     "alternate_ids": [
       "800",
       "801"
-    ],
-    "redundancy": 3
+    ]
   },
   "701": {
+    "exiting": "1",
+    "entering": "1",
     "summary": "N/A",
     "alternate_ids": [
       "702",
       "703"
-    ],
-    "redundancy": 1
+    ]
   },
   "771": {
+    "exiting": "2B",
+    "entering": "2B",
     "summary": "Accessible route available",
-    "alternate_ids": [],
-    "redundancy": 2
+    "alternate_ids": []
   },
   "734": {
+    "exiting": "2D",
+    "entering": "2D",
     "summary": "Accessible route available",
     "alternate_ids": [
       "733",
       "735"
-    ],
-    "redundancy": 2
+    ]
   },
   "979": {
+    "exiting": "2",
+    "entering": "2",
     "summary": "Accessible route available",
     "alternate_ids": [
       "808",
       "804"
-    ],
-    "redundancy": 2
+    ]
   },
   "936": {
+    "exiting": "3A",
+    "entering": "3A",
     "summary": "Exit at Silver Line Way. Take an inbound SL bus back to World Trade Center.",
     "alternate_ids": [
       "935",
       "937",
       "938"
-    ],
-    "redundancy": 3
+    ]
   },
   "957": {
+    "exiting": "3A",
+    "entering": "3A",
     "summary": "Exit at Savin Hill. Take an Ashmont train back to Fields Corner.",
     "alternate_ids": [
       "958",
       "953",
       "954"
-    ],
-    "redundancy": 3
+    ]
   },
   "998": {
+    "exiting": "1",
+    "entering": "1",
     "summary": "N/A",
     "alternate_ids": [
       "999",
       "869"
-    ],
-    "redundancy": 1
+    ]
   },
   "971": {
+    "exiting": "3AB",
+    "entering": "3A",
     "summary": "Visit mbta.com/elevators for more info.",
     "alternate_ids": [
       "972",
       "948",
       "976",
       "977"
-    ],
-    "redundancy": 3
+    ]
   },
   "913": {
+    "exiting": "2A",
+    "entering": "2A",
     "summary": "Accessible route available",
     "alternate_ids": [
       "924",
       "925"
-    ],
-    "redundancy": 2
+    ]
   },
   "855": {
+    "exiting": "3D",
+    "entering": "3D",
     "summary": "Exit at Ruggles or Forest Hills. Take the Orange Line to Back Bay.",
     "alternate_ids": [
       "849",
       "850",
       "841",
       "842"
-    ],
-    "redundancy": 3
+    ]
   },
   "731": {
+    "exiting": "2",
+    "entering": "2",
     "summary": "Accessible route available",
     "alternate_ids": [
       "912",
       "732"
-    ],
-    "redundancy": 2
+    ]
   },
   "892": {
+    "exiting": "2",
+    "entering": "2",
     "summary": "Accessible route available",
     "alternate_ids": [
       "804"
-    ],
-    "redundancy": 2
+    ]
   },
   "854": {
+    "exiting": "3D",
+    "entering": "3D",
     "summary": "Exit at Ruggles or Forest Hills. Take the Orange Line to Back Bay.",
     "alternate_ids": [
       "849",
       "850",
       "841",
       "842"
-    ],
-    "redundancy": 3
+    ]
   },
   "815": {
+    "exiting": "1",
+    "entering": "1",
     "summary": "N/A",
     "alternate_ids": [
       "814"
-    ],
-    "redundancy": 1
+    ]
   },
   "712": {
+    "exiting": "2",
+    "entering": "2",
     "summary": "Accessible route available",
     "alternate_ids": [
       "713",
       "715"
-    ],
-    "redundancy": 2
+    ]
   },
   "938": {
+    "exiting": "3A",
+    "entering": "3A",
     "summary": "Exit at World Trade Center. Take an inbound SL bus to Courthouse.",
     "alternate_ids": [
       "937",
@@ -301,72 +338,81 @@
       "918",
       "919",
       "927"
-    ],
-    "redundancy": 3
+    ]
   },
   "896": {
+    "exiting": "5",
+    "entering": "3D",
     "summary": "Visit mbta.com/elevators for more info.",
     "alternate_ids": [
       "810",
       "805",
       "830",
       "831"
-    ],
-    "redundancy": 5
+    ]
   },
   "886": {
+    "exiting": "3A",
+    "entering": "3A",
     "summary": "Exit at Suffolk Downs. Take a Wonderland train back to Beachmont.",
     "alternate_ids": [
       "887",
       "884",
       "885"
-    ],
-    "redundancy": 3
+    ]
   },
   "994": {
+    "exiting": "1",
+    "entering": "1",
     "summary": "N/A",
     "alternate_ids": [
       "995"
-    ],
-    "redundancy": 1
+    ]
   },
   "713": {
+    "exiting": "2",
+    "entering": "2",
     "summary": "Accessible route available",
     "alternate_ids": [
       "712",
       "714"
-    ],
-    "redundancy": 2
+    ]
   },
   "933": {
+    "exiting": "3B",
+    "entering": "3B",
     "summary": "Exit at Sullivan. Request shuttle bus back to Community College.",
     "alternate_ids": [
       "840",
       "881"
-    ],
-    "redundancy": 3
+    ]
   },
   "897": {
+    "exiting": "2",
+    "entering": "2",
     "summary": "Accessible route available",
     "alternate_ids": [
       "900"
-    ],
-    "redundancy": 2
+    ]
   },
   "769": {
+    "exiting": "2B",
+    "entering": "2B",
     "summary": "Accessible route available",
-    "alternate_ids": [],
-    "redundancy": 2
+    "alternate_ids": []
   },
   "869": {
+    "exiting": "2",
+    "entering": "2",
     "summary": "Accessible route available",
     "alternate_ids": [
       "998",
       "999"
-    ],
-    "redundancy": 2
+    ]
   },
   "908": {
+    "exiting": "2D",
+    "entering": "2D",
     "summary": "Accessible route available",
     "alternate_ids": [
       "904",
@@ -374,75 +420,85 @@
       "906",
       "907",
       "903"
-    ],
-    "redundancy": 2
+    ]
   },
   "910": {
+    "exiting": "5",
+    "entering": "3A",
     "summary": "Visit mbta.com/elevators for more info.",
     "alternate_ids": [
       "911",
       "905",
       "906",
       "907"
-    ],
-    "redundancy": 5
+    ]
   },
   "813": {
+    "exiting": "2A",
+    "entering": "2A",
     "summary": "Accessible route available",
     "alternate_ids": [
       "961"
-    ],
-    "redundancy": 2
+    ]
   },
   "891": {
+    "exiting": "2",
+    "entering": "2",
     "summary": "Accessible route available",
-    "alternate_ids": [],
-    "redundancy": 2
+    "alternate_ids": []
   },
   "947": {
+    "exiting": "2B",
+    "entering": "2B",
     "summary": "Accessible route available",
-    "alternate_ids": [],
-    "redundancy": 2
+    "alternate_ids": []
   },
   "724": {
+    "exiting": "2A",
+    "entering": "2A",
     "summary": "Accessible route available",
     "alternate_ids": [
       "842"
-    ],
-    "redundancy": 2
+    ]
   },
   "711": {
+    "exiting": "2",
+    "entering": "2",
     "summary": "Accessible route available",
     "alternate_ids": [
       "710"
-    ],
-    "redundancy": 2
+    ]
   },
   "782": {
+    "exiting": "",
+    "entering": "?",
     "summary": "Request assistance from conductor.",
-    "alternate_ids": [],
-    "redundancy": null
+    "alternate_ids": []
   },
   "972": {
+    "exiting": "3A",
+    "entering": "3A",
     "summary": "Exit at Copley. Take a Kenmore & West train back to Kenmore.",
     "alternate_ids": [
       "971",
       "948",
       "977",
       "976"
-    ],
-    "redundancy": 3
+    ]
   },
   "803": {
+    "exiting": "2",
+    "entering": "2",
     "summary": "Accessible route available",
     "alternate_ids": [
       "975",
       "892",
       "891"
-    ],
-    "redundancy": 2
+    ]
   },
   "978": {
+    "exiting": "2",
+    "entering": "2",
     "summary": "Accessible route available",
     "alternate_ids": [
       "804",
@@ -451,31 +507,35 @@
       "812",
       "823",
       "979"
-    ],
-    "redundancy": 2
+    ]
   },
   "992": {
+    "exiting": "",
+    "entering": "?",
     "summary": "Request assistance from conductor.",
-    "alternate_ids": [],
-    "redundancy": null
+    "alternate_ids": []
   },
   "859": {
+    "exiting": "3B",
+    "entering": "3B",
     "summary": "Exit at Back Bay. Request shuttle bus back to Tufts Medical Center.",
     "alternate_ids": [
       "853",
       "858"
-    ],
-    "redundancy": 3
+    ]
   },
   "702": {
+    "exiting": "1",
+    "entering": "1",
     "summary": "N/A",
     "alternate_ids": [
       "701",
       "703"
-    ],
-    "redundancy": 1
+    ]
   },
   "757": {
+    "exiting": "1",
+    "entering": "1",
     "summary": "N/A",
     "alternate_ids": [
       "756",
@@ -484,179 +544,202 @@
       "973",
       "951",
       "952"
-    ],
-    "redundancy": 1
+    ]
   },
   "965": {
+    "exiting": "2A",
+    "entering": "2A",
     "summary": "Accessible route available",
     "alternate_ids": [
       "966"
-    ],
-    "redundancy": 2
+    ]
   },
   "722": {
+    "exiting": "1",
+    "entering": "1",
     "summary": "N/A",
     "alternate_ids": [
       "723"
-    ],
-    "redundancy": 1
+    ]
   },
   "898": {
+    "exiting": "2",
+    "entering": "2",
     "summary": "Accessible route available",
     "alternate_ids": [
       "900"
-    ],
-    "redundancy": 2
+    ]
   },
   "717": {
+    "exiting": "2D",
+    "entering": "2D",
     "summary": "Accessible route available",
     "alternate_ids": [
       "718",
       "719"
-    ],
-    "redundancy": 2
+    ]
   },
   "915": {
+    "exiting": "2D",
+    "entering": "2",
     "summary": "Accessible route available",
     "alternate_ids": [
       "923",
       "924",
       "925"
-    ],
-    "redundancy": 2
+    ]
   },
   "807": {
+    "exiting": "1",
+    "entering": "1",
     "summary": "N/A",
     "alternate_ids": [
       "806"
-    ],
-    "redundancy": 1
+    ]
   },
   "852": {
+    "exiting": "3B",
+    "entering": "3B",
     "summary": "Exit at Back Bay. Request shuttle bus back to Mass Ave.",
     "alternate_ids": [
       "853"
-    ],
-    "redundancy": 3
+    ]
   },
   "858": {
+    "exiting": "3B",
+    "entering": "3B",
     "summary": "Exit at Back Bay. Request shuttle bus back to Tufts Medical Center.",
     "alternate_ids": [
       "853",
       "859"
-    ],
-    "redundancy": 3
+    ]
   },
   "944": {
+    "exiting": "5",
+    "entering": "3D",
     "summary": "Visit mbta.com/elevators for more info.",
     "alternate_ids": [
       "945",
       "911",
       "731",
       "732"
-    ],
-    "redundancy": 5
+    ]
   },
   "850": {
+    "exiting": "3B",
+    "entering": "3B",
     "summary": "Exit at Jackson Sq. Request shuttle bus back to Ruggles.",
     "alternate_ids": [
       "846",
       "847"
-    ],
-    "redundancy": 3
+    ]
   },
   "967": {
+    "exiting": "1",
+    "entering": "1",
     "summary": "N/A",
     "alternate_ids": [
       "974",
       "975",
       "802"
-    ],
-    "redundancy": 1
+    ]
   },
   "768": {
+    "exiting": "1",
+    "entering": "1",
     "summary": "N/A",
     "alternate_ids": [
       "767"
-    ],
-    "redundancy": 1
+    ]
   },
   "909": {
+    "exiting": "2",
+    "entering": "2",
     "summary": "Accessible route available",
     "alternate_ids": [
       "912",
       "731"
-    ],
-    "redundancy": 2
+    ]
   },
   "970": {
+    "exiting": "4B",
+    "entering": "N/A",
     "summary": "Request assistance to exit.",
-    "alternate_ids": [],
-    "redundancy": 4
+    "alternate_ids": []
   },
   "868": {
+    "exiting": "3B",
+    "entering": "3B",
     "summary": "Exit at Andrew. Request shuttle bus back to Broadway.",
     "alternate_ids": [
       "872",
       "879",
       "880"
-    ],
-    "redundancy": 3
+    ]
   },
   "52": {
+    "exiting": "4A",
+    "entering": "4A",
     "summary": "Request assistance from conductor.",
-    "alternate_ids": [],
-    "redundancy": 4
+    "alternate_ids": []
   },
   "920": {
+    "exiting": "3A",
+    "entering": "3A",
     "summary": "Exit at Northeastern. Take a Medford/Tufts train back to Prudential.",
     "alternate_ids": [
       "921",
       "917",
       "977",
       "976"
-    ],
-    "redundancy": 3
+    ]
   },
   "949": {
+    "exiting": "2",
+    "entering": "2",
     "summary": "Accessible route available",
     "alternate_ids": [
       "926",
       "6476"
-    ],
-    "redundancy": 2
+    ]
   },
   "746": {
+    "exiting": "1",
+    "entering": "1",
     "summary": "N/A",
     "alternate_ids": [
       "743"
-    ],
-    "redundancy": 1
+    ]
   },
   "805": {
+    "exiting": "1",
+    "entering": "1",
     "summary": "N/A",
     "alternate_ids": [
       "736",
       "810"
-    ],
-    "redundancy": 1
+    ]
   },
   "930": {
+    "exiting": "1",
+    "entering": "1",
     "summary": "N/A",
     "alternate_ids": [
       "929"
-    ],
-    "redundancy": 1
+    ]
   },
   "719": {
+    "exiting": "2D",
+    "entering": "2D",
     "summary": "Accessible route available",
     "alternate_ids": [
       "716",
       "717"
-    ],
-    "redundancy": 2
+    ]
   },
   "937": {
+    "exiting": "3A",
+    "entering": "3A",
     "summary": "Exit at South Station. Take an outbound SL bus to Courthouse.",
     "alternate_ids": [
       "938",
@@ -666,153 +749,172 @@
       "918",
       "919",
       "927"
-    ],
-    "redundancy": 3
+    ]
   },
   "966": {
+    "exiting": "2A",
+    "entering": "2A",
     "summary": "Accessible route available",
     "alternate_ids": [
       "965"
-    ],
-    "redundancy": 2
+    ]
   },
   "946": {
+    "exiting": "3B",
+    "entering": "3B",
     "summary": "Exit at JFK/UMass. Request shuttle bus back to Savin Hill.",
     "alternate_ids": [
       "831",
       "830"
-    ],
-    "redundancy": 3
+    ]
   },
   "814": {
+    "exiting": "1",
+    "entering": "1",
     "summary": "N/A",
     "alternate_ids": [
       "815"
-    ],
-    "redundancy": 1
+    ]
   },
   "709": {
+    "exiting": "2",
+    "entering": "2",
     "summary": "Accessible route available",
     "alternate_ids": [
       "701",
       "702",
       "703"
-    ],
-    "redundancy": 2
+    ]
   },
   "721": {
+    "exiting": "1",
+    "entering": "1",
     "summary": "N/A",
     "alternate_ids": [
       "720"
-    ],
-    "redundancy": 1
+    ]
   },
   "762": {
+    "exiting": "1",
+    "entering": "1",
     "summary": "N/A",
     "alternate_ids": [
       "763",
       "764"
-    ],
-    "redundancy": 1
+    ]
   },
   "846": {
+    "exiting": "3B",
+    "entering": "3B",
     "summary": "Exit at Stony Brook. Request shuttle bus back to Jackson Sq.",
     "alternate_ids": [
       "845",
       "847"
-    ],
-    "redundancy": 3
+    ]
   },
   "802": {
+    "exiting": "1",
+    "entering": "1",
     "summary": "N/A",
     "alternate_ids": [
       "967",
       "974",
       "975"
-    ],
-    "redundancy": 1
+    ]
   },
   "880": {
+    "exiting": "3A",
+    "entering": "3A",
     "summary": "Exit at Broadway. Take an Ashmont/Braintree train back to Andrew.",
     "alternate_ids": [
       "879",
       "872"
-    ],
-    "redundancy": 3
+    ]
   },
   "781": {
+    "exiting": "",
+    "entering": "?",
     "summary": "Request assistance from conductor.",
-    "alternate_ids": [],
-    "redundancy": null
+    "alternate_ids": []
   },
   "876": {
+    "exiting": "3C",
+    "entering": "3A",
     "summary": "Exit at Tufts Medical Center. Take an SL4 or SL5 bus to Chinatown.",
     "alternate_ids": [
       "922",
       "857",
       "858",
       "859"
-    ],
-    "redundancy": 3
+    ]
   },
   "715": {
+    "exiting": "2",
+    "entering": "2",
     "summary": "Accessible route available",
     "alternate_ids": [
       "714",
       "712"
-    ],
-    "redundancy": 2
+    ]
   },
   "864": {
+    "exiting": "2AB",
+    "entering": "2AB",
     "summary": "Accessible route available",
     "alternate_ids": [
       "865"
-    ],
-    "redundancy": 2
+    ]
   },
   "969": {
+    "exiting": "2",
+    "entering": "2",
     "summary": "Accessible route available",
     "alternate_ids": [
       "968"
-    ],
-    "redundancy": 2
+    ]
   },
   "890": {
+    "exiting": "3A",
+    "entering": "3A",
     "summary": "Exit at Orient Heights. Take a Bowdoin train back to Wood Island.",
     "alternate_ids": [
       "712",
       "714",
       "931",
       "932"
-    ],
-    "redundancy": 3
+    ]
   },
   "927": {
+    "exiting": "2D",
+    "entering": "2D",
     "summary": "Accessible route available",
     "alternate_ids": [
       "919",
       "918"
-    ],
-    "redundancy": 2
+    ]
   },
   "889": {
+    "exiting": "3A",
+    "entering": "3A",
     "summary": "Exit at Airport. Take a Wonderland train back to Wood Island.",
     "alternate_ids": [
       "712",
       "714",
       "931",
       "932"
-    ],
-    "redundancy": 3
+    ]
   },
   "973": {
+    "exiting": "2",
+    "entering": "2",
     "summary": "Accessible route available",
     "alternate_ids": [
       "821"
-    ],
-    "redundancy": 2
+    ]
   },
   "904": {
+    "exiting": "2D",
+    "entering": "2D",
     "summary": "Accessible route available",
     "alternate_ids": [
       "903",
@@ -820,90 +922,101 @@
       "906",
       "907",
       "908"
-    ],
-    "redundancy": 2
+    ]
   },
   "870": {
+    "exiting": "3",
+    "entering": "3",
     "summary": "Exit at Park St. ",
     "alternate_ids": [
       "979",
       "978"
-    ],
-    "redundancy": 3
+    ]
   },
   "975": {
+    "exiting": "2D",
+    "entering": "2D",
     "summary": "Accessible route available",
     "alternate_ids": [
       "974",
       "967",
       "802"
-    ],
-    "redundancy": 2
+    ]
   },
   "964": {
+    "exiting": "3B",
+    "entering": "3B",
     "summary": "Exit at Copley. Request shuttle bus back to Arlington.",
     "alternate_ids": [
       "976",
       "977"
-    ],
-    "redundancy": 3
+    ]
   },
   "982": {
+    "exiting": "1",
+    "entering": "2",
     "summary": "N/A",
     "alternate_ids": [
       "985"
-    ],
-    "redundancy": 1
+    ]
   },
   "847": {
+    "exiting": "3B",
+    "entering": "3B",
     "summary": "Exit at Ruggles. Request shuttle bus back to Roxbury Crossing.",
     "alternate_ids": [
       "846",
       "850"
-    ],
-    "redundancy": 3
+    ]
   },
   "923": {
+    "exiting": "2",
+    "entering": "2",
     "summary": "Accessible route available",
     "alternate_ids": [
       "914",
       "915"
-    ],
-    "redundancy": 2
+    ]
   },
   "857": {
+    "exiting": "3B",
+    "entering": "3B",
     "summary": "Exit at Back Bay. Request shuttle bus back to Tufts Medical Center.",
     "alternate_ids": [
       "853",
       "876",
       "922"
-    ],
-    "redundancy": 3
+    ]
   },
   "808": {
+    "exiting": "2",
+    "entering": "2",
     "summary": "Accessible route available",
     "alternate_ids": [
       "978",
       "979"
-    ],
-    "redundancy": 2
+    ]
   },
   "732": {
+    "exiting": "2",
+    "entering": "2",
     "summary": "Accessible route available",
     "alternate_ids": [
       "731",
       "912"
-    ],
-    "redundancy": 2
+    ]
   },
   "851": {
+    "exiting": "3B",
+    "entering": "3B",
     "summary": "Exit at Ruggles. Request shuttle bus back to Ruggles.",
     "alternate_ids": [
       "N/A"
-    ],
-    "redundancy": 3
+    ]
   },
   "905": {
+    "exiting": "2D",
+    "entering": "2D",
     "summary": "Accessible route available",
     "alternate_ids": [
       "904",
@@ -911,17 +1024,19 @@
       "906",
       "907",
       "908"
-    ],
-    "redundancy": 2
+    ]
   },
   "806": {
+    "exiting": "1",
+    "entering": "1",
     "summary": "N/A",
     "alternate_ids": [
       "807"
-    ],
-    "redundancy": 1
+    ]
   },
   "849": {
+    "exiting": "3D",
+    "entering": "3D",
     "summary": "Exit at Back Bay. Take the Orange Line to Ruggles. ",
     "alternate_ids": [
       "850",
@@ -929,78 +1044,87 @@
       "854",
       "855",
       "856"
-    ],
-    "redundancy": 3
+    ]
   },
   "885": {
+    "exiting": "3A",
+    "entering": "3A",
     "summary": "Exit at Wonderland. Take a Bowdoin train back to Revere Beach.",
     "alternate_ids": [
       "884",
       "709",
       "710"
-    ],
-    "redundancy": 3
+    ]
   },
   "912": {
+    "exiting": "2",
+    "entering": "2",
     "summary": "Accessible route available",
     "alternate_ids": [
       "731",
       "732",
       "909",
       ""
-    ],
-    "redundancy": 2
+    ]
   },
   "845": {
+    "exiting": "3B",
+    "entering": "3B",
     "summary": "Exit at Jackson Sq. Request shuttle bus back to Stony Brook.",
     "alternate_ids": [
       "846"
-    ],
-    "redundancy": 3
+    ]
   },
   "811": {
+    "exiting": "3B",
+    "entering": "3B",
     "summary": "Exit at Quincy Adams. Request shuttle bus back to Braintree.",
     "alternate_ids": [
       "805",
       "810"
-    ],
-    "redundancy": 3
+    ]
   },
   "900": {
+    "exiting": "2",
+    "entering": "2",
     "summary": "Accessible route available",
     "alternate_ids": [
       "897",
       "898",
       "899"
-    ],
-    "redundancy": 2
+    ]
   },
   "763": {
+    "exiting": "1",
+    "entering": "1",
     "summary": "N/A",
     "alternate_ids": [
       "762",
       "764"
-    ],
-    "redundancy": 1
+    ]
   },
   "735": {
+    "exiting": "2",
+    "entering": "2",
     "summary": "Accessible route available",
     "alternate_ids": [
       "734"
-    ],
-    "redundancy": 2
+    ]
   },
   "823": {
+    "exiting": "2",
+    "entering": "2",
     "summary": "Accessible route available",
     "alternate_ids": [
       "808",
       "978",
       "804",
       "979"
-    ],
-    "redundancy": 2
+    ]
   },
   "841": {
+    "exiting": "3D",
+    "entering": "3D",
     "summary": "Exit at Ruggles or Back Bay. Take the Orange Line to Forest Hills.",
     "alternate_ids": [
       "850",
@@ -1010,18 +1134,20 @@
       "855",
       "856",
       "724"
-    ],
-    "redundancy": 3
+    ]
   },
   "999": {
+    "exiting": "1",
+    "entering": "1",
     "summary": "N/A",
     "alternate_ids": [
       "998",
       "869"
-    ],
-    "redundancy": 1
+    ]
   },
   "906": {
+    "exiting": "2",
+    "entering": "2",
     "summary": "Accessible route available",
     "alternate_ids": [
       "903",
@@ -1029,10 +1155,11 @@
       "905",
       "907",
       "908"
-    ],
-    "redundancy": 2
+    ]
   },
   "954": {
+    "exiting": "3A",
+    "entering": "3A",
     "summary": "Exit at Ashmont. Take an Alewife train back to Shawmut.",
     "alternate_ids": [
       "953",
@@ -1041,10 +1168,11 @@
       "968",
       "969",
       "970"
-    ],
-    "redundancy": 3
+    ]
   },
   "953": {
+    "exiting": "3A",
+    "entering": "3A",
     "summary": "Exit at Fields Corner. Take an Ashmont train back to Shawmut.",
     "alternate_ids": [
       "954",
@@ -1053,17 +1181,19 @@
       "968",
       "969",
       "970"
-    ],
-    "redundancy": 3
+    ]
   },
   "772": {
+    "exiting": "1",
+    "entering": "1",
     "summary": "N/A",
     "alternate_ids": [
       "770"
-    ],
-    "redundancy": 1
+    ]
   },
   "861": {
+    "exiting": "3C",
+    "entering": "3A",
     "summary": "Exit at Harvard. Take a Route 1 bus to Central. ",
     "alternate_ids": [
       "860",
@@ -1071,24 +1201,27 @@
       "973",
       "863",
       "866"
-    ],
-    "redundancy": 3
+    ]
   },
   "952": {
+    "exiting": "3A",
+    "entering": "3A",
     "summary": "Exit at Kendall/MIT. Take an Ashmont/Braintree train back to Charles/MGH.",
     "alternate_ids": [
       "951",
       "866",
       "863"
-    ],
-    "redundancy": 3
+    ]
   },
   "843": {
+    "exiting": "2",
+    "entering": "2",
     "summary": "Accessible route available",
-    "alternate_ids": [],
-    "redundancy": 2
+    "alternate_ids": []
   },
   "962": {
+    "exiting": "3A",
+    "entering": "3A",
     "summary": "Exit at Copley. Take a Park St & North train back to Arlington.",
     "alternate_ids": [
       "963",
@@ -1096,80 +1229,90 @@
       "823",
       "976",
       "977"
-    ],
-    "redundancy": 3
+    ]
   },
   "884": {
+    "exiting": "3A",
+    "entering": "3A",
     "summary": "Exit at Beachmont. Take a Wonderland train back to Revere Beach.",
     "alternate_ids": [
       "885",
       "709",
       "710"
-    ],
-    "redundancy": 3
+    ]
   },
   "831": {
+    "exiting": "3AB",
+    "entering": "3A",
     "summary": "Visit mbta.com/elevators for more info.",
     "alternate_ids": [
       "830",
       "880",
       "879"
-    ],
-    "redundancy": 3
+    ]
   },
   "723": {
+    "exiting": "1",
+    "entering": "1",
     "summary": "N/A",
     "alternate_ids": [
       "722"
-    ],
-    "redundancy": 1
+    ]
   },
   "50": {
+    "exiting": "",
+    "entering": "7",
     "summary": "Request assistance from conductor.",
-    "alternate_ids": [],
-    "redundancy": null
+    "alternate_ids": []
   },
   "935": {
+    "exiting": "3",
+    "entering": "3A",
     "summary": "Exit at Courthouse. Take an outbound SL bus to World Trade Center.",
     "alternate_ids": [
       "936",
       "937",
       "938"
-    ],
-    "redundancy": 3
+    ]
   },
   "728": {
+    "exiting": "2",
+    "entering": "2",
     "summary": "Accessible route available",
     "alternate_ids": [
       "848"
-    ],
-    "redundancy": 2
+    ]
   },
   "745": {
+    "exiting": "2",
+    "entering": "2",
     "summary": "Accessible route available",
     "alternate_ids": [
       "744",
       "945",
       "800"
-    ],
-    "redundancy": 2
+    ]
   },
   "765": {
+    "exiting": "2A",
+    "entering": "2A",
     "summary": "Accessible route available",
     "alternate_ids": [
       "766"
-    ],
-    "redundancy": 2
+    ]
   },
   "919": {
+    "exiting": "2",
+    "entering": "2",
     "summary": "Accessible route available",
     "alternate_ids": [
       "927",
       "901"
-    ],
-    "redundancy": 2
+    ]
   },
   "963": {
+    "exiting": "3A",
+    "entering": "3A",
     "summary": "Exit at Park St. Take a westbound train back to Arlington.",
     "alternate_ids": [
       "962",
@@ -1177,44 +1320,50 @@
       "823",
       "976",
       "977"
-    ],
-    "redundancy": 3
+    ]
   },
   "991": {
+    "exiting": "",
+    "entering": "?",
     "summary": "Request assistance from conductor.",
-    "alternate_ids": [],
-    "redundancy": null
+    "alternate_ids": []
   },
   "985": {
+    "exiting": "2",
+    "entering": "2",
     "summary": "Accessible route available",
     "alternate_ids": [
       "982"
-    ],
-    "redundancy": 2
+    ]
   },
   "53": {
+    "exiting": "4A",
+    "entering": "4A",
     "summary": "Request assistance from conductor.",
-    "alternate_ids": [],
-    "redundancy": 4
+    "alternate_ids": []
   },
   "736": {
+    "exiting": "1",
+    "entering": "1",
     "summary": "N/A",
     "alternate_ids": [
       "805",
       "810"
-    ],
-    "redundancy": 1
+    ]
   },
   "867": {
+    "exiting": "3B",
+    "entering": "3B",
     "summary": "Exit at Andrew. Request shuttle bus back to Broadway.",
     "alternate_ids": [
       "872",
       "879",
       "880"
-    ],
-    "redundancy": 3
+    ]
   },
   "756": {
+    "exiting": "1",
+    "entering": "1",
     "summary": "N/A",
     "alternate_ids": [
       "757",
@@ -1223,10 +1372,11 @@
       "973",
       "951",
       "952"
-    ],
-    "redundancy": 1
+    ]
   },
   "903": {
+    "exiting": "2D",
+    "entering": "2D",
     "summary": "Accessible route available",
     "alternate_ids": [
       "904",
@@ -1234,189 +1384,214 @@
       "906",
       "907",
       "908"
-    ],
-    "redundancy": 2
+    ]
   },
   "940": {
+    "exiting": "2",
+    "entering": "2",
     "summary": "Accessible route available",
     "alternate_ids": [
       "939"
-    ],
-    "redundancy": 2
+    ]
   },
   "800": {
+    "exiting": "2",
+    "entering": "2",
     "summary": "Accessible route available",
     "alternate_ids": [
       "744",
       "945",
       "745"
-    ],
-    "redundancy": 2
+    ]
   },
   "726": {
+    "exiting": "",
+    "entering": "?",
     "summary": "Request assistance from conductor.",
     "alternate_ids": [
       "727"
-    ],
-    "redundancy": null
+    ]
   },
   "764": {
+    "exiting": "2A",
+    "entering": "2A",
     "summary": "Accessible route available",
     "alternate_ids": [
       "762",
       "763"
-    ],
-    "redundancy": 2
+    ]
   },
   "703": {
+    "exiting": "1",
+    "entering": "1",
     "summary": "N/A",
     "alternate_ids": [
       "701",
       "702"
-    ],
-    "redundancy": 1
+    ]
   },
   "887": {
+    "exiting": "3A",
+    "entering": "3A",
     "summary": "Exit at Revere Beach. Take a Bowdoin train back to Beachmont.",
     "alternate_ids": [
       "886",
       "884",
       "885"
-    ],
-    "redundancy": 3
+    ]
   },
   "872": {
+    "exiting": "3B",
+    "entering": "3B",
     "summary": "Exit at Broadway. Request shuttle bus back to Andrew.",
     "alternate_ids": [
       "868",
       "867"
-    ],
-    "redundancy": 3
+    ]
   },
   "733": {
+    "exiting": "2",
+    "entering": "2",
     "summary": "Accessible route available",
     "alternate_ids": [
       "734"
-    ],
-    "redundancy": 2
+    ]
   },
   "830": {
+    "exiting": "3AB",
+    "entering": "3A",
     "summary": "Visit mbta.com/elevators for more info.",
     "alternate_ids": [
       "831",
       "880",
       "879"
-    ],
-    "redundancy": 3
+    ]
   },
   "817": {
+    "exiting": "3B",
+    "entering": "3B",
     "summary": "Exit at Harvard. Request shuttle bus back to Davis.",
     "alternate_ids": [
       "821",
       "973"
-    ],
-    "redundancy": 3
+    ]
   },
   "853": {
+    "exiting": "3B",
+    "entering": "3B",
     "summary": "Exit at Mass Ave. Request shuttle bus back to Back Bay.",
     "alternate_ids": [
       "852"
-    ],
-    "redundancy": 3
+    ]
   },
   "955": {
+    "exiting": "2",
+    "entering": "2",
     "summary": "Accessible route available",
     "alternate_ids": [
       "932",
       "931"
-    ],
-    "redundancy": 2
+    ]
   },
   "968": {
+    "exiting": "2",
+    "entering": "2",
     "summary": "Accessible route available",
     "alternate_ids": [
       "969"
-    ],
-    "redundancy": 2
+    ]
   },
   "821": {
+    "exiting": "2",
+    "entering": "2",
     "summary": "Accessible route available",
     "alternate_ids": [
       "973"
-    ],
-    "redundancy": 2
+    ]
   },
   "928": {
+    "exiting": "4A",
+    "entering": "4A",
     "summary": "Request assistance from conductor.",
-    "alternate_ids": [],
-    "redundancy": 4
+    "alternate_ids": []
   },
   "931": {
+    "exiting": "2",
+    "entering": "2",
     "summary": "Accessible route available",
     "alternate_ids": [
       "956",
       "955"
-    ],
-    "redundancy": 2
+    ]
   },
   "766": {
+    "exiting": "2A",
+    "entering": "2A",
     "summary": "Accessible route available",
     "alternate_ids": [
       "765"
-    ],
-    "redundancy": 2
+    ]
   },
   "961": {
+    "exiting": "2A",
+    "entering": "2A",
     "summary": "Accessible route available",
     "alternate_ids": [
       "813"
-    ],
-    "redundancy": 2
+    ]
   },
   "993": {
+    "exiting": "",
+    "entering": "?",
     "summary": "Request assistance from conductor.",
-    "alternate_ids": [],
-    "redundancy": null
+    "alternate_ids": []
   },
   "997": {
+    "exiting": "1",
+    "entering": "1",
     "summary": "N/A",
     "alternate_ids": [
       "996"
-    ],
-    "redundancy": 1
+    ]
   },
   "812": {
+    "exiting": "2",
+    "entering": "2",
     "summary": "Accessible route available",
     "alternate_ids": [
       "808",
       "978",
       "804",
       "979"
-    ],
-    "redundancy": 2
+    ]
   },
   "990": {
+    "exiting": "",
+    "entering": "?",
     "summary": "Request assistance from conductor.",
-    "alternate_ids": [],
-    "redundancy": null
+    "alternate_ids": []
   },
   "926": {
+    "exiting": "2",
+    "entering": "2",
     "summary": "Accessible route available",
     "alternate_ids": [
       "949",
       "6476"
-    ],
-    "redundancy": 2
+    ]
   },
   "956": {
+    "exiting": "2",
+    "entering": "2",
     "summary": "Accessible route available",
     "alternate_ids": [
       "931",
       "932"
-    ],
-    "redundancy": 2
+    ]
   },
   "976": {
+    "exiting": "3A",
+    "entering": "3A",
     "summary": "Exit at Arlington. Take a westbound train back to Copley.",
     "alternate_ids": [
       "977",
@@ -1424,145 +1599,164 @@
       "963",
       "972",
       "971"
-    ],
-    "redundancy": 3
+    ]
   },
   "727": {
+    "exiting": "",
+    "entering": "?",
     "summary": "Request assistance from conductor.",
     "alternate_ids": [
       "725",
       "726"
-    ],
-    "redundancy": null
+    ]
   },
   "848": {
+    "exiting": "2",
+    "entering": "2",
     "summary": "Accessible route available",
     "alternate_ids": [
       "728"
-    ],
-    "redundancy": 2
+    ]
   },
   "983": {
+    "exiting": "1",
+    "entering": "1",
     "summary": "N/A",
     "alternate_ids": [
       "987"
-    ],
-    "redundancy": 1
+    ]
   },
   "743": {
+    "exiting": "1",
+    "entering": "1",
     "summary": "N/A",
     "alternate_ids": [
       "746"
-    ],
-    "redundancy": 1
+    ]
   },
   "810": {
+    "exiting": "3B",
+    "entering": "3B",
     "summary": "Exit at Quincy Adams. Request shuttle bus back to Quincy Center.",
     "alternate_ids": [
       "805",
       "806"
-    ],
-    "redundancy": 3
+    ]
   },
   "924": {
+    "exiting": "2",
+    "entering": "2",
     "summary": "Accessible route available",
     "alternate_ids": [
       "913",
       "915"
-    ],
-    "redundancy": 2
+    ]
   },
   "987": {
+    "exiting": "1",
+    "entering": "1",
     "summary": "N/A",
     "alternate_ids": [
       "983"
-    ],
-    "redundancy": 1
+    ]
   },
   "720": {
+    "exiting": "1",
+    "entering": "1",
     "summary": "N/A",
     "alternate_ids": [
       "721"
-    ],
-    "redundancy": 1
+    ]
   },
   "718": {
+    "exiting": "2D",
+    "entering": "2D",
     "summary": "Accessible route available",
     "alternate_ids": [
       "716",
       "717"
-    ],
-    "redundancy": 2
+    ]
   },
   "865": {
+    "exiting": "2AB",
+    "entering": "2AB",
     "summary": "Accessible route available",
     "alternate_ids": [
       "864"
-    ],
-    "redundancy": 2
+    ]
   },
   "911": {
+    "exiting": "3A",
+    "entering": "3A",
     "summary": "Exit at Community College. Take Forest Hills train back to North Station.",
     "alternate_ids": [
       "910",
       "905",
       "906",
       "907"
-    ],
-    "redundancy": 3
+    ]
   },
   "981": {
+    "exiting": "3A",
+    "entering": "3A",
     "summary": "Exit at Lechmere. Take a Copley & West  train back to Science Park/West End.",
     "alternate_ids": [
       "980"
-    ],
-    "redundancy": 3
+    ]
   },
   "932": {
+    "exiting": "2",
+    "entering": "2",
     "summary": "Accessible route available",
     "alternate_ids": [
       "955",
       "956"
-    ],
-    "redundancy": 2
+    ]
   },
   "716": {
+    "exiting": "2D",
+    "entering": "2D",
     "summary": "Accessible route available",
     "alternate_ids": [
       "718",
       "719"
-    ],
-    "redundancy": 2
+    ]
   },
   "980": {
+    "exiting": "3A",
+    "entering": "3A",
     "summary": "Exit at North Station. Take a Lechmere & North train back to Science Park/West End.",
     "alternate_ids": [
       "981"
-    ],
-    "redundancy": 3
+    ]
   },
   "948": {
+    "exiting": "2",
+    "entering": "2",
     "summary": "Accessible route available",
     "alternate_ids": [
       "972"
-    ],
-    "redundancy": 2
+    ]
   },
   "929": {
+    "exiting": "1",
+    "entering": "1",
     "summary": "N/A",
     "alternate_ids": [
       "930"
-    ],
-    "redundancy": 1
+    ]
   },
   "840": {
+    "exiting": "2AB",
+    "entering": "2AB",
     "summary": "Accessible route available",
     "alternate_ids": [
       "881"
-    ],
-    "redundancy": 2
+    ]
   },
   "907": {
+    "exiting": "2D",
+    "entering": "2D",
     "summary": "Accessible route available",
     "alternate_ids": [
       "903",
@@ -1570,101 +1764,114 @@
       "905",
       "906",
       "908"
-    ],
-    "redundancy": 2
+    ]
   },
   "844": {
+    "exiting": "3B",
+    "entering": "3B",
     "summary": "Exit at Forest Hills. Request shuttle bus back to Green Street.",
     "alternate_ids": [
       "842"
-    ],
-    "redundancy": 3
+    ]
   },
   "714": {
+    "exiting": "2",
+    "entering": "2",
     "summary": "Accessible route available",
     "alternate_ids": [
       "715",
       "713"
-    ],
-    "redundancy": 2
+    ]
   },
   "974": {
+    "exiting": "2D",
+    "entering": "2D",
     "summary": "Accessible route available",
     "alternate_ids": [
       "975",
       "967",
       "802"
-    ],
-    "redundancy": 2
+    ]
   },
   "917": {
+    "exiting": "3C",
+    "entering": "3C",
     "summary": "Exit at Northeastern. Take a Route 39 bus to Prudential. ",
-    "alternate_ids": [],
-    "redundancy": 3
+    "alternate_ids": []
   },
   "770": {
+    "exiting": "1",
+    "entering": "1",
     "summary": "N/A",
     "alternate_ids": [
       "772"
-    ],
-    "redundancy": 1
+    ]
   },
   "860": {
+    "exiting": "3A",
+    "entering": "3C",
     "summary": "Exit at Harvard. Take an Ashmont/Braintree train back to Central.",
     "alternate_ids": [
       "861",
       "821",
       "973"
-    ],
-    "redundancy": 3
+    ]
   },
   "951": {
+    "exiting": "3A",
+    "entering": "3A",
     "summary": "Exit at Park St. Take an Alewife train back to Charles/MGH.",
     "alternate_ids": [
       "952",
       "866",
       "863"
-    ],
-    "redundancy": 3
+    ]
   },
   "939": {
+    "exiting": "2",
+    "entering": "2",
     "summary": "Accessible route available",
     "alternate_ids": [
       "940"
-    ],
-    "redundancy": 2
+    ]
   },
   "934": {
+    "exiting": "",
+    "entering": "",
     "summary": "Visit mbta.com/elevators for more info.",
     "alternate_ids": [
       "935",
       "901",
       "927"
-    ],
-    "redundancy": null
+    ]
   },
   "51": {
+    "exiting": "",
+    "entering": "7",
     "summary": "Request assistance from conductor.",
-    "alternate_ids": [],
-    "redundancy": null
+    "alternate_ids": []
   },
   "708": {
+    "exiting": "2",
+    "entering": "2",
     "summary": "Accessible route available",
     "alternate_ids": [
       "701",
       "702",
       "703"
-    ],
-    "redundancy": 2
+    ]
   },
   "881": {
+    "exiting": "2AB",
+    "entering": "2AB",
     "summary": "Accessible route available",
     "alternate_ids": [
       "840"
-    ],
-    "redundancy": 2
+    ]
   },
   "977": {
+    "exiting": "3AB",
+    "entering": "3A",
     "summary": "Visit mbta.com/elevators for more info.",
     "alternate_ids": [
       "976",
@@ -1674,46 +1881,50 @@
       "921",
       "972",
       "971"
-    ],
-    "redundancy": 3
+    ]
   },
   "6476": {
+    "exiting": "2",
+    "entering": "2",
     "summary": "Accessible route available",
     "alternate_ids": [
       "926",
       "949"
-    ],
-    "redundancy": 2
+    ]
   },
   "801": {
+    "exiting": "3B",
+    "entering": "3B",
     "summary": "Exit at Malden Center. Request shuttle bus back to Oak Grove.",
     "alternate_ids": [
       "744",
       "800",
       "945"
-    ],
-    "redundancy": 3
+    ]
   },
   "767": {
+    "exiting": "1",
+    "entering": "1",
     "summary": "N/A",
     "alternate_ids": [
       "768"
-    ],
-    "redundancy": 1
+    ]
   },
   "914": {
+    "exiting": "2",
+    "entering": "2D",
     "summary": "Accessible route available",
     "alternate_ids": [
       "923",
       "925"
-    ],
-    "redundancy": 2
+    ]
   },
   "995": {
+    "exiting": "1",
+    "entering": "1",
     "summary": "N/A",
     "alternate_ids": [
       "994"
-    ],
-    "redundancy": 1
+    ]
   }
 }

--- a/scripts/format_elevator_data.exs
+++ b/scripts/format_elevator_data.exs
@@ -25,7 +25,8 @@ formatted_data =
      %{
        "elevator_id" => id,
        "alternate_elevator_ids" => alternate,
-       "Exiting System Categorization" => category,
+       "Entering System Categorization" => entering,
+       "Exiting System Categorization" => exiting,
        "Short Text" => summary
      }} ->
       alternate_ids =
@@ -34,13 +35,15 @@ formatted_data =
           ids -> ids
         end
 
-      redundancy =
-        case Integer.parse(category) do
-          {integer, _rest} -> integer
-          :error -> nil
-        end
-
-      {id, %{alternate_ids: alternate_ids, redundancy: redundancy, summary: summary}}
+      {
+        id,
+        %{
+          alternate_ids: alternate_ids,
+          entering: entering |> String.split("-", parts: 2) |> hd() |> String.trim(),
+          exiting: exiting |> String.split("-", parts: 2) |> hd() |> String.trim(),
+          summary: summary
+        }
+      }
   end)
   |> Enum.reject(&is_nil/1)
   |> Map.new()

--- a/test/screens/elevator_test.exs
+++ b/test/screens/elevator_test.exs
@@ -23,11 +23,18 @@ defmodule Screens.ElevatorTest do
       assert %Elevator{alternate_ids: ~w[901 927 919]} = Elevator.get("918")
     end
 
-    test "gets elevators in each redundancy category" do
-      assert %Elevator{redundancy: :nearby} = Elevator.get("996")
-      assert %Elevator{redundancy: :in_station} = Elevator.get("918")
+    test "gets elevators in each entering redundancy category" do
+      assert %Elevator{entering_redundancy: :nearby} = Elevator.get("996")
+      assert %Elevator{entering_redundancy: :in_station} = Elevator.get("918")
+      assert %Elevator{entering_redundancy: :shuttle} = Elevator.get("816")
+      assert %Elevator{entering_redundancy: :other} = Elevator.get("958")
+    end
 
-      assert %Elevator{redundancy: {:other, "Request assistance from conductor."}} =
+    test "gets elevators in each exiting redundancy category" do
+      assert %Elevator{exiting_redundancy: :nearby} = Elevator.get("996")
+      assert %Elevator{exiting_redundancy: :in_station} = Elevator.get("918")
+
+      assert %Elevator{exiting_redundancy: {:other, "Request assistance from conductor."}} =
                Elevator.get("780")
     end
 


### PR DESCRIPTION
Previously the logic for elevator redundancy only cared about "exiting redundancy", so that was the only column of the spreadsheet we loaded. For the future elevator closures feature, we'll also have logic that depends on "entering redundancy", so both categories should be loaded and distinguishable.