### PR TITLE
Added suppression of alert 623609 for the Green Line diversion

### DIFF
--- a/lib/screens/v2/widget_instance/reconstructed_alert.ex
+++ b/lib/screens/v2/widget_instance/reconstructed_alert.ex
@@ -1313,7 +1313,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
 
   def alert_ids(%__MODULE__{} = t), do: [t.alert.id]
 
-  @suppressed_alert_ids ~w[590467]
+  @suppressed_alert_ids ~w[623609]
 
   def valid_candidate?(%__MODULE__{alert: %{id: alert_id}}) do
     alert_id not in @suppressed_alert_ids

--- a/test/screens/v2/widget_instance/reconstructed_alert_test.exs
+++ b/test/screens/v2/widget_instance/reconstructed_alert_test.exs
@@ -3182,7 +3182,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
       assert WidgetInstance.valid_candidate?(widget)
     end
 
-    suppressed_alerts = ~w[590467]
+    suppressed_alerts = ~w[623609]
 
     for alert_id <- suppressed_alerts do
       @tag alert_id: alert_id


### PR DESCRIPTION
**Asana task**: [Custom image for Govt Ctr pre-fare](https://app.asana.com/0/1209229552734401/1209391199110652)

Description
- Replaced suppression of old alert
- This in conjunction with the config changes will effectively replace the Alert with a custom image on the Govt Ctr prefare screens and takeovers for Kenmore and Haymarket on DUP screens

- [x] Tests added?
