### PR TITLE
refactor: unify local time and service date logic

### DIFF
--- a/lib/screens/departures/departure.ex
+++ b/lib/screens/departures/departure.ex
@@ -62,12 +62,7 @@ defmodule Screens.Departures.Departure do
 
   @spec fetch_schedules_by_datetime(query_params(), DateTime.t()) :: {:ok, t()} | :error
   def fetch_schedules_by_datetime(%{} = query_params, dt) do
-    # Find the current service date by shifting the given datetime to Pacific Time.
-    # This splits the service day at 3am, as midnight at Pacific Time is always 3am here.
-    {:ok, pacific_time} = DateTime.shift_zone(dt, "America/Los_Angeles")
-    service_date = DateTime.to_date(pacific_time)
-
-    schedules = Schedule.fetch(query_params, Date.to_string(service_date))
+    schedules = Schedule.fetch(query_params, dt |> Util.service_date() |> Date.to_string())
 
     case schedules do
       {:ok, data} ->
@@ -378,7 +373,7 @@ defmodule Screens.Departures.Departure do
   end
 
   defp format_query_param({:date, %DateTime{} = date}) do
-    {"filter[date]", Util.get_service_date_today(date)}
+    {"filter[date]", Util.service_date(date)}
   end
 
   defp format_query_param({:date, %Date{} = date}) do

--- a/lib/screens/headways.ex
+++ b/lib/screens/headways.ex
@@ -7,6 +7,7 @@ defmodule Screens.Headways do
   alias Screens.Routes.Route
   alias Screens.SignsUiConfig.Cache, as: SignsUi
   alias Screens.Stops.Stop
+  alias Screens.Util
 
   # Compact mapping of stop IDs to headway keys, leaning on the fact that subway stop IDs happen
   # to be numeric and often contiguous as we "traverse" the line in a given direction.
@@ -187,10 +188,8 @@ defmodule Screens.Headways do
 
   @spec period(DateTime.t()) :: :peak | :off_peak | :saturday | :sunday
   defp period(datetime) do
-    local_dt = DateTime.shift_zone!(datetime, "America/New_York")
-
-    # Subtract 3 hours, since the service day starts/ends at 3:00 AM
-    day_of_week = local_dt |> DateTime.add(-3, :hour) |> Date.day_of_week()
+    local_dt = Util.to_eastern(datetime)
+    day_of_week = local_dt |> Util.service_date() |> Date.day_of_week()
 
     time = {local_dt.hour, local_dt.minute}
     am_peak? = time >= {7, 0} and time < {9, 0}

--- a/lib/screens/last_trip/poller.ex
+++ b/lib/screens/last_trip/poller.ex
@@ -2,10 +2,10 @@ defmodule Screens.LastTrip.Poller do
   @moduledoc """
   GenServer that polls predictions to calculate the last trip of the day
   """
-  alias Screens.LastTrip.Cache
-  alias Screens.LastTrip.Parser
-  alias Screens.LastTrip.TripUpdates
-  alias Screens.LastTrip.VehiclePositions
+
+  alias Screens.LastTrip.{Cache, Parser, TripUpdates, VehiclePositions}
+  alias Screens.Util
+
   use GenServer
 
   defstruct [:next_reset]
@@ -73,14 +73,10 @@ defmodule Screens.LastTrip.Poller do
     |> Cache.update_recent_departures()
   end
 
-  defp now(now_fn \\ &DateTime.utc_now/0) do
-    now_fn.() |> DateTime.shift_zone!("America/New_York")
-  end
+  defp now(now_fn \\ &DateTime.utc_now/0), do: now_fn.() |> Util.to_eastern()
 
   defp next_reset do
-    now()
-    |> DateTime.add(1, :day)
-    |> DateTime.to_date()
-    |> DateTime.new!(~T[03:30:00], "America/New_York")
+    now = now()
+    DateTime.new!(Date.add(now, 1), ~T[03:30:00], now.time_zone)
   end
 end

--- a/lib/screens/schedules/schedule.ex
+++ b/lib/screens/schedules/schedule.ex
@@ -27,7 +27,9 @@ defmodule Screens.Schedules.Schedule do
           direction_id: Trip.direction()
         }
 
