### PR TITLE
chore: Use consts defined in colors.scss for all equivalent hex code colors

### DIFF
--- a/assets/css/v2/bus_shelter/alert.scss
+++ b/assets/css/v2/bus_shelter/alert.scss
@@ -1,3 +1,5 @@
+@use "CSS/colors";
+
 .alert-widget--flex-zone {
   // Slot dimensions are 480x580, but this leaves space for the drop-shadow.
   width: 520px;
@@ -108,7 +110,7 @@
 .alert-widget--full-body {
   width: 1080px;
   height: 1648px;
-  background: #fd0;
+  background: colors.$alert-yellow;
 
   .alert-widget__card {
     transform: translateY(10px);

--- a/assets/css/v2/bus_shelter/flex/page_indicator.scss
+++ b/assets/css/v2/bus_shelter/flex/page_indicator.scss
@@ -1,3 +1,5 @@
+@use "CSS/colors";
+
 .flex-zone-page-indicator {
   position: absolute;
   top: 624px;
@@ -10,7 +12,7 @@
 .flex-zone-page-indicator__page__progress-bar {
   position: absolute;
   height: 16px;
-  background: #171f26;
+  background: colors.$cool-black-15;
 }
 
 .flex-zone-page-indicator__page {
@@ -20,7 +22,7 @@
   height: 16px;
   margin-left: 44px;
   overflow: hidden;
-  background: #cccbc8;
+  background: colors.$warm-neutral-80;
   border-radius: 24px;
   box-shadow: inset 1px 2px 6px 0 #bfbebb;
 

--- a/assets/css/v2/bus_shelter/link_footer.scss
+++ b/assets/css/v2/bus_shelter/link_footer.scss
@@ -1,7 +1,9 @@
+@use "CSS/colors";
+
 .link-footer {
   position: relative;
   height: 156px;
-  background: #d9d6d0;
+  background: colors.$warm-neutral-85;
 }
 
 .link-footer__contents {

--- a/assets/css/v2/dup/alert/full_screen_alert.scss
+++ b/assets/css/v2/dup/alert/full_screen_alert.scss
@@ -1,3 +1,5 @@
+@use "CSS/colors";
+
 .full-screen-alert__body {
   box-sizing: border-box;
   width: 1920px;
@@ -5,7 +7,7 @@
   padding-top: 72px;
   padding-right: 64px;
   padding-left: 64px;
-  background-color: #171f26;
+  background-color: colors.$cool-black-15;
 }
 
 .full-screen-alert__link {

--- a/assets/css/v2/dup/departures/destination.scss
+++ b/assets/css/v2/dup/departures/destination.scss
@@ -1,9 +1,11 @@
+@use "CSS/colors";
+
 .departure-destination {
   display: inline-block;
   width: 1176px;
   font-family: Inter, sans-serif;
   font-size: 138px;
-  color: #171f26;
+  color: colors.$cool-black-15;
   vertical-align: middle;
 }
 

--- a/assets/css/v2/dup/departures/row.scss
+++ b/assets/css/v2/dup/departures/row.scss
@@ -1,3 +1,5 @@
+@use "CSS/colors";
+
 .departure-row {
   position: relative;
   height: 208px;
@@ -9,7 +11,7 @@
     width: 1586px;
     height: 4px;
     content: "";
-    background-color: #cccbc8;
+    background-color: colors.$warm-neutral-80;
   }
 }
 
@@ -28,7 +30,7 @@
   width: 400px;
   margin-right: 32px;
   font-size: 138px;
-  color: #171f26;
+  color: colors.$cool-black-15;
   text-align: right;
   vertical-align: middle;
 }

--- a/assets/css/v2/dup/departures/time.scss
+++ b/assets/css/v2/dup/departures/time.scss
@@ -1,8 +1,10 @@
+@use "CSS/colors";
+
 .departure-time {
   font-family: Inter, sans-serif;
   font-size: 138px;
   line-height: 1em;
-  color: #171f26;
+  color: colors.$cool-black-15;
   text-align: right;
 
   &:not(:first-child) {

--- a/assets/css/v2/dup/empty_state.scss
+++ b/assets/css/v2/dup/empty_state.scss
@@ -1,3 +1,5 @@
+@use "CSS/colors";
+
 .no-data__container,
 .loading__container {
   height: 100%;
@@ -30,7 +32,7 @@
   font-size: 144px;
   font-weight: 800;
   line-height: 160px;
-  color: #171f26;
+  color: colors.$cool-black-15;
   vertical-align: top;
 }
 
@@ -43,7 +45,7 @@
   font-size: 112px;
   font-weight: normal;
   line-height: 140px;
-  color: #171f26;
+  color: colors.$cool-black-15;
   vertical-align: top;
 }
 
@@ -66,6 +68,6 @@
   margin-left: 72px;
   font-family: Inter, sans-serif;
   font-size: 108px;
-  color: #171f26;
+  color: colors.$cool-black-15;
   vertical-align: middle;
 }

--- a/assets/css/v2/dup/free_text.scss
+++ b/assets/css/v2/dup/free_text.scss
@@ -147,7 +147,7 @@
 .partial-alert {
   &--yellow {
     .free-text {
-      color: #171f26;
+      color: colors.$cool-black-15;
     }
   }
 
@@ -193,7 +193,7 @@
 
 .headway-section {
   .free-text {
-    color: #171f26;
+    color: colors.$cool-black-15;
   }
 
   .free-text__text-pill {
@@ -229,7 +229,7 @@
   .free-text__line {
     width: 1400px;
     font-weight: 600;
-    color: #171f26;
+    color: colors.$cool-black-15;
   }
 
   .free-text__icon-container {

--- a/assets/css/v2/dup/normal_header.scss
+++ b/assets/css/v2/dup/normal_header.scss
@@ -34,7 +34,7 @@
     background-color: colors.$alert-yellow;
 
     .normal-header-title__text {
-      color: #171f26;
+      color: colors.$cool-black-15;
     }
   }
 }

--- a/assets/css/v2/lcd_common/departures/destination.scss
+++ b/assets/css/v2/lcd_common/departures/destination.scss
@@ -1,3 +1,5 @@
+@use "CSS/colors";
+
 .departure-destination {
   width: 592px;
   font-family: Inter, sans-serif;
@@ -9,7 +11,7 @@
   font-size: 64px;
   font-weight: 600;
   line-height: 64px;
-  color: #171f26;
+  color: colors.$cool-black-15;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -19,5 +21,5 @@
   font-size: 48px;
   font-weight: 400;
   line-height: 56px;
-  color: #171f26;
+  color: colors.$cool-black-15;
 }

--- a/assets/css/v2/lcd_common/departures/section.scss
+++ b/assets/css/v2/lcd_common/departures/section.scss
@@ -1,3 +1,5 @@
+@use "CSS/colors";
+
 .departures-section {
   & > .departure-row:not(:last-child)::after {
     position: absolute;
@@ -6,7 +8,7 @@
     width: 848px;
     height: 4px;
     content: "";
-    background-color: #cccbc8;
+    background-color: colors.$warm-neutral-80;
     border-radius: 2px;
   }
 }

--- a/assets/css/v2/lcd_common/departures/time.scss
+++ b/assets/css/v2/lcd_common/departures/time.scss
@@ -1,3 +1,5 @@
+@use "CSS/colors";
+
 .departure-times-with-crowding {
   width: 256px;
 }
@@ -35,7 +37,7 @@
 .departure-time {
   display: inline-block;
   font-family: Inter, sans-serif;
-  color: #171f26;
+  color: colors.$cool-black-15;
   vertical-align: middle;
 }
 

--- a/assets/css/v2/lcd_common/departures_no_data.scss
+++ b/assets/css/v2/lcd_common/departures_no_data.scss
@@ -1,3 +1,5 @@
+@use "CSS/colors";
+
 .departures-no-data-container {
   position: relative;
   box-sizing: border-box;
@@ -33,7 +35,7 @@
   width: 753px;
   height: 2px;
   content: "";
-  background: #737373;
+  background: colors.$true-grey-45;
 }
 
 .departures-no-data__alternatives-container {

--- a/assets/css/v2/lcd_common/route_pill.scss
+++ b/assets/css/v2/lcd_common/route_pill.scss
@@ -41,11 +41,11 @@
 
   &--outline {
     background: none;
-    border: 2px solid #2e3e4d;
+    border: 2px solid colors.$cool-black-30;
     box-shadow: none;
 
     .route-pill__slashed-text {
-      color: #2e3e4d;
+      color: colors.$cool-black-30;
     }
   }
 }
@@ -74,7 +74,7 @@
   }
 
   &--outline {
-    color: #2e3e4d;
+    color: colors.$cool-black-30;
   }
 }
 

--- a/assets/css/v2/lcd_common/subway_status.scss
+++ b/assets/css/v2/lcd_common/subway_status.scss
@@ -1,9 +1,8 @@
+@use "CSS/colors";
+
 .subway-status {
   /// Reusable values for the component
   /// (Defined here to avoid polluting the global namespace)
-  $text-dark-gray: #171f26;
-  $widget-background: #e5e4e1;
-  $rule-color: #cccbc8;
   $rule-width: 808px;
   $status-top-padding: 18px;
   $status-left-padding: 24px;
@@ -25,8 +24,8 @@
   padding-top: 6px;
   overflow: hidden;
   font-family: Inter, sans-serif;
-  color: $text-dark-gray;
-  background: $widget-background;
+  color: colors.$cool-black-15;
+  background: colors.$warm-neutral-90;
   border-radius: 16px;
   box-shadow: 0 12px 24px 0 rgb(23 31 38 / 25%);
 
@@ -77,7 +76,7 @@
     width: $rule-width;
     height: 4px;
     content: "";
-    background: $rule-color;
+    background: colors.$warm-neutral-80;
     border-radius: 2px;
   }
 

--- a/assets/css/v2/pre_fare/cr_departures/cr_departures.scss
+++ b/assets/css/v2/pre_fare/cr_departures/cr_departures.scss
@@ -1,13 +1,15 @@
+@use "CSS/colors";
+
 .departures-container {
   height: 100%;
   padding: 32px;
   font-family: Inter, sans-serif;
-  background-color: #80276c;
+  background-color: colors.$line-cr;
 }
 
 .departures-card {
   height: 1656px;
-  background-color: #d9d6d0;
+  background-color: colors.$warm-neutral-85;
   border-radius: 16px;
 }
 

--- a/assets/css/v2/pre_fare/cr_departures/cr_departures_table.scss
+++ b/assets/css/v2/pre_fare/cr_departures/cr_departures_table.scss
@@ -1,3 +1,5 @@
+@use "CSS/colors";
+
 .cr-departures-table {
   table-layout: fixed;
   border-collapse: collapse;
@@ -11,7 +13,7 @@
   tr {
     &:not(:first-child) {
       height: 272px;
-      border-top: 4px solid #cccbc8;
+      border-top: 4px solid colors.$warm-neutral-80;
     }
   }
 

--- a/assets/css/v2/pre_fare/cr_departures/overnight_cr_departures.scss
+++ b/assets/css/v2/pre_fare/cr_departures/overnight_cr_departures.scss
@@ -1,13 +1,15 @@
+@use "CSS/colors";
+
 .overnight-cr-departures__container {
   position: relative;
   height: 100%;
   padding: 32px;
   font-family: Inter, sans-serif;
-  background-color: #80276c;
+  background-color: colors.$line-cr;
 
   .overnight-cr-departures__card {
     height: 1656px;
-    background-color: #d9d6d0;
+    background-color: colors.$warm-neutral-85;
     border-radius: 16px;
 
     .overnight-cr-departures__body {

--- a/assets/css/v2/pre_fare/departure_time.scss
+++ b/assets/css/v2/pre_fare/departure_time.scss
@@ -1,8 +1,9 @@
 @use "CSS/base/base_departure_time";
+@use "CSS/colors";
 
 .departure-time {
   display: inline-block;
-  color: #171f26;
+  color: colors.$cool-black-15;
   text-align: right;
   vertical-align: middle;
 

--- a/assets/css/v2/pre_fare/disruption_diagram/disruption_diagram.scss
+++ b/assets/css/v2/pre_fare/disruption_diagram/disruption_diagram.scss
@@ -36,12 +36,12 @@
   }
 
   &--affected {
-    stroke: #171f26;
+    stroke: colors.$cool-black-15;
   }
 }
 
 .shuttle-stop {
-  stroke: #171f26;
+  stroke: colors.$cool-black-15;
 }
 
 .middle-slot__background {
@@ -118,7 +118,7 @@
 }
 
 .station-closure-icon {
-  fill: #171f26;
+  fill: colors.$cool-black-15;
 
   &--current-stop {
     fill: #ee2e24;

--- a/assets/css/v2/pre_fare/elevator_status.scss
+++ b/assets/css/v2/pre_fare/elevator_status.scss
@@ -10,14 +10,16 @@ If any changes to this stylesheet affect that, be sure to update
 the backend page-fitting logic as well.
 *** HEADS UP ***/
 
+@use "CSS/colors";
+
 .elevator-status {
   position: relative;
   width: 1024px;
   height: 1000px;
   margin: 16px 28px;
   overflow: hidden;
-  color: #171f26;
-  background: #e5e4e1;
+  color: colors.$cool-black-15;
+  background: colors.$warm-neutral-90;;
   border-radius: 16px;
   box-shadow: 0 10px 20px 0 rgb(0 0 0 / 25%);
 
@@ -47,7 +49,7 @@ the backend page-fitting logic as well.
     bottom: 0;
     width: 1024px;
     height: 124px;
-    background: #cccbc8;
+    background: colors.$warm-neutral-80;
     border-radius: 0 0 16px 16px;
 
     .elevator-status__footer-text {

--- a/assets/css/v2/pre_fare/elevator_status.scss
+++ b/assets/css/v2/pre_fare/elevator_status.scss
@@ -19,7 +19,7 @@ the backend page-fitting logic as well.
   margin: 16px 28px;
   overflow: hidden;
   color: colors.$cool-black-15;
-  background: colors.$warm-neutral-90;;
+  background: colors.$warm-neutral-90;
   border-radius: 16px;
   box-shadow: 0 10px 20px 0 rgb(0 0 0 / 25%);
 

--- a/assets/css/v2/pre_fare/flex/paging_indicator.scss
+++ b/assets/css/v2/pre_fare/flex/paging_indicator.scss
@@ -1,3 +1,5 @@
+@use "CSS/colors";
+
 .flex-zone-page-indicator {
   position: absolute;
   right: 0;
@@ -12,7 +14,7 @@
 .flex-zone-page-indicator__page__progress-bar {
   position: absolute;
   height: 16px;
-  background: #171f26;
+  background: colors.$cool-black-15;
 }
 
 .flex-zone-page-indicator__page {
@@ -21,7 +23,7 @@
   width: 144px;
   height: 16px;
   overflow: hidden;
-  background: #cccbc8;
+  background: colors.$warm-neutral-80;
   border-radius: 24px;
   box-shadow: inset 1px 2px 6px 0 #bfbebb;
 

--- a/assets/css/v2/pre_fare/prefare_single_screen_alert.scss
+++ b/assets/css/v2/pre_fare/prefare_single_screen_alert.scss
@@ -53,7 +53,7 @@
     display: flex;
     flex-direction: column;
     height: 100%;
-    background-color: colors.$warm-neutral-90;;
+    background-color: colors.$warm-neutral-90;
     box-shadow: 0 10px 20px 0 rgb(23 31 38 / 25%);
 
     &--no-banner {

--- a/assets/css/v2/pre_fare/prefare_single_screen_alert.scss
+++ b/assets/css/v2/pre_fare/prefare_single_screen_alert.scss
@@ -53,7 +53,7 @@
     display: flex;
     flex-direction: column;
     height: 100%;
-    background-color: #e5e4e1;
+    background-color: colors.$warm-neutral-90;;
     box-shadow: 0 10px 20px 0 rgb(23 31 38 / 25%);
 
     &--no-banner {
@@ -118,7 +118,7 @@
     min-width: 124px;
     height: 124px;
     margin-right: 45px;
-    color: #171f26;
+    color: colors.$cool-black-15;
   }
 
   .alert-card__content-block__text {
@@ -143,7 +143,7 @@
   .alert-card__fallback__icon {
     height: 192px;
     margin-bottom: 48px;
-    color: #171f26;
+    color: colors.$cool-black-15;
   }
 
   .alert-card__fallback__issue-text {
@@ -190,7 +190,7 @@
     height: 84px;
     padding: 20px 60px;
     font-size: 32px;
-    background: #cccbc8;
+    background: colors.$warm-neutral-80;
     border-radius: 0 0 4px 4px;
   }
 

--- a/assets/css/v2/pre_fare/reconstructed_alert.scss
+++ b/assets/css/v2/pre_fare/reconstructed_alert.scss
@@ -205,7 +205,7 @@ $alert-card-footer-height: 80px;
     width: 1016px;
     height: 100%;
     color: colors.$cool-black-15;
-    background-color: colors.$warm-neutral-90;;
+    background-color: colors.$warm-neutral-90;
     border-radius: 4px;
 
     &__body {

--- a/assets/css/v2/pre_fare/reconstructed_alert.scss
+++ b/assets/css/v2/pre_fare/reconstructed_alert.scss
@@ -9,7 +9,7 @@ $alert-card-footer-height: 80px;
 .alert-container {
   // Takeover fonts
   font-family: Inter, sans-serif;
-  color: #171f26;
+  color: colors.$cool-black-15;
 
   .x-large-text {
     font-size: 200px;
@@ -181,7 +181,7 @@ $alert-card-footer-height: 80px;
 
   .alert-card__footer {
     height: $alert-card-footer-height;
-    background-color: #cccbc8;
+    background-color: colors.$warm-neutral-80;
     border-radius: 0 0 32px 32px;
   }
 
@@ -204,8 +204,8 @@ $alert-card-footer-height: 80px;
   .alert-card {
     width: 1016px;
     height: 100%;
-    color: #171f26;
-    background-color: #e5e4e1;
+    color: colors.$cool-black-15;
+    background-color: colors.$warm-neutral-90;;
     border-radius: 4px;
 
     &__body {
@@ -294,7 +294,7 @@ $alert-card-footer-height: 80px;
       font-weight: 400;
       color: #000;
       text-align: center;
-      background-color: #cccbc8;
+      background-color: colors.$warm-neutral-80;
       border-radius: 0 0 4px 4px;
 
       &__cause {
@@ -351,7 +351,7 @@ $alert-card-footer-height: 80px;
   .alert-card__body__route-pills
     .route-pills__branches
     .route-pills__branches__dot {
-    background-color: #171f26;
+    background-color: colors.$cool-black-15;
   }
 }
 

--- a/assets/css/v2/pre_fare/subway_status.scss
+++ b/assets/css/v2/pre_fare/subway_status.scss
@@ -1,3 +1,4 @@
+@use "CSS/colors";
 @use "CSS/v2/lcd_common/subway_status";
 
 .subway-status {
@@ -5,10 +6,10 @@
 }
 
 .subway-status-footer {
-  background-color: #cccbc8;
+  background-color: colors.$warm-neutral-80;
 }
 
 .subway-status-footer__link {
   font-weight: unset;
-  color: #171f26;
+  color: colors.$cool-black-15;
 }


### PR DESCRIPTION
There were a lot of CSS files I noticed that used color definitions where we had already defined constants in the `colors` namespace. Went through all the colors defined in the namespace and replaced any instances where we used the same hex code. 