### PR TITLE
fix: Pre-Fare full duo takeover slot

### DIFF
--- a/assets/src/components/v2/pre_fare/body_takeover.tsx
+++ b/assets/src/components/v2/pre_fare/body_takeover.tsx
@@ -3,14 +3,16 @@ import React from "react";
 import Widget, { WidgetData } from "Components/v2/widget";
 
 interface Props {
-  full_body: WidgetData;
+  full_body_duo: WidgetData;
 }
 
-const BodyTakeover: React.ComponentType<Props> = ({ full_body: fullBody }) => {
+const BodyTakeover: React.ComponentType<Props> = ({
+  full_body_duo: fullBodyDuo,
+}) => {
   return (
     <div className="body-takeover">
       <div className="body-takeover__full-body">
-        <Widget data={fullBody} />
+        <Widget data={fullBodyDuo} />
       </div>
     </div>
   );


### PR DESCRIPTION
Widgets that should have taken over the full dual-screen body of a Pre-Fare "duo" (e.g. alerts that close the station the screen is at) were not appearing. The reason was that 5caacf9 changed the name of this slot, but neglected to change the corresponding prop name on the frontend.

**Asana task**: https://app.asana.com/0/1185117109217413/1209631307935941

Screenshot of the same alert that caused the reported bug, running on this branch:

<img width="1085" alt="Screenshot 2025-03-10 at 1 36 44 PM" src="https://github.com/user-attachments/assets/ee4fadf3-7cf4-4db5-9f80-822406c744f6" />