-  @spec fetch(Departure.query_params(), String.t() | nil) :: {:ok, list(t())} | :error
+  @spec fetch(Departure.query_params()) :: {:ok, list(t())} | :error
+  @spec fetch(Departure.query_params(), DateTime.t() | Date.t() | String.t() | nil) ::
+          {:ok, list(t())} | :error
   def fetch(%{} = query_params, date \\ nil) do
     extra_params = if is_nil(date), do: %{}, else: %{date: date}
 

--- a/lib/screens/util.ex
+++ b/lib/screens/util.ex
@@ -159,30 +159,20 @@ defmodule Screens.Util do
   def to_set(ids) when is_list(ids), do: MapSet.new(ids)
   def to_set(%MapSet{} = already_a_set), do: already_a_set
 
+  @doc "Shifts a datetime into Eastern time."
+  @spec to_eastern(DateTime.t()) :: DateTime.t()
+  def to_eastern(datetime), do: DateTime.shift_zone!(datetime, "America/New_York")
+
   @doc """
-    Calculates the service day for the given DateTime.
-    For context, MBTA service days end at 3am, not at midnight.
-    So getting the service day means subtracting 3 hours from the current time.
-    To avoid duplicate DateTime calculations existing throughout the code,
-    this function will handle the actual calculations needed to get the service day.
+  Determines the MBTA service date at a given moment in time.
+
+  The boundary between service dates is 3:00am local time. In the period between midnight and
+  3:00am, the calendar date is one day ahead of the service date.
   """
