### PR TITLE
Enable offline caching of Sentry events

### DIFF
--- a/assets/src/hooks/v2/use_api_response.tsx
+++ b/assets/src/hooks/v2/use_api_response.tsx
@@ -92,7 +92,6 @@ const doFailureBuffer = (
   } else {
     const elapsedMs = Date.now() - lastSuccess;
     if (elapsedMs < MINUTE_IN_MS) {
-      SentryLogger.info("Keeping current state.");
       setApiResponse((state) => state);
     }
     if (elapsedMs >= MINUTE_IN_MS) {
@@ -200,6 +199,7 @@ const useBaseApiResponse = ({
       const response = parseRawResponse(json);
 
       if (response.state == "failure") {
+        SentryLogger.info("Request failed.", { json });
         doFailureBuffer(lastSuccess, setApiResponse, response);
       } else {
         setApiResponse((prevApiResponse) => {
@@ -210,7 +210,8 @@ const useBaseApiResponse = ({
         });
         setLastSuccess(now);
       }
-    } catch {
+    } catch (err) {
+      SentryLogger.captureException(err);
       doFailureBuffer(lastSuccess, setApiResponse);
     }
 

--- a/assets/src/hooks/v2/use_api_response.tsx
+++ b/assets/src/hooks/v2/use_api_response.tsx
@@ -91,8 +91,8 @@ const doFailureBuffer = (
     setApiResponse(FAILURE_RESPONSE);
   } else {
     const elapsedMs = Date.now() - lastSuccess;
-
     if (elapsedMs < MINUTE_IN_MS) {
+      SentryLogger.info("Keeping current state.");
       setApiResponse((state) => state);
     }
     if (elapsedMs >= MINUTE_IN_MS) {

--- a/assets/src/hooks/v2/use_api_response.tsx
+++ b/assets/src/hooks/v2/use_api_response.tsx
@@ -91,6 +91,7 @@ const doFailureBuffer = (
     setApiResponse(FAILURE_RESPONSE);
   } else {
     const elapsedMs = Date.now() - lastSuccess;
+
     if (elapsedMs < MINUTE_IN_MS) {
       setApiResponse((state) => state);
     }

--- a/assets/src/util/sentry.tsx
+++ b/assets/src/util/sentry.tsx
@@ -58,7 +58,7 @@ async function resendCachedEvents() {
   const cached = localStorage.getItem(OFFLINE_EVENTS_KEY);
   if (!cached) return;
 
-  let events = JSON.parse(cached);
+  const events = JSON.parse(cached);
 
   for (let i = 0; i < events.length; i++) {
     try {

--- a/assets/src/util/sentry.tsx
+++ b/assets/src/util/sentry.tsx
@@ -3,7 +3,7 @@ import { isRealScreen } from "Util/utils";
 import { getDataset } from "Util/dataset";
 // Previously tried @sentry/react and @sentry/browser as the SDK, but the QtWeb browser on e-inks could not
 // use them. Raven is an older stable SDK that better works with older browsers.
-import Raven, { RavenOptions } from "raven-js";
+import Raven, { RavenOptions, RavenTransportOptions } from "raven-js";
 
 // https://docs.sentry.io/clients/javascript/usage/#raven-js-additional-context
 type LogLevel = "info" | "warning" | "error";
@@ -19,6 +19,58 @@ const captureException = (ex: unknown, options?: RavenOptions) => {
   Raven.captureException(ex, options);
 };
 
+const offline_events_key = "sentry_offline_events";
+
+// Store offline Sentry events in localStorage for later retry
+function cacheEvent(options: RavenTransportOptions) {
+  try {
+    const cached = localStorage.getItem(offline_events_key);
+    const events = cached ? JSON.parse(cached) : [];
+    events.push({
+      ...options,
+      data: {
+        ...options.data,
+        extra: {
+          ...(options.data.extra || {}),
+          cached: new Date().toISOString(),
+        },
+      },
+    });
+    localStorage.setItem(offline_events_key, JSON.stringify(events));
+  } catch {}
+}
+
+function resendCachedEvents() {
+  const cached = localStorage.getItem(offline_events_key);
+  if (!cached) return;
+
+  // Retry each event in the cache
+  JSON.parse(cached).forEach((event: RavenTransportOptions) => {
+    fetch(event.url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(event.data),
+    });
+  });
+
+  localStorage.removeItem(offline_events_key);
+}
+
+function customTransport(options: RavenTransportOptions) {
+  fetch(options.url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(options.data),
+  }).catch(() => {
+    // Cache the event only if the fetch was rejected, indicating that the network was likely unavailable
+    cacheEvent(options);
+  });
+}
+
 /**
  * Initializes Sentry if the DSN is defined AND this client is running on
  * a real production screen.
@@ -27,7 +79,11 @@ const initSentry = (appString: string) => {
   const { sentry: sentryDsn, environmentName: env } = getDataset();
 
   if (sentryDsn && isRealScreen()) {
+    Raven.setTransport(customTransport);
     Raven.config(sentryDsn, { environment: env }).install();
+
+    // Set listener to retry any cached Sentry events any time the browser transitions from offline to online
+    window.addEventListener("online", resendCachedEvents);
 
     if (isDup()) {
       const today = new Date();

--- a/assets/src/util/sentry.tsx
+++ b/assets/src/util/sentry.tsx
@@ -40,17 +40,24 @@ function cacheEvent(options: RavenTransportOptions) {
   } catch {}
 }
 
+function buildSentryAuthHeader(auth) {
+  return `Sentry sentry_version=${auth.sentry_version}, sentry_client=${auth.sentry_client}, sentry_key=${auth.sentry_key}`;
+}
+
 function resendCachedEvents() {
   const cached = localStorage.getItem(offline_events_key);
   if (!cached) return;
 
   // Retry each event in the cache
   JSON.parse(cached).forEach((event: RavenTransportOptions) => {
+    const headers = {
+      "Content-Type": "application/json",
+      "X-Sentry-Auth": buildSentryAuthHeader(event.auth),
+    };
+
     fetch(event.url, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
+      headers,
       body: JSON.stringify(event.data),
     });
   });


### PR DESCRIPTION
**Asana task**: [Prefare/bus shelter apps collectively making fewer requests](https://app.asana.com/0/1185117109217413/1209235802491489/f)

Description
1. Add sentry logging in cases where we get a failed screen data API request but it hasn't been a minute yet and therefore does not trigger the no-data state
2. Enable offline caching of Sentry events in cases where the screen doesn't have network access when it tries to send the event to sentry. Once the browser is back online, it will retry any cached events before clearing the cache.

Note: Raven doesn't support offline caching out of the box so had to write a custom transport callback and do the caching manually.

New event logged to sentry with `cached` field: https://mbtace.sentry.io/issues/6469468736/?project=6061747&query=&referrer=issue-stream&stream_index=2