### PR TITLE
refactor: fetch and parse Facility resources

### DIFF
--- a/lib/screens/facilities/facility.ex
+++ b/lib/screens/facilities/facility.ex
@@ -3,20 +3,73 @@ defmodule Screens.Facilities.Facility do
   Functions for fetching facility data from the V3 API.
   """
 
-  alias Screens.Stops
+  alias Screens.Facilities.Parser
+  alias Screens.Stops.Stop
+  alias Screens.V3Api
 
   @type id :: String.t()
 
-  @callback fetch_stop_for_facility(id()) :: {:ok, Stops.Stop.t()} | {:error, term()}
-  def fetch_stop_for_facility(facility_id) do
-    case Screens.V3Api.get_json("facilities/#{facility_id}", %{
-           "include" => "stop"
-         }) do
-      {:ok, %{"data" => _data, "included" => [stop_map]}} ->
-        {:ok, Stops.Parser.parse_stop(stop_map, [])}
+  @type type ::
+          :bike_storage
+          | :bridge_plate
+          | :electric_car_chargers
+          | :elevated_subplatform
+          | :elevator
+          | :escalator
+          | :fare_media_assistance_facility
+          | :fare_media_assistant
+          | :fare_vending_machine
+          | :fare_vending_retailer
+          | :fully_elevated_platform
+          | :other
+          | :parking_area
+          | :pick_drop
+          | :portable_boarding_lift
+          | :ramp
+          | :taxi_stand
+          | :ticket_window
 
-      error ->
-        {:error, error}
+  @type t :: %__MODULE__{
+          id: id(),
+          excludes_stop_ids: [Stop.id()],
+          latitude: float() | nil,
+          longitude: float() | nil,
+          long_name: String.t(),
+          short_name: String.t(),
+          stop: Stop.t() | :unloaded,
+          type: type()
+        }
+
+  @type params :: [stop_ids: [Stop.id()], types: [type()]]
+
+  @enforce_keys ~w[id long_name short_name stop type]a
+  defstruct @enforce_keys ++ [excludes_stop_ids: [], latitude: nil, longitude: nil]
+
+  @callback fetch(params()) :: {:ok, [t()]} | :error
+  def fetch(params, get_json_fn \\ &V3Api.get_json/2) do
+    encoded_params =
+      params |> Enum.map(&encode_param/1) |> Map.new() |> Map.put("include", "stop")
+
+    case get_json_fn.("facilities", encoded_params) do
+      {:ok, response} -> {:ok, Parser.parse(response)}
+      _ -> :error
+    end
+  end
+
+  defp encode_param({:stop_ids, ids}), do: {"filter[stop]", Enum.join(ids, ",")}
+
+  defp encode_param({:types, types}) do
+    {
+      "filter[type]",
+      Enum.map_join(types, ",", fn type -> type |> to_string() |> String.upcase() end)
+    }
+  end
+
+  @callback fetch_by_id(id()) :: {:ok, Stop.t()} | :error
+  def fetch_by_id(id, get_json_fn \\ &V3Api.get_json/2) do
+    case get_json_fn.("facilities/#{id}", %{"include" => "stop"}) do
+      {:ok, response} -> {:ok, Parser.parse(response)}
+      _ -> :error
     end
   end
 end

--- a/lib/screens/facilities/parser.ex
+++ b/lib/screens/facilities/parser.ex
@@ -1,0 +1,52 @@
+defmodule Screens.Facilities.Parser do
+  @moduledoc false
+
+  alias Screens.Facilities.Facility
+  alias Screens.Stops
+
+  def parse(%{"data" => data} = response) do
+    included =
+      response
+      |> Map.get("included", [])
+      |> Map.new(fn %{"id" => id, "type" => type} = resource -> {{id, type}, resource} end)
+
+    cond do
+      is_list(data) -> Enum.map(data, &parse_facility(&1, included))
+      is_map(data) -> parse_facility(data, included)
+    end
+  end
+
+  def parse_facility(
+        %{
+          "id" => id,
+          "attributes" => %{
+            "latitude" => latitude,
+            "longitude" => longitude,
+            "long_name" => long_name,
+            "short_name" => short_name,
+            "properties" => properties,
+            "type" => type
+          },
+          "relationships" => %{"stop" => %{"data" => %{"id" => stop_id}}}
+        },
+        included
+      ) do
+    %Facility{
+      id: id,
+      excludes_stop_ids: Enum.flat_map(properties, &excluded_stop_id/1),
+      latitude: latitude,
+      longitude: longitude,
+      long_name: long_name,
+      short_name: short_name,
+      stop:
+        case Map.get(included, {stop_id, "stop"}) do
+          nil -> :unloaded
+          stop -> Stops.Parser.parse_stop(stop, included)
+        end,
+      type: type |> String.downcase() |> String.to_existing_atom()
+    }
+  end
+
+  defp excluded_stop_id(%{"name" => "excludes-stop", "value" => id}), do: [to_string(id)]
+  defp excluded_stop_id(_property), do: []
+end

--- a/lib/screens/stops/parser.ex
+++ b/lib/screens/stops/parser.ex
@@ -59,7 +59,7 @@ defmodule Screens.Stops.Parser do
     connecting_stops =
       case get_in(relationships, ~w[connecting_stops data]) do
         nil ->
-          nil
+          :unloaded
 
         stop_references ->
           Enum.map(stop_references, fn %{"id" => id} ->

--- a/lib/screens/v2/candidate_generator/elevator/closures.ex
+++ b/lib/screens/v2/candidate_generator/elevator/closures.ex
@@ -60,14 +60,14 @@ defmodule Screens.V2.CandidateGenerator.Elevator.Closures do
         %Screen{app_params: %ElevatorConfig{elevator_id: elevator_id} = app_params} = config,
         now
       ) do
-    {:ok, alerts} = @alert.fetch_elevator_alerts_with_facilities()
+    {:ok, alerts} = @alert.fetch(activity: "USING_WHEELCHAIR")
     {active, upcoming} = Enum.split_with(alerts, &Alert.happening_now?/1)
     active_closures = Enum.flat_map(active, &elevator_closure/1)
     at_this_elevator? = fn %Closure{id: id} -> id == elevator_id end
 
     case Enum.find(active_closures, at_this_elevator?) do
       nil ->
-        {:ok, %Stop{id: stop_id}} = @facility.fetch_stop_for_facility(elevator_id)
+        {:ok, %Facility{stop: %Stop{id: stop_id}}} = @facility.fetch_by_id(elevator_id)
 
         relevant_closures =
           Enum.filter(active_closures, &relevant_closure?(&1, stop_id, active_closures))
@@ -138,7 +138,7 @@ defmodule Screens.V2.CandidateGenerator.Elevator.Closures do
       [] ->
         []
 
-      [{station_id, %{id: id, name: name}}] ->
+      [{station_id, %Facility{id: id, short_name: name}}] ->
         [
           %Closure{
             id: id,

--- a/lib/screens/v2/candidate_generator/widgets/elevator_closures.ex
+++ b/lib/screens/v2/candidate_generator/widgets/elevator_closures.ex
@@ -42,11 +42,11 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ElevatorClosures do
         } = config,
         now \\ DateTime.utc_now(),
         fetch_location_context_fn \\ &LocationContext.fetch/3,
-        fetch_elevator_alerts_with_facilities_fn \\ &Alert.fetch_elevator_alerts_with_facilities/0
+        fetch_alerts_fn \\ &Alert.fetch/1
       ) do
     with {:ok, location_context} <- fetch_location_context_fn.(PreFare, parent_station_id, now),
          {:ok, parent_station_map} <- @stop.fetch_parent_station_name_map(),
-         {:ok, alerts} <- fetch_elevator_alerts_with_facilities_fn.() do
+         {:ok, alerts} <- fetch_alerts_fn.(activity: "USING_WHEELCHAIR") do
       elevator_closures =
         alerts
         |> elevator_alerts()
@@ -127,7 +127,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ElevatorClosures do
       [] ->
         []
 
-      [{station_id, %{id: id}}] ->
+      [{station_id, %Facility{id: id}}] ->
         [
           %Closure{
             id: id,

--- a/lib/screens/v2/widget_instance/elevator_status.ex
+++ b/lib/screens/v2/widget_instance/elevator_status.ex
@@ -77,6 +77,7 @@ defmodule Screens.V2.WidgetInstance.ElevatorStatus do
   @subway_icons ~w[red blue orange green silver]a
 
   alias Screens.Alerts.Alert
+  alias Screens.Facilities.Facility
   alias Screens.LocationContext
   alias Screens.V2.AlertsWidget
   alias Screens.V2.LocalizedAlert
@@ -251,7 +252,7 @@ defmodule Screens.V2.WidgetInstance.ElevatorStatus do
     end)
   end
 
-  defp serialize_closure(alert, %{name: name, id: id}, now) do
+  defp serialize_closure(alert, %Facility{id: id, short_name: name}, now) do
     %{
       alert_id: alert.id,
       elevator_name: name,
@@ -276,11 +277,8 @@ defmodule Screens.V2.WidgetInstance.ElevatorStatus do
     closures =
       alerts
       |> Enum.sort_by(&get_informed_facility(&1.informed_entities))
-      |> Enum.map(fn %Alert{
-                       informed_entities: entities
-                     } = alert ->
+      |> Enum.map(fn %Alert{informed_entities: entities} = alert ->
         facility = get_informed_facility(entities)
-
         serialize_closure(alert, facility, now)
       end)
 

--- a/test/screens/facilities/facility_test.exs
+++ b/test/screens/facilities/facility_test.exs
@@ -1,0 +1,83 @@
+defmodule Screens.Facilities.FacilityTest do
+  use ExUnit.Case, async: true
+
+  alias Screens.Stops.Stop
+  alias Screens.Facilities.Facility
+
+  @data %{
+    "id" => "954",
+    "attributes" => %{
+      "latitude" => -71.194994,
+      "longitude" => 42.316115,
+      "long_name" => "SHAWMUT - Ashmont Bound Platform to Lobby",
+      "short_name" => "Ashmont platform to lobby",
+      "properties" => [
+        %{"name" => "alternate-service-text", "value" => "some text"},
+        %{"name" => "excludes-stop", "value" => 70091}
+      ],
+      "type" => "ELEVATOR"
+    },
+    "relationships" => %{
+      "stop" => %{"data" => %{"id" => "place-smmnl", "type" => "stop"}}
+    }
+  }
+
+  @included [
+    %{
+      "id" => "place-smmnl",
+      "type" => "stop",
+      "attributes" => %{
+        "name" => "Shawmut",
+        "location_type" => 1,
+        "platform_code" => nil,
+        "platform_name" => nil,
+        "vehicle_type" => 1
+      },
+      "relationships" => %{}
+    }
+  ]
+
+  @expected %Facility{
+    id: "954",
+    excludes_stop_ids: ["70091"],
+    latitude: -71.194994,
+    longitude: 42.316115,
+    long_name: "SHAWMUT - Ashmont Bound Platform to Lobby",
+    short_name: "Ashmont platform to lobby",
+    stop: %Stop{
+      id: "place-smmnl",
+      child_stops: :unloaded,
+      connecting_stops: :unloaded,
+      location_type: 1,
+      name: "Shawmut",
+      vehicle_type: :subway
+    },
+    type: :elevator
+  }
+
+  describe "fetch/2" do
+    test "fetches and parses facilities" do
+      get_json_fn = fn "facilities",
+                       %{
+                         "filter[stop]" => "place-smmnl",
+                         "filter[type]" => "ELEVATOR",
+                         "include" => "stop"
+                       } ->
+        {:ok, %{"data" => [@data], "included" => @included}}
+      end
+
+      assert Facility.fetch([stop_ids: ["place-smmnl"], types: [:elevator]], get_json_fn) ==
+               {:ok, [@expected]}
+    end
+  end
+
+  describe "fetch_by_id/2" do
+    test "fetches and parses a facility by ID" do
+      get_json_fn = fn "facilities/954", %{"include" => "stop"} ->
+        {:ok, %{"data" => @data, "included" => @included}}
+      end
+
+      assert Facility.fetch_by_id("954", get_json_fn) == {:ok, @expected}
+    end
+  end
+end

--- a/test/screens/route_patterns/route_pattern_test.exs
+++ b/test/screens/route_patterns/route_pattern_test.exs
@@ -156,7 +156,8 @@ defmodule Screens.RoutePatterns.RoutePatternTest do
         platform_code: nil,
         platform_name: "Exit Only",
         vehicle_type: :subway,
-        child_stops: []
+        child_stops: [],
+        connecting_stops: :unloaded
       }
 
       orient_heights = %Stop{
@@ -166,7 +167,8 @@ defmodule Screens.RoutePatterns.RoutePatternTest do
         platform_code: nil,
         platform_name: "Bowdoin",
         vehicle_type: :subway,
-        child_stops: []
+        child_stops: [],
+        connecting_stops: :unloaded
       }
 
       wonderland = %Stop{
@@ -176,7 +178,8 @@ defmodule Screens.RoutePatterns.RoutePatternTest do
         platform_code: "1",
         platform_name: "Bowdoin",
         vehicle_type: :subway,
-        child_stops: []
+        child_stops: [],
+        connecting_stops: :unloaded
       }
 
       expected = [

--- a/test/screens/v2/candidate_generator/widgets/elevator_closures_test.exs
+++ b/test/screens/v2/candidate_generator/widgets/elevator_closures_test.exs
@@ -3,6 +3,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ElevatorClosuresTest do
 
   alias Screens.Alerts.Alert
   alias Screens.Elevator
+  alias Screens.Facilities.Facility
   alias Screens.Routes.Route
   alias Screens.Stops.Stop
   alias Screens.V2.CandidateGenerator.Widgets.ElevatorClosures
@@ -16,6 +17,8 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ElevatorClosuresTest do
   @elevator injected(Elevator)
   @route injected(Route)
   @stop injected(Stop)
+
+  @alert_opts [activity: "USING_WHEELCHAIR"]
 
   setup :verify_on_exit!
 
@@ -64,6 +67,13 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ElevatorClosuresTest do
     )
   end
 
+  defp build_facility(id, fields \\ []) do
+    struct!(
+      %Facility{id: id, long_name: "long", short_name: "short", type: :elevator, stop: :unloaded},
+      fields
+    )
+  end
+
   defp build_alert(fields) do
     struct!(%Alert{active_period: [{DateTime.utc_now(), nil}], effect: :elevator_closure}, fields)
   end
@@ -73,12 +83,12 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ElevatorClosuresTest do
       {:ok, :mocked_location_context}
     end
 
-    alerts_mock = fn ->
+    alerts_mock = fn @alert_opts ->
       {:ok,
        [
          build_alert(
            id: "alert_1",
-           informed_entities: [%{facility: %{id: "elev_1", name: "Test"}, stop: "place-test"}]
+           informed_entities: [%{facility: build_facility("elev_1"), stop: "place-test"}]
          )
        ]}
     end
@@ -99,7 +109,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ElevatorClosuresTest do
       {:ok, :mocked_location_context}
     end
 
-    alerts_mock = fn -> {:ok, []} end
+    alerts_mock = fn @alert_opts -> {:ok, []} end
 
     result =
       ElevatorClosures.elevator_status_instances(config, now, location_context_mock, alerts_mock)
@@ -112,16 +122,16 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ElevatorClosuresTest do
       {:ok, :mocked_location_context}
     end
 
-    alerts_mock = fn ->
+    alerts_mock = fn @alert_opts ->
       {:ok,
        [
          build_alert(
            id: "alert_1",
-           informed_entities: [%{facility: %{id: "elev_1"}, stop: "place-1"}]
+           informed_entities: [%{facility: build_facility("elev_1"), stop: "place-1"}]
          ),
          build_alert(
            id: "alert_2",
-           informed_entities: [%{facility: %{id: "elev_2"}, stop: "place-2"}]
+           informed_entities: [%{facility: build_facility("elev_2"), stop: "place-2"}]
          )
        ]}
     end
@@ -142,16 +152,16 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ElevatorClosuresTest do
       {:ok, :mocked_location_context}
     end
 
-    alerts_mock = fn ->
+    alerts_mock = fn @alert_opts ->
       {:ok,
        [
          build_alert(
            id: "alert_1",
-           informed_entities: [%{facility: %{id: "elev_1"}, stop: "place-1"}]
+           informed_entities: [%{facility: build_facility("elev_1"), stop: "place-1"}]
          ),
          build_alert(
            id: "alert_2",
-           informed_entities: [%{facility: %{id: "elev_2"}, stop: "place-2"}]
+           informed_entities: [%{facility: build_facility("elev_2"), stop: "place-2"}]
          )
        ]}
     end
@@ -176,20 +186,20 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ElevatorClosuresTest do
       {:ok, :mocked_location_context}
     end
 
-    alerts_mock = fn ->
+    alerts_mock = fn @alert_opts ->
       {:ok,
        [
          build_alert(
            id: "alert_1",
-           informed_entities: [%{facility: %{id: "elev_1"}, stop: "place-1"}]
+           informed_entities: [%{facility: build_facility("elev_1"), stop: "place-1"}]
          ),
          build_alert(
            id: "alert_2",
-           informed_entities: [%{facility: %{id: "elev_2"}, stop: "place-2"}]
+           informed_entities: [%{facility: build_facility("elev_2"), stop: "place-2"}]
          ),
          build_alert(
            id: "alert_3",
-           informed_entities: [%{facility: %{id: "elev_3"}, stop: "place-1"}]
+           informed_entities: [%{facility: build_facility("elev_3"), stop: "place-1"}]
          )
        ]}
     end
@@ -219,12 +229,14 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ElevatorClosuresTest do
       {:ok, :mocked_location_context}
     end
 
-    alerts_mock = fn ->
+    alerts_mock = fn @alert_opts ->
       {:ok,
        [
          build_alert(
            id: "alert_1",
-           informed_entities: [%{facility: %{id: "elev_1"}, stop: "place-test-parent-station-id"}]
+           informed_entities: [
+             %{facility: build_facility("elev_1"), stop: "place-test-parent-station-id"}
+           ]
          )
        ]}
     end

--- a/test/screens/v2/widget_instance/elevator_status_test.exs
+++ b/test/screens/v2/widget_instance/elevator_status_test.exs
@@ -2,6 +2,7 @@ defmodule Screens.V2.WidgetInstance.ElevatorStatusTest do
   use ExUnit.Case, async: true
 
   alias Screens.Alerts.Alert
+  alias Screens.Facilities.Facility
   alias Screens.LocationContext
   alias Screens.RoutePatterns.RoutePattern
   alias Screens.V2.WidgetInstance
@@ -19,6 +20,16 @@ defmodule Screens.V2.WidgetInstance.ElevatorStatusTest do
 
   # Convenience function to build an informed entity
   defp ie(opts), do: %{stop: opts[:stop], facility: opts[:facility]}
+
+  defp facility(id) do
+    %Facility{
+      id: to_string(id),
+      long_name: "",
+      short_name: "Elevator #{id}",
+      stop: :unloaded,
+      type: :elevator
+    }
+  end
 
   setup do
     home_station_id = "place-foo"
@@ -47,8 +58,6 @@ defmodule Screens.V2.WidgetInstance.ElevatorStatusTest do
     now = ~U[2022-01-01T10:00:00Z]
     happening_now_active_period = [{~U[2022-01-01T00:00:00Z], ~U[2022-01-01T22:00:00Z]}]
     upcoming_active_period = [{~U[2022-02-01T00:00:00Z], ~U[2022-02-01T22:00:00Z]}]
-
-    facility_id_to_map = fn id -> %{id: to_string(id), name: "Elevator #{id}"} end
 
     station_id_to_name = %{
       "place-foo" => "Foo Station",
@@ -83,28 +92,28 @@ defmodule Screens.V2.WidgetInstance.ElevatorStatusTest do
     }
 
     home_ies = fn facility_id ->
-      facility = facility_id_to_map.(facility_id)
+      facility = facility(facility_id)
 
       [ie(stop: home_station_id, facility: facility)] ++
         Enum.map(home_platform_ids, &ie(stop: &1, facility: facility))
     end
 
     connecting_ies = fn facility_id ->
-      facility = facility_id_to_map.(facility_id)
+      facility = facility(facility_id)
 
       [ie(stop: connecting_station_id, facility: facility)] ++
         Enum.map(connecting_platform_ids, &ie(stop: &1, facility: facility))
     end
 
     elsewhere_ies = fn facility_id ->
-      facility = facility_id_to_map.(facility_id)
+      facility = facility(facility_id)
 
       [ie(stop: elsewhere_station_id, facility: facility)] ++
         Enum.map(elsewhere_platform_ids, &ie(stop: &1, facility: facility))
     end
 
     other_elsewhere_ies = fn facility_id ->
-      facility = facility_id_to_map.(facility_id)
+      facility = facility(facility_id)
 
       [ie(stop: other_elsewhere_station_id, facility: facility)] ++
         Enum.map(other_elsewhere_platform_ids, &ie(stop: &1, facility: facility))


### PR DESCRIPTION
* Introduce a `Facility` struct and generic fetch functions for it. Allows replacing the narrower `fetch_stop_for_facility` function with fetching the facility and reading its `stop` relationship.

* Parse facilities related to alerts as the complete `Facility` instead of a map of ID and short name, potentially including relationships of the facilities as well. Allows replacing the special-purpose `fetch_elevator_alerts_with_facilities` with the normal `fetch`, since related facilities are now always included.

* Fix a minor bug in Stop parsing where `connecting_stops` being unloaded was represented as `nil`, rather than `:unloaded` as the typespec suggested.

For now only the `excludes-stop` facility property is parsed. This plus the `stop` relationship will ultimately let us determine the child stop IDs affected by a facility alert (e.g. the specific platforms within a station that may be inaccessible if a given elevator is offline), which is a necessary component of determining whether a given elevator outage is "downstream" of a screen location.