### PR TITLE
Clean up phrasing of elevator widget audio on pre-fares

### DIFF
--- a/lib/screens_web/views/v2/audio/elevator_status_view.ex
+++ b/lib/screens_web/views/v2/audio/elevator_status_view.ex
@@ -16,7 +16,7 @@ defmodule ScreensWeb.V2.Audio.ElevatorStatusView do
   end
 
   defp render_closures(list_pages, upcoming_at_home_pages, elsewhere_pages) do
-    if not Enum.all?(Enum.concat(list_pages, upcoming_at_home_pages, elsewhere_pages)) do
+    if Enum.empty?(list_pages) and Enum.empty?(upcoming_at_home_pages) and Enum.empty?(elsewhere_pages) do
       "All other MBTA elevators are working or have a backup elevator within 20 feet."
     else
       Enum.map(list_pages, &render_page/1)

--- a/lib/screens_web/views/v2/audio/elevator_status_view.ex
+++ b/lib/screens_web/views/v2/audio/elevator_status_view.ex
@@ -9,14 +9,21 @@ defmodule ScreensWeb.V2.Audio.ElevatorStatusView do
       }) do
     ~E|
     <p>Elevator Closures across the T.</p>
-    <p><%= render_cta() %></p>
     <p><%= render_active_at_home(active_at_home_pages) %></p>
     <p>Other elevator closures:</p>
-    <p><%= Enum.map(list_pages, &render_page/1) %></p>
-    <p><%= Enum.map(upcoming_at_home_pages, &render_page/1) %></p>
-    <p><%= Enum.map(elsewhere_pages, &render_page/1) %></p>
-    <p><%= render_cta() %></p>
+    <p><%= render_closures(list_pages, upcoming_at_home_pages, elsewhere_pages) %></p>
     |
+  end
+
+  defp render_closures(list_pages, upcoming_at_home_pages, elsewhere_pages) do
+    if not Enum.all?(Enum.concat(list_pages, upcoming_at_home_pages, elsewhere_pages)) do
+      "All other MBTA elevators are working or have a backup elevator within 20 feet."
+    else
+      Enum.map(list_pages, &render_page/1)
+      Enum.map(upcoming_at_home_pages, &render_page/1)
+      Enum.map(elsewhere_pages, &render_page/1)
+      render_cta()
+    end
   end
 
   defp render_cta do

--- a/lib/screens_web/views/v2/audio/elevator_status_view.ex
+++ b/lib/screens_web/views/v2/audio/elevator_status_view.ex
@@ -15,16 +15,12 @@ defmodule ScreensWeb.V2.Audio.ElevatorStatusView do
     |
   end
 
+  defp render_closures([], [], []) do
+    "All other MBTA elevators are working or have a backup elevator within 20 feet."
+  end
+
   defp render_closures(list_pages, upcoming_at_home_pages, elsewhere_pages) do
-    if Enum.empty?(list_pages) and Enum.empty?(upcoming_at_home_pages) and
-         Enum.empty?(elsewhere_pages) do
-      "All other MBTA elevators are working or have a backup elevator within 20 feet."
-    else
-      Enum.map(list_pages, &render_page/1)
-      Enum.map(upcoming_at_home_pages, &render_page/1)
-      Enum.map(elsewhere_pages, &render_page/1)
-      render_cta()
-    end
+    Enum.map(list_pages ++ upcoming_at_home_pages ++ elsewhere_pages, &render_page/1) ++ render_cta()
   end
 
   defp render_cta do

--- a/lib/screens_web/views/v2/audio/elevator_status_view.ex
+++ b/lib/screens_web/views/v2/audio/elevator_status_view.ex
@@ -16,7 +16,8 @@ defmodule ScreensWeb.V2.Audio.ElevatorStatusView do
   end
 
   defp render_closures(list_pages, upcoming_at_home_pages, elsewhere_pages) do
-    if Enum.empty?(list_pages) and Enum.empty?(upcoming_at_home_pages) and Enum.empty?(elsewhere_pages) do
+    if Enum.empty?(list_pages) and Enum.empty?(upcoming_at_home_pages) and
+         Enum.empty?(elsewhere_pages) do
       "All other MBTA elevators are working or have a backup elevator within 20 feet."
     else
       Enum.map(list_pages, &render_page/1)

--- a/lib/screens_web/views/v2/audio/elevator_status_view.ex
+++ b/lib/screens_web/views/v2/audio/elevator_status_view.ex
@@ -20,7 +20,8 @@ defmodule ScreensWeb.V2.Audio.ElevatorStatusView do
   end
 
   defp render_closures(list_pages, upcoming_at_home_pages, elsewhere_pages) do
