### PR TITLE
Fixed admin image upload failing with 400 error

### DIFF
--- a/assets/src/components/admin/admin_image_manager.tsx
+++ b/assets/src/components/admin/admin_image_manager.tsx
@@ -82,7 +82,7 @@ const ImageUpload = (): JSX.Element => {
     formData.append("image", stagedImageUpload, stagedImageUpload.name);
 
     try {
-      const result = await fetch.post("/api/admin/image", formData);
+      const result = await fetch.formData("/api/admin/image", formData);
 
       if (result.success) {
         alert(`Success. Image has been uploaded as "${result.uploaded_name}".`);

--- a/assets/src/util/admin.tsx
+++ b/assets/src/util/admin.tsx
@@ -42,6 +42,16 @@ const fetch = {
   delete: (path) => doFetch(path, { method: "DELETE" }),
 
   text: (path) => doFetch(path, {}, (response) => response.text()),
+
+  formData: (path: string, data: FormData) => {
+    return doFetch(path, {
+      body: data,
+      headers: {
+        "x-csrf-token": getCsrfToken(),
+      },
+      method: "POST",
+    });
+  },
 };
 
 const doFetch = async (


### PR DESCRIPTION
**Asana task**: [Fix Screens admin UI image uploads](https://app.asana.com/0/1185117109217413/1209279595523788)

Description
- Seems like previously we were passing FormData all the way through without serializing it and attaching content-type to the headers, in the new code we attempt to stringify + add the content-type of `application/json`
- Added the `formData` function in `fetch` to allow passing data through without trying to serialize it into JSON and attaching a content-type to it

- [ ] Tests added?
