### PR TITLE
fix: support Fall River/New Bedford line

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -456,16 +456,7 @@ config :screens,
     "Wickford Junction" => "Wickford Jct",
     "Needham Heights" => "Needham Hts",
     "Houghs Neck via McGrath & Germantown" => "Houghs Neck via McGth & Gtwn",
-    "Houghs Neck via Germantown" => "Houghs Neck via Germntwn",
-    "Middleborough/Lakeville" => "Middleborough / Lakeville",
-
-    # The following are special headsigns for the 2022 Orange Line surge
-    "Needham Heights via Ruggles" => "Needham Hts via Ruggles",
-    "Needham Heights via Forest Hills" => "Needham Hts via Forest Hills",
-    "Wickford Junction via Ruggles" => "Wickford Jct via Ruggles",
-    "Wickford Junction via Forest Hills" => "Wickford Jct via Forest Hills",
-    "Providence & Needham via Forest Hills" => "Providence via Forest Hills",
-    "Norwood Central via Ruggles" => "Norwood Cntrl via Ruggles"
+    "Houghs Neck via Germantown" => "Houghs Neck via Germntwn"
   },
   dup_headway_branch_stations: ["place-kencl", "place-jfk", "place-coecl"],
   dup_headway_branch_terminals: [

--- a/lib/screens/v2/widget_instance/serializer/route_pill.ex
+++ b/lib/screens/v2/widget_instance/serializer/route_pill.ex
@@ -47,8 +47,8 @@ defmodule Screens.V2.WidgetInstance.Serializer.RoutePill do
     "Haverhill" => "HVL",
     "Kingston" => "KNG",
     "Lowell" => "LWL",
-    "Middleborough" => "MID",
     "Needham" => "NDM",
+    "NewBedford" => "FRV",
     "Newburyport" => "NBP",
     "Providence" => "PVD",
     "Worcester" => "WOR"


### PR DESCRIPTION
The Middleborough/Lakeville line is now the Fall River/New Bedford line, with a new route ID (`CR-NewBedford`).

* Add a route pill abbreviation for this line. Remove the abbreviation for the old route ID.
* Remove a DUP headsign abbreviation that only applied to the old line.
* Clean up some old DUP headsign abbreviations from the Orange Line Super Surge.

**Asana task**: https://app.asana.com/0/1185117109217413/1209770072971451