### PR TITLE
refactor: migrate off deprecated Sass `@import`

### DIFF
--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -1,4 +1,4 @@
-@import "admin/inspector";
+@use "admin/inspector";
 
 #app {
   font-family: sans-serif;

--- a/assets/css/base/base_departure_destination.scss
+++ b/assets/css/base/base_departure_destination.scss
@@ -1,4 +1,4 @@
-@use "../fonts";
+@use "CSS/fonts";
 
 .base-departure-destination__primary {
   @include fonts.text--65medium;

--- a/assets/css/base/base_departure_time.scss
+++ b/assets/css/base/base_departure_time.scss
@@ -1,4 +1,4 @@
-@use "../fonts";
+@use "CSS/fonts";
 
 .base-departure-time {
   line-height: 1em;

--- a/assets/css/base/base_route_pill.scss
+++ b/assets/css/base/base_route_pill.scss
@@ -1,4 +1,4 @@
-@use "../fonts";
+@use "CSS/fonts";
 
 .base-route-pill__pill {
   text-align: center;

--- a/assets/css/bus_eink_v2.scss
+++ b/assets/css/bus_eink_v2.scss
@@ -1,43 +1,38 @@
-@import "fonts/inter_font_face";
-@import "fonts/helvetica_font_face";
+@use "fonts/inter_font_face";
+@use "fonts/helvetica_font_face";
 
-@import "v2/bus_eink/screen/normal";
-@import "v2/eink/screen/takeover";
+@use "v2/multi_screen_page";
+@use "v2/placeholder";
+@use "v2/simulation_common";
 
-@import "v2/bus_eink/body/normal";
-@import "v2/eink/body/takeover";
-@import "v2/bus_eink/body/bottom_takeover";
-@import "v2/bus_eink/body/flex_zone_takeover";
+@use "v2/eink/alert";
+@use "v2/eink/body/takeover" as *;
+@use "v2/eink/bottom_screen_filler";
+@use "v2/eink/departures";
+@use "v2/eink/departures_no_data";
+@use "v2/eink/departures_no_service";
+@use "v2/eink/fare_info_footer";
+@use "v2/eink/flex/one_medium";
+@use "v2/eink/flex/page_indicator";
+@use "v2/eink/free_text";
+@use "v2/eink/link_footer";
+@use "v2/eink/no_data";
+@use "v2/eink/normal_header";
+@use "v2/eink/page_load_no_data";
+@use "v2/eink/route_pill";
+@use "v2/eink/screen/takeover" as *;
+@use "v2/eink/subway_status";
 
-@import "v2/placeholder";
-@import "v2/eink/normal_header";
-@import "v2/eink/link_footer";
-@import "v2/eink/fare_info_footer";
-@import "v2/eink/free_text";
-@import "v2/eink/departures";
-@import "v2/eink/no_data";
-@import "v2/eink/page_load_no_data";
-@import "v2/eink/alert";
-@import "v2/eink/bottom_screen_filler";
-@import "v2/eink/departures_no_data";
-@import "v2/eink/departures_no_service";
-@import "v2/eink/subway_status";
-
-@import "v2/eink/flex/page_indicator";
-@import "v2/eink/flex/one_medium";
-
-@import "v2/eink/route_pill";
-@import "v2/bus_eink/departures/row";
-@import "v2/bus_eink/departures/destination";
-@import "v2/bus_eink/departures/time";
-@import "v2/bus_eink/departures/crowding";
-
-@import "v2/bus_eink/evergreen/image";
-
-@import "v2/multi_screen_page";
-
-@import "v2/simulation_common";
-@import "v2/bus_eink/simulation";
+@use "v2/bus_eink/body/bottom_takeover";
+@use "v2/bus_eink/body/flex_zone_takeover";
+@use "v2/bus_eink/body/normal" as *;
+@use "v2/bus_eink/departures/crowding";
+@use "v2/bus_eink/departures/destination";
+@use "v2/bus_eink/departures/row";
+@use "v2/bus_eink/departures/time";
+@use "v2/bus_eink/evergreen/image";
+@use "v2/bus_eink/screen/normal" as *;
+@use "v2/bus_eink/simulation";
 
 body {
   margin: 0;

--- a/assets/css/bus_shelter_v2.scss
+++ b/assets/css/bus_shelter_v2.scss
@@ -1,47 +1,36 @@
+@use "v2/multi_screen_page";
+@use "v2/placeholder";
+@use "v2/simulation_common";
+
+@use "v2/lcd_common/departures" as *;
+@use "v2/lcd_common/departures_no_data" as *;
+@use "v2/lcd_common/evergreen" as *;
+@use "v2/lcd_common/free_text";
+@use "v2/lcd_common/no_data";
+@use "v2/lcd_common/normal_header";
+@use "v2/lcd_common/page_load_no_data";
+@use "v2/lcd_common/route_pill";
+@use "v2/lcd_common/screen_container";
+@use "v2/lcd_common/simulation" as *;
+@use "v2/lcd_common/subway_status";
+
+@use "v2/bus_shelter/alert";
+@use "v2/bus_shelter/body/normal" as *;
+@use "v2/bus_shelter/body/takeover" as *;
+@use "v2/bus_shelter/departures" as *;
+@use "v2/bus_shelter/departures_no_data" as *;
+@use "v2/bus_shelter/evergreen" as *;
+@use "v2/bus_shelter/flex/one_large";
+@use "v2/bus_shelter/flex/one_medium_two_small";
+@use "v2/bus_shelter/flex/page_indicator";
+@use "v2/bus_shelter/flex/two_medium";
+@use "v2/bus_shelter/link_footer";
+@use "v2/bus_shelter/screen/normal" as *;
+@use "v2/bus_shelter/screen/takeover" as *;
+@use "v2/bus_shelter/simulation" as *;
+@use "v2/bus_shelter/survey";
+
 @import "https://rsms.me/inter/inter.css";
-
-@import "colors";
-
-@import "v2/lcd_common/screen_container";
-
-@import "v2/bus_shelter/screen/normal";
-@import "v2/bus_shelter/screen/takeover";
-
-@import "v2/bus_shelter/body/normal";
-@import "v2/bus_shelter/body/takeover";
-
-@import "v2/bus_shelter/flex/page_indicator";
-@import "v2/bus_shelter/flex/one_large";
-@import "v2/bus_shelter/flex/one_medium_two_small";
-@import "v2/bus_shelter/flex/two_medium";
-
-@import "v2/placeholder";
-@import "v2/lcd_common/normal_header";
-@import "v2/bus_shelter/link_footer";
-@import "v2/lcd_common/subway_status";
-@import "v2/lcd_common/route_pill";
-@import "v2/lcd_common/free_text";
-
-@import "v2/lcd_common/departures";
-@import "v2/bus_shelter/departures";
-
-@import "v2/bus_shelter/alert";
-
-@import "v2/lcd_common/evergreen";
-@import "v2/bus_shelter/evergreen";
-
-@import "v2/bus_shelter/survey";
-
-@import "v2/lcd_common/no_data";
-@import "v2/lcd_common/page_load_no_data";
-@import "v2/lcd_common/departures_no_data";
-@import "v2/bus_shelter/departures_no_data";
-
-@import "v2/multi_screen_page";
-
-@import "v2/simulation_common";
-@import "v2/lcd_common/simulation";
-@import "v2/bus_shelter/simulation";
 
 body {
   margin: 0;

--- a/assets/css/busway_v2.scss
+++ b/assets/css/busway_v2.scss
@@ -1,32 +1,25 @@
+@use "v2/multi_screen_page";
+@use "v2/placeholder";
+@use "v2/simulation_common";
+
+@use "v2/lcd_common/departures" as *;
+@use "v2/lcd_common/departures_no_data" as *;
+@use "v2/lcd_common/evergreen";
+@use "v2/lcd_common/free_text";
+@use "v2/lcd_common/no_data";
+@use "v2/lcd_common/normal_header";
+@use "v2/lcd_common/page_load_no_data";
+@use "v2/lcd_common/route_pill";
+@use "v2/lcd_common/screen_container";
+@use "v2/lcd_common/simulation";
+@use "v2/lcd_common/subway_status";
+
+@use "v2/busway/departures" as *;
+@use "v2/busway/departures_no_data" as *;
+@use "v2/busway/screen/normal";
+@use "v2/busway/screen/takeover";
+
 @import "https://rsms.me/inter/inter.css";
-
-@import "colors";
-
-@import "v2/placeholder";
-@import "v2/multi_screen_page";
-
-@import "v2/lcd_common/screen_container";
-
-@import "v2/busway/screen/normal";
-@import "v2/busway/screen/takeover";
-@import "v2/lcd_common/normal_header";
-
-@import "v2/lcd_common/evergreen";
-
-@import "v2/lcd_common/free_text";
-@import "v2/lcd_common/route_pill";
-@import "v2/lcd_common/subway_status";
-
-@import "v2/lcd_common/no_data";
-@import "v2/lcd_common/page_load_no_data";
-
-@import "v2/busway/departures";
-@import "v2/lcd_common/departures";
-@import "v2/busway/departures_no_data";
-@import "v2/lcd_common/departures_no_data";
-
-@import "v2/simulation_common";
-@import "v2/lcd_common/simulation";
 
 body {
   margin: 0;

--- a/assets/css/colors.scss
+++ b/assets/css/colors.scss
@@ -1,11 +1,11 @@
-$line-color-green: #00843d;
-$line-color-blue: #003da5;
-$line-color-red: #da291c;
-$line-color-orange: #ed8b00;
-$line-color-silver: #7c878e;
-$line-color-cr: #80276c;
-$line-color-bus: #ffc72c;
-$line-color-ferry: #008eaa;
+$line-green: #00843d;
+$line-blue: #003da5;
+$line-red: #da291c;
+$line-orange: #ed8b00;
+$line-silver: #7c878e;
+$line-cr: #80276c;
+$line-bus: #ffc72c;
+$line-ferry: #008eaa;
 
 $alert-yellow: #fd0;
 

--- a/assets/css/dup_v2.scss
+++ b/assets/css/dup_v2.scss
@@ -1,41 +1,36 @@
-@import "fonts/inter_font_face";
-@import "fonts/helvetica_font_face";
-@import "colors";
-@import "v2/common/widget";
+@use "fonts/inter_font_face";
+@use "fonts/helvetica_font_face";
 
-@import "v2/dup/screen/normal";
-@import "v2/dup/rotation/normal";
-@import "v2/dup/rotation/takeover";
-@import "v2/dup/body/normal";
-@import "v2/dup/body/split";
-@import "v2/dup/viewport";
-@import "v2/dup/free_text";
+@use "v2/common/widget";
+@use "v2/multi_screen_page";
+@use "v2/outfront_common/debug" as *;
+@use "v2/placeholder";
+@use "v2/simulation_common";
 
-@import "v2/placeholder";
-@import "v2/dup/normal_header";
-@import "v2/dup/evergreen";
-@import "v2/dup/departures";
-@import "v2/dup/departures/section";
-@import "v2/dup/departures/row";
-@import "v2/dup/departures/destination";
-@import "v2/dup/departures/time";
-@import "v2/dup/departures/crowding";
-@import "v2/dup/departures/route_pill";
-@import "v2/dup/departures/headway_section";
-@import "v2/dup/departures/no_data_section";
-@import "v2/dup/departures/overnight";
-
-@import "v2/dup/alert/partial_alert";
-@import "v2/dup/alert/full_screen_alert";
-
-@import "v2/multi_screen_page";
-@import "v2/simulation_common";
-@import "v2/dup/simulation";
-
-@import "v2/outfront_common/debug";
-@import "v2/dup/debug";
-
-@import "v2/dup/empty_state";
+@use "v2/dup/alert/full_screen_alert";
+@use "v2/dup/alert/partial_alert";
+@use "v2/dup/body/normal" as *;
+@use "v2/dup/body/split";
+@use "v2/dup/debug" as *;
+@use "v2/dup/departures";
+@use "v2/dup/departures/crowding";
+@use "v2/dup/departures/destination";
+@use "v2/dup/departures/headway_section";
+@use "v2/dup/departures/no_data_section";
+@use "v2/dup/departures/overnight";
+@use "v2/dup/departures/route_pill";
+@use "v2/dup/departures/row";
+@use "v2/dup/departures/section";
+@use "v2/dup/departures/time";
+@use "v2/dup/empty_state";
+@use "v2/dup/evergreen";
+@use "v2/dup/free_text";
+@use "v2/dup/normal_header";
+@use "v2/dup/rotation/normal" as *;
+@use "v2/dup/rotation/takeover";
+@use "v2/dup/screen/normal" as *;
+@use "v2/dup/simulation";
+@use "v2/dup/viewport";
 
 body {
   margin: 0;

--- a/assets/css/elevator_v2.scss
+++ b/assets/css/elevator_v2.scss
@@ -2,17 +2,23 @@
 // When writing styles for widgets on these screens,
 // verify browser compatibility in the MDN web docs.
 
+@use "colors";
+
+@use "v2/arrow";
+@use "v2/simulation_common";
+
+@use "v2/lcd_common/route_pill";
+@use "v2/lcd_common/screen_container";
+@use "v2/lcd_common/simulation";
+
+@use "v2/elevator/alternate_path";
+@use "v2/elevator/closures";
+@use "v2/elevator/footer";
+@use "v2/elevator/header";
+@use "v2/elevator/normal";
+@use "v2/elevator/screen/takeover";
+
 @import "https://rsms.me/inter/inter.css";
-@import "colors";
-@import "v2/lcd_common/screen_container";
-@import "v2/elevator/normal";
-@import "v2/simulation_common";
-@import "v2/lcd_common/simulation";
-@import "v2/elevator/header";
-@import "v2/elevator/footer";
-@import "v2/lcd_common/route_pill";
-@import "v2/arrow";
-@import "v2/elevator/screen/takeover";
 
 .evergreen-content-image__container,
 .evergreen-content-image__image {
@@ -39,7 +45,7 @@ body {
 .footer {
   &--closed {
     color: white;
-    background-color: $accessibility-blue;
+    background-color: colors.$accessibility-blue;
   }
 }
 
@@ -49,8 +55,8 @@ body {
   display: flex;
   flex-direction: column;
   height: 100%;
-  color: $cool-black-15;
-  background-color: $warm-neutral-90;
+  color: colors.$cool-black-15;
+  background-color: colors.$warm-neutral-90;
 
   .subheading {
     font-size: 80px;
@@ -68,6 +74,3 @@ body {
     margin-right: 27px;
   }
 }
-
-@import "v2/elevator/alternate_path";
-@import "v2/elevator/closures";

--- a/assets/css/gl_eink_v2.scss
+++ b/assets/css/gl_eink_v2.scss
@@ -1,44 +1,39 @@
-@import "fonts/inter_font_face";
-@import "fonts/helvetica_font_face";
+@use "fonts/inter_font_face";
+@use "fonts/helvetica_font_face";
 
-@import "v2/gl_eink/screen/normal";
-@import "v2/eink/screen/takeover";
+@use "v2/multi_screen_page";
+@use "v2/placeholder";
+@use "v2/simulation_common";
 
-@import "v2/gl_eink/body/normal";
-@import "v2/eink/body/takeover";
-@import "v2/eink/body/flex_zone_takeover";
-@import "v2/gl_eink/body/top_takeover";
-@import "v2/gl_eink/body/bottom_takeover";
-@import "v2/eink/flex/one_medium";
-@import "v2/eink/flex/page_indicator";
+@use "v2/eink/alert";
+@use "v2/eink/body/flex_zone_takeover";
+@use "v2/eink/body/takeover" as *;
+@use "v2/eink/bottom_screen_filler";
+@use "v2/eink/departures";
+@use "v2/eink/departures/overnight";
+@use "v2/eink/departures_no_data";
+@use "v2/eink/fare_info_footer";
+@use "v2/eink/flex/one_medium";
+@use "v2/eink/flex/page_indicator";
+@use "v2/eink/free_text";
+@use "v2/eink/link_footer";
+@use "v2/eink/no_data";
+@use "v2/eink/normal_header";
+@use "v2/eink/page_load_no_data";
+@use "v2/eink/route_pill" as *;
+@use "v2/eink/screen/takeover" as *;
+@use "v2/eink/subway_status";
 
-@import "v2/placeholder";
-@import "v2/eink/normal_header";
-@import "v2/eink/link_footer";
-@import "v2/eink/fare_info_footer";
-@import "v2/eink/free_text";
-@import "v2/eink/alert";
-@import "v2/eink/bottom_screen_filler";
-@import "v2/eink/departures_no_data";
-@import "v2/eink/subway_status";
-
-@import "v2/eink/departures";
-@import "v2/eink/departures/overnight";
-@import "v2/eink/no_data";
-@import "v2/eink/page_load_no_data";
-
-@import "v2/eink/route_pill";
-@import "v2/gl_eink/route_pill";
-@import "v2/gl_eink/departures/row";
-@import "v2/gl_eink/departures/time";
-@import "v2/gl_eink/line_map";
-
-@import "v2/gl_eink/evergreen/image";
-
-@import "v2/multi_screen_page";
-
-@import "v2/simulation_common";
-@import "v2/gl_eink/simulation";
+@use "v2/gl_eink/body/bottom_takeover";
+@use "v2/gl_eink/body/normal" as *;
+@use "v2/gl_eink/body/top_takeover";
+@use "v2/gl_eink/departures/row";
+@use "v2/gl_eink/departures/time";
+@use "v2/gl_eink/evergreen/image";
+@use "v2/gl_eink/line_map";
+@use "v2/gl_eink/route_pill" as *;
+@use "v2/gl_eink/screen/normal" as *;
+@use "v2/gl_eink/simulation";
 
 body {
   margin: 0;

--- a/assets/css/on_bus_v2.scss
+++ b/assets/css/on_bus_v2.scss
@@ -1,9 +1,9 @@
-@import "fonts/inter_font_face";
-@import "fonts/helvetica_font_face";
+@use "fonts/inter_font_face";
+@use "fonts/helvetica_font_face";
 
-@import "v2/multi_screen_page";
-@import "v2/placeholder";
-@import "v2/simulation_common";
+@use "v2/multi_screen_page";
+@use "v2/placeholder";
+@use "v2/simulation_common";
 
 body {
   margin: 0;

--- a/assets/css/pre_fare_v2.scss
+++ b/assets/css/pre_fare_v2.scss
@@ -1,66 +1,51 @@
+@use "v2/arrow";
+@use "v2/clock_icon";
+@use "v2/multi_screen_page";
+@use "v2/placeholder";
+@use "v2/simulation_common";
+
+@use "v2/lcd_common/no_data" as *;
+@use "v2/lcd_common/page_load_no_data";
+@use "v2/lcd_common/route_pill";
+
+@use "v2/pre_fare/alert-banner";
+@use "v2/pre_fare/body/normal" as *;
+@use "v2/pre_fare/body/takeover" as *;
+@use "v2/pre_fare/body_left/flex";
+@use "v2/pre_fare/body_left/normal" as *;
+@use "v2/pre_fare/body_left/takeover" as *;
+@use "v2/pre_fare/body_right/normal" as *;
+@use "v2/pre_fare/body_right/surge";
+@use "v2/pre_fare/body_right/takeover" as *;
+@use "v2/pre_fare/cr_departures/cr_departure_time";
+@use "v2/pre_fare/cr_departures/cr_departures";
+@use "v2/pre_fare/cr_departures/cr_departures_header";
+@use "v2/pre_fare/cr_departures/cr_departures_table";
+@use "v2/pre_fare/cr_departures/overnight_cr_departures";
+@use "v2/pre_fare/departure_time";
+@use "v2/pre_fare/disruption_diagram/disruption_diagram";
+@use "v2/pre_fare/elevator_status";
+@use "v2/pre_fare/evergreen/image";
+@use "v2/pre_fare/evergreen/video";
+@use "v2/pre_fare/flex/one_large";
+@use "v2/pre_fare/flex/paging_indicator";
+@use "v2/pre_fare/flex/two_medium";
+@use "v2/pre_fare/free_text";
+@use "v2/pre_fare/full_line_map";
+@use "v2/pre_fare/no_data" as *;
+@use "v2/pre_fare/normal_header";
+@use "v2/pre_fare/prefare_single_screen_alert";
+@use "v2/pre_fare/reconstructed_alert";
+@use "v2/pre_fare/screen/normal" as *;
+@use "v2/pre_fare/screen/split_takeover";
+@use "v2/pre_fare/screen/takeover" as *;
+@use "v2/pre_fare/screen_container";
+@use "v2/pre_fare/shuttle_bus_info";
+@use "v2/pre_fare/simulation";
+@use "v2/pre_fare/subway_status";
+@use "v2/pre_fare/viewport";
+
 @import "https://rsms.me/inter/inter.css";
-
-@import "colors";
-
-@import "v2/arrow";
-@import "v2/clock_icon";
-
-@import "v2/pre_fare/screen_container";
-
-@import "v2/pre_fare/screen/normal";
-@import "v2/pre_fare/screen/takeover";
-@import "v2/pre_fare/screen/split_takeover";
-
-@import "v2/pre_fare/body/normal";
-@import "v2/pre_fare/body/takeover";
-
-@import "v2/pre_fare/body_left/normal";
-@import "v2/pre_fare/body_left/takeover";
-@import "v2/pre_fare/body_left/flex";
-
-@import "v2/pre_fare/body_right/normal";
-@import "v2/pre_fare/body_right/takeover";
-@import "v2/pre_fare/body_right/surge";
-
-@import "v2/pre_fare/normal_header";
-
-@import "v2/pre_fare/flex/one_large";
-@import "v2/pre_fare/flex/two_medium";
-
-@import "v2/pre_fare/evergreen/image";
-@import "v2/pre_fare/evergreen/video";
-
-@import "v2/placeholder";
-@import "v2/pre_fare/departure_time";
-@import "v2/pre_fare/elevator_status";
-@import "v2/pre_fare/flex/paging_indicator";
-@import "v2/pre_fare/full_line_map";
-@import "v2/pre_fare/reconstructed_alert";
-@import "v2/pre_fare/alert-banner";
-@import "v2/pre_fare/prefare_single_screen_alert";
-@import "v2/pre_fare/free_text";
-@import "v2/pre_fare/shuttle_bus_info";
-
-@import "v2/pre_fare/cr_departures/cr_departures";
-@import "v2/pre_fare/cr_departures/overnight_cr_departures";
-@import "v2/pre_fare/cr_departures/cr_departures_header";
-@import "v2/pre_fare/cr_departures/cr_departures_table";
-@import "v2/pre_fare/cr_departures/cr_departure_time";
-
-@import "v2/pre_fare/subway_status";
-@import "v2/lcd_common/route_pill";
-
-@import "v2/lcd_common/no_data";
-@import "v2/lcd_common/page_load_no_data";
-@import "v2/pre_fare/no_data";
-
-@import "v2/multi_screen_page";
-
-@import "v2/simulation_common";
-@import "v2/pre_fare/simulation";
-@import "v2/pre_fare/viewport";
-
-@import "v2/pre_fare/disruption_diagram/disruption_diagram";
 
 body {
   margin: 0;

--- a/assets/css/v2/busway/departures.scss
+++ b/assets/css/v2/busway/departures.scss
@@ -1,5 +1,5 @@
-@import "departures/header";
-@import "departures/arrow";
+@use "departures/arrow";
+@use "departures/header";
 
 .departures-container {
   height: 100%;

--- a/assets/css/v2/busway/departures/header.scss
+++ b/assets/css/v2/busway/departures/header.scss
@@ -1,4 +1,5 @@
-@use "../../../fonts";
+@use "CSS/colors";
+@use "CSS/fonts";
 
 .departures-header {
   @include fonts.inter--bold;
@@ -12,12 +13,12 @@
   text-transform: uppercase;
   letter-spacing: 3px;
   white-space: pre-line; // Allow using embedded line breaks to control wrapping
-  border-top: 4px solid $true-grey-70;
+  border-top: 4px solid colors.$true-grey-70;
 
   &:not(:empty) {
     min-height: 104px;
     padding: 18px 32px 18px 48px;
-    background-color: $warm-neutral-80;
+    background-color: colors.$warm-neutral-80;
   }
 }
 

--- a/assets/css/v2/dup/alert/partial_alert.scss
+++ b/assets/css/v2/dup/alert/partial_alert.scss
@@ -1,35 +1,37 @@
+@use "CSS/colors";
+
 .partial-alert {
   border-top: 6px solid #00000040;
 
   &--green {
-    background: $line-color-green;
+    background: colors.$line-green;
   }
 
   &--blue {
-    background: $line-color-blue;
+    background: colors.$line-blue;
   }
 
   &--red {
-    background: $line-color-red;
+    background: colors.$line-red;
   }
 
   &--orange {
-    background: $line-color-orange;
+    background: colors.$line-orange;
   }
 
   &--silver {
-    background: $line-color-silver;
+    background: colors.$line-silver;
   }
 
   &--purple {
-    background: $line-color-cr;
+    background: colors.$line-cr;
   }
 
   &--yellow {
-    background: $alert-yellow;
+    background: colors.$alert-yellow;
   }
 
   &--teal {
-    background: $line-color-ferry;
+    background: colors.$line-ferry;
   }
 }

--- a/assets/css/v2/dup/departures/route_pill.scss
+++ b/assets/css/v2/dup/departures/route_pill.scss
@@ -1,3 +1,5 @@
+@use "CSS/colors";
+
 .route-pill {
   position: relative;
   width: 248px;
@@ -6,31 +8,31 @@
   border-radius: 100px;
 
   &--blue {
-    background-color: $line-color-blue;
+    background-color: colors.$line-blue;
   }
 
   &--green {
-    background-color: $line-color-green;
+    background-color: colors.$line-green;
   }
 
   &--orange {
-    background-color: $line-color-orange;
+    background-color: colors.$line-orange;
   }
 
   &--purple {
-    background-color: $line-color-cr;
+    background-color: colors.$line-cr;
   }
 
   &--red {
-    background-color: $line-color-red;
+    background-color: colors.$line-red;
   }
 
   &--silver {
-    background-color: $line-color-silver;
+    background-color: colors.$line-silver;
   }
 
   &--teal {
-    background-color: $line-color-ferry;
+    background-color: colors.$line-ferry;
   }
 
   &--yellow {
@@ -41,7 +43,7 @@
     margin-left: 0;
     color: black;
     letter-spacing: -2px;
-    background-color: $line-color-bus;
+    background-color: colors.$line-bus;
     border-radius: 0 20px 20px 0;
     box-shadow: 2px 4px 2px rgb(0 0 0 / 25%);
   }

--- a/assets/css/v2/dup/free_text.scss
+++ b/assets/css/v2/dup/free_text.scss
@@ -1,3 +1,5 @@
+@use "CSS/colors";
+
 // General styles for free text / route pills
 .free-text {
   font-family: Inter, sans-serif;
@@ -59,33 +61,33 @@
   &--green_c,
   &--green_d,
   &--green_e {
-    background: $line-color-green;
+    background: colors.$line-green;
   }
 
   &--blue {
-    background: $line-color-blue;
+    background: colors.$line-blue;
   }
 
   &--red,
   &--mattapan {
-    background: $line-color-red;
+    background: colors.$line-red;
   }
 
   &--orange {
-    background: $line-color-orange;
+    background: colors.$line-orange;
   }
 
   &--silver {
-    background: $line-color-silver;
+    background: colors.$line-silver;
   }
 
   &--cr,
   &--purple {
-    background: $line-color-cr;
+    background: colors.$line-cr;
   }
 
   &--bus {
-    background: $line-color-bus;
+    background: colors.$line-bus;
     box-shadow: 2px 4px 2px 0 rgb(0 0 0 / 25%);
   }
 }

--- a/assets/css/v2/dup/normal_header.scss
+++ b/assets/css/v2/dup/normal_header.scss
@@ -1,3 +1,5 @@
+@use "CSS/colors";
+
 .normal-header {
   position: relative;
   width: 100%;
@@ -5,31 +7,31 @@
   background: rgb(23 31 38);
 
   &--red {
-    background-color: $line-color-red;
+    background-color: colors.$line-red;
   }
 
   &--orange {
-    background-color: $line-color-orange;
+    background-color: colors.$line-orange;
   }
 
   &--green {
-    background-color: $line-color-green;
+    background-color: colors.$line-green;
   }
 
   &--blue {
-    background-color: $line-color-blue;
+    background-color: colors.$line-blue;
   }
 
   &--teal {
-    background-color: $line-color-ferry;
+    background-color: colors.$line-ferry;
   }
 
   &--silver {
-    background-color: $line-color-silver;
+    background-color: colors.$line-silver;
   }
 
   &--yellow {
-    background-color: $alert-yellow;
+    background-color: colors.$alert-yellow;
 
     .normal-header-title__text {
       color: #171f26;

--- a/assets/css/v2/elevator/alternate_path.scss
+++ b/assets/css/v2/elevator/alternate_path.scss
@@ -1,3 +1,5 @@
+@use "CSS/colors";
+
 .elevator-alternate-path {
   position: relative;
   height: 100%;
@@ -7,7 +9,7 @@
     top: 0;
     right: 0;
     display: inline-block;
-    border-right: 345px solid $accessibility-blue;
+    border-right: 345px solid colors.$accessibility-blue;
     border-bottom: 300px solid transparent;
   }
 
@@ -59,7 +61,7 @@
     }
 
     .alternate-direction-text {
-      color: $cool-black-30;
+      color: colors.$cool-black-30;
 
       &.small {
         font-size: 48px;

--- a/assets/css/v2/elevator/closures.scss
+++ b/assets/css/v2/elevator/closures.scss
@@ -1,10 +1,12 @@
+@use "CSS/colors";
+
 .elevator-closures {
   display: flex;
   flex: 1;
   flex-direction: column;
   font-size: 48px;
   line-height: 62px;
-  color: $cool-black-30;
+  color: colors.$cool-black-30;
 
   .in-station-summary {
     position: relative;
@@ -23,13 +25,13 @@
       width: 100%;
       height: 24px;
       content: "";
-      background: $cool-black-15;
+      background: colors.$cool-black-15;
     }
   }
 
   .closures-info {
     height: 100%;
-    background-color: $warm-neutral-90;
+    background-color: colors.$warm-neutral-90;
 
     .upcoming-closure {
       display: flex;
@@ -96,7 +98,7 @@
               height: 2px;
               margin: 0 24px;
               content: "";
-              background: $true-grey-45;
+              background: colors.$true-grey-45;
               opacity: 0.5;
             }
 
@@ -110,14 +112,14 @@
           }
 
           &.current-station {
-            background-color: $warm-neutral-85;
+            background-color: colors.$warm-neutral-85;
           }
 
           &__station-name {
             font-size: 62px;
             font-weight: 600;
             line-height: 80px;
-            color: $cool-black-15;
+            color: colors.$cool-black-15;
           }
 
           &__name-and-pills {

--- a/assets/css/v2/elevator/footer.scss
+++ b/assets/css/v2/elevator/footer.scss
@@ -1,3 +1,5 @@
+@use "CSS/colors";
+
 .footer {
   height: 100%;
   padding: 26px 48px;
@@ -5,7 +7,7 @@
   font-weight: 500;
   line-height: 62px;
   color: white;
-  background-color: $cool-black-30;
+  background-color: colors.$cool-black-30;
 
   b {
     letter-spacing: -0.2px;

--- a/assets/css/v2/elevator/header.scss
+++ b/assets/css/v2/elevator/header.scss
@@ -1,3 +1,5 @@
+@use "CSS/colors";
+
 .normal-header {
   display: flex;
   align-items: center;
@@ -7,6 +9,6 @@
   font-family: Inter, sans-serif;
   font-size: 48px;
   line-height: 62px;
-  color: $warm-neutral-90;
-  background-color: $cool-black-15;
+  color: colors.$warm-neutral-90;
+  background-color: colors.$cool-black-15;
 }

--- a/assets/css/v2/lcd_common/departures.scss
+++ b/assets/css/v2/lcd_common/departures.scss
@@ -1,11 +1,11 @@
+@use "departures/crowding";
+@use "departures/destination";
+@use "departures/later_departures";
+@use "departures/row";
+@use "departures/section";
+@use "departures/time";
+
 .departures-container {
   box-sizing: border-box;
   background-color: #e6e4e1;
 }
-
-@import "departures/section";
-@import "departures/row";
-@import "departures/destination";
-@import "departures/time";
-@import "departures/crowding";
-@import "departures/later_departures";

--- a/assets/css/v2/lcd_common/departures/later_departures.scss
+++ b/assets/css/v2/lcd_common/departures/later_departures.scss
@@ -1,4 +1,5 @@
 @use "sass:math";
+@use "CSS/colors";
 
 .later-departures__carousel {
   position: relative;
@@ -18,7 +19,7 @@
   flex-direction: column;
   flex-shrink: 0;
   width: 100%;
-  background-color: $warm-neutral-90;
+  background-color: colors.$warm-neutral-90;
 
   &__header {
     box-sizing: inherit;
@@ -26,7 +27,7 @@
     flex-direction: row;
     justify-content: space-between;
     margin: 0 32px;
-    border-bottom: 4px solid $true-grey-70;
+    border-bottom: 4px solid colors.$true-grey-70;
 
     h3 {
       box-sizing: inherit;
@@ -37,7 +38,7 @@
       font-size: 40px;
       font-weight: 500;
       line-height: 43px;
-      color: $cool-black-15;
+      color: colors.$cool-black-15;
       text-transform: uppercase;
       letter-spacing: 2px;
     }
@@ -97,9 +98,9 @@
       width: $caret-size;
       height: $caret-size;
       content: " ";
-      background-color: $warm-neutral-90;
-      border-top: 4px solid $true-grey-70;
-      border-left: 4px solid $true-grey-70;
+      background-color: colors.$warm-neutral-90;
+      border-top: 4px solid colors.$true-grey-70;
+      border-left: 4px solid colors.$true-grey-70;
       transform: rotate(45deg);
     }
   }

--- a/assets/css/v2/lcd_common/free_text.scss
+++ b/assets/css/v2/lcd_common/free_text.scss
@@ -1,3 +1,5 @@
+@use "CSS/colors";
+
 .free-text {
   font-family: Inter, sans-serif;
   font-size: 48px;
@@ -51,41 +53,41 @@
   &--green_c,
   &--green_d,
   &--green_e {
-    background: $line-color-green;
+    background: colors.$line-green;
   }
 
   &--blue {
-    background: $line-color-blue;
+    background: colors.$line-blue;
   }
 
   &--red,
   &--mattapan {
-    background: $line-color-red;
+    background: colors.$line-red;
   }
 
   &--orange {
-    background: $line-color-orange;
+    background: colors.$line-orange;
   }
 
   &--silver {
-    background: $line-color-silver;
+    background: colors.$line-silver;
   }
 
   &--cr,
   &--purple {
-    background: $line-color-cr;
+    background: colors.$line-cr;
   }
 
   &--bus,
   &--yellow {
     color: black;
-    background: $line-color-bus;
+    background: colors.$line-bus;
     box-shadow: 2px 4px 2px 0 rgb(0 0 0 / 25%);
   }
 
   &--ferry,
   &--teal {
-    background-color: $line-color-ferry;
+    background-color: colors.$line-ferry;
   }
 }
 

--- a/assets/css/v2/lcd_common/normal_header.scss
+++ b/assets/css/v2/lcd_common/normal_header.scss
@@ -1,4 +1,4 @@
-@use "../../fonts";
+@use "CSS/fonts";
 
 .normal-header {
   position: relative;

--- a/assets/css/v2/lcd_common/route_pill.scss
+++ b/assets/css/v2/lcd_common/route_pill.scss
@@ -1,3 +1,5 @@
+@use "CSS/colors";
+
 .route-pill {
   position: relative;
   width: 144px;
@@ -5,35 +7,35 @@
   border-radius: 100px;
 
   &--blue {
-    background-color: $line-color-blue;
+    background-color: colors.$line-blue;
   }
 
   &--green {
-    background-color: $line-color-green;
+    background-color: colors.$line-green;
   }
 
   &--orange {
-    background-color: $line-color-orange;
+    background-color: colors.$line-orange;
   }
 
   &--purple {
-    background-color: $line-color-cr;
+    background-color: colors.$line-cr;
   }
 
   &--red {
-    background-color: $line-color-red;
+    background-color: colors.$line-red;
   }
 
   &--silver {
-    background-color: $line-color-silver;
+    background-color: colors.$line-silver;
   }
 
   &--teal {
-    background-color: $line-color-ferry;
+    background-color: colors.$line-ferry;
   }
 
   &--yellow {
-    background-color: $line-color-bus;
+    background-color: colors.$line-bus;
     box-shadow: 2px 4px 2px 0 rgb(0 0 0 / 25%);
   }
 

--- a/assets/css/v2/pre_fare/departure_time.scss
+++ b/assets/css/v2/pre_fare/departure_time.scss
@@ -1,4 +1,4 @@
-@import "../../base/base_departure_time";
+@use "CSS/base/base_departure_time";
 
 .departure-time {
   display: inline-block;

--- a/assets/css/v2/pre_fare/disruption_diagram/disruption_diagram.scss
+++ b/assets/css/v2/pre_fare/disruption_diagram/disruption_diagram.scss
@@ -1,36 +1,38 @@
+@use "CSS/colors";
+
 .end-slot__arrow {
   &--red {
-    fill: $line-color-red;
+    fill: colors.$line-red;
   }
 
   &--blue {
-    fill: $line-color-blue;
+    fill: colors.$line-blue;
   }
 
   &--orange {
-    fill: $line-color-orange;
+    fill: colors.$line-orange;
   }
 
   &--green {
-    fill: $line-color-green;
+    fill: colors.$line-green;
   }
 }
 
 .end-slot__icon {
   &--red {
-    stroke: $line-color-red;
+    stroke: colors.$line-red;
   }
 
   &--blue {
-    stroke: $line-color-blue;
+    stroke: colors.$line-blue;
   }
 
   &--orange {
-    stroke: $line-color-orange;
+    stroke: colors.$line-orange;
   }
 
   &--green {
-    stroke: $line-color-green;
+    stroke: colors.$line-green;
   }
 
   &--affected {
@@ -44,37 +46,37 @@
 
 .middle-slot__background {
   &--red {
-    fill: $line-color-red;
+    fill: colors.$line-red;
   }
 
   &--blue {
-    fill: $line-color-blue;
+    fill: colors.$line-blue;
   }
 
   &--orange {
-    fill: $line-color-orange;
+    fill: colors.$line-orange;
   }
 
   &--green {
-    fill: $line-color-green;
+    fill: colors.$line-green;
   }
 }
 
 .middle-slot__icon {
   &--red {
-    stroke: $line-color-red;
+    stroke: colors.$line-red;
   }
 
   &--blue {
-    stroke: $line-color-blue;
+    stroke: colors.$line-blue;
   }
 
   &--orange {
-    stroke: $line-color-orange;
+    stroke: colors.$line-orange;
   }
 
   &--green {
-    stroke: $line-color-green;
+    stroke: colors.$line-green;
   }
 }
 

--- a/assets/css/v2/pre_fare/free_text.scss
+++ b/assets/css/v2/pre_fare/free_text.scss
@@ -1,3 +1,5 @@
+@use "CSS/colors";
+
 .free-text__element {
   &:not(:last-child)::after {
     content: " ";
@@ -28,28 +30,28 @@
   &--green_c,
   &--green_d,
   &--green_e {
-    background: $line-color-green;
+    background: colors.$line-green;
   }
 
   &--blue {
-    background: $line-color-blue;
+    background: colors.$line-blue;
   }
 
   &--red,
   &--mattapan {
-    background: $line-color-red;
+    background: colors.$line-red;
   }
 
   &--orange {
-    background: $line-color-orange;
+    background: colors.$line-orange;
   }
 
   &--silver {
-    background: $line-color-silver;
+    background: colors.$line-silver;
   }
 
   &--cr {
-    background: $line-color-cr;
+    background: colors.$line-cr;
   }
 
   .free-text__route-pill_text {

--- a/assets/css/v2/pre_fare/normal_header.scss
+++ b/assets/css/v2/pre_fare/normal_header.scss
@@ -1,4 +1,4 @@
-@use "../../fonts";
+@use "CSS/fonts";
 
 .normal-header {
   position: relative;

--- a/assets/css/v2/pre_fare/prefare_single_screen_alert.scss
+++ b/assets/css/v2/pre_fare/prefare_single_screen_alert.scss
@@ -1,3 +1,5 @@
+@use "CSS/colors";
+
 @mixin large-text {
   font-size: 112px;
   font-weight: 700;
@@ -26,23 +28,23 @@
   /* Background colors */
 
   &.alert-container--blue {
-    background-color: $line-color-blue;
+    background-color: colors.$line-blue;
   }
 
   &.alert-container--red {
-    background-color: $line-color-red;
+    background-color: colors.$line-red;
   }
 
   &.alert-container--orange {
-    background-color: $line-color-orange;
+    background-color: colors.$line-orange;
   }
 
   &.alert-container--yellow {
-    background-color: $alert-yellow;
+    background-color: colors.$alert-yellow;
   }
 
   &.alert-container--green {
-    background-color: $line-color-green;
+    background-color: colors.$line-green;
   }
 
   /* Alert contents */

--- a/assets/css/v2/pre_fare/reconstructed_alert.scss
+++ b/assets/css/v2/pre_fare/reconstructed_alert.scss
@@ -1,3 +1,5 @@
+@use "CSS/colors";
+
 $takeover-card-height: 1656px;
 $takeover-card-footer-height: 84px;
 
@@ -357,22 +359,22 @@ $alert-card-footer-height: 80px;
 .alert-container--urgent {
   /* Background colors */
   &.alert-container--blue {
-    background-color: $line-color-blue;
+    background-color: colors.$line-blue;
   }
 
   &.alert-container--red {
-    background-color: $line-color-red;
+    background-color: colors.$line-red;
   }
 
   &.alert-container--orange {
-    background-color: $line-color-orange;
+    background-color: colors.$line-orange;
   }
 
   &.alert-container--yellow {
-    background-color: $alert-yellow;
+    background-color: colors.$alert-yellow;
   }
 
   &.alert-container--green {
-    background-color: $line-color-green;
+    background-color: colors.$line-green;
   }
 }

--- a/assets/css/v2/pre_fare/subway_status.scss
+++ b/assets/css/v2/pre_fare/subway_status.scss
@@ -1,4 +1,4 @@
-@import "../lcd_common/subway_status";
+@use "CSS/v2/lcd_common/subway_status";
 
 .subway-status {
   margin: 26px 28px;

--- a/assets/stylelint.config.mjs
+++ b/assets/stylelint.config.mjs
@@ -17,11 +17,6 @@ export default {
     // Docs: "We recommend turning this rule off if you use a lot of nesting."
     "no-descending-specificity": null,
 
-    // Since we use SCSS exclusively, our `@import`s are all Sass imports
-    // (which are allowed to appear anywhere in a file) and not native CSS
-    // imports (which aren't, as this rule warns about).
-    "no-invalid-position-at-import-rule": null,
-
     // Existing class/mixin names do not follow a single consistent scheme; for
     // now, these patterns just allow them all, while not allowing anything too
     // far beyond that. Most names are "BEM-like" (`block__element--modifier`).

--- a/assets/tsconfig.json
+++ b/assets/tsconfig.json
@@ -45,6 +45,7 @@
     "moduleResolution": "node" /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */,
     "baseUrl": "." /* Base directory to resolve non-absolute module names. */,
     "paths": {
+      "CSS/*": ["css/*"],
       "Components/*": ["src/components/*"],
       "Hooks/*": ["src/hooks/*"],
       "Util/*": ["src/util/*"],

--- a/assets/webpack.config.js
+++ b/assets/webpack.config.js
@@ -13,6 +13,7 @@ const common_export_body = {
     extensions: [".ts", ".tsx", ".js", ".jsx"],
     alias: {
       // Please also update the "paths" list in tsconfig.json when you add aliases here!
+      CSS: path.resolve(__dirname, "css"),
       Components: path.resolve(__dirname, "src/components"),
       Hooks: path.resolve(__dirname, "src/hooks"),
       Util: path.resolve(__dirname, "src/util"),


### PR DESCRIPTION
https://sass-lang.com/blog/import-is-deprecated/

* Replace `@import` with `@use`.

* This requires files using shared mixins or variables to directly `@use` the file that contains them, rather than relying on them being in a global namespace. Since this could otherwise require a fragile sequence of `../../..` in paths, introduce a Webpack alias that allows referencing a file relative to the root `css` directory.

* Reorganize imports such that it should be less ambiguous how to keep them organized moving forward. Use a small number of "groups" and alphabetize within each group.