-    Enum.map(list_pages ++ upcoming_at_home_pages ++ elsewhere_pages, &render_page/1) ++ render_cta()
+    Enum.map(list_pages ++ upcoming_at_home_pages ++ elsewhere_pages, &render_page/1) ++
+      render_cta()
   end
 
   defp render_cta do

--- a/test/screens_web/views/v2/audio/elevator_status_view_test.exs
+++ b/test/screens_web/views/v2/audio/elevator_status_view_test.exs
@@ -11,7 +11,8 @@ defmodule ScreensWeb.V2.Audio.ElevatorStatusViewTest do
         elsewhere_pages: []
       }
 
-      assert render(assigns) == "\n    <p>Elevator Closures across the T.</p>\n    <p>All elevators are working at this station.</p>\n    <p>Other elevator closures:</p>\n    <p>All other MBTA elevators are working or have a backup elevator within 20 feet.</p>\n    "
+      assert render(assigns) ==
+               "\n    <p>Elevator Closures across the T.</p>\n    <p>All elevators are working at this station.</p>\n    <p>Other elevator closures:</p>\n    <p>All other MBTA elevators are working or have a backup elevator within 20 feet.</p>\n    "
     end
   end
 
@@ -25,6 +26,7 @@ defmodule ScreensWeb.V2.Audio.ElevatorStatusViewTest do
       }
 
       assert render(assigns) =~ "take a different elevator :)"
+
       assert render(assigns) =~
                "All other MBTA elevators are working or have a backup elevator within 20 feet."
     end

--- a/test/screens_web/views/v2/audio/elevator_status_view_test.exs
+++ b/test/screens_web/views/v2/audio/elevator_status_view_test.exs
@@ -8,7 +8,7 @@ defmodule ScreensWeb.V2.Audio.ElevatorStatusViewTest do
         active_at_home_pages: [],
         list_pages: [],
         upcoming_at_home_pages: [],
-        elsewhere_pages: [],
+        elsewhere_pages: []
       }
 
       assert render(assigns) =~ "All elevators are working at this station."
@@ -21,9 +21,11 @@ defmodule ScreensWeb.V2.Audio.ElevatorStatusViewTest do
         active_at_home_pages: test_stations(),
         list_pages: [],
         upcoming_at_home_pages: [],
-        elsewhere_pages: [],
+        elsewhere_pages: []
       }
-      assert render(assigns) =~ "All other MBTA elevators are working or have a backup elevator within 20 feet."
+
+      assert render(assigns) =~
+               "All other MBTA elevators are working or have a backup elevator within 20 feet."
     end
   end
 
@@ -33,35 +35,38 @@ defmodule ScreensWeb.V2.Audio.ElevatorStatusViewTest do
         active_at_home_pages: test_stations(),
         list_pages: test_stations(),
         upcoming_at_home_pages: [],
-        elsewhere_pages: [],
+        elsewhere_pages: []
       }
+
       assert render(assigns) =~ "For a full list of elevator alerts"
     end
-
   end
 
   ## Helper functions
 
   defp test_stations do
     [
-      %{station: %{
-        is_at_home_stop: true,
-        name: "Haymarket",
-        elevator_closures: [
-          %{
-            elevator_id: "1",
-            elevator_name: "haymarket elevator",
-            description: "take a differente elevator :)",
-            timeframe: %{
-              active_period: %{
-                "start" => "2022-01-01T00:00:00Z",
-                "end" => "2022-01-01T22:00:00Z"
-              },
-              happening_now: true
-            },
-          }
-        ]
-    }}]
+      %{
+        station: %{
+          is_at_home_stop: true,
+          name: "Haymarket",
+          elevator_closures: [
+            %{
+              elevator_id: "1",
+              elevator_name: "haymarket elevator",
+              description: "take a differente elevator :)",
+              timeframe: %{
+                active_period: %{
+                  "start" => "2022-01-01T00:00:00Z",
+                  "end" => "2022-01-01T22:00:00Z"
+                },
+                happening_now: true
+              }
+            }
+          ]
+        }
+      }
+    ]
   end
 
   defp render(data) do

--- a/test/screens_web/views/v2/audio/elevator_status_view_test.exs
+++ b/test/screens_web/views/v2/audio/elevator_status_view_test.exs
@@ -11,12 +11,12 @@ defmodule ScreensWeb.V2.Audio.ElevatorStatusViewTest do
         elsewhere_pages: []
       }
 
-      assert render(assigns) =~ "All elevators are working at this station."
+      assert render(assigns) == "\n    <p>Elevator Closures across the T.</p>\n    <p>All elevators are working at this station.</p>\n    <p>Other elevator closures:</p>\n    <p>All other MBTA elevators are working or have a backup elevator within 20 feet.</p>\n    "
     end
   end
 
