### PR TITLE
Suppress crowding data for first stop

### DIFF
--- a/lib/screens/v2/departure.ex
+++ b/lib/screens/v2/departure.ex
@@ -198,13 +198,12 @@ defmodule Screens.V2.Departure do
   def vehicle_status(_), do: nil
 
   defp crowding_data_relevant?(%Trip{id: trip_trip_id, stops: [first_stop | _]}, %Vehicle{
-         current_status: current_status,
          trip_id: vehicle_trip_id,
          stop_id: next_stop
        })
        when not is_nil(trip_trip_id) and not is_nil(vehicle_trip_id) do
     vehicle_on_prediction_trip? = trip_trip_id == vehicle_trip_id
-    vehicle_started_trip? = not (current_status == :in_transit_to and next_stop == first_stop)
+    vehicle_started_trip? = not (next_stop == first_stop)
     vehicle_on_prediction_trip? and vehicle_started_trip?
   end
 

--- a/test/screens/v2/departure_test.exs
+++ b/test/screens/v2/departure_test.exs
@@ -85,7 +85,7 @@ defmodule Screens.V2.DepartureTest do
       assert nil == Departure.crowding_level(departure)
     end
 
-    test "returns nil when the vehicle is in transit to the first stop" do
+    test "returns nil when the vehicle is at the first stop" do
       trip = %Trip{id: "trip-1", stops: ["1", "2", "3"]}
 
       vehicle = %Vehicle{


### PR DESCRIPTION
**Asana task**: [Don't display bus crowding at first stop on trip](https://app.asana.com/0/1185117109217413/1209411176930017/f)

- Removed checks for `current_status` for vehicle when doing crowding_data checks

Description
- [ ] Tests added?