-  @spec get_service_date_today(DateTime.t()) :: Date.t()
-  def get_service_date_today(now) do
-    {:ok, now_eastern} = DateTime.shift_zone(now, "America/New_York")
-
-    # If it is at least 3am, the current date matches the service date.
-    # If current time is between 12am and 3am, the date has changed but we are still in service for the previous day.
-    # That means we need to subtract 1 day to get the current service date.
-    if now_eastern.hour >= 3 do
-      DateTime.to_date(now_eastern)
-    else
-      Date.add(now_eastern, -1)
-    end
-  end
-
-  @spec get_service_date_tomorrow(DateTime.t()) :: Date.t()
-  def get_service_date_tomorrow(now) do
-    Date.add(get_service_date_today(now), 1)
+  @spec service_date(DateTime.t()) :: Date.t()
+  def service_date(datetime) do
+    dt = to_eastern(datetime)
+    if dt.hour >= 3, do: DateTime.to_date(dt), else: Date.add(dt, -1)
   end
 
   @doc """

--- a/lib/screens/v2/candidate_generator/dup/departures.ex
+++ b/lib/screens/v2/candidate_generator/dup/departures.ex
@@ -630,7 +630,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
       end
 
     tomorrow =
-      case fetch_schedules_fn.(fetch_params, Util.get_service_date_tomorrow(now)) do
+      case fetch_schedules_fn.(fetch_params, now |> Util.service_date() |> Date.add(1)) do
         {:ok, schedules} when schedules != [] ->
           Enum.filter(schedules, &(&1.route.id in route_ids_serving_section))
 

--- a/lib/screens/v2/candidate_generator/widgets/cr_departures.ex
+++ b/lib/screens/v2/candidate_generator/widgets/cr_departures.ex
@@ -2,6 +2,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.CRDepartures do
   @moduledoc false
 
   alias Screens.Schedules.Schedule
+  alias Screens.Util
   alias Screens.V2.Departure
   alias Screens.V2.WidgetInstance.CRDepartures, as: CRDeparturesWidget
   alias Screens.V2.WidgetInstance.{DeparturesNoData, OvernightCRDepartures}
@@ -107,12 +108,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.CRDepartures do
   end
 
   defp fetch_last_schedule_tomorrow(direction_to_destination, station, now) do
-    # Any time between midnight and 3AM should be considered part of yesterday's service day.
-    service_datetime =
-      now |> DateTime.shift_zone!("America/New_York") |> DateTime.add(-3 * 60 * 60, :second)
-
-    next_service_day =
-      service_datetime |> DateTime.add(60 * 60 * 24, :second) |> Timex.format!("{YYYY}-{0M}-{0D}")
+    service_date_tomorrow = now |> Util.service_date() |> Date.add(1)
 
     params = %{
       direction_id: direction_to_destination,
@@ -127,7 +123,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.CRDepartures do
       sort: "-departure_time"
     }
 
-    {:ok, schedules} = Schedule.fetch(params, next_service_day)
+    {:ok, schedules} = Schedule.fetch(params, service_date_tomorrow)
     List.first(schedules)
   end
 

--- a/lib/screens/v2/screen_data/parameters.ex
+++ b/lib/screens/v2/screen_data/parameters.ex
@@ -115,8 +115,9 @@ defmodule Screens.V2.ScreenData.Parameters do
           night_volume: night_volume
         }
       } ->
-        {:ok, now} = DateTime.shift_zone(now, "America/New_York")
-        if Util.time_in_range?(now, night_start, night_end), do: night_volume, else: day_volume
+        if now |> Util.to_eastern() |> Util.time_in_range?(night_start, night_end),
+          do: night_volume,
+          else: day_volume
     end
   end
 

--- a/lib/screens/v2/widget_instance/departures.ex
+++ b/lib/screens/v2/widget_instance/departures.ex
@@ -483,11 +483,12 @@ defmodule Screens.V2.WidgetInstance.Departures do
   end
 
   defp serialize_timestamp(departure_time, now) do
-    {:ok, local_time} = DateTime.shift_zone(departure_time, "America/New_York")
+    local_time = Util.to_eastern(departure_time)
     hour = 1 + Integer.mod(local_time.hour - 1, 12)
     minute = local_time.minute
     am_pm = if local_time.hour >= 12, do: :pm, else: :am
-    show_am_pm = Util.get_service_date_tomorrow(now).day == local_time.day
+    service_date_tomorrow = now |> Util.service_date() |> Date.add(1)
+    show_am_pm = local_time.day == service_date_tomorrow.day
     %{type: :timestamp, hour: hour, minute: minute, am_pm: am_pm, show_am_pm: show_am_pm}
   end
 end

--- a/lib/screens/v2/widget_instance/line_map.ex
+++ b/lib/screens/v2/widget_instance/line_map.ex
@@ -3,6 +3,7 @@ defmodule Screens.V2.WidgetInstance.LineMap do
 
   alias Screens.Predictions.Prediction
   alias Screens.Trips.Trip
+  alias Screens.Util
   alias Screens.V2.Departure
   alias Screens.V2.WidgetInstance.LineMap
   alias Screens.Vehicles.Vehicle
@@ -280,12 +281,8 @@ defmodule Screens.V2.WidgetInstance.LineMap do
     if prediction_count < 2 and not is_nil(departure) do
       %{name: origin_stop_name} = Enum.at(stops, 0)
 
-      {:ok, local_time} =
-        departure
-        |> Departure.time()
-        |> DateTime.shift_zone("America/New_York")
-
-      {:ok, timestamp} = Timex.format(local_time, "{h12}:{m}")
+      {:ok, timestamp} =
+        departure |> Departure.time() |> Util.to_eastern() |> Timex.format("{h12}:{m}")
 
       %{timestamp: timestamp, station_name: origin_stop_name}
     end

--- a/lib/screens/v2/widget_instance/overnight_cr_departures.ex
+++ b/lib/screens/v2/widget_instance/overnight_cr_departures.ex
@@ -7,6 +7,7 @@ defmodule Screens.V2.WidgetInstance.OvernightCRDepartures do
 
   alias Screens.Schedules.Schedule
   alias Screens.Trips.Trip
+  alias Screens.Util
   alias Screens.V2.Departure
   alias Screens.V2.WidgetInstance
 
@@ -30,19 +31,14 @@ defmodule Screens.V2.WidgetInstance.OvernightCRDepartures do
   def serialize(%__MODULE__{
         destination: destination,
         direction_to_destination: direction_to_destination,
-        last_tomorrow_schedule:
-          %Schedule{
-            departure_time: departure_time
-          } = schedule
+        last_tomorrow_schedule: %Schedule{departure_time: departure_time} = schedule
       }) do
-    {:ok, local_departure_time} = DateTime.shift_zone(departure_time, "America/New_York")
-
     {headsign_stop, headsign_via} =
       format_headsign(Departure.headsign(%Departure{schedule: schedule}))
 
     %{
       direction: direction_to_destination,
-      last_schedule_departure_time: local_departure_time,
+      last_schedule_departure_time: Util.to_eastern(departure_time),
       last_schedule_headsign_stop: headsign_stop,
       last_schedule_headsign_via: serialize_via_string(destination, headsign_via)
     }

--- a/lib/screens/v2/widget_instance/reconstructed_alert.ex
+++ b/lib/screens/v2/widget_instance/reconstructed_alert.ex
@@ -1107,12 +1107,12 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
   end
 
   defp format_updated_at(updated_at, now) do
-    shifted_updated_at = DateTime.shift_zone!(updated_at, "America/New_York")
+    local_updated_at = Util.to_eastern(updated_at)
 
     if Date.compare(updated_at, now) == :lt do
-      Timex.format!(shifted_updated_at, "{M}/{D}/{YY}")
+      Timex.format!(local_updated_at, "{M}/{D}/{YY}")
     else
-      Timex.format!(shifted_updated_at, "{WDfull}, {h12}:{m} {am}")
+      Timex.format!(local_updated_at, "{WDfull}, {h12}:{m} {am}")
     end
   end
 

--- a/lib/screens/v2/widget_instance/shuttle_bus_info.ex
+++ b/lib/screens/v2/widget_instance/shuttle_bus_info.ex
@@ -75,11 +75,8 @@ defmodule Screens.V2.WidgetInstance.ShuttleBusInfo do
   def audio_view(_instance), do: ScreensWeb.V2.Audio.ShuttleBusInfoView
 
   defp get_minute_range(schedule, now) do
-    # Shift the time to local time.
-    {:ok, local_time_now} = DateTime.shift_zone(now, "America/New_York")
-
-    # Shift to find current service day. i.e. 1AM Monday is actually still in the Sunday service day.
-    service_day_now = DateTime.add(local_time_now, -3 * 60 * 60, :second)
+    local_now = Util.to_eastern(now)
+    service_day_of_week = local_now |> Util.service_date() |> Date.day_of_week()
 
     %ShuttleBusSchedule{minute_range: minutes_range_to_destination} =
       Enum.find(schedule, fn %ShuttleBusSchedule{
@@ -94,8 +91,8 @@ defmodule Screens.V2.WidgetInstance.ShuttleBusInfo do
             :sunday -> [7]
           end
 
-        Date.day_of_week(service_day_now) in day_range and
-          Util.time_in_range?(DateTime.to_time(local_time_now), start_time, end_time)
+        service_day_of_week in day_range and
+          Util.time_in_range?(DateTime.to_time(local_now), start_time, end_time)
       end)
 
     minutes_range_to_destination

--- a/test/screens/util_test.exs
+++ b/test/screens/util_test.exs
@@ -102,19 +102,19 @@ defmodule Screens.UtilTest do
     end
   end
 
-  describe "get_service_date_today/1" do
+  describe "service_date/1" do
     test "returns the current date if after 3am" do
       now_eastern = DateTime.new!(~D[2022-01-01], ~T[09:00:00], "America/New_York")
       now = DateTime.shift_zone!(now_eastern, "Etc/UTC")
       expected = ~D[2022-01-01]
-      assert(expected == get_service_date_today(now))
+      assert(expected == service_date(now))
     end
 
     test "returns the yesterday's date if between 12am and 3am" do
       now_eastern = DateTime.new!(~D[2022-01-01], ~T[00:00:00], "America/New_York")
       now = DateTime.shift_zone!(now_eastern, "Etc/UTC")
       expected = ~D[2021-12-31]
-      assert expected == get_service_date_today(now)
+      assert expected == service_date(now)
     end
   end
 end


### PR DESCRIPTION
* Replaces a multitude of slightly different one-off routines for translating a datetime into a "service date" with calls to a shared utility function.
* Replaces a bunch of duplicated `America/New_York` strings with calls to a new utility function.