-  describe "Single elevator alert" do
-    test "renders no additional closures messages" do
+  describe "Elevator alert" do
+    test "with no additional closures renders closure message + other elevators working message" do
       assigns = %{
         active_at_home_pages: test_stations(),
         list_pages: [],
@@ -24,13 +24,12 @@ defmodule ScreensWeb.V2.Audio.ElevatorStatusViewTest do
         elsewhere_pages: []
       }
 
+      assert render(assigns) =~ "take a different elevator :)"
       assert render(assigns) =~
                "All other MBTA elevators are working or have a backup elevator within 20 feet."
     end
-  end
 
-  describe "Multiple elevator alerts" do
-    test "render additional closure messages" do
+    test "with additional closures renders closure message + additional closures message" do
       assigns = %{
         active_at_home_pages: test_stations(),
         list_pages: test_stations(),
@@ -38,6 +37,7 @@ defmodule ScreensWeb.V2.Audio.ElevatorStatusViewTest do
         elsewhere_pages: []
       }
 
+      assert render(assigns) =~ "take a different elevator :)"
       assert render(assigns) =~ "For a full list of elevator alerts"
     end
   end
@@ -53,8 +53,8 @@ defmodule ScreensWeb.V2.Audio.ElevatorStatusViewTest do
           elevator_closures: [
             %{
               elevator_id: "1",
-              elevator_name: "haymarket elevator",
-              description: "take a differente elevator :)",
+              elevator_name: "Haymarket",
+              description: "take a different elevator :)",
               timeframe: %{
                 active_period: %{
                   "start" => "2022-01-01T00:00:00Z",

--- a/test/screens_web/views/v2/audio/elevator_status_view_test.exs
+++ b/test/screens_web/views/v2/audio/elevator_status_view_test.exs
@@ -1,0 +1,72 @@
+defmodule ScreensWeb.V2.Audio.ElevatorStatusViewTest do
+  use ScreensWeb.ConnCase, async: true
+  alias ScreensWeb.V2.Audio.ElevatorStatusView
+
+  describe "No elevator alerts" do
+    test "renders all clear message" do
+      assigns = %{
+        active_at_home_pages: [],
+        list_pages: [],
+        upcoming_at_home_pages: [],
+        elsewhere_pages: [],
+      }
+
+      assert render(assigns) =~ "All elevators are working at this station."
+    end
+  end
+
+  describe "Single elevator alert" do
+    test "renders no additional closures messages" do
+      assigns = %{
+        active_at_home_pages: test_stations(),
+        list_pages: [],
+        upcoming_at_home_pages: [],
+        elsewhere_pages: [],
+      }
+      assert render(assigns) =~ "All other MBTA elevators are working or have a backup elevator within 20 feet."
+    end
+  end
+
+  describe "Multiple elevator alerts" do
+    test "render additional closure messages" do
+      assigns = %{
+        active_at_home_pages: test_stations(),
+        list_pages: test_stations(),
+        upcoming_at_home_pages: [],
+        elsewhere_pages: [],
+      }
+      assert render(assigns) =~ "For a full list of elevator alerts"
+    end
+
+  end
+
+  ## Helper functions
+
+  defp test_stations do
+    [
+      %{station: %{
+        is_at_home_stop: true,
+        name: "Haymarket",
+        elevator_closures: [
+          %{
+            elevator_id: "1",
+            elevator_name: "haymarket elevator",
+            description: "take a differente elevator :)",
+            timeframe: %{
+              active_period: %{
+                "start" => "2022-01-01T00:00:00Z",
+                "end" => "2022-01-01T22:00:00Z"
+              },
+              happening_now: true
+            },
+          }
+        ]
+    }}]
+  end
+
+  defp render(data) do
+    "_widget.ssml"
+    |> ElevatorStatusView.render(data)
+    |> Phoenix.HTML.safe_to_string()
+  end
+end

--- a/test/screens_web/views/v2/audio/elevator_status_view_test.exs
+++ b/test/screens_web/views/v2/audio/elevator_status_view_test.exs
@@ -55,7 +55,7 @@ defmodule ScreensWeb.V2.Audio.ElevatorStatusViewTest do
           elevator_closures: [
             %{
               elevator_id: "1",
-              elevator_name: "Haymarket",
+              elevator_name: "Haymarket1",
               description: "take a different elevator :)",
               timeframe: %{
                 active_period: %{


### PR DESCRIPTION
**Asana task**: [Clean up phrasing of elevator widget audio on pre-fares](https://app.asana.com/0/1185117109217413/1209294078164616)

Only renders the additional closures messaging if there are actually additional closures. Added a test suite for this module. First elixir PR so let me know if this is the "elixir-y" way to go about this!  I think some of the functional programming mindset is starting to come back to me (I worked on an app in Clojure a looong time ago) :) 

- [x] Tests added?
