### PR TITLE
refactor: alert parsing and active period handling

### DIFF
--- a/lib/screens/alerts/alert.ex
+++ b/lib/screens/alerts/alert.ex
@@ -98,7 +98,7 @@ defmodule Screens.Alerts.Alert do
           | :track_change
           | :unknown
 
-  @type active_period :: {DateTime.t() | nil, DateTime.t() | nil}
+  @type active_period :: {DateTime.t(), DateTime.t() | nil}
 
   @type informed_entity :: %{
           facility: %{id: String.t(), name: String.t()} | nil,
@@ -255,10 +255,6 @@ defmodule Screens.Alerts.Alert do
 
   def happening_now?(%{active_period: aps}, now \\ DateTime.utc_now()) do
     Enum.any?(aps, &in_active_period(&1, now))
-  end
-
-  defp in_active_period({nil, end_t}, t) do
-    DateTime.compare(t, end_t) in [:lt, :eq]
   end
 
   defp in_active_period({start_t, nil}, t) do

--- a/lib/screens/v2/candidate_generator/elevator/closures.ex
+++ b/lib/screens/v2/candidate_generator/elevator/closures.ex
@@ -205,7 +205,6 @@ defmodule Screens.V2.CandidateGenerator.Elevator.Closures do
   defp build_upcoming_closure([]), do: nil
 
   defp build_upcoming_closure([closure | _] = closures) do
-    # Note: don't have to account for periods with `nil` start here; those are `happening_now?`
     next_date_period =
       closures
       |> Enum.filter(fn

--- a/lib/screens/v2/widget_instance/alert.ex
+++ b/lib/screens/v2/widget_instance/alert.ex
@@ -258,8 +258,7 @@ defmodule Screens.V2.WidgetInstance.Alert do
   end
 
   @spec seconds_from_onset(t()) :: integer()
-  def seconds_from_onset(%__MODULE__{alert: %Alert{active_period: [{start, _} | _]}, now: now})
-      when not is_nil(start) do
+  def seconds_from_onset(%__MODULE__{alert: %Alert{active_period: [{start, _} | _]}, now: now}) do
     DateTime.diff(now, start, :second)
   end
 

--- a/lib/screens/v2/widget_instance/elevator_status.ex
+++ b/lib/screens/v2/widget_instance/elevator_status.ex
@@ -308,9 +308,6 @@ defmodule Screens.V2.WidgetInstance.ElevatorStatus do
     }
   end
 
-  defp serialize_active_period({nil, end_t}),
-    do: %{"start" => nil, "end" => DateTime.to_iso8601(end_t)}
-
   defp serialize_active_period({start_t, nil}),
     do: %{"start" => DateTime.to_iso8601(start_t), "end" => nil}
 


### PR DESCRIPTION
* The `start` of alert active periods is documented as non-nullable in the V3 API, so we can remove some special cases that assumed it could be null. This logic was unreachable anyway, since `Alerts.Parser` did _not_ have such handling and would have crashed if we ever encountered this situation.

* Remove some redundancy in the active period parsing code.

* Add a test case to cover `Alert.fetch/1` and more of the behavior of `Alerts.Parser`, using more realistic test data.

**Asana task**: https://app.asana.com/0/1185117109217413/1209447170673650
