### PR TITLE
feat(admin): inspector shows current screen URL

### DIFF
--- a/assets/css/admin/inspector.scss
+++ b/assets/css/admin/inspector.scss
@@ -65,7 +65,10 @@
 }
 
 .inspector__screen {
+  display: flex;
   flex: 1 1 auto;
+  flex-direction: column;
+  gap: 0.5em;
 
   iframe {
     width: 100%;

--- a/assets/src/components/admin/inspector.tsx
+++ b/assets/src/components/admin/inspector.tsx
@@ -146,6 +146,8 @@ const Inspector: ComponentType = () => {
       </div>
 
       <div className="inspector__screen">
+        <input disabled value={iframeUrl} />
+
         <iframe
           name={INSPECTOR_FRAME_NAME}
           onLoad={adjustFrame}


### PR DESCRIPTION
* Provide a basic "URL bar" for the inspector iframe, allowing an admin to see and copy the current screen URL.

* Minor refactor to iframe URL building to put all the logic in one place and allow the URL to be used as the key for resetting data controls, fixing potential issues where these might not be reset even when the URL changed.

<img width="1035" alt="Screenshot 2025-03-04 at 3 51 41 PM" src="https://github.com/user-attachments/assets/e4570012-7980-40fb-b291-b5e70a76643a" />
