### PR TITLE
fix: incorrect boldness in elevator outages

### DIFF
--- a/lib/screens/elevator.ex
+++ b/lib/screens/elevator.ex
@@ -38,11 +38,11 @@ defmodule Screens.Elevator do
   end
 
   defp entering_redundancy(%{"entering" => "1"}), do: :nearby
-  defp entering_redundancy(%{"entering" => "2"}), do: :in_station
+  defp entering_redundancy(%{"entering" => "2" <> _}), do: :in_station
   defp entering_redundancy(%{"entering" => "3B"}), do: :shuttle
   defp entering_redundancy(_other), do: :other
 
   defp exiting_redundancy(%{"exiting" => "1"}), do: :nearby
-  defp exiting_redundancy(%{"exiting" => "2"}), do: :in_station
+  defp exiting_redundancy(%{"exiting" => "2" <> _}), do: :in_station
   defp exiting_redundancy(%{"summary" => summary}), do: {:other, summary}
 end

--- a/test/screens/elevator_test.exs
+++ b/test/screens/elevator_test.exs
@@ -27,7 +27,7 @@ defmodule Screens.ElevatorTest do
       assert %Elevator{entering_redundancy: :nearby} = Elevator.get("996")
       assert %Elevator{entering_redundancy: :in_station} = Elevator.get("918")
       assert %Elevator{entering_redundancy: :shuttle} = Elevator.get("816")
-      assert %Elevator{entering_redundancy: :other} = Elevator.get("958")
+      assert %Elevator{entering_redundancy: :other} = Elevator.get("970")
     end
 
     test "gets elevators in each exiting redundancy category" do
@@ -36,6 +36,19 @@ defmodule Screens.ElevatorTest do
 
       assert %Elevator{exiting_redundancy: {:other, "Request assistance from conductor."}} =
                Elevator.get("780")
+    end
+
+    test "handles sub-categories of in-station redundancy" do
+      assert %Elevator{entering_redundancy: :in_station, exiting_redundancy: :in_station} =
+               Elevator.get("842")
+
+      assert %Elevator{entering_redundancy: :in_station, exiting_redundancy: :in_station} =
+               Elevator.get("771")
+    end
+
+    test "only interprets sub-category 3B as shuttle for entering redundancy" do
+      assert %Elevator{entering_redundancy: :shuttle} = Elevator.get("945")
+      assert %Elevator{entering_redundancy: :other} = Elevator.get("958")
     end
 
     test "returns nil and logs a warning when redundancy data does not exist" do


### PR DESCRIPTION
For some elevators with in-station redundancy, the text "Accessible route available" would incorrectly be shown in the bold font reserved for more noteworthy redundancy categories.

The reason is that we were expecting the redundancy category to be exactly `2`, but some elevators had categories like `2A` or `2B`. Since the individual exiting summaries for category-2 elevators are all "Accessible route available" (which we normally ignore in favor of a hard-coded string that happens to be identical), this resulted in screens still showing the correct phrasing, but more boldly than intended.

<img width="551" alt="Screenshot 2025-02-06 at 5 15 45 PM" src="https://github.com/user-attachments/assets/7b48b0bb-b302-490d-a994-a97f0ef2bb16" />

**Asana task**: https://app.asana.com/0/1185117109217413/1209314103629054