### PR TITLE
Moved 288px height to normal_header.scss instead of normal.scss

### DIFF
--- a/assets/css/v2/bus_eink/screen/normal.scss
+++ b/assets/css/v2/bus_eink/screen/normal.scss
@@ -10,7 +10,6 @@
   top: 0;
   left: 0;
   width: 1200px;
-  height: 288px;
 }
 
 .screen-normal__body {

--- a/assets/css/v2/bus_eink/screen/normal.scss
+++ b/assets/css/v2/bus_eink/screen/normal.scss
@@ -9,13 +9,10 @@
   position: absolute;
   top: 0;
   left: 0;
-  width: 1200px;
 }
 
 .screen-normal__body {
   position: absolute;
   top: 288px;
   left: 0;
-  width: 1200px;
-  height: 2912px;
 }

--- a/assets/css/v2/eink/normal_header.scss
+++ b/assets/css/v2/eink/normal_header.scss
@@ -1,7 +1,7 @@
 .normal-header {
   position: relative;
   width: 100%;
-  height: 100%;
+  height: 288px;
   background: #000;
 }
 

--- a/assets/css/v2/eink/normal_header.scss
+++ b/assets/css/v2/eink/normal_header.scss
@@ -1,6 +1,6 @@
 .normal-header {
   position: relative;
-  width: 100%;
+  width: 1200px;
   height: 288px;
   background: #000;
 }

--- a/assets/css/v2/gl_eink/screen/normal.scss
+++ b/assets/css/v2/gl_eink/screen/normal.scss
@@ -10,7 +10,6 @@
   top: 0;
   left: 0;
   width: 1200px;
-  height: 288px;
 }
 
 .screen-normal__body {

--- a/assets/css/v2/gl_eink/screen/normal.scss
+++ b/assets/css/v2/gl_eink/screen/normal.scss
@@ -9,13 +9,10 @@
   position: absolute;
   top: 0;
   left: 0;
-  width: 1200px;
 }
 
 .screen-normal__body {
   position: absolute;
   top: 288px;
   left: 0;
-  width: 1200px;
-  height: 2912px;
 }


### PR DESCRIPTION
**Asana task**: [[extra] bus e-ink header has incorrect appearance on widget endpoint](https://app.asana.com/0/1185117109217413/1209279595523778)

Description
- Fixed issue where header widget height was not being set to 288px
- Removed 288px from the other two spots in bus_eink and gl_eink

Let me know if removing them/putting them here has adverse effects, I tried to check the places that I could but I'm sure I missed places. 

- [ ] Tests added?

<img width="1485" alt="Screenshot 2025-02-05 at 3 59 24 PM" src="https://github.com/user-attachments/assets/82bc107d-a753-4eaf-8afc-3051e307af31" />