### PR TITLE
feat: "here" station closures for Pre-Fare solo

### DIFF
--- a/assets/src/components/v2/pre_fare_single_screen_alert.tsx
+++ b/assets/src/components/v2/pre_fare_single_screen_alert.tsx
@@ -22,8 +22,8 @@ interface PreFareSingleScreenAlertProps {
   routes: EnrichedRoute[];
   unaffected_routes: EnrichedRoute[];
   endpoints: [string, string];
-  effect: string;
-  region: string;
+  effect: "suspension" | "shuttle" | "station_closure" | "delay";
+  region: "here" | "boundary" | "outside";
   updated_at: string;
   disruption_diagram?: DisruptionDiagramData;
 }
@@ -106,7 +106,7 @@ const DownstreamLayout: React.ComponentType<DownstreamLayoutProps> = ({
   </div>
 );
 
-interface MultiLineLayoutProps {
+interface PartialClosureLayoutProps {
   routes: EnrichedRoute[];
   unaffected_routes: EnrichedRoute[];
   disruptionDiagram?: DisruptionDiagramData;
@@ -115,7 +115,7 @@ interface MultiLineLayoutProps {
 // Covers the case where a station_closure only affects one line at a transfer station.
 // In the even rarer case that there are multiple branches in the routes list or unaffected routes list
 // the font size may need to shrink to accommodate.
-const MultiLineLayout: React.ComponentType<MultiLineLayoutProps> = ({
+const PartialClosureLayout: React.ComponentType<PartialClosureLayoutProps> = ({
   routes,
   unaffected_routes,
   disruptionDiagram,
@@ -315,14 +315,14 @@ const MapSection: React.ComponentType<MapSectionProps> = ({
   );
 };
 
-const isMultiLine = (
-  effect: string,
-  region: string,
-  unaffectedRoutes: EnrichedRoute[],
-) =>
+const isPartialClosure = ({
+  effect,
+  region,
+  unaffected_routes,
+}: PreFareSingleScreenAlertProps): boolean =>
   effect === "station_closure" &&
   region === "here" &&
-  unaffectedRoutes.length > 0;
+  unaffected_routes.length > 0;
 
 const PreFareSingleScreenAlert: React.ComponentType<
   PreFareSingleScreenAlertProps
@@ -345,8 +345,8 @@ const PreFareSingleScreenAlert: React.ComponentType<
   /**
    * This switch statement picks the alert layout
    * - fallback: icon, followed by a summary & pio text, or just the pio text
-   * - multiline: icon + route pill + text explaining the lines that are closed at the station
-   *              and then icon + route pill + text explaining normal service. Finally, the map section
+   * - partial closure: icon + route pill + text explaining the lines that are closed at the station
+   *                    and then icon + route pill + text explaining normal service. Finally, the map section
    * - standard: icon + issue, and icon + remedy, and then map section
    * - downstream: map, issue without icon, then icon + remedy
    **/
@@ -365,9 +365,9 @@ const PreFareSingleScreenAlert: React.ComponentType<
         />
       );
       break;
-    case isMultiLine(effect, region, unaffected_routes):
+    case isPartialClosure(alert):
       layout = (
-        <MultiLineLayout
+        <PartialClosureLayout
           routes={routes}
           unaffected_routes={unaffected_routes}
           disruptionDiagram={disruption_diagram}
@@ -431,7 +431,7 @@ const PreFareSingleScreenAlert: React.ComponentType<
       );
   }
 
-  const showBanner = !isMultiLine(effect, region, unaffected_routes);
+  const showBanner = !isPartialClosure(alert);
 
   return (
     <div className="pre-fare-alert__page">

--- a/assets/src/components/v2/pre_fare_single_screen_alert.tsx
+++ b/assets/src/components/v2/pre_fare_single_screen_alert.tsx
@@ -315,8 +315,14 @@ const MapSection: React.ComponentType<MapSectionProps> = ({
   );
 };
 
-const isMultiLine = (effect: string, region: string) =>
-  effect === "station_closure" && region === "here";
+const isMultiLine = (
+  effect: string,
+  region: string,
+  unaffectedRoutes: EnrichedRoute[],
+) =>
+  effect === "station_closure" &&
+  region === "here" &&
+  unaffectedRoutes.length > 0;
 
 const PreFareSingleScreenAlert: React.ComponentType<
   PreFareSingleScreenAlertProps
@@ -359,11 +365,22 @@ const PreFareSingleScreenAlert: React.ComponentType<
         />
       );
       break;
-    case effect === "station_closure" && region === "here":
+    case isMultiLine(effect, region, unaffected_routes):
       layout = (
         <MultiLineLayout
           routes={routes}
           unaffected_routes={unaffected_routes}
+          disruptionDiagram={disruption_diagram}
+        />
+      );
+      break;
+    case effect === "station_closure" && region === "here":
+      layout = (
+        <StandardLayout
+          issue={issue}
+          remedy={remedy}
+          effect={effect}
+          location={location}
           disruptionDiagram={disruption_diagram}
         />
       );
@@ -414,7 +431,7 @@ const PreFareSingleScreenAlert: React.ComponentType<
       );
   }
 
-  const showBanner = !isMultiLine(effect, region);
+  const showBanner = !isMultiLine(effect, region, unaffected_routes);
 
   return (
     <div className="pre-fare-alert__page">

--- a/lib/screens/v2/widget_instance/reconstructed_alert.ex
+++ b/lib/screens/v2/widget_instance/reconstructed_alert.ex
@@ -639,7 +639,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
     }
   end
 
-  # Station closure for 1 line at a multi-line station
+  # This station closed for entire/only route
   defp single_screen_fields(%__MODULE__{alert: %Alert{effect: :station_closure}} = t, :inside) do
     %__MODULE__{alert: %{cause: cause, updated_at: updated_at}, now: now} = t
     affected_routes = LocalizedAlert.consolidated_informed_subway_routes(t)
@@ -661,7 +661,8 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
       end
 
     %{
-      issue: nil,
+      issue: if(unaffected_routes == [], do: "Station closed"),
+      remedy: if(unaffected_routes == [], do: "Seek alternate route"),
       unaffected_routes:
         Enum.flat_map(unaffected_routes, fn route -> build_pills_from_headsign(route, nil) end),
       cause: get_cause(cause),

--- a/test/screens/v2/widget_instance/reconstructed_alert_test.exs
+++ b/test/screens/v2/widget_instance/reconstructed_alert_test.exs
@@ -653,7 +653,20 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
         |> put_cause(:unknown)
         |> put_is_priority(true)
 
-      expected = %{
+      diagram = %{
+        effect: :station_closure,
+        closed_station_slot_indices: [1],
+        line: :orange,
+        current_station_slot_index: 1,
+        slots: [
+          %{type: :terminal, label_id: "place-ogmnl"},
+          %{label: %{full: "Malden Center", abbrev: "Malden Ctr"}, show_symbol: true},
+          %{label: %{full: "Wellington", abbrev: "Wellington"}, show_symbol: true},
+          %{type: :terminal, label_id: "place-astao"}
+        ]
+      }
+
+      expected_duo = %{
         issue: "Station closed",
         location: %ScreensConfig.V2.FreeTextLine{
           icon: nil,
@@ -665,24 +678,23 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
         updated_at: "Friday, 5:00 am",
         routes: [%{color: :orange, text: "ORANGE LINE", type: :text}],
         other_closures: ["Malden Center"],
-        disruption_diagram: %{
-          effect: :station_closure,
-          closed_station_slot_indices: [1],
-          line: :orange,
-          current_station_slot_index: 1,
-          slots: [
-            %{type: :terminal, label_id: "place-ogmnl"},
-            %{label: %{full: "Malden Center", abbrev: "Malden Ctr"}, show_symbol: true},
-            %{label: %{full: "Wellington", abbrev: "Wellington"}, show_symbol: true},
-            %{type: :terminal, label_id: "place-astao"}
-          ]
-        }
+        disruption_diagram: diagram
       }
 
-      assert expected == ReconstructedAlert.serialize(widget)
+      expected_solo = %{
+        cause: nil,
+        effect: :station_closure,
+        region: :here,
+        disruption_diagram: diagram,
+        issue: "Station closed",
+        remedy: "Seek alternate route",
+        routes: [%{route_id: "Orange", svg_name: "ol"}],
+        unaffected_routes: [],
+        updated_at: "Friday, 5:00 am"
+      }
 
-      assert %{effect: :station_closure, region: :here} =
-               widget |> put_solo_screen() |> ReconstructedAlert.serialize()
+      assert expected_duo == ReconstructedAlert.serialize(widget)
+      assert expected_solo == widget |> put_solo_screen() |> ReconstructedAlert.serialize()
     end
 
     test "boundary suspension with cause", %{widget: widget} do
@@ -1276,8 +1288,9 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
 
       expected = %{
         issue: nil,
-        unaffected_routes: [%{route_id: "Red", svg_name: "rl"}],
+        remedy: nil,
         cause: nil,
+        unaffected_routes: [%{route_id: "Red", svg_name: "rl"}],
         routes: [%{route_id: "Orange", svg_name: "ol"}],
         effect: :station_closure,
         updated_at: "Friday, 5:00 am",


### PR DESCRIPTION
The code previously assumed a station closure alert "here" (at the screen's station) would only be presented as a single-screen takeover if it was a closure of a single route at a transfer station; if an alert eliminated all service at the station, it would be a dual-screen takeover. This assumption is no longer valid with the addition of the "solo" template, which uses a single-screen takeover for anything that would have been a dual-screen takeover on a "duo".

This change enables such "full" station closures to be displayed as a single-screen takeover, with a disruption diagram and text matching the dual-screen version.

**Asana task**: https://app.asana.com/0/1185117109217413/1209255549956020

<img width="480" src="https://github.com/user-attachments/assets/e2615ac5-391d-4bb4-a8cd-2486560090a6" />
