### PR TITLE
refactor: remove unused module

### DIFF
--- a/lib/screens/v2/candidate_generator/widgets.ex
+++ b/lib/screens/v2/candidate_generator/widgets.ex
@@ -1,3 +1,0 @@
-defmodule Screens.V2.CandidateGenerator.Widgets do
-  @moduledoc false
-end


### PR DESCRIPTION
This module contained nothing and has never been referenced anywhere (introduced in 9bb1e3aa).