### PR TITLE
refactor: rework naming of elevator screen widgets

### DIFF
--- a/assets/css/elevator_v2.scss
+++ b/assets/css/elevator_v2.scss
@@ -43,8 +43,8 @@ body {
   }
 }
 
-.elevator-closures-list,
-.current-elevator-closed {
+.elevator-alternate-path,
+.elevator-closures {
   position: relative;
   display: flex;
   flex-direction: column;
@@ -69,5 +69,5 @@ body {
   }
 }
 
-@import "v2/elevator/current_elevator_closed";
-@import "v2/elevator/elevator_closures_list";
+@import "v2/elevator/alternate_path";
+@import "v2/elevator/closures";

--- a/assets/css/v2/elevator/alternate_path.scss
+++ b/assets/css/v2/elevator/alternate_path.scss
@@ -1,4 +1,4 @@
-.current-elevator-closed {
+.elevator-alternate-path {
   position: relative;
   height: 100%;
 

--- a/assets/css/v2/elevator/closures.scss
+++ b/assets/css/v2/elevator/closures.scss
@@ -1,4 +1,4 @@
-.elevator-closures-list {
+.elevator-closures {
   display: flex;
   flex: 1;
   flex-direction: column;

--- a/assets/src/apps/v2/elevator.tsx
+++ b/assets/src/apps/v2/elevator.tsx
@@ -15,8 +15,8 @@ import EvergreenContent from "Components/v2/evergreen_content";
 import ScreenPage from "Components/v2/screen_page";
 import { MappingContext } from "Components/v2/widget";
 import MultiScreenPage from "Components/v2/multi_screen_page";
-import ElevatorClosuresList from "Components/v2/elevator/elevator_closures_list";
-import CurrentElevatorClosed from "Components/v2/elevator/current_elevator_closed";
+import Closures from "Components/v2/elevator/closures";
+import AlternatePath from "Components/v2/elevator/alternate_path";
 import SimulationScreenPage from "Components/v2/simulation_screen_page";
 import Footer from "Components/v2/elevator/footer";
 import NormalHeader from "Components/v2/normal_header";
@@ -25,8 +25,8 @@ import NoData from "Components/v2/elevator/no_data";
 const TYPE_TO_COMPONENT = {
   normal: NormalScreen,
   takeover: TakeoverScreen,
-  elevator_closures_list: ElevatorClosuresList,
-  current_elevator_closed: CurrentElevatorClosed,
+  elevator_closures: Closures,
+  elevator_alternate_path: AlternatePath,
   evergreen_content: EvergreenContent,
   footer: Footer,
   normal_header: NormalHeader,

--- a/assets/src/components/v2/elevator/alternate_path.tsx
+++ b/assets/src/components/v2/elevator/alternate_path.tsx
@@ -12,7 +12,7 @@ import CurrentLocationBackground from "Images/svgr_bundled/current-location-back
 import NoService from "Images/svgr_bundled/no-service-black.svg";
 import ElevatorWayfinding from "Images/svgr_bundled/elevator-wayfinding.svg";
 import IsaNegative from "Images/svgr_bundled/isa-negative.svg";
-import { CURRENT_CLOSED_PAGING_INTERVAL_MS } from "./elevator_constants";
+import { ALTERNATE_PATH_PAGING_INTERVAL_MS } from "./constants";
 
 type Coordinates = {
   x: number;
@@ -35,7 +35,7 @@ interface Props extends WrappedComponentProps {
   accessible_path_image_here_coordinates: Coordinates;
 }
 
-const CurrentElevatorClosed = ({
+const AlternatePath = ({
   alternate_direction_text: alternateDirectionText,
   accessible_path_direction_arrow: accessiblePathDirectionArrow,
   accessible_path_image_url: accessiblePathImageUrl,
@@ -45,7 +45,7 @@ const CurrentElevatorClosed = ({
   const numPages = accessiblePathImageUrl ? 2 : 1;
   const pageIndex = useIntervalPaging({
     numPages,
-    intervalMs: CURRENT_CLOSED_PAGING_INTERVAL_MS,
+    intervalMs: ALTERNATE_PATH_PAGING_INTERVAL_MS,
     updateVisibleData,
   });
 
@@ -56,7 +56,7 @@ const CurrentElevatorClosed = ({
   });
 
   return (
-    <div className="current-elevator-closed">
+    <div className="elevator-alternate-path">
       <div className="notch"></div>
       <div className="header">
         <div className="icons">
@@ -103,5 +103,5 @@ const CurrentElevatorClosed = ({
 };
 
 export default makePersistent(
-  CurrentElevatorClosed as ComponentType<WrappedComponentProps>,
+  AlternatePath as ComponentType<WrappedComponentProps>,
 );

--- a/assets/src/components/v2/elevator/closures.tsx
+++ b/assets/src/components/v2/elevator/closures.tsx
@@ -13,7 +13,7 @@ import {
 import useIntervalPaging from "Hooks/v2/use_interval_paging";
 import NormalService from "Images/svgr_bundled/normal-service.svg";
 import AccessibilityAlert from "Images/svgr_bundled/accessibility-alert.svg";
-import { CLOSURE_LIST_PAGING_INTERVAL_MS } from "./elevator_constants";
+import { CLOSURES_PAGING_INTERVAL_MS } from "./constants";
 
 interface ClosureRowProps {
   station: StationWithClosures;
@@ -100,16 +100,16 @@ const InStationSummary = ({ closures }: InStationSummaryProps) => {
   );
 };
 
-interface OutsideClosureListProps extends WrappedComponentProps {
+interface CurrentClosuresProps extends WrappedComponentProps {
   stations: StationWithClosures[];
   stationId: string;
 }
 
-const OutsideClosureList = ({
+const CurrentClosures = ({
   stations,
   stationId,
   updateVisibleData,
-}: OutsideClosureListProps) => {
+}: CurrentClosuresProps) => {
   const ref = useRef<HTMLDivElement>(null);
 
   const sortedStations = [...stations].sort((a, b) => {
@@ -135,7 +135,7 @@ const OutsideClosureList = ({
 
   const pageIndex = useIntervalPaging({
     numPages,
-    intervalMs: CLOSURE_LIST_PAGING_INTERVAL_MS,
+    intervalMs: CLOSURES_PAGING_INTERVAL_MS,
     updateVisibleData,
   });
 
@@ -221,19 +221,19 @@ interface Props extends WrappedComponentProps {
   station_id: string;
 }
 
-const ElevatorClosuresList = ({
+const Closures = ({
   stations_with_closures: stations,
   station_id: stationId,
   updateVisibleData,
 }: Props) => {
   return (
-    <div className="elevator-closures-list">
+    <div className="elevator-closures">
       <InStationSummary
         closures={stations
           .filter((s) => s.id === stationId)
           .flatMap((s) => s.closures)}
       />
-      <OutsideClosureList
+      <CurrentClosures
         stations={stations}
         stationId={stationId}
         updateVisibleData={updateVisibleData}
@@ -242,6 +242,4 @@ const ElevatorClosuresList = ({
   );
 };
 
-export default makePersistent(
-  ElevatorClosuresList as ComponentType<WrappedComponentProps>,
-);
+export default makePersistent(Closures as ComponentType<WrappedComponentProps>);

--- a/assets/src/components/v2/elevator/constants.ts
+++ b/assets/src/components/v2/elevator/constants.ts
@@ -1,0 +1,2 @@
+export const ALTERNATE_PATH_PAGING_INTERVAL_MS = 12000; // 12 seconds
+export const CLOSURES_PAGING_INTERVAL_MS = 8000; // 8 seconds

--- a/assets/src/components/v2/elevator/elevator_constants.tsx
+++ b/assets/src/components/v2/elevator/elevator_constants.tsx
@@ -1,2 +1,0 @@
-export const CURRENT_CLOSED_PAGING_INTERVAL_MS = 12000; // 12 seconds
-export const CLOSURE_LIST_PAGING_INTERVAL_MS = 8000; // 8 seconds

--- a/lib/screens/v2/candidate_generator/elevator.ex
+++ b/lib/screens/v2/candidate_generator/elevator.ex
@@ -2,14 +2,14 @@ defmodule Screens.V2.CandidateGenerator.Elevator do
   @moduledoc false
 
   alias Screens.V2.CandidateGenerator
-  alias Screens.V2.CandidateGenerator.Elevator.Closures, as: ElevatorClosures
+  alias Screens.V2.CandidateGenerator.Elevator.Closures
   alias Screens.V2.CandidateGenerator.Widgets.Evergreen
   alias Screens.V2.Template.Builder
 
   @behaviour CandidateGenerator
 
   @instance_fns [
-    &ElevatorClosures.elevator_status_instances/2,
+    &Closures.elevator_status_instances/2,
     &Evergreen.evergreen_content_instances/2
   ]
 

--- a/lib/screens/v2/candidate_generator/elevator/closures.ex
+++ b/lib/screens/v2/candidate_generator/elevator/closures.ex
@@ -1,8 +1,8 @@
 defmodule Screens.V2.CandidateGenerator.Elevator.Closures do
   @moduledoc """
-  Generates the standard widgets for elevator screens: `CurrentElevatorClosed` when the screen's
-  elevator is closed, otherwise `ElevatorClosuresList`. Includes the header and footer, as these
-  have different variants depending on the "main" widget.
+  Generates the standard widgets for elevator screens: `ElevatorAlternatePath` when the screen's
+  elevator is closed, otherwise `ElevatorClosures`. Includes the header and footer, as these have
+  different variants depending on the "main" widget.
   """
 
   defmodule Closure do
@@ -31,16 +31,8 @@ defmodule Screens.V2.CandidateGenerator.Elevator.Closures do
   alias Screens.Routes.Route
   alias Screens.Stops.Stop
   alias Screens.V2.WidgetInstance
-  alias Screens.V2.WidgetInstance.{Footer, NormalHeader}
-
-  alias Screens.V2.WidgetInstance.{
-    CurrentElevatorClosed,
-    ElevatorClosuresList,
-    Footer,
-    NormalHeader
-  }
-
   alias Screens.V2.WidgetInstance.Elevator.Closure, as: WidgetClosure
+  alias Screens.V2.WidgetInstance.{ElevatorAlternatePath, ElevatorClosures, Footer, NormalHeader}
   alias Screens.V2.WidgetInstance.Serializer.RoutePill
   alias ScreensConfig.Screen
   alias ScreensConfig.V2.Elevator, as: ElevatorConfig
@@ -67,11 +59,11 @@ defmodule Screens.V2.CandidateGenerator.Elevator.Closures do
 
     case Enum.find(closures, fn %Closure{id: id} -> id == elevator_id end) do
       nil ->
-        [elevator_closures_list(closures, app_params) | header_footer_instances(config, now)]
+        [elevator_closures(closures, app_params) | header_footer_instances(config, now)]
 
       _closure ->
         [
-          %CurrentElevatorClosed{app_params: app_params}
+          %ElevatorAlternatePath{app_params: app_params}
           | header_footer_instances(config, now, :closed)
         ]
     end
@@ -112,7 +104,7 @@ defmodule Screens.V2.CandidateGenerator.Elevator.Closures do
 
   defp elevator_closure(_alert), do: []
 
-  defp elevator_closures_list(
+  defp elevator_closures(
          closures,
          %ElevatorConfig{elevator_id: elevator_id} = app_params
        ) do
@@ -120,7 +112,7 @@ defmodule Screens.V2.CandidateGenerator.Elevator.Closures do
     {:ok, station_names} = @stop.fetch_parent_station_name_map()
     station_route_pills = fetch_station_route_pills(closures, stop_id)
 
-    %ElevatorClosuresList{
+    %ElevatorClosures{
       app_params: app_params,
       station_id: stop_id,
       stations_with_closures:
@@ -149,7 +141,7 @@ defmodule Screens.V2.CandidateGenerator.Elevator.Closures do
     |> Enum.filter(&relevant_closure?(&1, home_station_id, closures))
     |> Enum.group_by(& &1.station_id)
     |> Enum.map(fn {station_id, station_closures} ->
-      %ElevatorClosuresList.Station{
+      %ElevatorClosures.Station{
         id: station_id,
         name: Map.fetch!(station_names, station_id),
         route_icons:

--- a/lib/screens/v2/widget_instance/elevator_alternate_path.ex
+++ b/lib/screens/v2/widget_instance/elevator_alternate_path.ex
@@ -1,5 +1,5 @@
-defmodule Screens.V2.WidgetInstance.CurrentElevatorClosed do
-  @moduledoc false
+defmodule Screens.V2.WidgetInstance.ElevatorAlternatePath do
+  @moduledoc "The main content of an elevator screen when its associated elevator is closed."
 
   alias Screens.Util.Assets
   alias ScreensConfig.V2.Elevator
@@ -28,16 +28,16 @@ defmodule Screens.V2.WidgetInstance.CurrentElevatorClosed do
       }
 
   defimpl Screens.V2.WidgetInstance do
-    alias Screens.V2.WidgetInstance.CurrentElevatorClosed
+    alias Screens.V2.WidgetInstance.ElevatorAlternatePath
 
     def priority(_instance), do: [1]
-    def serialize(instance), do: CurrentElevatorClosed.serialize(instance)
+    def serialize(instance), do: ElevatorAlternatePath.serialize(instance)
     def slot_names(_instance), do: [:main_content]
-    def widget_type(_instance), do: :current_elevator_closed
+    def widget_type(_instance), do: :elevator_alternate_path
     def valid_candidate?(_instance), do: true
     def audio_serialize(_instance), do: %{}
     def audio_sort_key(_instance), do: [0]
     def audio_valid_candidate?(_instance), do: false
-    def audio_view(_instance), do: ScreensWeb.V2.Audio.CurrentElevatorClosedView
+    def audio_view(_instance), do: ScreensWeb.V2.Audio.ElevatorAlternatePathView
   end
 end

--- a/lib/screens/v2/widget_instance/elevator_closures.ex
+++ b/lib/screens/v2/widget_instance/elevator_closures.ex
@@ -1,5 +1,5 @@
-defmodule Screens.V2.WidgetInstance.ElevatorClosuresList do
-  @moduledoc false
+defmodule Screens.V2.WidgetInstance.ElevatorClosures do
+  @moduledoc "The main content of an elevator screen when its associated elevator is working."
 
   alias Screens.Stops.Stop
   alias Screens.V2.WidgetInstance.Elevator.Closure
@@ -44,16 +44,16 @@ defmodule Screens.V2.WidgetInstance.ElevatorClosuresList do
       }
 
   defimpl Screens.V2.WidgetInstance do
-    alias Screens.V2.WidgetInstance.ElevatorClosuresList
+    alias Screens.V2.WidgetInstance.ElevatorClosures
 
     def priority(_instance), do: [1]
-    def serialize(instance), do: ElevatorClosuresList.serialize(instance)
+    def serialize(instance), do: ElevatorClosures.serialize(instance)
     def slot_names(_instance), do: [:main_content]
-    def widget_type(_instance), do: :elevator_closures_list
+    def widget_type(_instance), do: :elevator_closures
     def valid_candidate?(_instance), do: true
     def audio_serialize(_instance), do: %{}
     def audio_sort_key(_instance), do: [0]
     def audio_valid_candidate?(_instance), do: false
-    def audio_view(_instance), do: ScreensWeb.V2.Audio.ElevatorClosuresListView
+    def audio_view(_instance), do: ScreensWeb.V2.Audio.ElevatorClosuresView
   end
 end

--- a/lib/screens_web/views/v2/audio/elevator_alternate_path_view.ex
+++ b/lib/screens_web/views/v2/audio/elevator_alternate_path_view.ex
@@ -1,4 +1,4 @@
-defmodule ScreensWeb.V2.Audio.ElevatorClosuresListView do
+defmodule ScreensWeb.V2.Audio.ElevatorAlternatePathView do
   use ScreensWeb, :view
 
   def render("_widget.ssml", _) do

--- a/lib/screens_web/views/v2/audio/elevator_closures_view.ex
+++ b/lib/screens_web/views/v2/audio/elevator_closures_view.ex
@@ -1,4 +1,4 @@
-defmodule ScreensWeb.V2.Audio.CurrentElevatorClosedView do
+defmodule ScreensWeb.V2.Audio.ElevatorClosuresView do
   use ScreensWeb, :view
 
   def render("_widget.ssml", _) do

--- a/test/screens/v2/candidate_generator/elevator/closures_test.exs
+++ b/test/screens/v2/candidate_generator/elevator/closures_test.exs
@@ -5,16 +5,9 @@ defmodule Screens.V2.CandidateGenerator.Elevator.ClosuresTest do
   alias Screens.Elevator
   alias Screens.Routes.Route
   alias Screens.Stops.Stop
-  alias Screens.V2.CandidateGenerator.Elevator.Closures, as: ElevatorClosures
+  alias Screens.V2.CandidateGenerator.Elevator.Closures, as: Generator
   alias Screens.V2.WidgetInstance.Elevator.Closure
-
-  alias Screens.V2.WidgetInstance.{
-    CurrentElevatorClosed,
-    Footer,
-    NormalHeader,
-    ElevatorClosuresList
-  }
-
+  alias Screens.V2.WidgetInstance.{ElevatorAlternatePath, ElevatorClosures, Footer, NormalHeader}
   alias ScreensConfig.Screen
   alias ScreensConfig.V2.Elevator, as: ElevatorConfig
 
@@ -83,7 +76,7 @@ defmodule Screens.V2.CandidateGenerator.Elevator.ClosuresTest do
                _elevator_closures,
                %NormalHeader{screen: @screen, text: "Elevator 111", time: ^now, variant: nil},
                %Footer{screen: @screen, variant: nil}
-             ] = ElevatorClosures.elevator_status_instances(@screen, now)
+             ] = Generator.elevator_status_instances(@screen, now)
     end
 
     test "returns variant header and footer when current elevator is closed", %{now: now} do
@@ -98,7 +91,7 @@ defmodule Screens.V2.CandidateGenerator.Elevator.ClosuresTest do
       end)
 
       assert [_current_closed, %NormalHeader{variant: :closed}, %Footer{variant: :closed}] =
-               ElevatorClosures.elevator_status_instances(@screen, now)
+               Generator.elevator_status_instances(@screen, now)
     end
 
     test "returns a closure list based on currently-active elevator alerts", %{now: now} do
@@ -131,11 +124,11 @@ defmodule Screens.V2.CandidateGenerator.Elevator.ClosuresTest do
         {:ok, alerts}
       end)
 
-      expected_closures = %ElevatorClosuresList{
+      expected_closures = %ElevatorClosures{
         app_params: @screen.app_params,
         station_id: "place-test",
         stations_with_closures: [
-          %ElevatorClosuresList.Station{
+          %ElevatorClosures.Station{
             id: "place-test",
             name: "Place Test",
             route_icons: [%{type: :text, text: "RL", color: :red}],
@@ -145,7 +138,7 @@ defmodule Screens.V2.CandidateGenerator.Elevator.ClosuresTest do
         ]
       }
 
-      assert hd(ElevatorClosures.elevator_status_instances(@screen, now)) == expected_closures
+      assert hd(Generator.elevator_status_instances(@screen, now)) == expected_closures
     end
 
     test "groups multiple outside closures by station", %{now: now} do
@@ -179,9 +172,9 @@ defmodule Screens.V2.CandidateGenerator.Elevator.ClosuresTest do
       end)
 
       assert [
-               %ElevatorClosuresList{
+               %ElevatorClosures{
                  stations_with_closures: [
-                   %ElevatorClosuresList.Station{
+                   %ElevatorClosures.Station{
                      id: "place-haecl",
                      name: "Haymarket",
                      route_icons: [%{type: :text, text: "OL", color: :orange}],
@@ -194,7 +187,7 @@ defmodule Screens.V2.CandidateGenerator.Elevator.ClosuresTest do
                  ]
                }
                | _
-             ] = ElevatorClosures.elevator_status_instances(@screen, now)
+             ] = Generator.elevator_status_instances(@screen, now)
     end
 
     test "filters out alerts with no facilities or more than one facility", %{now: now} do
@@ -220,8 +213,8 @@ defmodule Screens.V2.CandidateGenerator.Elevator.ClosuresTest do
 
       logs =
         capture_log([level: :warning], fn ->
-          assert [%ElevatorClosuresList{stations_with_closures: []} | _] =
-                   ElevatorClosures.elevator_status_instances(@screen, now)
+          assert [%ElevatorClosures{stations_with_closures: []} | _] =
+                   Generator.elevator_status_instances(@screen, now)
         end)
 
       assert logs =~ "elevator_closure_affects_multiple"
@@ -274,15 +267,15 @@ defmodule Screens.V2.CandidateGenerator.Elevator.ClosuresTest do
       end)
 
       assert [
-               %ElevatorClosuresList{
+               %ElevatorClosures{
                  stations_with_closures: [
-                   %ElevatorClosuresList.Station{
+                   %ElevatorClosures.Station{
                      id: "place-test",
                      name: "This Station",
                      route_icons: [%{type: :text, text: "RL", color: :red}],
                      closures: [%Closure{id: "112", name: "In Station Elevator"}]
                    },
-                   %ElevatorClosuresList.Station{
+                   %ElevatorClosures.Station{
                      id: "place-test-no-redundancy",
                      name: "Other No Redundancy",
                      route_icons: [%{type: :text, text: "RL", color: :red}],
@@ -291,7 +284,7 @@ defmodule Screens.V2.CandidateGenerator.Elevator.ClosuresTest do
                  ]
                }
                | _
-             ] = ElevatorClosures.elevator_status_instances(@screen, now)
+             ] = Generator.elevator_status_instances(@screen, now)
     end
 
     test "generates backup route summaries based on exiting redundancy", %{now: now} do
@@ -346,19 +339,19 @@ defmodule Screens.V2.CandidateGenerator.Elevator.ClosuresTest do
       end)
 
       assert [
-               %ElevatorClosuresList{
+               %ElevatorClosures{
                  stations_with_closures: [
-                   %ElevatorClosuresList.Station{
+                   %ElevatorClosures.Station{
                      id: "place-1",
                      closures: [%Closure{id: "1"}],
                      summary: nil
                    },
-                   %ElevatorClosuresList.Station{
+                   %ElevatorClosures.Station{
                      id: "place-2",
                      closures: [%Closure{id: "2"}],
                      summary: "some summary"
                    },
-                   %ElevatorClosuresList.Station{
+                   %ElevatorClosures.Station{
                      id: "place-3",
                      closures: [%Closure{id: "3"}],
                      summary: "Visit mbta.com/elevators for more info"
@@ -366,10 +359,10 @@ defmodule Screens.V2.CandidateGenerator.Elevator.ClosuresTest do
                  ]
                }
                | _
-             ] = ElevatorClosures.elevator_status_instances(@screen, now)
+             ] = Generator.elevator_status_instances(@screen, now)
     end
 
-    test "returns CurrentElevatorClosed when configured elevator is closed", %{now: now} do
+    test "returns ElevatorAlternatePath when configured elevator is closed", %{now: now} do
       expect(@alert, :fetch_elevator_alerts_with_facilities, fn ->
         alerts = [
           build_alert(
@@ -382,8 +375,8 @@ defmodule Screens.V2.CandidateGenerator.Elevator.ClosuresTest do
 
       app_params = @screen.app_params
 
-      assert [%CurrentElevatorClosed{app_params: ^app_params} | _] =
-               ElevatorClosures.elevator_status_instances(@screen, now)
+      assert [%ElevatorAlternatePath{app_params: ^app_params} | _] =
+               Generator.elevator_status_instances(@screen, now)
     end
 
     test "omits route pills on closures when there is a routes API error", %{now: now} do
@@ -402,9 +395,9 @@ defmodule Screens.V2.CandidateGenerator.Elevator.ClosuresTest do
       end)
 
       assert [
-               %ElevatorClosuresList{
+               %ElevatorClosures{
                  stations_with_closures: [
-                   %ElevatorClosuresList.Station{
+                   %ElevatorClosures.Station{
                      id: "place-test",
                      name: "Place Test",
                      closures: [%Closure{id: "facility-test", name: "Test"}]
@@ -412,7 +405,7 @@ defmodule Screens.V2.CandidateGenerator.Elevator.ClosuresTest do
                  ]
                }
                | _
-             ] = ElevatorClosures.elevator_status_instances(@screen, now)
+             ] = Generator.elevator_status_instances(@screen, now)
     end
   end
 end

--- a/test/screens/v2/widget_instance/elevator_alternate_path_test.exs
+++ b/test/screens/v2/widget_instance/elevator_alternate_path_test.exs
@@ -1,13 +1,13 @@
-defmodule Screens.V2.WidgetInstance.CurrentElevatorClosedTest do
+defmodule Screens.V2.WidgetInstance.ElevatorAlternatePathTest do
   use ExUnit.Case, async: true
 
   alias Screens.V2.WidgetInstance
-  alias Screens.V2.WidgetInstance.CurrentElevatorClosed
+  alias Screens.V2.WidgetInstance.ElevatorAlternatePath
   alias ScreensConfig.V2.Elevator
 
   setup do
     %{
-      instance: %CurrentElevatorClosed{
+      instance: %ElevatorAlternatePath{
         app_params:
           struct(Elevator,
             elevator_id: "111",
@@ -44,8 +44,8 @@ defmodule Screens.V2.WidgetInstance.CurrentElevatorClosedTest do
   end
 
   describe "widget_type/1" do
-    test "returns current_elevator_closed", %{instance: instance} do
-      assert :current_elevator_closed == WidgetInstance.widget_type(instance)
+    test "returns elevator_alternate_path", %{instance: instance} do
+      assert :elevator_alternate_path == WidgetInstance.widget_type(instance)
     end
   end
 
@@ -68,8 +68,8 @@ defmodule Screens.V2.WidgetInstance.CurrentElevatorClosedTest do
   end
 
   describe "audio_view/1" do
-    test "returns CurrentElevatorClosedView", %{instance: instance} do
-      assert ScreensWeb.V2.Audio.CurrentElevatorClosedView == WidgetInstance.audio_view(instance)
+    test "returns ElevatorAlternatePathView", %{instance: instance} do
+      assert ScreensWeb.V2.Audio.ElevatorAlternatePathView == WidgetInstance.audio_view(instance)
     end
   end
 end

--- a/test/screens/v2/widget_instance/elevator_closures_test.exs
+++ b/test/screens/v2/widget_instance/elevator_closures_test.exs
@@ -1,14 +1,14 @@
-defmodule Screens.V2.WidgetInstance.ElevatorClosuresListTest do
+defmodule Screens.V2.WidgetInstance.ElevatorClosuresTest do
   use ExUnit.Case, async: true
 
   alias Screens.V2.WidgetInstance
   alias Screens.V2.WidgetInstance.Elevator.Closure
-  alias Screens.V2.WidgetInstance.ElevatorClosuresList
+  alias Screens.V2.WidgetInstance.ElevatorClosures
   alias ScreensConfig.V2.Elevator
 
   setup do
     %{
-      instance: %ElevatorClosuresList{
+      instance: %ElevatorClosures{
         app_params:
           struct(Elevator,
             elevator_id: "1",
@@ -16,7 +16,7 @@ defmodule Screens.V2.WidgetInstance.ElevatorClosuresListTest do
             accessible_path_direction_arrow: :n
           ),
         stations_with_closures: [
-          %ElevatorClosuresList.Station{
+          %ElevatorClosures.Station{
             name: "Forest Hills",
             route_icons: ["Orange"],
             closures: [%Closure{id: "222", name: "FH Elevator"}]
@@ -49,8 +49,8 @@ defmodule Screens.V2.WidgetInstance.ElevatorClosuresListTest do
   end
 
   describe "widget_type/1" do
-    test "returns elevator_closures_list", %{instance: instance} do
-      assert :elevator_closures_list == WidgetInstance.widget_type(instance)
+    test "returns elevator_closures", %{instance: instance} do
+      assert :elevator_closures == WidgetInstance.widget_type(instance)
     end
   end
 
@@ -73,9 +73,8 @@ defmodule Screens.V2.WidgetInstance.ElevatorClosuresListTest do
   end
 
   describe "audio_view/1" do
-    test "returns ElevatorClosuresListView", %{instance: instance} do
-      assert ScreensWeb.V2.Audio.ElevatorClosuresListView ==
-               WidgetInstance.audio_view(instance)
+    test "returns ElevatorClosuresView", %{instance: instance} do
+      assert ScreensWeb.V2.Audio.ElevatorClosuresView == WidgetInstance.audio_view(instance)
     end
   end
 end


### PR DESCRIPTION
Goals:

* Align naming of the "this elevator is working" widget with the idea that it isn't _only_ a "list" of closures. (This already wasn't the case, since this widget incorporates the "status bar" for elevators at the current station, but it will be even more so with the introduction of future elevator closure info.)

* Clean up duplicative "elevator" naming. When a module is already in an `elevator` namespace, it does not itself need to include `elevator` in its name.

I'd like feedback / possible alternatives for these names — I don't love them (in particular how the word _"closures"_ is getting thrown around a lot), I just think it's incrementally better than before. Part of the problem is that we also have the entirely-separate-yet-similar-in-function "elevator _status_" widget for Pre-Fare screens, so using the word "status" here could cause confusion.