### PR TITLE
Rs/hanover departures widget

### DIFF
--- a/assets/css/on_bus_v2.scss
+++ b/assets/css/on_bus_v2.scss
@@ -4,6 +4,7 @@
 @import "v2/multi_screen_page";
 @import "v2/placeholder";
 @import "v2/simulation_common";
+@import "v2/on_bus/departures";
 
 body {
   margin: 0;

--- a/assets/css/v2/on_bus/departures.scss
+++ b/assets/css/v2/on_bus/departures.scss
@@ -1,0 +1,30 @@
+.departure-row {
+  position: relative;
+  padding-bottom: 30px;
+}
+
+.departure-row__route {
+  display: inline-block;
+  margin-top: 32px;
+  margin-left: 32px;
+  vertical-align: top;
+
+  &.center {
+    vertical-align: middle;
+  }
+}
+
+.departure-row__destination {
+  display: inline-block;
+  margin-top: 32px;
+  margin-right: 20px;
+  margin-left: 32px;
+  vertical-align: middle;
+}
+
+.departure-row__time {
+  display: inline-block;
+  margin-top: 44px;
+  margin-right: 32px;
+  vertical-align: top;
+}

--- a/assets/src/apps/v2/on_bus.tsx
+++ b/assets/src/apps/v2/on_bus.tsx
@@ -22,9 +22,12 @@ import {
   ResponseMapperContext,
 } from "Components/v2/screen_container";
 import { URL_PARAMS_BY_SCREEN_TYPE } from "Util/query_params";
+import Departures from "Components/v2/departures";
 
 const TYPE_TO_COMPONENT = {
   body_normal: NormalBody,
+  departures: Departures,
+  departures_no_data: NoData,
   no_data: NoData,
   placeholder: Placeholder,
   screen_normal: NormalScreen,

--- a/lib/screens/v2/candidate_generator/on_bus.ex
+++ b/lib/screens/v2/candidate_generator/on_bus.ex
@@ -2,6 +2,7 @@ defmodule Screens.V2.CandidateGenerator.OnBus do
   @moduledoc false
 
   alias Screens.V2.CandidateGenerator
+  alias Screens.V2.CandidateGenerator.Widgets.OnBus
   alias Screens.V2.Template.Builder
   alias Screens.V2.WidgetInstance.Placeholder
 
@@ -26,9 +27,14 @@ defmodule Screens.V2.CandidateGenerator.OnBus do
   end
 
   @impl CandidateGenerator
-  def candidate_instances(_config, query_params) do
+  def candidate_instances(
+        config,
+        query_params,
+        departures_instances_fn \\ &OnBus.Departures.departures_instances/3
+      ) do
     [
-      fn -> body_instances(query_params) end
+      fn -> body_instances(query_params) end,
+      fn -> departures_instances_fn.(config, query_params.route_id, query_params.stop_id) end
     ]
     |> Task.async_stream(& &1.())
     |> Enum.flat_map(fn {:ok, instances} -> instances end)

--- a/lib/screens/v2/candidate_generator/on_bus/departures.ex
+++ b/lib/screens/v2/candidate_generator/on_bus/departures.ex
@@ -1,199 +1,80 @@
 defmodule Screens.V2.CandidateGenerator.Widgets.OnBus.Departures do
   @moduledoc false
 
-  alias Screens.Routes.Route
-  alias Screens.RouteType
-  alias Screens.V2.CandidateGenerator.Widgets.OnBus.Departures
   alias Screens.V2.Departure
   alias Screens.V2.WidgetInstance.Departures, as: DeparturesWidget
   alias Screens.V2.WidgetInstance.Departures.NormalSection
-  alias Screens.V2.WidgetInstance.{DeparturesNoData, DeparturesNoService, OvernightDepartures}
+  alias Screens.V2.WidgetInstance.{DeparturesNoData, DeparturesNoService}
   alias ScreensConfig.Screen
-  alias ScreensConfig.V2.Departures.Filters.RouteDirections
-  alias ScreensConfig.V2.Departures.Filters.RouteDirections.RouteDirection
-  alias ScreensConfig.V2.Departures.{Filters, Query, Section}
 
-  alias ScreensConfig.V2.OnBus
-
-  @type t :: %__MODULE__{
-          stop_id: Stop.id(),
-          route_id: Route.id()
-        }
-
-  @enforce_keys ~w[stop_id route_id]a
-  defstruct @enforce_keys
-
-  @type options :: [
-          departure_fetch_fn: Departure.fetch(),
-          disabled_modes_fn: (-> RouteType.t()),
-          post_process_fn: (Departure.result(), Screen.t() -> Departure.result() | :overnight),
-          route_fetch_fn: (Route.params() -> {:ok, [Route.t()]} | :error),
-          now: DateTime.t()
-        ]
+  @max_departure_results 2
 
   @type widget ::
           DeparturesNoData.t()
           | DeparturesNoService.t()
           | DeparturesWidget.t()
-          | OvernightDepartures.t()
+  @type options :: [
+          departure_fetch_fn: Departure.fetch(),
+          now: DateTime.t()
+        ]
 
-  @spec departures_instances(Screen.t(), options()) :: [widget()]
-  def departures_instances(%Screen{app_params: %app{}} = config, now, options \\ [])
-      when app in [BusEink, BusShelter, Busway, GlEink] do
-    disabled_modes =
-      Keyword.get(options, :disabled_modes_fn, &Screens.Config.Cache.disabled_modes/0).()
-
-    if screen_devops_mode(config) in disabled_modes do
-      [%DeparturesNoData{screen: config, show_alternatives?: false}]
-    else
-      do_departures_instances(
-        config,
-        disabled_modes,
-        Keyword.get(options, :departure_fetch_fn, &Departure.fetch/2),
-        Keyword.get(options, :post_process_fn, fn results, _config -> results end),
-        Keyword.get(options, :route_fetch_fn, &Route.fetch/1),
-        now
+  @spec departures_instances(Screen.t(), String.t(), String.t(), options()) :: [DeparturesWidget]
+  def departures_instances(config, route_id, stop_id, options \\ []) do
+    departures =
+      fetch_departures(
+        route_id,
+        stop_id,
+        Keyword.get(options, :departure_fetch_fn, &Departure.fetch/2)
       )
+
+    case departures do
+      {:error, _} ->
+        [%DeparturesNoData{screen: config, show_alternatives?: true}]
+
+      {:ok, departure_data} ->
+        [
+          %DeparturesWidget{
+            screen: config,
+            sections: [
+              %NormalSection{
+                rows: departure_data,
+                layout: %ScreensConfig.V2.Departures.Layout{
+                  base: nil,
+                  include_later: false,
+                  max: @max_departure_results,
+                  min: 0
+                },
+                header: %ScreensConfig.V2.Departures.Header{
+                  arrow: nil,
+                  read_as: nil,
+                  title: nil
+                }
+              }
+            ],
+            now: DateTime.utc_now(),
+            slot_names: [:main_content]
+          }
+        ]
     end
   end
 
-  defp do_departures_instances(%Departures{
-         route_id: route_id,
-         stop_id: stop_id
-       }) do
-    departures = fetch_departures(stop_id, route_id, departure_fetch_fn)
-    # |> post_process_fn.(config)
-    # |> post_process_no_data(&1, has_multiple_sections, route_fetch_fn)
-
-    departures
-    # departures_instance =
-    #   cond do
-    #     Enum.any?(sections_data, &(&1.result == :error)) ->
-    #       %DeparturesNoData{screen: config, show_alternatives?: true}
-
-    #     match?([%{result: :overnight}], sections_data) ->
-    #       %OvernightDepartures{}
-
-    #     true ->
-    #       sections =
-    #         Enum.map(sections_data, fn
-    #           %{section: %Section{header: header, layout: layout}, result: result} ->
-    #             %NormalSection{
-    #               rows: normal_section_rows(result),
-    #               layout: layout,
-    #               header: header
-    #             }
-    #         end)
-
-    #       %DeparturesWidget{screen: config, sections: sections, now: now}
-    #   end
-
-    # [departures_instance]
-  end
-
-  # When a section has no departures on a screen with multiple sections, populate it with a "no
-  # data" entry. This may include a "representative" route for the section, used to determine an
-  # icon to display alongside the message.
-  #
-  # NOTE: Assumes any given section is configured such that it only displays departures from a
-  # single route-type-or-subway-line. If there would be more than one route-type-or-subway-line,
-  # one is picked arbitrarily.
-  defp post_process_no_data({:ok, []}, section, true = _has_multiple_sections, route_fetch_fn) do
-    %Section{
-      query: %Query{
-        params: %Query.Params{route_ids: route_ids, route_type: route_type, stop_ids: stop_ids}
-      }
-    } = section
-
-    fetch_params =
-      Map.reject(
-        %{
-          limit: 1,
-          ids: route_ids,
-          route_types: if(route_type, do: [route_type], else: []),
-          stop_ids: stop_ids
-        },
-        fn {_key, value} -> value == [] end
-      )
-
-    route =
-      case route_fetch_fn.(fetch_params) do
-        {:ok, [route | _]} -> route
-        _ -> nil
-      end
-
-    {:no_data, route}
-  end
-
-  defp post_process_no_data(fetch_result, _, _, _), do: fetch_result
-
-  defp normal_section_rows({:ok, departures}), do: departures
-
-  # defp normal_section_rows({:no_data, route?}) do
-  #   [
-  #     %FreeTextLine{
-  #       icon: if(route?, do: Route.icon(route?), else: nil),
-  #       text: ["No departures currently available"]
-  #     }
-  #   ]
-  # end
-
-  @spec fetch_departures() :: Departure.result()
-  def fetch_departures(route_id, stop_id, departure_fetch_fn) do
-    fetch_params = %{route_id => route_id, stop_id => stop_id}
-    fetch_opts = %{:include_schedules => true}
+  defp fetch_departures(route_id, stop_id, departure_fetch_fn) do
+    fetch_params = %{:stop_ids => [stop_id]}
+    fetch_opts = [include_schedules: false]
 
     is_bidirectional = true
 
     with {:ok, departures} <- departure_fetch_fn.(fetch_params, fetch_opts) do
       {:ok,
        departures
-       #  |> filter_departures(filters, now) #TODO: Add back filters
+       |> filter_current_route(route_id)
        |> make_bidirectional(is_bidirectional)}
     end
   end
 
-  defp filter_departures(
-         departures,
-         %Filters{max_minutes: max_minutes, route_directions: route_directions},
-         now
-       ) do
-    departures
-    |> filter_by_time(max_minutes, now)
-    |> filter_by_route_direction(route_directions)
-  end
-
-  defp filter_by_time(departures, nil, _now), do: departures
-
-  defp filter_by_time(departures, max_minutes, now) do
-    latest_time = DateTime.add(now, max_minutes, :minute)
-    Enum.reject(departures, &(DateTime.compare(Departure.time(&1), latest_time) == :gt))
-  end
-
-  defp filter_by_route_direction(departures, %RouteDirections{
-         action: :include,
-         targets: targets
-       }) do
-    Enum.filter(departures, &departure_in_route_directions?(&1, targets))
-  end
-
-  defp filter_by_route_direction(departures, %RouteDirections{
-         action: :exclude,
-         targets: targets
-       }) do
-    Enum.reject(departures, &departure_in_route_directions?(&1, targets))
-  end
-
-  defp filter_by_route_direction(departures, nil) do
-    departures
-  end
-
-  defp departure_in_route_directions?(d, route_directions) do
-    route_direction(d) in route_directions
-  end
-
-  defp route_direction(d) do
-    %RouteDirection{route_id: Departure.route(d).id, direction_id: Departure.direction_id(d)}
+  # Only return departures that are not from the bus's current route in either direction
+  defp filter_current_route(departures, route_id) do
+    Enum.filter(departures, &(&1.prediction.trip.route_id != route_id))
   end
 
   # "Bidirectional" mode: take only the first departure, and the next departure in the opposite
@@ -210,9 +91,4 @@ defmodule Screens.V2.CandidateGenerator.Widgets.OnBus.Departures do
   end
 
   defp make_bidirectional(departures, _), do: departures
-
-  # Some screen types are always configured to show departures for one specific transit mode. In
-  # that case, if the mode is devops-disabled, we immediately know the whole screen should display
-  # a "no data" message.
-  defp screen_devops_mode(_), do: nil
 end

--- a/lib/screens/v2/candidate_generator/on_bus/departures.ex
+++ b/lib/screens/v2/candidate_generator/on_bus/departures.ex
@@ -1,0 +1,218 @@
+defmodule Screens.V2.CandidateGenerator.Widgets.OnBus.Departures do
+  @moduledoc false
+
+  alias Screens.Routes.Route
+  alias Screens.RouteType
+  alias Screens.V2.CandidateGenerator.Widgets.OnBus.Departures
+  alias Screens.V2.Departure
+  alias Screens.V2.WidgetInstance.Departures, as: DeparturesWidget
+  alias Screens.V2.WidgetInstance.Departures.NormalSection
+  alias Screens.V2.WidgetInstance.{DeparturesNoData, DeparturesNoService, OvernightDepartures}
+  alias ScreensConfig.Screen
+  alias ScreensConfig.V2.Departures.Filters.RouteDirections
+  alias ScreensConfig.V2.Departures.Filters.RouteDirections.RouteDirection
+  alias ScreensConfig.V2.Departures.{Filters, Query, Section}
+
+  alias ScreensConfig.V2.OnBus
+
+  @type t :: %__MODULE__{
+          stop_id: Stop.id(),
+          route_id: Route.id()
+        }
+
+  @enforce_keys ~w[stop_id route_id]a
+  defstruct @enforce_keys
+
+  @type options :: [
+          departure_fetch_fn: Departure.fetch(),
+          disabled_modes_fn: (-> RouteType.t()),
+          post_process_fn: (Departure.result(), Screen.t() -> Departure.result() | :overnight),
+          route_fetch_fn: (Route.params() -> {:ok, [Route.t()]} | :error),
+          now: DateTime.t()
+        ]
+
+  @type widget ::
+          DeparturesNoData.t()
+          | DeparturesNoService.t()
+          | DeparturesWidget.t()
+          | OvernightDepartures.t()
+
+  @spec departures_instances(Screen.t(), options()) :: [widget()]
+  def departures_instances(%Screen{app_params: %app{}} = config, now, options \\ [])
+      when app in [BusEink, BusShelter, Busway, GlEink] do
+    disabled_modes =
+      Keyword.get(options, :disabled_modes_fn, &Screens.Config.Cache.disabled_modes/0).()
+
+    if screen_devops_mode(config) in disabled_modes do
+      [%DeparturesNoData{screen: config, show_alternatives?: false}]
+    else
+      do_departures_instances(
+        config,
+        disabled_modes,
+        Keyword.get(options, :departure_fetch_fn, &Departure.fetch/2),
+        Keyword.get(options, :post_process_fn, fn results, _config -> results end),
+        Keyword.get(options, :route_fetch_fn, &Route.fetch/1),
+        now
+      )
+    end
+  end
+
+  defp do_departures_instances(%Departures{
+         route_id: route_id,
+         stop_id: stop_id
+       }) do
+    departures = fetch_departures(stop_id, route_id, departure_fetch_fn)
+    # |> post_process_fn.(config)
+    # |> post_process_no_data(&1, has_multiple_sections, route_fetch_fn)
+
+    departures
+    # departures_instance =
+    #   cond do
+    #     Enum.any?(sections_data, &(&1.result == :error)) ->
+    #       %DeparturesNoData{screen: config, show_alternatives?: true}
+
+    #     match?([%{result: :overnight}], sections_data) ->
+    #       %OvernightDepartures{}
+
+    #     true ->
+    #       sections =
+    #         Enum.map(sections_data, fn
+    #           %{section: %Section{header: header, layout: layout}, result: result} ->
+    #             %NormalSection{
+    #               rows: normal_section_rows(result),
+    #               layout: layout,
+    #               header: header
+    #             }
+    #         end)
+
+    #       %DeparturesWidget{screen: config, sections: sections, now: now}
+    #   end
+
+    # [departures_instance]
+  end
+
+  # When a section has no departures on a screen with multiple sections, populate it with a "no
+  # data" entry. This may include a "representative" route for the section, used to determine an
+  # icon to display alongside the message.
+  #
+  # NOTE: Assumes any given section is configured such that it only displays departures from a
+  # single route-type-or-subway-line. If there would be more than one route-type-or-subway-line,
+  # one is picked arbitrarily.
+  defp post_process_no_data({:ok, []}, section, true = _has_multiple_sections, route_fetch_fn) do
+    %Section{
+      query: %Query{
+        params: %Query.Params{route_ids: route_ids, route_type: route_type, stop_ids: stop_ids}
+      }
+    } = section
+
+    fetch_params =
+      Map.reject(
+        %{
+          limit: 1,
+          ids: route_ids,
+          route_types: if(route_type, do: [route_type], else: []),
+          stop_ids: stop_ids
+        },
+        fn {_key, value} -> value == [] end
+      )
+
+    route =
+      case route_fetch_fn.(fetch_params) do
+        {:ok, [route | _]} -> route
+        _ -> nil
+      end
+
+    {:no_data, route}
+  end
+
+  defp post_process_no_data(fetch_result, _, _, _), do: fetch_result
+
+  defp normal_section_rows({:ok, departures}), do: departures
+
+  # defp normal_section_rows({:no_data, route?}) do
+  #   [
+  #     %FreeTextLine{
+  #       icon: if(route?, do: Route.icon(route?), else: nil),
+  #       text: ["No departures currently available"]
+  #     }
+  #   ]
+  # end
+
+  @spec fetch_departures() :: Departure.result()
+  def fetch_departures(route_id, stop_id, departure_fetch_fn) do
+    fetch_params = %{route_id => route_id, stop_id => stop_id}
+    fetch_opts = %{:include_schedules => true}
+
+    is_bidirectional = true
+
+    with {:ok, departures} <- departure_fetch_fn.(fetch_params, fetch_opts) do
+      {:ok,
+       departures
+       #  |> filter_departures(filters, now) #TODO: Add back filters
+       |> make_bidirectional(is_bidirectional)}
+    end
+  end
+
+  defp filter_departures(
+         departures,
+         %Filters{max_minutes: max_minutes, route_directions: route_directions},
+         now
+       ) do
+    departures
+    |> filter_by_time(max_minutes, now)
+    |> filter_by_route_direction(route_directions)
+  end
+
+  defp filter_by_time(departures, nil, _now), do: departures
+
+  defp filter_by_time(departures, max_minutes, now) do
+    latest_time = DateTime.add(now, max_minutes, :minute)
+    Enum.reject(departures, &(DateTime.compare(Departure.time(&1), latest_time) == :gt))
+  end
+
+  defp filter_by_route_direction(departures, %RouteDirections{
+         action: :include,
+         targets: targets
+       }) do
+    Enum.filter(departures, &departure_in_route_directions?(&1, targets))
+  end
+
+  defp filter_by_route_direction(departures, %RouteDirections{
+         action: :exclude,
+         targets: targets
+       }) do
+    Enum.reject(departures, &departure_in_route_directions?(&1, targets))
+  end
+
+  defp filter_by_route_direction(departures, nil) do
+    departures
+  end
+
+  defp departure_in_route_directions?(d, route_directions) do
+    route_direction(d) in route_directions
+  end
+
+  defp route_direction(d) do
+    %RouteDirection{route_id: Departure.route(d).id, direction_id: Departure.direction_id(d)}
+  end
+
+  # "Bidirectional" mode: take only the first departure, and the next departure in the opposite
+  # direction from the first, if one exists.
+  defp make_bidirectional([first | rest], true) do
+    first_direction = Departure.direction_id(first)
+
+    opposite? =
+      Enum.find(rest, Enum.at(rest, 0), fn departure ->
+        Departure.direction_id(departure) == 1 - first_direction
+      end)
+
+    Enum.reject([first, opposite?], &is_nil/1)
+  end
+
+  defp make_bidirectional(departures, _), do: departures
+
+  # Some screen types are always configured to show departures for one specific transit mode. In
+  # that case, if the mode is devops-disabled, we immediately know the whole screen should display
+  # a "no data" message.
+  defp screen_devops_mode(_), do: nil
+end

--- a/test/screens/v2/candidate_generator/on_bus/departures_test.exs
+++ b/test/screens/v2/candidate_generator/on_bus/departures_test.exs
@@ -1,0 +1,127 @@
+defmodule Screens.V2.CandidateGenerator.Widgets.OnBus.DeparturesTest do
+  use ExUnit.Case, async: true
+
+  alias Screens.V2.WidgetInstance.DeparturesNoData
+  alias Screens.V2.WidgetInstance.Departures.NormalSection
+  alias Screens.Predictions.Prediction
+  alias Screens.Routes.Route
+  alias Screens.Trips.Trip
+  alias Screens.V2.CandidateGenerator.Widgets.OnBus.Departures
+  alias Screens.V2.Departure
+  alias Screens.V2.WidgetInstance.Departures, as: DeparturesWidget
+  alias ScreensConfig.Screen
+  alias ScreensConfig.V2.OnBus
+
+  defp build_config() do
+    %Screen{
+      app_params: %OnBus{
+        evergreen_content: []
+      },
+      vendor: nil,
+      device_id: nil,
+      name: nil,
+      app_id: :on_bus_v2
+    }
+  end
+
+  defp build_departure(
+         route_id,
+         direction_id,
+         route_type \\ :bus,
+         arrival_time \\ ~U[2024-01-01 12:00:00Z]
+       ) do
+    %Departure{
+      prediction: %Prediction{
+        route: %Route{id: route_id, type: route_type},
+        trip: %Trip{direction_id: direction_id},
+        arrival_time: arrival_time
+      }
+    }
+  end
+
+  # defp build_fetch_fn(stop_ids_to_result, stop_id) do
+  #   fn %{stop_ids: [stop_id]}, %{include_schedules: false} ->
+  #     Map.fetch!(stop_ids_to_result, stop_id)
+  #   end
+  # end
+
+  defp departures_instances(config, route_id, stop_id, options) do
+    Departures.departures_instances(
+      config,
+      route_id,
+      stop_id,
+      Keyword.merge(
+        [
+          departure_fetch_fn: fn _, _ -> :error end
+        ],
+        options
+      )
+    )
+  end
+
+  describe "departures_instances/4" do
+    test "happy path returns a DeparturesWidget with single section containing two departures" do
+      config = build_config()
+      route_id = "88"
+      stop_id = "100"
+
+      mock_departures = [build_departure(~c"66", 0), build_departure(~c"109", 0)]
+
+      mock_fetch_fn = fn %{stop_ids: [^stop_id]}, [include_schedules: false] ->
+        {:ok, mock_departures}
+      end
+
+      assert [
+               %DeparturesWidget{
+                 screen: ^config,
+                 sections: [
+                   %NormalSection{rows: ^mock_departures}
+                 ]
+               }
+             ] =
+               departures_instances(config, route_id, stop_id, departure_fetch_fn: mock_fetch_fn)
+    end
+
+    test "returns DeparturesNoData section when fetch fails" do
+      route_id = "88"
+      stop_id = "100"
+      mock_fetch_fn = fn _, _ -> {:error, :service_down} end
+      config = build_config()
+
+      assert departures_instances(config, route_id, stop_id, departure_fetch_fn: mock_fetch_fn) ==
+               [
+                 %DeparturesNoData{screen: config, show_alternatives?: true}
+               ]
+    end
+
+    test "filters out departures for the current route_id" do
+      config = build_config()
+      route_id = "86"
+      stop_id = "22549"
+
+      mock_departures = [
+        build_departure(~c"66", 0),
+        build_departure(~c"109", 0)
+      ]
+
+      # 86 prediction scheduled for 1 minute earlier
+      mock_departures_on_route = [
+        build_departure(~c"86", 0, :bus, ~U[2024-01-01 11:59:00Z])
+      ]
+
+      mock_fetch_fn = fn %{stop_ids: [^stop_id]}, [include_schedules: false] ->
+        {:ok, mock_departures ++ mock_departures_on_route}
+      end
+
+      assert [
+               %DeparturesWidget{
+                 screen: ^config,
+                 sections: [
+                   %NormalSection{rows: ^mock_departures}
+                 ]
+               }
+             ] =
+               departures_instances(config, route_id, stop_id, departure_fetch_fn: mock_fetch_fn)
+    end
+  end
+end


### PR DESCRIPTION
**Asana task**: [Generate and populate departures widget](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1209537234084968)

- Creates a new candidate generator for departures for the On Bus screen app
- CSS styling is just placeholder to be able to see the 2 departures that are being passed to the Frontend

- [X] Tests added?
