### PR TITLE
bugfix: ScreenData API sets default value for query_params for self_refresh_runner

### DIFF
--- a/lib/screens/v2/screen_data.ex
+++ b/lib/screens/v2/screen_data.ex
@@ -55,7 +55,7 @@ defmodule Screens.V2.ScreenData do
   defp select_variant(screen_id, opts, then_fn) do
     config = get_config(screen_id, opts)
     selected_variant = Keyword.get(opts, :generator_variant)
-    query_params = Keyword.get(opts, :query_params) || %QueryParams{}
+    query_params = Keyword.get(opts, :query_params, %QueryParams{})
 
     if Keyword.get(opts, :run_all_variants?, false) do
       other_variants = List.delete([nil | @parameters.variants(config)], selected_variant)
@@ -79,7 +79,7 @@ defmodule Screens.V2.ScreenData do
         when data: t() | simulation_data()
   defp all_variants(screen_id, opts, then_fn) do
     config = get_config(screen_id, opts)
-    query_params = Keyword.get(opts, :query_params) || %QueryParams{}
+    query_params = Keyword.get(opts, :query_params, %QueryParams{})
 
     ParallelRunSupervisor
     |> Task.Supervisor.async_stream(


### PR DESCRIPTION
**Asana task**: Fixing an alert caused by self_refresh_runner captured [here in Sentry](https://mbtace.sentry.io/issues/6300694849/?alert_rule_id=9523677&alert_timestamp=1739566014665&alert_type=email&environment=screens-prod&notification_uuid=dd59eeb0-0ee9-4514-a3b6-850f3f3a6a7d&project=6061747&referrer=alert_email)

Description

- [ ] Tests added?
