### PR TITLE
refactor: DRY up V3 API response parsing

### DIFF
--- a/lib/screens/alerts/alert.ex
+++ b/lib/screens/alerts/alert.ex
@@ -1,7 +1,7 @@
 defmodule Screens.Alerts.Alert do
   @moduledoc false
 
-  alias Screens.Alerts.{Alert, InformedEntity, Parser}
+  alias Screens.Alerts.InformedEntity
   alias Screens.Facilities.Facility
   alias Screens.Routes.Route
   alias Screens.RouteType
@@ -153,7 +153,7 @@ defmodule Screens.Alerts.Alert do
         |> Map.put("include", Enum.join(includes, ","))
 
       case get_json_fn.("alerts", params) do
-        {:ok, response} -> {:ok, Parser.parse(response)}
+        {:ok, response} -> {:ok, V3Api.Parser.parse(response)}
         _ -> :error
       end
     end)
@@ -352,7 +352,7 @@ defmodule Screens.Alerts.Alert do
 
   def partial_station_closure?(_, _), do: false
 
-  @spec informs_stop_id?(Alert.t(), Stop.id()) :: boolean()
+  @spec informs_stop_id?(t(), Stop.id()) :: boolean()
   def informs_stop_id?(%__MODULE__{informed_entities: informed_entities}, stop_id) do
     Enum.any?(informed_entities, &(&1.stop == stop_id))
   end

--- a/lib/screens/alerts/parser.ex
+++ b/lib/screens/alerts/parser.ex
@@ -2,18 +2,9 @@ defmodule Screens.Alerts.Parser do
   @moduledoc false
 
   alias Screens.Alerts.Alert
-  alias Screens.Facilities
+  alias Screens.V3Api
 
