### PR TITLE
test: fix unused variable warnings

### DIFF
--- a/test/screens/v2/candidate_generator/elevator/closures_test.exs
+++ b/test/screens/v2/candidate_generator/elevator/closures_test.exs
@@ -88,25 +88,8 @@ defmodule Screens.V2.CandidateGenerator.Elevator.ClosuresTest do
         {:ok, alerts}
       end)
 
-      elevator_closures = %ElevatorClosures{
-        app_params: @screen.app_params,
-        now: now,
-        station_id: "place-test",
-        stations_with_closures: [
-          %ElevatorClosures.Station{
-            id: "place-haecl",
-            name: "Haymarket",
-            route_icons: [%{type: :text, text: "OL", color: :orange}],
-            closures: [
-              %Closure{id: "facility-test-2", name: "Test 2"}
-            ],
-            summary: "Visit mbta.com/elevators for more info"
-          }
-        ]
-      }
-
       assert [
-               elevator_closures,
+               _elevator_closures,
                %NormalHeader{screen: @screen, text: "Elevator 111", time: ^now, variant: nil},
                %Footer{screen: @screen, variant: nil}
              ] = Generator.elevator_status_instances(@screen, now)
@@ -252,6 +235,31 @@ defmodule Screens.V2.CandidateGenerator.Elevator.ClosuresTest do
                }
                | _
              ] = Generator.elevator_status_instances(@screen, now)
+    end
+
+    test "uses :no_closures when all elevators are working", %{now: now} do
+      assert [%ElevatorClosures{stations_with_closures: :no_closures} | _] =
+               Generator.elevator_status_instances(@screen, now)
+    end
+
+    test "uses :nearby_redundancy when all closed elevators have nearby redundancy", %{now: now} do
+      stub(@elevator, :get, fn
+        "111" -> build_elevator("111")
+        "222" -> build_elevator("222", exiting_redundancy: :nearby)
+      end)
+
+      expect(@alert, :fetch_elevator_alerts_with_facilities, fn ->
+        alerts = [
+          build_alert(
+            informed_entities: [%{stop: "place-other", facility: %{name: "Elevator", id: "222"}}]
+          )
+        ]
+
+        {:ok, alerts}
+      end)
+
+      assert [%ElevatorClosures{stations_with_closures: :nearby_redundancy} | _] =
+               Generator.elevator_status_instances(@screen, now)
     end
 
     test "filters out alerts with no facilities or more than one facility", %{now: now} do
@@ -446,79 +454,6 @@ defmodule Screens.V2.CandidateGenerator.Elevator.ClosuresTest do
                  ]
                }
                | _
-             ] = Generator.elevator_status_instances(@screen, now)
-    end
-
-    test "shows only upcoming closure when all other elevators are working",
-         %{now: now} do
-      expect(@alert, :fetch_elevator_alerts_with_facilities, fn ->
-        upcoming_period = {DateTime.add(now, 1, :day), DateTime.add(now, 3, :day)}
-
-        alerts = [
-          build_alert(
-            active_period: [upcoming_period],
-            informed_entities: [%{stop: "place-test", facility: %{name: "Test", id: "111"}}]
-          )
-        ]
-
-        {:ok, alerts}
-      end)
-
-      expected_closures = %ElevatorClosures{
-        app_params: @screen.app_params,
-        now: now,
-        station_id: "place-test",
-        stations_with_closures: :no_closures,
-        upcoming_closure: %ElevatorClosures.Station{
-          id: "place-test",
-          name: "Place Test",
-          route_icons: [%{type: :text, text: "RL", color: :red}],
-          closures: [%Closure{id: "facility-test", name: "Test"}],
-          summary: nil
-        }
-      }
-
-      assert [
-               expected_closures,
-               %NormalHeader{screen: @screen, text: "Elevator 111", time: ^now, variant: nil},
-               %Footer{variant: nil}
-             ] = Generator.elevator_status_instances(@screen, now)
-    end
-
-    test "shows only upcoming closure when all other elevators are working or have redundancy", %{
-      now: now
-    } do
-      expect(@alert, :fetch_elevator_alerts_with_facilities, fn ->
-        upcoming_period = {DateTime.add(now, 1, :day), DateTime.add(now, 3, :day)}
-
-        alerts = [
-          build_alert(
-            active_period: [upcoming_period],
-            informed_entities: [%{stop: "place-test", facility: %{name: "Test", id: "111"}}]
-          )
-        ]
-
-        {:ok, alerts}
-      end)
-
-      expected_closures = %ElevatorClosures{
-        app_params: @screen.app_params,
-        now: now,
-        station_id: "place-test",
-        stations_with_closures: :nearby_redundancy,
-        upcoming_closure: %ElevatorClosures.Station{
-          id: "place-test",
-          name: "Place Test",
-          route_icons: [%{type: :text, text: "RL", color: :red}],
-          closures: [%Closure{id: "facility-test", name: "Test"}],
-          summary: nil
-        }
-      }
-
-      assert [
-               expected_closures,
-               %NormalHeader{screen: @screen, text: "Elevator 111", time: ^now, variant: nil},
-               %Footer{variant: nil}
              ] = Generator.elevator_status_instances(@screen, now)
     end
   end


### PR DESCRIPTION
Some test assertions using `=` were written with an unpinned variable, causing the variable to be reassigned and therefore unused. We can also cut down on matching some values that are not relevant to the specific test cases in question.

As a separate commit, includes a minor refactor to the no-data logic being tested here:

* Push down an API fetch into the one branch that needs it.
* Push down the no-data conditional logic into the function that generates the only field it affects.