### PR TITLE
dev: remove `babel-loader` from Dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -46,7 +46,6 @@ updates:
           - "@jest*"
       babel:
         patterns:
-          - "babel*"
           - "@babel*"
       webpack:
         patterns:


### PR DESCRIPTION
This package is a Webpack plugin and does not align with Babel's major releases, resulting in some odd PRs like #2487 where Dependabot tries to update to a new patch version of `@babel/core` and a new _major_ version of `babel-loader` at the same time. With this line removed, the latter is sorted into the `webpack` group, due to the existing `*-loader` pattern.