### PR TITLE
Added support for Pre-fare Solo layout to the Screenplay simulation

### DIFF
--- a/assets/css/pre_fare_v2.scss
+++ b/assets/css/pre_fare_v2.scss
@@ -60,6 +60,7 @@
 
 @import "v2/simulation_common";
 @import "v2/pre_fare/simulation";
+@import "v2/pre_fare/viewport";
 
 @import "v2/pre_fare/disruption_diagram/disruption_diagram";
 

--- a/assets/css/v2/pre_fare/screen_container.scss
+++ b/assets/css/v2/pre_fare/screen_container.scss
@@ -1,26 +1,6 @@
 .screen-container {
   position: relative;
-  height: 1920px;
   margin: 0 auto;
-  overflow: hidden;
-  // width of a single Pre-Fare display unit; "duo" installations are two of
-  // these side-by-side
-  --panel-width: 1080px;
-
-  &--duo {
-    width: calc(var(--panel-width) * 2);
-  }
-
-  &--left,
-  &--right,
-  &--solo {
-    width: var(--panel-width);
-  }
-
-  &--right > *,
-  &--solo > * {
-    margin-left: calc(var(--panel-width) * -1);
-  }
 }
 
 .screen-container-blink {

--- a/assets/css/v2/pre_fare/viewport.scss
+++ b/assets/css/v2/pre_fare/viewport.scss
@@ -1,0 +1,23 @@
+.screen-container,
+.simulation {
+  height: 1920px;
+  overflow: hidden;
+  // width of a single Pre-Fare display unit; "duo" installations are two of
+  // these side-by-side
+  --panel-width: 1080px;
+
+  &--duo {
+    width: calc(var(--panel-width) * 2);
+  }
+
+  &--left,
+  &--right,
+  &--solo {
+    width: var(--panel-width);
+  }
+
+  &--right > *,
+  &--solo > * {
+    margin-left: calc(var(--panel-width) * -1);
+  }
+}

--- a/assets/src/components/v2/pre_fare/simulation_screen_container.tsx
+++ b/assets/src/components/v2/pre_fare/simulation_screen_container.tsx
@@ -9,6 +9,7 @@ import {
   useSimulationApiResponse,
 } from "Hooks/v2/use_api_response";
 import WidgetTreeErrorBoundary from "Components/v2/widget_tree_error_boundary";
+import { classWithModifier, getScreenSide } from "Util/utils";
 
 interface SimulationScreenLayoutProps {
   apiResponse: ApiResponse;
@@ -43,7 +44,10 @@ const SimulationScreenLayout: ComponentType<SimulationScreenLayoutProps> = ({
         {apiResponse && (
           <div className="simulation__full-page">
             <div className="simulation__title">Live view</div>
-            <div className="simulation" id="simulation">
+            <div
+              className={classWithModifier("simulation", getScreenSide())}
+              id="simulation"
+            >
               <WidgetTreeErrorBoundary>
                 <Widget data={fullPage} />
               </WidgetTreeErrorBoundary>


### PR DESCRIPTION
**Asana task**: [Screenplay renaming / support for layout](https://app.asana.com/0/1185117109217413/1209255549956022)

<img width="185" alt="Screenshot 2025-03-06 at 4 59 54 PM" src="https://github.com/user-attachments/assets/e79eb2e1-99fc-44b6-8c76-ab6f8a3f415e" />
<img width="365" alt="Screenshot 2025-03-06 at 5 00 15 PM" src="https://github.com/user-attachments/assets/7304213c-8bdc-4fe2-8770-f8324ffe7591" />

Description
- These changes fix the cut off duo layout too
- [ ] Tests added?
