### PR TITLE
chore: When running prettier, only log files that have been changed

### DIFF
--- a/assets/package.json
+++ b/assets/package.json
@@ -15,7 +15,7 @@
     "unused": "knip --tags=-knipignore",
     "styles": "stylelint --fix \"css/**/*\"",
     "styles:check": "stylelint \"css/**/*\"",
-    "format": "prettier --write .",
+    "format": "prettier --write --list-different .",
     "format:check": "prettier --check ."
   },
   "dependencies": {


### PR DESCRIPTION
Just a change to the package.json that's been bothering me. Adds the [--list-different option](https://prettier.io/docs/cli#--list-different) so you can easily see what files prettier changed.

- [ ] Tests added?
