### PR TITLE
UI for the "all elevators working" state

### DIFF
--- a/assets/css/v2/elevator/closures.scss
+++ b/assets/css/v2/elevator/closures.scss
@@ -31,6 +31,8 @@
   }
 
   .divider {
+    height: 4px;
+    width: 936px;
     background-color: #73737364;
     border-radius: 2px;
   }
@@ -43,13 +45,13 @@
     padding: 148px 72px;
     color: colors.$cool-black-15;
 
-    .no-closures-header {
+    &__header {
       font-size: 90px;
       font-weight: 700;
       line-height: 106px;
     }
 
-    .no-closures-text {
+    &__text {
       margin-bottom: 30px;
       font-size: 70px;
       font-weight: 400;
@@ -60,6 +62,28 @@
   .closures-info {
     height: 100%;
     background-color: colors.$warm-neutral-90;
+
+    .small-info-strip {
+      display: flex;
+      flex-direction: row;
+      gap: 10px;
+      align-items: center;
+      justify-content: space-between;
+      padding: 24px 72px;
+      font-size: 48px;
+      font-weight: 400;
+
+      &__divider {
+        height: 24px;
+        background-color: colors.$cool-black-15;
+      }
+    }
+
+    .maintenance-header {
+      font-size: 150px;
+      font-weight: 700;
+      line-height: 150px;
+    }
 
     .upcoming-closure {
       display: flex;

--- a/assets/css/v2/elevator/closures.scss
+++ b/assets/css/v2/elevator/closures.scss
@@ -65,11 +65,11 @@
       font-weight: 400;
       padding: 24px 72px;
       justify-content: space-between;
-    }
 
-    .divider {
-      height: 24px;
-      background-color: $cool-black-15;
+      .divider {
+        height: 24px;
+        background-color: $cool-black-15;
+      }
     }
 
     .upcoming-closure {

--- a/assets/css/v2/elevator/closures.scss
+++ b/assets/css/v2/elevator/closures.scss
@@ -11,8 +11,8 @@
   .in-station-summary {
     position: relative;
     display: flex;
-    justify-content: space-between;
     align-items: center;
+    justify-content: space-between;
     padding: 24px 48px;
 
     .text {
@@ -64,13 +64,14 @@
     .upcoming-closure-small {
       display: flex;
       flex-direction: row;
-      justify-content: space-between;
+      gap: 10px;
       align-items: center;
+      justify-content: space-between;
       padding: 24px 72px;
       font-size: 48px;
       font-weight: 400;
-      gap: 10px;
     }
+
     .closure-divider {
       height: 24px;
       background-color: colors.$cool-black-15;

--- a/assets/css/v2/elevator/closures.scss
+++ b/assets/css/v2/elevator/closures.scss
@@ -31,8 +31,8 @@
   }
 
   .divider {
-    height: 4px;
     width: 936px;
+    height: 4px;
     background-color: #73737364;
     border-radius: 2px;
   }
@@ -77,12 +77,6 @@
         height: 24px;
         background-color: colors.$cool-black-15;
       }
-    }
-
-    .maintenance-header {
-      font-size: 150px;
-      font-weight: 700;
-      line-height: 150px;
     }
 
     .upcoming-closure {

--- a/assets/css/v2/elevator/closures.scss
+++ b/assets/css/v2/elevator/closures.scss
@@ -28,16 +28,16 @@
   }
 
   .divider {
-    border-radius: 2px;
     background-color: #73737364;
+    border-radius: 2px;
   }
 
   .no-closures {
     position: relative;
     display: flex;
     flex-direction: column;
-    padding: 148px 72px;
     gap: 80px;
+    padding: 148px 72px;
     color: $cool-black-15;
 
     .no-closures-header {
@@ -47,10 +47,10 @@
     }
 
     .no-closures-text {
+      margin-bottom: 30px;
       font-size: 70px;
       font-weight: 400;
       line-height: 92px;
-      margin-bottom: 30px;
     }
   }
 
@@ -61,10 +61,10 @@
     .upcoming-closure-small {
       display: flex;
       flex-direction: row;
+      justify-content: space-between;
+      padding: 24px 72px;
       font-size: 48px;
       font-weight: 400;
-      padding: 24px 72px;
-      justify-content: space-between;
 
       .divider {
         height: 24px;

--- a/assets/css/v2/elevator/closures.scss
+++ b/assets/css/v2/elevator/closures.scss
@@ -63,22 +63,6 @@
     height: 100%;
     background-color: colors.$warm-neutral-90;
 
-    .small-info-strip {
-      display: flex;
-      flex-direction: row;
-      gap: 10px;
-      align-items: center;
-      justify-content: space-between;
-      padding: 24px 72px;
-      font-size: 48px;
-      font-weight: 400;
-
-      &__divider {
-        height: 24px;
-        background-color: colors.$cool-black-15;
-      }
-    }
-
     .upcoming-closure {
       display: flex;
       flex-direction: column;
@@ -86,6 +70,7 @@
       font-size: 80px;
       font-weight: 400;
       line-height: 88px;
+      color: colors.$cool-black-30;
 
       & > * {
         margin-bottom: 40px;
@@ -100,6 +85,7 @@
         font-size: var(--size);
         font-weight: 700;
         line-height: 1;
+        color: colors.$cool-black-15;
       }
 
       &__postfix {

--- a/assets/css/v2/elevator/closures.scss
+++ b/assets/css/v2/elevator/closures.scss
@@ -12,6 +12,7 @@
     position: relative;
     display: flex;
     justify-content: space-between;
+    align-items: center;
     padding: 24px 48px;
 
     .text {
@@ -64,14 +65,15 @@
       display: flex;
       flex-direction: row;
       justify-content: space-between;
+      align-items: center;
       padding: 24px 72px;
       font-size: 48px;
       font-weight: 400;
-
-      .divider {
-        height: 24px;
-        background-color: colors.$cool-black-15;
-      }
+      gap: 10px;
+    }
+    .closure-divider {
+      height: 24px;
+      background-color: colors.$cool-black-15;
     }
 
     .upcoming-closure {

--- a/assets/css/v2/elevator/closures.scss
+++ b/assets/css/v2/elevator/closures.scss
@@ -61,22 +61,6 @@
     height: 100%;
     background-color: colors.$warm-neutral-90;
 
-    .upcoming-closure-small {
-      display: flex;
-      flex-direction: row;
-      gap: 10px;
-      align-items: center;
-      justify-content: space-between;
-      padding: 24px 72px;
-      font-size: 48px;
-      font-weight: 400;
-    }
-
-    .closure-divider {
-      height: 24px;
-      background-color: colors.$cool-black-15;
-    }
-
     .upcoming-closure {
       display: flex;
       flex-direction: column;

--- a/assets/css/v2/elevator/closures.scss
+++ b/assets/css/v2/elevator/closures.scss
@@ -27,9 +27,50 @@
     }
   }
 
+  .divider {
+    border-radius: 2px;
+    background-color: #73737364;
+  }
+
+  .no-closures {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    padding: 148px 72px;
+    gap: 80px;
+    color: $cool-black-15;
+
+    .no-closures-header {
+      font-size: 90px;
+      font-weight: 700;
+      line-height: 106px;
+    } 
+
+    .no-closures-text {
+      font-size: 70px;
+      font-weight: 400;
+      line-height: 92px;
+      margin-bottom: 30px;
+    }
+  }
+
   .closures-info {
     height: 100%;
     background-color: $warm-neutral-90;
+
+    .upcoming-closure-small {
+      display: flex;
+      flex-direction: row;
+      font-size: 48px;
+      font-weight: 400;
+      padding: 24px 72px;
+      justify-content: space-between;
+    }
+
+    .divider {
+      height: 24px;
+      background-color: $cool-black-15;
+    }
 
     .upcoming-closure {
       display: flex;

--- a/assets/css/v2/elevator/closures.scss
+++ b/assets/css/v2/elevator/closures.scss
@@ -40,7 +40,7 @@
     flex-direction: column;
     gap: 80px;
     padding: 148px 72px;
-    color: $cool-black-15;
+    color: colors.$cool-black-15;
 
     .no-closures-header {
       font-size: 90px;
@@ -70,7 +70,7 @@
 
       .divider {
         height: 24px;
-        background-color: $cool-black-15;
+        background-color: colors.$cool-black-15;
       }
     }
 

--- a/assets/css/v2/elevator/closures.scss
+++ b/assets/css/v2/elevator/closures.scss
@@ -44,7 +44,7 @@
       font-size: 90px;
       font-weight: 700;
       line-height: 106px;
-    } 
+    }
 
     .no-closures-text {
       font-size: 70px;

--- a/assets/css/v2/elevator/normal.scss
+++ b/assets/css/v2/elevator/normal.scss
@@ -12,7 +12,7 @@
 
 .screen-normal__body {
   width: 1080px;
-  height: 1632px;
+  height: 100%;
 }
 
 .screen-normal__footer {

--- a/assets/css/v2/elevator/normal.scss
+++ b/assets/css/v2/elevator/normal.scss
@@ -1,6 +1,9 @@
 .screen-normal {
   position: relative;
+  display: flex;
+  flex-direction: column;
   width: 1080px;
+  height: 1920px;
   margin-right: auto;
   margin-left: auto;
 }
@@ -11,12 +14,13 @@
 }
 
 .screen-normal__body {
+  flex: 1;
   width: 1080px;
-  height: 100%;
 }
 
 .screen-normal__footer {
   position: relative;
+  flex: 0;
   width: 1080px;
-  height: 184px;
+  max-height: 184px;
 }

--- a/assets/src/components/v2/elevator/closures.tsx
+++ b/assets/src/components/v2/elevator/closures.tsx
@@ -217,9 +217,11 @@ const sortStations = (
     }
   });
 
+type ClosuresStatus = "no_closures";
+
 interface Props extends WrappedComponentProps {
   id: string;
-  stations_with_closures: StationWithClosures[];
+  stations_with_closures: StationWithClosures[] | ClosuresStatus;
   station_id: string;
   upcoming_closure?: UpcomingClosureInfo;
 }
@@ -230,9 +232,11 @@ const Closures = ({
   upcoming_closure: upcomingClosure,
   updateVisibleData,
 }: Props) => {
-  const numClosuresInStation = stations
-    .filter((s) => s.id === stationId)
-    .flatMap((s) => s.closures).length;
+  const numClosuresInStation =
+    typeof stations === "string"
+      ? 0
+      : stations.filter((s) => s.id === stationId).flatMap((s) => s.closures)
+          .length;
 
   const listRef = useRef<HTMLDivElement>(null);
 
@@ -290,7 +294,9 @@ const Closures = ({
 
   return (
     <div className="elevator-closures">
-      {stations.length > 0 ? (
+      {stations === "no_closures" ? (
+        <NoCurrentClosures closure={upcomingClosure} />
+      ) : (
         <>
           <InStationSummary
             numClosures={numClosuresInStation}
@@ -333,8 +339,6 @@ const Closures = ({
             </div>
           </div>
         </>
-      ) : (
-        <NoCurrentClosures closure={upcomingClosure} />
       )}
       {numPages > 1 && (
         <div className="paging-info-container">

--- a/assets/src/components/v2/elevator/closures.tsx
+++ b/assets/src/components/v2/elevator/closures.tsx
@@ -10,6 +10,7 @@ import { type StationWithClosures } from "Components/v2/elevator/types";
 import useIntervalPaging from "Hooks/v2/use_interval_paging";
 import CalendarIcon from "Images/svgr_bundled/calendar.svg";
 import NormalServiceIcon from "Images/svgr_bundled/normal-service.svg";
+import CalenderAlertIcon from "Images/svgr_bundled/calendar-alert.svg";
 import AccessibilityAlert from "Images/svgr_bundled/accessibility-alert.svg";
 import Logo from "Images/svgr_bundled/logo.svg";
 import { hasOverflowX } from "Util/utils";
@@ -141,7 +142,7 @@ const UpcomingClosure = ({
 
   return (
     <div className="upcoming-closure">
-      <AccessibilityAlert height={249} width={249} />
+      <CalenderAlertIcon height={249} width={249} />
       <div className="upcoming-closure__title" ref={titleRef}>
         {title}:
       </div>
@@ -166,13 +167,12 @@ const NoCurrentClosures = ({ closure }: { closure?: UpcomingClosureInfo }) => {
     <>
       {closure ? (
         <div className="closures-info">
-          <div className="small-info-strip">
+          <div className="in-station-summary">
             <div>All MBTA elevators are working.</div>
             <div>
               <NormalServiceIcon width={72} height={72} fill="#145A06" />
             </div>
           </div>
-          <div className="small-info-strip__divider" />
           <UpcomingClosure closure={closure} />
         </div>
       ) : (

--- a/assets/src/components/v2/elevator/closures.tsx
+++ b/assets/src/components/v2/elevator/closures.tsx
@@ -162,61 +162,21 @@ const UpcomingClosure = ({
   );
 };
 
-const NoCurrentClosures = ({ closure }: { closure?: UpcomingClosureInfo }) => {
-  const getClosureTitle = (titles: string[]) => {
-    const titlesParsed = titles[0].split(" ");
-    if (titlesParsed[0] === "This") {
-      return (
-        <b>
-          {titlesParsed[0]} {titlesParsed[1]}:{" "}
-        </b>
-      );
-    }
-    return;
-  };
-  const getClosureDetail = (titles: string[]) => {
-    const titlesParsed = titles[0].split(" ");
-    if (titlesParsed[0] === "This") {
-      return titlesParsed.slice(1);
-    } else {
-      return titlesParsed.join(" ");
-    }
-  };
-
+const NoCurrentClosures = () => {
   return (
-    <>
-      {closure && (
-        <div className="closures-info">
-          <div className="upcoming-closure-small">
-            <div>
-              {getClosureTitle(closure.details.titles)}
-              This elevator will be closed{" "}
-              {getClosureDetail(closure.details.titles)}{" "}
-              {closure.details.postfix}
-            </div>
-            <div>
-              <CalendarIcon width={72} height={72} />
-            </div>
-          </div>
-          <div className="closure-divider" />
-        </div>
-      )}
-      <div className="no-closures">
-        <NormalServiceIcon height={150} width={150} fill="#145A06" />
-        <div className="no-closures-header">
-          All MBTA elevators are working.
-        </div>
-        <svg height={4} width={936} className="divider">
-          <line x1="0" y1="4" x2={936} y2={4} />
-        </svg>
-        <div className="no-closures-text">
-          For info on elevator outages and alternate paths:{" "}
-          <b>mbta.com/elevators</b> or call the elevator hotline:{" "}
-          <b>617-222-2828</b>
-        </div>
-        {!closure && <Logo height={124} width={124} />}
+    <div className="no-closures">
+      <NormalServiceIcon height={150} width={150} fill="#145A06" />
+      <div className="no-closures-header">All MBTA elevators are working.</div>
+      <svg height={4} width={936} className="divider">
+        <line x1="0" y1="4" x2={936} y2={4} />
+      </svg>
+      <div className="no-closures-text">
+        For info on elevator outages and alternate paths:{" "}
+        <b>mbta.com/elevators</b> or call the elevator hotline:{" "}
+        <b>617-222-2828</b>
       </div>
-    </>
+      <Logo height={124} width={124} />
+    </div>
   );
 };
 
@@ -317,7 +277,7 @@ const Closures = ({
   return (
     <div className="elevator-closures">
       {stations === "no_closures" ? (
-        <NoCurrentClosures closure={upcomingClosure} />
+        <NoCurrentClosures />
       ) : (
         <>
           <InStationSummary

--- a/assets/src/components/v2/elevator/closures.tsx
+++ b/assets/src/components/v2/elevator/closures.tsx
@@ -162,21 +162,66 @@ const UpcomingClosure = ({
   );
 };
 
-const NoCurrentClosures = () => {
+const NoCurrentClosures = ({ closure }: { closure?: UpcomingClosureInfo }) => {
+  const getClosureTitle = (titles: string[]) => {
+    const titlesParsed = titles[0].split(" ");
+    return (
+      <b>
+        {titlesParsed[0]} {titlesParsed[1]}:{" "}
+      </b>
+    );
+  };
+  const getClosureDetail = (titles: string[]) => {
+    const titlesParsed = titles[0].split(" ");
+    if (titlesParsed[0] === "This") {
+      return titlesParsed.slice(1);
+    } else {
+      return titlesParsed.join(" ");
+    }
+  };
+
   return (
-    <div className="no-closures">
-      <NormalServiceIcon height={150} width={150} fill="#145A06" />
-      <div className="no-closures-header">All MBTA elevators are working.</div>
-      <svg height={4} width={936} className="divider">
-        <line x1="0" y1="4" x2={936} y2={4} />
-      </svg>
-      <div className="no-closures-text">
-        For info on elevator outages and alternate paths:{" "}
-        <b>mbta.com/elevators</b> or call the elevator hotline:{" "}
-        <b>617-222-2828</b>
-      </div>
-      <Logo height={124} width={124} />
-    </div>
+    <>
+      {closure ? (
+        <div className="closures-info">
+          <div className="small-info-strip">
+            <div>All MBTA elevators are working.</div>
+            <div>
+              <NormalServiceIcon width={72} height={72} fill="#145A06" />
+            </div>
+          </div>
+          <div className="small-info-strip__divider" />
+          <div className="upcoming-closure">
+            <AccessibilityAlert height={249} width={249} />
+            <div className="maintenance-header">
+              {getClosureTitle(closure.details.titles)}
+            </div>
+            <div className="no-closures__text">
+              This elevator will be closed{" "}
+              {getClosureDetail(closure.details.titles)}{" "}
+              {closure.details.postfix}.
+              <br />
+              <br />
+              {closure.details.summary}
+            </div>
+          </div>
+        </div>
+      ) : (
+        <div className="no-closures">
+          <NormalServiceIcon height={150} width={150} fill="#145A06" />
+          <div className="no-closures__header">
+            All MBTA elevators are working.
+          </div>
+          <div className="divider" />
+          <div className="no-closures__text">
+            For info on elevator outages and alternate paths:{" "}
+            <b>mbta.com/elevators</b> or call the elevator hotline:{" "}
+            <b>617-222-2828</b>
+          </div>
+          <Logo height={124} width={124} />
+        </div>
+      )}
+    </>
   );
 };
 
@@ -277,7 +322,7 @@ const Closures = ({
   return (
     <div className="elevator-closures">
       {stations === "no_closures" ? (
-        <NoCurrentClosures />
+        <NoCurrentClosures closure={upcomingClosure} />
       ) : (
         <>
           <InStationSummary

--- a/assets/src/components/v2/elevator/closures.tsx
+++ b/assets/src/components/v2/elevator/closures.tsx
@@ -9,7 +9,6 @@ import PagingIndicators from "Components/v2/elevator/paging_indicators";
 import { type StationWithClosures } from "Components/v2/elevator/types";
 import useIntervalPaging from "Hooks/v2/use_interval_paging";
 import CalendarIcon from "Images/svgr_bundled/calendar.svg";
-import CalendarAlertIcon from "Images/svgr_bundled/calendar-alert.svg";
 import NormalServiceIcon from "Images/svgr_bundled/normal-service.svg";
 import AccessibilityAlert from "Images/svgr_bundled/accessibility-alert.svg";
 import Logo from "Images/svgr_bundled/logo.svg";
@@ -142,7 +141,7 @@ const UpcomingClosure = ({
 
   return (
     <div className="upcoming-closure">
-      <CalendarAlertIcon width={224} />
+      <AccessibilityAlert height={249} width={249} />
       <div className="upcoming-closure__title" ref={titleRef}>
         {title}:
       </div>
@@ -163,23 +162,6 @@ const UpcomingClosure = ({
 };
 
 const NoCurrentClosures = ({ closure }: { closure?: UpcomingClosureInfo }) => {
-  const getClosureTitle = (titles: string[]) => {
-    const titlesParsed = titles[0].split(" ");
-    return (
-      <b>
-        {titlesParsed[0]} {titlesParsed[1]}:{" "}
-      </b>
-    );
-  };
-  const getClosureDetail = (titles: string[]) => {
-    const titlesParsed = titles[0].split(" ");
-    if (titlesParsed[0] === "This") {
-      return titlesParsed.slice(1);
-    } else {
-      return titlesParsed.join(" ");
-    }
-  };
-
   return (
     <>
       {closure ? (
@@ -191,20 +173,7 @@ const NoCurrentClosures = ({ closure }: { closure?: UpcomingClosureInfo }) => {
             </div>
           </div>
           <div className="small-info-strip__divider" />
-          <div className="upcoming-closure">
-            <AccessibilityAlert height={249} width={249} />
-            <div className="maintenance-header">
-              {getClosureTitle(closure.details.titles)}
-            </div>
-            <div className="no-closures__text">
-              This elevator will be closed{" "}
-              {getClosureDetail(closure.details.titles)}{" "}
-              {closure.details.postfix}.
-              <br />
-              <br />
-              {closure.details.summary}
-            </div>
-          </div>
+          <UpcomingClosure closure={closure} />
         </div>
       ) : (
         <div className="no-closures">

--- a/assets/src/components/v2/elevator/closures.tsx
+++ b/assets/src/components/v2/elevator/closures.tsx
@@ -12,6 +12,7 @@ import CalendarIcon from "Images/svgr_bundled/calendar.svg";
 import CalendarAlertIcon from "Images/svgr_bundled/calendar-alert.svg";
 import NormalServiceIcon from "Images/svgr_bundled/normal-service.svg";
 import AccessibilityAlert from "Images/svgr_bundled/accessibility-alert.svg";
+import Logo from "Images/svgr_bundled/logo.svg";
 import { hasOverflowX } from "Util/utils";
 import { CLOSURES_PAGING_INTERVAL_MS } from "./constants";
 
@@ -161,6 +162,42 @@ const UpcomingClosure = ({
   );
 };
 
+const NoCurrentClosures = ({ closure }: { closure?: UpcomingClosureInfo }) => {
+  return (
+    <>
+      {closure && (
+        <div className="closures-info">
+          <div className="upcoming-closure-small">
+            <div>
+              This elevator will be closed {closure.details.titles[0]}{" "}
+              {closure.details.postfix}
+            </div>
+            <div>
+              <CalendarIcon width={72} height={72} />
+            </div>
+          </div>
+          <div className="divider" />
+        </div>
+      )}
+      <div className="no-closures">
+        <NormalServiceIcon height={150} width={150} fill="#145A06" />
+        <div className="no-closures-header">
+          All MBTA elevators are working.
+        </div>
+        <svg height={4} width={936} className="divider">
+          <line x1="0" y1="4" x2={936} y2={4} />
+        </svg>
+        <div className="no-closures-text">
+          For info on elevator outages and alternate paths:{" "}
+          <b>mbta.com/elevators</b> or call the elevator hotline:{" "}
+          <b>617-222-2828</b>
+        </div>
+        {!closure && <Logo height={124} width={124} />}
+      </div>
+    </>
+  );
+};
+
 const sortStations = (
   stations: StationWithClosures[],
   thisStationId: string,
@@ -253,41 +290,52 @@ const Closures = ({
 
   return (
     <div className="elevator-closures">
-      <InStationSummary
-        numClosures={numClosuresInStation}
-        upcomingClosure={isUpcomingClosurePage ? undefined : upcomingClosure}
-      />
+      {stations.length > 0 ? (
+        <>
+          <InStationSummary
+            numClosures={numClosuresInStation}
+            upcomingClosure={
+              isUpcomingClosurePage ? undefined : upcomingClosure
+            }
+          />
 
-      <div className="closures-info">
-        {isUpcomingClosurePage ? (
-          <UpcomingClosure closure={upcomingClosure} />
-        ) : (
-          <div className="header-container">
-            <div className="header">
-              <div className="header__title">MBTA Elevator Closures</div>
-              <div>
-                <AccessibilityAlert height={128} width={155} />
+          <div className="closures-info">
+            {isUpcomingClosurePage ? (
+              <UpcomingClosure closure={upcomingClosure} />
+            ) : (
+              <div className="header-container">
+                <div className="header">
+                  <div className="header__title">MBTA Elevator Closures</div>
+                  <div>
+                    <AccessibilityAlert height={128} width={155} />
+                  </div>
+                </div>
               </div>
+            )}
+
+            <div className="closure-list-container">
+              {
+                <div
+                  className="closure-list"
+                  ref={listRef}
+                  style={listOffsetStyle}
+                >
+                  {sortStations(stations, stationId).map((station, index) => (
+                    <ClosureRow
+                      isCurrentStation={station.id == stationId}
+                      isFirstRowOnPage={firstRowIndices.includes(index)}
+                      key={station.id}
+                      station={station}
+                    />
+                  ))}
+                </div>
+              }
             </div>
           </div>
-        )}
-
-        <div className="closure-list-container">
-          {
-            <div className="closure-list" ref={listRef} style={listOffsetStyle}>
-              {sortStations(stations, stationId).map((station, index) => (
-                <ClosureRow
-                  isCurrentStation={station.id == stationId}
-                  isFirstRowOnPage={firstRowIndices.includes(index)}
-                  key={station.id}
-                  station={station}
-                />
-              ))}
-            </div>
-          }
-        </div>
-      </div>
-
+        </>
+      ) : (
+        <NoCurrentClosures closure={upcomingClosure} />
+      )}
       {numPages > 1 && (
         <div className="paging-info-container">
           {!isUpcomingClosurePage && numRowsOffPage > 0 && (

--- a/assets/src/components/v2/elevator/closures.tsx
+++ b/assets/src/components/v2/elevator/closures.tsx
@@ -163,20 +163,42 @@ const UpcomingClosure = ({
 };
 
 const NoCurrentClosures = ({ closure }: { closure?: UpcomingClosureInfo }) => {
+  const getClosureTitle = (titles: string[]) => {
+    const titlesParsed = titles[0].split(" ");
+    if (titlesParsed[0] === "This") {
+      return (
+        <b>
+          {titlesParsed[0]} {titlesParsed[1]}:{" "}
+        </b>
+      );
+    }
+    return;
+  };
+  const getClosureDetail = (titles: string[]) => {
+    const titlesParsed = titles[0].split(" ");
+    if (titlesParsed[0] === "This") {
+      return titlesParsed.slice(1);
+    } else {
+      return titlesParsed.join(" ");
+    }
+  };
+
   return (
     <>
       {closure && (
         <div className="closures-info">
           <div className="upcoming-closure-small">
             <div>
-              This elevator will be closed {closure.details.titles[0]}{" "}
+              {getClosureTitle(closure.details.titles)}
+              This elevator will be closed{" "}
+              {getClosureDetail(closure.details.titles)}{" "}
               {closure.details.postfix}
             </div>
             <div>
               <CalendarIcon width={72} height={72} />
             </div>
           </div>
-          <div className="divider" />
+          <div className="closure-divider" />
         </div>
       )}
       <div className="no-closures">

--- a/config/config.exs
+++ b/config/config.exs
@@ -24,6 +24,8 @@ config :logger, :console,
   format: "$time $metadata[$level] $message\n",
   metadata: [:client_ip, :remote_ip, :request_id]
 
+config :logger, level: :error
+
 # Use Jason for JSON parsing in Phoenix
 config :phoenix, :json_library, Jason
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -24,8 +24,6 @@ config :logger, :console,
   format: "$time $metadata[$level] $message\n",
   metadata: [:client_ip, :remote_ip, :request_id]
 
-config :logger, level: :error
-
 # Use Jason for JSON parsing in Phoenix
 config :phoenix, :json_library, Jason
 

--- a/lib/screens/v2/candidate_generator/elevator/closures.ex
+++ b/lib/screens/v2/candidate_generator/elevator/closures.ex
@@ -76,12 +76,19 @@ defmodule Screens.V2.CandidateGenerator.Elevator.Closures do
           upcoming |> Enum.flat_map(&elevator_closure/1) |> Enum.filter(at_this_elevator?)
 
         [
-          elevator_closures(relevant_closures, upcoming_closures, app_params, now, stop_id)
+          elevator_closures(
+            relevant_closures,
+            active_closures,
+            upcoming_closures,
+            app_params,
+            now,
+            stop_id
+          )
           | header_footer_instances(
               config,
               now,
               nil,
-              relevant_closures ++ upcoming_closures
+              relevant_closures
             )
         ]
 
@@ -173,6 +180,7 @@ defmodule Screens.V2.CandidateGenerator.Elevator.Closures do
 
   defp elevator_closures(
          [],
+         _active_closures,
          upcoming_closures,
          %ElevatorConfig{elevator_id: _elevator_id} = app_params,
          now,
@@ -188,6 +196,7 @@ defmodule Screens.V2.CandidateGenerator.Elevator.Closures do
   end
 
   defp elevator_closures(
+         relevant_closures,
          active_closures,
          upcoming_closures,
          %ElevatorConfig{elevator_id: elevator_id} = app_params,
@@ -203,6 +212,7 @@ defmodule Screens.V2.CandidateGenerator.Elevator.Closures do
       station_id: stop_id,
       stations_with_closures:
         build_stations_with_closures(
+          relevant_closures,
           active_closures,
           station_names,
           station_route_pills,
@@ -229,12 +239,13 @@ defmodule Screens.V2.CandidateGenerator.Elevator.Closures do
   end
 
   defp build_stations_with_closures(
-         closures,
+         relevant_closures,
+         active_closures,
          station_names,
          station_route_pills,
          elevator_id
        ) do
-    closures
+    relevant_closures
     |> log_station_closures(elevator_id)
     |> Enum.group_by(& &1.station_id)
     |> Enum.map(fn {station_id, station_closures} ->
@@ -250,7 +261,7 @@ defmodule Screens.V2.CandidateGenerator.Elevator.Closures do
             station_closures,
             fn %Closure{id: id, name: name} -> %WidgetClosure{id: id, name: name} end
           ),
-        summary: active_summary(station_closures, closures)
+        summary: active_summary(station_closures, active_closures)
       }
     end)
   end

--- a/lib/screens/v2/candidate_generator/elevator/closures.ex
+++ b/lib/screens/v2/candidate_generator/elevator/closures.ex
@@ -76,7 +76,9 @@ defmodule Screens.V2.CandidateGenerator.Elevator.Closures do
           upcoming |> Enum.flat_map(&elevator_closure/1) |> Enum.filter(at_this_elevator?)
 
         footer =
-          if relevant_closures ++ upcoming_closures == [], do: [], else: [%Footer{screen: config}]
+          if Enum.empty?(relevant_closures) and Enum.empty?(upcoming_closures),
+            do: [],
+            else: [%Footer{screen: config}]
 
         [
           elevator_closures(
@@ -162,7 +164,7 @@ defmodule Screens.V2.CandidateGenerator.Elevator.Closures do
          [],
          _active_closures,
          upcoming_closures,
-         %ElevatorConfig{elevator_id: _elevator_id} = app_params,
+         app_params,
          now,
          stop_id
        ) do

--- a/lib/screens/v2/candidate_generator/elevator/closures.ex
+++ b/lib/screens/v2/candidate_generator/elevator/closures.ex
@@ -68,7 +68,7 @@ defmodule Screens.V2.CandidateGenerator.Elevator.Closures do
     {:ok, %Stop{id: stop_id}} = @facility.fetch_stop_for_facility(elevator_id)
 
     relevant_closures =
-      active_closures |> Enum.filter(&relevant_closure?(&1, stop_id, active_closures))
+      Enum.filter(active_closures, &relevant_closure?(&1, stop_id, active_closures))
 
     case Enum.find(active_closures, at_this_elevator?) do
       nil ->
@@ -88,7 +88,7 @@ defmodule Screens.V2.CandidateGenerator.Elevator.Closures do
               config,
               now,
               nil,
-              relevant_closures
+              relevant_closures ++ upcoming_closures
             )
         ]
 

--- a/lib/screens/v2/candidate_generator/elevator/closures.ex
+++ b/lib/screens/v2/candidate_generator/elevator/closures.ex
@@ -75,6 +75,9 @@ defmodule Screens.V2.CandidateGenerator.Elevator.Closures do
         upcoming_closures =
           upcoming |> Enum.flat_map(&elevator_closure/1) |> Enum.filter(at_this_elevator?)
 
+        footer =
+          if relevant_closures ++ upcoming_closures == [], do: [], else: [%Footer{screen: config}]
+
         [
           elevator_closures(
             relevant_closures,
@@ -83,13 +86,12 @@ defmodule Screens.V2.CandidateGenerator.Elevator.Closures do
             app_params,
             now,
             stop_id
+          ),
+          header_instances(
+            config,
+            now
           )
-          | header_footer_instances(
-              config,
-              now,
-              nil,
-              relevant_closures ++ upcoming_closures
-            )
+          | footer
         ]
 
       _closure ->
@@ -111,34 +113,12 @@ defmodule Screens.V2.CandidateGenerator.Elevator.Closures do
     ]
   end
 
-  defp header_footer_instances(
+  defp header_instances(
          %Screen{app_params: %ElevatorConfig{elevator_id: elevator_id}} = config,
          now,
-         variant,
-         closures
+         variant \\ nil
        ) do
-    case Enum.any?(closures) do
-      true ->
-        [
-          %NormalHeader{
-            text: "Elevator #{elevator_id}",
-            screen: config,
-            time: now,
-            variant: variant
-          },
-          %Footer{screen: config, variant: variant}
-        ]
-
-      false ->
-        [
-          %NormalHeader{
-            text: "Elevator #{elevator_id}",
-            screen: config,
-            time: now,
-            variant: variant
-          }
-        ]
-    end
+    %NormalHeader{text: "Elevator #{elevator_id}", screen: config, time: now, variant: variant}
   end
 
   defp elevator_closure(%Alert{

--- a/lib/screens/v2/widget_instance/elevator_closures.ex
+++ b/lib/screens/v2/widget_instance/elevator_closures.ex
@@ -20,7 +20,7 @@ defmodule Screens.V2.WidgetInstance.ElevatorClosures do
             id: Stop.id(),
             name: String.t(),
             route_icons: list(Route.icon()),
-            closures: list(Closure.t()),
+            closures: list(Closure.t()) | :no_closures,
             summary: String.t() | nil
           }
   end
@@ -119,7 +119,7 @@ defmodule Screens.V2.WidgetInstance.ElevatorClosures do
   @type t :: %__MODULE__{
           app_params: Elevator.t(),
           now: DateTime.t(),
-          stations_with_closures: list(Station.t()),
+          stations_with_closures: list(Station.t()) | :no_closures,
           station_id: String.t(),
           upcoming_closure: Upcoming.t() | nil
         }

--- a/lib/screens/v2/widget_instance/elevator_closures.ex
+++ b/lib/screens/v2/widget_instance/elevator_closures.ex
@@ -20,7 +20,7 @@ defmodule Screens.V2.WidgetInstance.ElevatorClosures do
             id: Stop.id(),
             name: String.t(),
             route_icons: list(Route.icon()),
-            closures: list(Closure.t()) | :no_closures,
+            closures: list(Closure.t()),
             summary: String.t() | nil
           }
   end

--- a/test/screens/v2/candidate_generator/elevator/closures_test.exs
+++ b/test/screens/v2/candidate_generator/elevator/closures_test.exs
@@ -71,6 +71,47 @@ defmodule Screens.V2.CandidateGenerator.Elevator.ClosuresTest do
   end
 
   describe "header and footer" do
+    test "have no variant when current elevator is not closed", %{now: now} do
+      expect(@stop, :fetch_parent_station_name_map, fn ->
+        {:ok, %{"place-haecl" => "Haymarket"}}
+      end)
+
+      expect(@alert, :fetch_elevator_alerts_with_facilities, fn ->
+        alerts = [
+          build_alert(
+            informed_entities: [
+              %{stop: "place-haecl", facility: %{name: "Test 2", id: "facility-test-2"}}
+            ]
+          )
+        ]
+
+        {:ok, alerts}
+      end)
+
+      elevator_closures = %ElevatorClosures{
+        app_params: @screen.app_params,
+        now: now,
+        station_id: "place-test",
+        stations_with_closures: [
+          %ElevatorClosures.Station{
+            id: "place-haecl",
+            name: "Haymarket",
+            route_icons: [%{type: :text, text: "OL", color: :orange}],
+            closures: [
+              %Closure{id: "facility-test-2", name: "Test 2"}
+            ],
+            summary: "Visit mbta.com/elevators for more info"
+          }
+        ]
+      }
+
+      assert [
+               elevator_closures,
+               %NormalHeader{screen: @screen, text: "Elevator 111", time: ^now, variant: nil},
+               %Footer{screen: @screen, variant: nil}
+             ] = Generator.elevator_status_instances(@screen, now)
+    end
+
     test "have closed variant when current elevator is closed", %{now: now} do
       expect(@alert, :fetch_elevator_alerts_with_facilities, fn ->
         alerts = [

--- a/test/screens/v2/candidate_generator/elevator/closures_test.exs
+++ b/test/screens/v2/candidate_generator/elevator/closures_test.exs
@@ -85,47 +85,12 @@ defmodule Screens.V2.CandidateGenerator.Elevator.ClosuresTest do
       assert [_current_closed, %NormalHeader{variant: :closed}, %Footer{variant: :closed}] =
                Generator.elevator_status_instances(@screen, now)
     end
-  end
 
-  describe "when all elevators are working" do
-    test "footer is not displayed, normal header is displayed with no variant", %{now: now} do
+    test "have footer not displayed and header with no variant when all elevators are working", %{
+      now: now
+    } do
       assert [
                _elevator_closures,
-               %NormalHeader{screen: @screen, text: "Elevator 111", time: ^now, variant: nil}
-             ] = Generator.elevator_status_instances(@screen, now)
-    end
-
-    test "but there is an upcoming closure at the current elevator, upcoming closure is displayed",
-         %{now: now} do
-      expect(@alert, :fetch_elevator_alerts_with_facilities, fn ->
-        upcoming_period = {DateTime.add(now, 1, :day), DateTime.add(now, 3, :day)}
-
-        alerts = [
-          build_alert(
-            active_period: [upcoming_period],
-            informed_entities: [%{stop: "place-test", facility: %{name: "Test", id: "111"}}]
-          )
-        ]
-
-        {:ok, alerts}
-      end)
-
-      expected_closures = %ElevatorClosures{
-        app_params: @screen.app_params,
-        now: now,
-        station_id: "place-test",
-        stations_with_closures: :no_closures,
-        upcoming_closure: %ElevatorClosures.Station{
-          id: "place-test",
-          name: "Place Test",
-          route_icons: [%{type: :text, text: "RL", color: :red}],
-          closures: [%Closure{id: "facility-test", name: "Test"}],
-          summary: nil
-        }
-      }
-
-      assert [
-               expected_closures,
                %NormalHeader{screen: @screen, text: "Elevator 111", time: ^now, variant: nil}
              ] = Generator.elevator_status_instances(@screen, now)
     end
@@ -440,6 +405,42 @@ defmodule Screens.V2.CandidateGenerator.Elevator.ClosuresTest do
                  ]
                }
                | _
+             ] = Generator.elevator_status_instances(@screen, now)
+    end
+
+    test "shows only upcoming closure when all other elevators are working",
+         %{now: now} do
+      expect(@alert, :fetch_elevator_alerts_with_facilities, fn ->
+        upcoming_period = {DateTime.add(now, 1, :day), DateTime.add(now, 3, :day)}
+
+        alerts = [
+          build_alert(
+            active_period: [upcoming_period],
+            informed_entities: [%{stop: "place-test", facility: %{name: "Test", id: "111"}}]
+          )
+        ]
+
+        {:ok, alerts}
+      end)
+
+      expected_closures = %ElevatorClosures{
+        app_params: @screen.app_params,
+        now: now,
+        station_id: "place-test",
+        stations_with_closures: :no_closures,
+        upcoming_closure: %ElevatorClosures.Station{
+          id: "place-test",
+          name: "Place Test",
+          route_icons: [%{type: :text, text: "RL", color: :red}],
+          closures: [%Closure{id: "facility-test", name: "Test"}],
+          summary: nil
+        }
+      }
+
+      assert [
+               expected_closures,
+               %NormalHeader{screen: @screen, text: "Elevator 111", time: ^now, variant: nil},
+               %Footer{variant: nil}
              ] = Generator.elevator_status_instances(@screen, now)
     end
   end

--- a/test/screens/v2/candidate_generator/elevator/closures_test.exs
+++ b/test/screens/v2/candidate_generator/elevator/closures_test.exs
@@ -58,10 +58,6 @@ defmodule Screens.V2.CandidateGenerator.Elevator.ClosuresTest do
     struct!(%Alert{active_period: [{DateTime.utc_now(), nil}], effect: :elevator_closure}, fields)
   end
 
-  defp build_alert(start_date, fields) do
-    struct!(%Alert{active_period: [{start_date, nil}], effect: :elevator_closure}, fields)
-  end
-
   defp build_elevator(id, fields \\ []) do
     struct!(
       %Elevator{


### PR DESCRIPTION
**Asana task**: [No elevator alerts](https://app.asana.com/1/15492006741476/project/1185117109217422/task/1209256677260370?focus=true)

Description
When the elevator alerts array is empty, display the "all elevators working screen." If there is an upcoming outage at the elevator, display that in a smaller bar on top.  One issue -- I wasn't sure how to remove the footer from these screens, or if I should. The mock-ups don't have a footer.


 Screenshots added below: 

<img width="414" alt="Screenshot 2025-03-14 at 12 58 25 PM" src="https://github.com/user-attachments/assets/76fbe7fa-405b-4e21-b8d4-cef85f116e4f" />

<img width="412" alt="Screenshot 2025-03-14 at 12 57 49 PM" src="https://github.com/user-attachments/assets/26f85e4b-5f65-4b3d-a450-9c12c21964e3" />


- [ ] Tests added?
