### PR TITLE
bugfix: Fallback logic for shuttle bus route pills

### DIFF
--- a/assets/src/components/v2/departures/route_pill.tsx
+++ b/assets/src/components/v2/departures/route_pill.tsx
@@ -98,7 +98,7 @@ type Props = {
 };
 
 const RoutePill: ComponentType<Props> = ({ pill, outline, useRouteAbbrev }) => {
-  const modifiers: string[] = [pill.color];
+  let modifiers: string[] = [pill.color];
   if (outline) modifiers.push("outline");
 
   let innerContent: JSX.Element | null = null;
@@ -115,7 +115,12 @@ const RoutePill: ComponentType<Props> = ({ pill, outline, useRouteAbbrev }) => {
   } else {
     switch (pill.type) {
       case "text":
-        innerContent = <TextRoutePill {...pill} outline={outline} />;
+        if (pill.text.length > 4) {
+          // Fallback for shuttle buses that may not have an existing route abbreviation in our system
+          innerContent = <IconRoutePill icon={"bus"} color={pill.color} />;
+        } else {
+          innerContent = <TextRoutePill {...pill} outline={outline} />;
+        }
         break;
 
       case "icon":


### PR DESCRIPTION
**Asana task**: [Quick fix for route pills on shuttle bus departures](https://app.asana.com/0/1208877354406742/1209298740143900)

Little bit of a hacky fix on the client side to override any unexpected shuttle names showing up in route pills. This logic should handle unexpected cases in the future as well though.

- Will override the pill icon to be displayed if the text is longer than 4 characters (longest expected pill text should be something of the form GL-B, unless I'm forgetting something)
- Has some nested logic that I don't love


- [ ] Tests added?