-  def parse(%{"data" => data} = response) do
-    included =
-      response
-      |> Map.get("included", [])
-      |> Map.new(fn %{"id" => id, "type" => type} = resource -> {{id, type}, resource} end)
-
-    Enum.map(data, &parse_alert(&1, included))
-  end
-
-  def parse_alert(
+  def parse(
         %{
           "id" => id,
           "attributes" => %{
@@ -63,9 +54,8 @@ defmodule Screens.Alerts.Parser do
 
   defp parse_informed_facility(nil, _included), do: nil
 
-  defp parse_informed_facility(id, included) do
-    included |> Map.fetch!({id, "facility"}) |> Facilities.Parser.parse_facility(included)
-  end
+  defp parse_informed_facility(id, included),
+    do: V3Api.Parser.included!(%{"data" => %{"id" => id, "type" => "facility"}}, included)
 
   defp parse_and_sort_active_periods(periods) do
     periods

--- a/lib/screens/facilities/facility.ex
+++ b/lib/screens/facilities/facility.ex
@@ -3,7 +3,6 @@ defmodule Screens.Facilities.Facility do
   Functions for fetching facility data from the V3 API.
   """
 
-  alias Screens.Facilities.Parser
   alias Screens.Stops.Stop
   alias Screens.V3Api
 
@@ -51,7 +50,7 @@ defmodule Screens.Facilities.Facility do
       params |> Enum.map(&encode_param/1) |> Map.new() |> Map.put("include", "stop")
 
     case get_json_fn.("facilities", encoded_params) do
-      {:ok, response} -> {:ok, Parser.parse(response)}
+      {:ok, response} -> {:ok, V3Api.Parser.parse(response)}
       _ -> :error
     end
   end
@@ -68,7 +67,7 @@ defmodule Screens.Facilities.Facility do
   @callback fetch_by_id(id()) :: {:ok, Stop.t()} | :error
   def fetch_by_id(id, get_json_fn \\ &V3Api.get_json/2) do
     case get_json_fn.("facilities/#{id}", %{"include" => "stop"}) do
-      {:ok, response} -> {:ok, Parser.parse(response)}
+      {:ok, response} -> {:ok, V3Api.Parser.parse(response)}
       _ -> :error
     end
   end

--- a/lib/screens/facilities/parser.ex
+++ b/lib/screens/facilities/parser.ex
@@ -2,21 +2,9 @@ defmodule Screens.Facilities.Parser do
   @moduledoc false
 
   alias Screens.Facilities.Facility
-  alias Screens.Stops
+  alias Screens.V3Api
 
-  def parse(%{"data" => data} = response) do
-    included =
-      response
-      |> Map.get("included", [])
-      |> Map.new(fn %{"id" => id, "type" => type} = resource -> {{id, type}, resource} end)
-
-    cond do
-      is_list(data) -> Enum.map(data, &parse_facility(&1, included))
-      is_map(data) -> parse_facility(data, included)
-    end
-  end
-
-  def parse_facility(
+  def parse(
         %{
           "id" => id,
           "attributes" => %{
@@ -27,7 +15,7 @@ defmodule Screens.Facilities.Parser do
             "properties" => properties,
             "type" => type
           },
-          "relationships" => %{"stop" => %{"data" => %{"id" => stop_id}}}
+          "relationships" => %{"stop" => stop}
         },
         included
       ) do
@@ -38,11 +26,7 @@ defmodule Screens.Facilities.Parser do
       longitude: longitude,
       long_name: long_name,
       short_name: short_name,
-      stop:
-        case Map.get(included, {stop_id, "stop"}) do
-          nil -> :unloaded
-          stop -> Stops.Parser.parse_stop(stop, included)
-        end,
+      stop: V3Api.Parser.included(stop, included, :unloaded),
       type: type |> String.downcase() |> String.to_existing_atom()
     }
   end

--- a/lib/screens/lines/parser.ex
+++ b/lib/screens/lines/parser.ex
@@ -1,14 +1,17 @@
 defmodule Screens.Lines.Parser do
   @moduledoc false
 
-  def parse_line(%{
-        "id" => id,
-        "attributes" => %{
-          "long_name" => long_name,
-          "short_name" => short_name,
-          "sort_order" => sort_order
-        }
-      }) do
+  def parse(
+        %{
+          "id" => id,
+          "attributes" => %{
+            "long_name" => long_name,
+            "short_name" => short_name,
+            "sort_order" => sort_order
+          }
+        },
+        _included
+      ) do
     %Screens.Lines.Line{
       id: id,
       long_name: long_name,

--- a/lib/screens/predictions/parser.ex
+++ b/lib/screens/predictions/parser.ex
@@ -1,19 +1,10 @@
 defmodule Screens.Predictions.Parser do
   @moduledoc false
 
-  alias Screens.{Routes, Stops, Trips, Vehicles}
   alias Screens.Predictions.{Prediction, ScheduleRelationship}
+  alias Screens.V3Api
 
-  def parse(%{"data" => data} = response) do
-    included =
-      response
-      |> Map.get("included", [])
-      |> Map.new(fn %{"id" => id, "type" => type} = resource -> {{id, type}, resource} end)
-
-    Enum.map(data, &parse_prediction(&1, included))
-  end
-
-  def parse_prediction(
+  def parse(
         %{
           "id" => id,
           "attributes" => %{
@@ -21,34 +12,23 @@ defmodule Screens.Predictions.Parser do
             "departure_time" => departure_time_string,
             "schedule_relationship" => schedule_relationship
           },
-          "relationships" =>
-            %{
-              "route" => %{"data" => %{"id" => route_id}},
-              "stop" => %{"data" => %{"id" => stop_id}},
-              "trip" => %{"data" => %{"id" => trip_id}}
-            } = relationships
+          "relationships" => %{
+            "route" => route,
+            "stop" => stop,
+            "trip" => trip,
+            "vehicle" => vehicle
+          }
         },
         included
       ) do
-    trip = included |> Map.fetch!({trip_id, "trip"}) |> Trips.Parser.parse_trip(included)
-    stop = included |> Map.fetch!({stop_id, "stop"}) |> Stops.Parser.parse_stop(included)
-    route = included |> Map.fetch!({route_id, "route"}) |> Routes.Parser.parse_route(included)
-
-    vehicle =
-      case get_in(relationships, ~w[vehicle data id]) do
-        nil ->
-          nil
-
-        vehicle_id ->
-          included |> Map.fetch!({vehicle_id, "vehicle"}) |> Vehicles.Parser.parse_vehicle()
-      end
+    stop = V3Api.Parser.included!(stop, included)
 
     %Prediction{
       id: id,
-      trip: trip,
+      trip: V3Api.Parser.included!(trip, included),
       stop: stop,
-      route: route,
-      vehicle: vehicle,
+      route: V3Api.Parser.included!(route, included),
+      vehicle: V3Api.Parser.included!(vehicle, included),
       arrival_time: parse_time(arrival_time_string),
       departure_time: parse_time(departure_time_string),
       track_number: stop.platform_code,

--- a/lib/screens/predictions/prediction.ex
+++ b/lib/screens/predictions/prediction.ex
@@ -33,15 +33,10 @@ defmodule Screens.Predictions.Prediction do
 
   @spec fetch(Departure.params()) :: {:ok, list(t())} | :error
   def fetch(%{} = params) do
-    predictions =
-      Departure.do_fetch(
-        "predictions",
-        Map.put(params, :include, @includes),
-        Screens.Predictions.Parser
-      )
+    result = Departure.do_fetch("predictions", Map.put(params, :include, @includes))
 
-    case predictions do
-      {:ok, result} -> {:ok, Enum.reject(result, &is_nil(&1.departure_time))}
+    case result do
+      {:ok, predictions} -> {:ok, Enum.reject(predictions, &is_nil(&1.departure_time))}
       :error -> :error
     end
   end

--- a/lib/screens/route_patterns/parser.ex
+++ b/lib/screens/route_patterns/parser.ex
@@ -2,50 +2,36 @@ defmodule Screens.RoutePatterns.Parser do
   @moduledoc false
 
   alias Screens.RoutePatterns.RoutePattern
-  alias Screens.{Routes, Stops}
+  alias Screens.V3Api
 
-  def parse(%{"data" => data} = response) do
-    included =
-      response
-      |> Map.get("included", [])
-      |> Map.new(fn %{"id" => id, "type" => type} = resource -> {{id, type}, resource} end)
-
-    Enum.map(data, &parse_route_pattern(&1, included))
-  end
-
-  defp parse_route_pattern(
-         %{
-           "id" => id,
-           "attributes" => %{
-             "canonical" => canonical?,
-             "direction_id" => direction_id,
-             "typicality" => typicality
-           },
-           "relationships" => %{
-             "route" => %{"data" => %{"id" => route_id}},
-             "representative_trip" => %{"data" => %{"id" => representative_trip_id}}
-           }
-         },
-         included
-       ) do
+  def parse(
+        %{
+          "id" => id,
+          "attributes" => %{
+            "canonical" => canonical?,
+            "direction_id" => direction_id,
+            "typicality" => typicality
+          },
+          "relationships" => %{
+            "route" => route,
+            "representative_trip" => %{"data" => %{"id" => representative_trip_id}}
+          }
+        },
+        included
+      ) do
     %{
       "attributes" => %{"headsign" => headsign},
-      "relationships" => %{"stops" => %{"data" => stop_references}}
+      "relationships" => %{"stops" => stops}
     } = Map.fetch!(included, {representative_trip_id, "trip"})
-
-    stops =
-      Enum.map(stop_references, fn %{"id" => stop_id} ->
-        included |> Map.fetch!({stop_id, "stop"}) |> Stops.Parser.parse_stop(included)
-      end)
 
     %RoutePattern{
       id: id,
       canonical?: canonical?,
       direction_id: direction_id,
-      typicality: typicality,
-      route: included |> Map.fetch!({route_id, "route"}) |> Routes.Parser.parse_route(included),
       headsign: headsign,
-      stops: stops
+      route: V3Api.Parser.included!(route, included),
+      stops: V3Api.Parser.included!(stops, included),
+      typicality: typicality
     }
   end
 end

--- a/lib/screens/route_patterns/route_direction_stops.ex
+++ b/lib/screens/route_patterns/route_direction_stops.ex
@@ -17,7 +17,7 @@ defmodule Screens.RoutePatterns.RouteDirectionStops do
   end
 
   defp parse_included(%{"type" => "stop"} = item) do
-    Screens.Stops.Parser.parse_stop(item, %{})
+    Screens.V3Api.Parser.parse_resource(item, %{})
   end
 
   defp parse_included(%{

--- a/lib/screens/route_patterns/route_pattern.ex
+++ b/lib/screens/route_patterns/route_pattern.ex
@@ -1,7 +1,7 @@
 defmodule Screens.RoutePatterns.RoutePattern do
   @moduledoc false
 
-  alias Screens.RoutePatterns.{Parser, RouteDirectionStops}
+  alias Screens.RoutePatterns.RouteDirectionStops
   alias Screens.Routes.Route
   alias Screens.RouteType
   alias Screens.Stops.Stop
@@ -47,7 +47,7 @@ defmodule Screens.RoutePatterns.RoutePattern do
 
     case get_json_fn.("route_patterns", encoded_params) do
       {:ok, response} ->
-        {:ok, Enum.reduce(filter_params, Parser.parse(response), &apply_filter/2)}
+        {:ok, Enum.reduce(filter_params, V3Api.Parser.parse(response), &apply_filter/2)}
 
       _ ->
         :error

--- a/lib/screens/routes/route.ex
+++ b/lib/screens/routes/route.ex
@@ -2,7 +2,6 @@ defmodule Screens.Routes.Route do
   @moduledoc false
 
   alias Screens.Lines.Line
-  alias Screens.Routes.Parser
   alias Screens.RouteType
   alias Screens.Stops.Stop
   alias Screens.V3Api
@@ -58,7 +57,7 @@ defmodule Screens.Routes.Route do
       |> Map.put("include", "line")
 
     case get_json_fn.("routes/", params) do
-      {:ok, response} -> {:ok, Parser.parse(response)}
+      {:ok, response} -> {:ok, V3Api.Parser.parse(response)}
       _ -> :error
     end
   end

--- a/lib/screens/schedules/parser.ex
+++ b/lib/screens/schedules/parser.ex
@@ -1,44 +1,29 @@
 defmodule Screens.Schedules.Parser do
   @moduledoc false
 
-  alias Screens.{Routes, Stops, Trips}
   alias Screens.Schedules.Schedule
+  alias Screens.V3Api
 
-  def parse(%{"data" => data} = response) do
-    included =
-      response
-      |> Map.get("included", [])
-      |> Map.new(fn %{"id" => id, "type" => type} = resource -> {{id, type}, resource} end)
-
-    Enum.map(data, &parse_schedule(&1, included))
-  end
-
-  defp parse_schedule(
-         %{
-           "id" => id,
-           "attributes" => %{
-             "arrival_time" => arrival_time_string,
-             "departure_time" => departure_time_string,
-             "stop_headsign" => stop_headsign,
-             "direction_id" => direction_id
-           },
-           "relationships" => %{
-             "route" => %{"data" => %{"id" => route_id}},
-             "stop" => %{"data" => %{"id" => stop_id}},
-             "trip" => %{"data" => %{"id" => trip_id}}
-           }
-         },
-         included
-       ) do
-    trip = included |> Map.fetch!({trip_id, "trip"}) |> Trips.Parser.parse_trip(included)
-    stop = included |> Map.fetch!({stop_id, "stop"}) |> Stops.Parser.parse_stop(included)
-    route = included |> Map.fetch!({route_id, "route"}) |> Routes.Parser.parse_route(included)
+  def parse(
+        %{
+          "id" => id,
+          "attributes" => %{
+            "arrival_time" => arrival_time_string,
+            "departure_time" => departure_time_string,
+            "stop_headsign" => stop_headsign,
+            "direction_id" => direction_id
+          },
+          "relationships" => %{"route" => route, "stop" => stop, "trip" => trip}
+        },
+        included
+      ) do
+    stop = V3Api.Parser.included!(stop, included)
 
     %Schedule{
       id: id,
-      trip: trip,
+      trip: V3Api.Parser.included!(trip, included),
       stop: stop,
-      route: route,
+      route: V3Api.Parser.included!(route, included),
       arrival_time: parse_time(arrival_time_string),
       departure_time: parse_time(departure_time_string),
       stop_headsign: stop_headsign,

--- a/lib/screens/schedules/schedule.ex
+++ b/lib/screens/schedules/schedule.ex
@@ -34,16 +34,10 @@ defmodule Screens.Schedules.Schedule do
           {:ok, list(t())} | :error
   def fetch(%{} = params, date \\ nil) do
     params = if is_nil(date), do: params, else: Map.put(params, :date, date)
+    result = Departure.do_fetch("schedules", Map.put(params, :include, @includes))
 
-    schedules =
-      Departure.do_fetch(
-        "schedules",
-        Map.put(params, :include, @includes),
-        Screens.Schedules.Parser
-      )
-
-    case schedules do
-      {:ok, result} -> {:ok, Enum.reject(result, &is_nil(&1.departure_time))}
+    case result do
+      {:ok, schedules} -> {:ok, Enum.reject(schedules, &is_nil(&1.departure_time))}
       :error -> :error
     end
   end

--- a/lib/screens/stops/stop.ex
+++ b/lib/screens/stops/stop.ex
@@ -4,7 +4,6 @@ defmodule Screens.Stops.Stop do
   require Logger
 
   alias Screens.RouteType
-  alias Screens.Stops.Parser
   alias Screens.V3Api
 
   defstruct ~w[
@@ -65,7 +64,7 @@ defmodule Screens.Stops.Stop do
       end)
 
     case get_json_fn.("stops", encoded_params) do
-      {:ok, response} -> {:ok, Parser.parse(response)}
+      {:ok, response} -> {:ok, V3Api.Parser.parse(response)}
       _ -> :error
     end
   end

--- a/lib/screens/trips/parser.ex
+++ b/lib/screens/trips/parser.ex
@@ -3,16 +3,7 @@ defmodule Screens.Trips.Parser do
 
   alias Screens.Trips.Trip
 
-  def parse(%{"data" => data} = response) do
-    included =
-      response
-      |> Map.get("included", [])
-      |> Map.new(fn %{"id" => id, "type" => type} = resource -> {{id, type}, resource} end)
-
-    Enum.map(data, &parse_trip(&1, included))
-  end
-
-  def parse_trip(
+  def parse(
         %{
           "id" => id,
           "attributes" => %{"headsign" => headsign, "direction_id" => direction_id},

--- a/lib/screens/v2/departure.ex
+++ b/lib/screens/v2/departure.ex
@@ -8,6 +8,7 @@ defmodule Screens.V2.Departure do
   alias Screens.Trips.Trip
   alias Screens.Util
   alias Screens.V2.Departure.Builder
+  alias Screens.V3Api
   alias Screens.Vehicles.Vehicle
 
   @type t :: %__MODULE__{
@@ -85,7 +86,7 @@ defmodule Screens.V2.Departure do
     end
   end
 
-  def do_fetch(endpoint, params, parser) do
+  def do_fetch(endpoint, params) do
     encoded_params =
       @default_params
       |> Map.merge(params)
@@ -93,8 +94,8 @@ defmodule Screens.V2.Departure do
       |> Enum.reject(&is_nil/1)
       |> Map.new()
 
-    case Screens.V3Api.get_json(endpoint, encoded_params) do
-      {:ok, result} -> {:ok, parser.parse(result)}
+    case V3Api.get_json(endpoint, encoded_params) do
+      {:ok, result} -> {:ok, V3Api.Parser.parse(result)}
       _ -> :error
     end
   end

--- a/lib/screens/v3_api/parser.ex
+++ b/lib/screens/v3_api/parser.ex
@@ -1,0 +1,90 @@
+defmodule Screens.V3Api.Parser do
+  @moduledoc "Tools for parsing V3 API responses."
+
+  @parsers %{
+    "alert" => Screens.Alerts.Parser,
+    "facility" => Screens.Facilities.Parser,
+    "line" => Screens.Lines.Parser,
+    "prediction" => Screens.Predictions.Parser,
+    "route" => Screens.Routes.Parser,
+    "route_pattern" => Screens.RoutePatterns.Parser,
+    "schedule" => Screens.Schedules.Parser,
+    "stop" => Screens.Stops.Parser,
+    "trip" => Screens.Trips.Parser,
+    "vehicle" => Screens.Vehicles.Parser
+  }
+
+  @typep included :: %{{id :: String.t(), type :: String.t()} => object()}
+  @typep object :: %{String.t() => term()}
+
+  @doc "Parse a complete JSON-decoded V3 API response."
+  @spec parse(response :: object()) :: struct() | [struct()]
+  def parse(%{"data" => data} = response) when is_map(data) do
+    [resource] = parse(%{response | "data" => [data]})
+    resource
+  end
+
+  def parse(%{"data" => data} = response) when is_list(data) do
+    included =
+      response
+      |> Map.get("included", [])
+      |> then(&Enum.concat(data, &1))
+      |> Map.new(fn %{"id" => id, "type" => type} = resource -> {{id, type}, resource} end)
+
+    Enum.map(data, &parse_resource(&1, included))
+  end
+
+  @doc """
+  Parse a single resource. Expects as the second argument a map of all resources that were present
+  in the response, keyed by ID and type, for resolving relationship references.
+  """
+  @spec parse_resource(object(), included()) :: struct()
+  for {type, module} <- @parsers do
+    def parse_resource(%{"type" => unquote(type)} = data, included),
+      do: unquote(module).parse(data, included)
+  end
+
+  @doc """
+  Convenience for looking up a relationship and parsing the referenced resource(s). Expects an
+  `included` map of the same kind as `parse_resource/2` does. If any referenced resources are not
+  present, returns `default`.
+  """
+  @spec included(relationship :: object(), included(), any()) :: any()
+  def included(
+        %{"data" => [%{"id" => first_id, "type" => first_type} | _]} = data,
+        included,
+        default
+      ) do
+    # Assuming a "many" relationship is either completely loaded or not, look at the first
+    # reference to determine whether it is.
+    case Map.get(included, {first_id, first_type}) do
+      nil -> default
+      _resource -> included!(data, included)
+    end
+  end
+
+  def included(%{"data" => %{"id" => id, "type" => type}}, included, default) do
+    case Map.get(included, {id, type}) do
+      nil -> default
+      resource -> parse_resource(resource, included)
+    end
+  end
+
+  def included(%{"data" => []}, _included, _default), do: []
+  def included(%{"data" => nil}, _included, _default), do: nil
+
+  @doc "As `included/3` but asserts that any referenced resources are present."
+  @spec included!(relationship :: object(), included()) :: struct() | [struct()] | nil
+  def included!(%{"data" => references}, included) when is_list(references) do
+    Enum.map(references, fn %{"id" => id, "type" => type} ->
+      included |> Map.fetch!({id, type}) |> parse_resource(included)
+    end)
+  end
+
+  def included!(%{"data" => reference}, included) when is_map(reference) do
+    [resource] = included!(%{"data" => [reference]}, included)
+    resource
+  end
+
+  def included!(%{"data" => nil}, _included), do: nil
+end

--- a/lib/screens/vehicles/parser.ex
+++ b/lib/screens/vehicles/parser.ex
@@ -1,45 +1,23 @@
 defmodule Screens.Vehicles.Parser do
   @moduledoc false
 
-  def parse_result(%{"data" => data}) do
-    data
-    |> Enum.map(&parse_vehicle/1)
-    |> Enum.reject(&is_nil(&1.stop_id))
-  end
-
-  def parse_vehicle(%{
-        "attributes" => %{
-          "direction_id" => direction_id,
-          "carriages" => carriages,
-          "current_status" => current_status,
-          "occupancy_status" => occupancy_status
+  def parse(
+        %{
+          "id" => id,
+          "attributes" => %{
+            "direction_id" => direction_id,
+            "carriages" => carriages,
+            "current_status" => current_status,
+            "occupancy_status" => occupancy_status
+          },
+          "relationships" => %{"trip" => trip_data, "stop" => stop_data}
         },
-        "id" => vehicle_id,
-        "relationships" => %{"trip" => trip_data, "stop" => stop_data}
-      }) do
+        _included
+      ) do
     %Screens.Vehicles.Vehicle{
-      id: vehicle_id,
+      id: id,
       direction_id: direction_id,
       carriages: parse_carriages(carriages),
-      current_status: parse_current_status(current_status),
-      occupancy_status: parse_occupancy_status(occupancy_status),
-      trip_id: trip_id_from_trip_data(trip_data),
-      stop_id: stop_id_from_stop_data(stop_data)
-    }
-  end
-
-  def parse_vehicle(%{
-        "attributes" => %{
-          "direction_id" => direction_id,
-          "current_status" => current_status,
-          "occupancy_status" => occupancy_status
-        },
-        "id" => vehicle_id,
-        "relationships" => %{"trip" => trip_data, "stop" => stop_data}
-      }) do
-    %Screens.Vehicles.Vehicle{
-      id: vehicle_id,
-      direction_id: direction_id,
       current_status: parse_current_status(current_status),
       occupancy_status: parse_occupancy_status(occupancy_status),
       trip_id: trip_id_from_trip_data(trip_data),

--- a/lib/screens/vehicles/vehicle.ex
+++ b/lib/screens/vehicles/vehicle.ex
@@ -2,6 +2,7 @@ defmodule Screens.Vehicles.Vehicle do
   @moduledoc false
 
   alias Screens.Trips.Trip
+  alias Screens.V3Api.Parser
   alias Screens.Vehicles.Carriage
 
   defstruct id: nil,
@@ -40,7 +41,7 @@ defmodule Screens.Vehicles.Vehicle do
            "filter[route]" => route_id,
            "filter[direction_id]" => direction_id
          }) do
-      {:ok, result} -> Screens.Vehicles.Parser.parse_result(result)
+      {:ok, result} -> result |> Parser.parse() |> Enum.reject(&is_nil(&1.stop_id))
       _ -> []
     end
   end

--- a/test/screens/alerts/alert_test.exs
+++ b/test/screens/alerts/alert_test.exs
@@ -29,7 +29,10 @@ defmodule Screens.Alerts.AlertTest do
   describe "fetch/2" do
     test "fetches and parses alerts" do
       get_json_fn = fn "alerts", %{"filter[route]" => "1"} ->
-        {:ok, %{"data" => [%{"id" => "999", "attributes" => @minimal_attributes}]}}
+        {
+          :ok,
+          %{"data" => [%{"id" => "999", "type" => "alert", "attributes" => @minimal_attributes}]}
+        }
       end
 
       expected = %Alert{
@@ -85,7 +88,7 @@ defmodule Screens.Alerts.AlertTest do
       get_json_fn = fn "alerts", %{} ->
         {:ok,
          %{
-           "data" => [%{"id" => "999", "attributes" => attributes}],
+           "data" => [%{"id" => "999", "type" => "alert", "attributes" => attributes}],
            "included" => [facility_data]
          }}
       end
@@ -98,7 +101,7 @@ defmodule Screens.Alerts.AlertTest do
   end
 
   describe "fetch_by_stop_and_route/3" do
-    defp alert_json(id), do: %{"id" => id, "attributes" => @minimal_attributes}
+    defp alert_json(id), do: %{"id" => id, "type" => "alert", "attributes" => @minimal_attributes}
 
     setup do
       stop_based_alerts = [alert_json("1"), alert_json("2"), alert_json("3")]

--- a/test/screens/facilities/facility_test.exs
+++ b/test/screens/facilities/facility_test.exs
@@ -6,6 +6,7 @@ defmodule Screens.Facilities.FacilityTest do
 
   @data %{
     "id" => "954",
+    "type" => "facility",
     "attributes" => %{
       "latitude" => -71.194994,
       "longitude" => 42.316115,

--- a/test/screens/route_patterns/route_pattern_test.exs
+++ b/test/screens/route_patterns/route_pattern_test.exs
@@ -16,6 +16,7 @@ defmodule Screens.RoutePatterns.RoutePatternTest do
               "data" => [
                 %{
                   "id" => "Blue-6-0",
+                  "type" => "route_pattern",
                   "attributes" => %{
                     "canonical" => true,
                     "direction_id" => 0,
@@ -30,6 +31,7 @@ defmodule Screens.RoutePatterns.RoutePatternTest do
                 },
                 %{
                   "id" => "Blue-8-0",
+                  "type" => "route_pattern",
                   "attributes" => %{
                     "canonical" => false,
                     "direction_id" => 0,
@@ -215,6 +217,7 @@ defmodule Screens.RoutePatterns.RoutePatternTest do
               "data" => [
                 %{
                   "id" => "rp-blue",
+                  "type" => "route_pattern",
                   "attributes" => %{
                     "canonical" => true,
                     "direction_id" => 0,
@@ -229,6 +232,7 @@ defmodule Screens.RoutePatterns.RoutePatternTest do
                 },
                 %{
                   "id" => "rp-bus-1",
+                  "type" => "route_pattern",
                   "attributes" => %{
                     "canonical" => false,
                     "direction_id" => 0,

--- a/test/screens/routes/route_test.exs
+++ b/test/screens/routes/route_test.exs
@@ -10,6 +10,7 @@ defmodule Screens.Routes.RouteTest do
           ids,
           &%{
             "id" => &1,
+            "type" => "route",
             "attributes" => %{
               "short_name" => nil,
               "long_name" => nil,


### PR DESCRIPTION
Some patterns were repeated across many of our resource parsing modules, including an implicit "API" for passing around included resources. This centralizes the shared logic in a `V3Api.Parser` module.