### PR TITLE
Fixed flex zones being cut off in Pre-fare simulations

### DIFF
--- a/assets/css/v2/pre_fare/viewport.scss
+++ b/assets/css/v2/pre_fare/viewport.scss
@@ -1,5 +1,5 @@
 .screen-container,
-.simulation {
+.simulation-viewport {
   height: 1920px;
   overflow: hidden;
   // width of a single Pre-Fare display unit; "duo" installations are two of

--- a/assets/src/components/v2/pre_fare/simulation_screen_container.tsx
+++ b/assets/src/components/v2/pre_fare/simulation_screen_container.tsx
@@ -45,7 +45,7 @@ const SimulationScreenLayout: ComponentType<SimulationScreenLayoutProps> = ({
           <div className="simulation__full-page">
             <div className="simulation__title">Live view</div>
             <div
-              className={classWithModifier("simulation", getScreenSide())}
+              className={`simulation ${classWithModifier("simulation-viewport", getScreenSide())}`}
               id="simulation"
             >
               <WidgetTreeErrorBoundary>


### PR DESCRIPTION
**Asana task**: [Pre-fare flex zone is broken in Screenplay](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1209673539034709?focus=true)

(correct me if my CSS knowledge is wrong here)

- Seems like we were transforming the div around the widget instead of just the widget, leading to some cut off widgets.
- Moves the transform into the widget itself rather than the surrounding div
- Adds some scaling logic for the solo/duo panels for simulations to prevent unneeded horizontal scrolling

<img width="506" alt="Screenshot 2025-03-14 at 12 23 30 PM" src="https://github.com/user-attachments/assets/39d30678-e4fa-41dc-b06a-a10b72794760" />
<img width="790" alt="Screenshot 2025-03-14 at 12 29 37 PM" src="https://github.com/user-attachments/assets/58ffdcd4-0a2c-4911-8bb8-b6b178a1303a" />

- [ ] Tests added?
