### PR TITLE
refactor: use facility stop in elevator closures

### DIFF
--- a/test/screens/v2/candidate_generator/elevator/closures_test.exs
+++ b/test/screens/v2/candidate_generator/elevator/closures_test.exs
@@ -21,7 +21,6 @@ defmodule Screens.V2.CandidateGenerator.Elevator.ClosuresTest do
   @elevator injected(Elevator)
   @facility injected(Screens.Facilities.Facility)
   @route injected(Route)
-  @stop injected(Stop)
 
   @app_params %ElevatorConfig{
     elevator_id: "111",
@@ -37,7 +36,7 @@ defmodule Screens.V2.CandidateGenerator.Elevator.ClosuresTest do
     vendor: :mimo
   }
 
-  @alert_opts [activities: [:using_wheelchair]]
+  @alert_opts [activities: [:using_wheelchair], include_all?: true]
 
   setup do
     stub(@alert, :fetch, fn @alert_opts -> {:ok, []} end)
@@ -45,15 +44,31 @@ defmodule Screens.V2.CandidateGenerator.Elevator.ClosuresTest do
     stub(@facility, :fetch_by_id, fn id -> {:ok, build_facility(id)} end)
     stub(@route, :fetch, fn _params -> {:ok, [%Route{id: "Red", type: :subway}]} end)
 
-    stub(@stop, :fetch_parent_station_name_map, fn ->
-      {:ok, %{"place-test" => "Place Test"}}
-    end)
-
     {:ok, %{now: DateTime.utc_now()}}
   end
 
   defp build_alert(fields) do
     struct!(%Alert{active_period: [{DateTime.utc_now(), nil}], effect: :elevator_closure}, fields)
+  end
+
+  defp build_facility_alert(facility_id, station_id, opts \\ []) do
+    {opts, alert_fields} = Keyword.split(opts, [:facility_name, :station_name])
+    facility_name = Keyword.get(opts, :facility_name, "Elevator #{facility_id}")
+    station_name = Keyword.get(opts, :station_name, "#{station_id} Station")
+
+    alert_fields
+    |> Keyword.merge(
+      informed_entities: [
+        %{
+          facility:
+            build_facility(facility_id,
+              short_name: facility_name,
+              stop: %Stop{id: station_id, name: station_name}
+            )
+        }
+      ]
+    )
+    |> build_alert()
   end
 
   defp build_elevator(id, fields \\ []) do
@@ -84,16 +99,8 @@ defmodule Screens.V2.CandidateGenerator.Elevator.ClosuresTest do
 
   describe "header and footer" do
     test "have no variant when current elevator is not closed", %{now: now} do
-      expect(@stop, :fetch_parent_station_name_map, fn ->
-        {:ok, %{"place-haecl" => "Haymarket"}}
-      end)
-
       expect(@alert, :fetch, fn @alert_opts ->
-        alerts = [
-          build_alert(informed_entities: [%{stop: "place-haecl", facility: build_facility("f1")}])
-        ]
-
-        {:ok, alerts}
+        {:ok, [build_facility_alert("f1", "place-haecl")]}
       end)
 
       assert [
@@ -105,11 +112,7 @@ defmodule Screens.V2.CandidateGenerator.Elevator.ClosuresTest do
 
     test "have closed variant when current elevator is closed", %{now: now} do
       expect(@alert, :fetch, fn @alert_opts ->
-        alerts = [
-          build_alert(informed_entities: [%{stop: "place-test", facility: build_facility("111")}])
-        ]
-
-        {:ok, alerts}
+        {:ok, [build_facility_alert("111", "place-test")]}
       end)
 
       assert [_current_closed, %NormalHeader{variant: :closed}, %Footer{variant: :closed}] =
@@ -129,11 +132,7 @@ defmodule Screens.V2.CandidateGenerator.Elevator.ClosuresTest do
   describe "alternate path widget" do
     test "is returned when the screen's elevator is closed", %{now: now} do
       expect(@alert, :fetch, fn @alert_opts ->
-        alerts = [
-          build_alert(informed_entities: [%{stop: "place-test", facility: build_facility("111")}])
-        ]
-
-        {:ok, alerts}
+        {:ok, [build_facility_alert("111", "place-test")]}
       end)
 
       app_params = @screen.app_params
@@ -150,20 +149,15 @@ defmodule Screens.V2.CandidateGenerator.Elevator.ClosuresTest do
         upcoming_period = {DateTime.add(now, 1, :day), DateTime.add(now, 3, :day)}
 
         alerts = [
-          build_alert(
-            active_period: [active_period],
-            informed_entities: [
-              %{stop: "place-test", facility: build_facility("f1", short_name: "Test 1")}
-            ]
+          build_facility_alert("f1", "place-test",
+            facility_name: "Test 1",
+            station_name: "Place Test",
+            active_period: [active_period]
           ),
-          build_alert(
-            active_period: [upcoming_period],
-            informed_entities: [%{stop: "place-test", facility: build_facility("f2")}]
-          ),
-          build_alert(
-            effect: :detour,
+          build_facility_alert("f2", "place-test", active_period: [upcoming_period]),
+          build_facility_alert("f3", "place-test",
             active_period: [active_period],
-            informed_entities: [%{stop: "place-test", facility: build_facility("f3")}]
+            effect: :detour
           )
         ]
 
@@ -189,10 +183,6 @@ defmodule Screens.V2.CandidateGenerator.Elevator.ClosuresTest do
     end
 
     test "groups multiple outside closures by station", %{now: now} do
-      expect(@stop, :fetch_parent_station_name_map, fn ->
-        {:ok, %{"place-haecl" => "Haymarket"}}
-      end)
-
       expect(@route, :fetch, 2, fn
         %{stop_id: "place-haecl"} ->
           {:ok, [%Route{id: "Orange", type: :subway}]}
@@ -203,15 +193,13 @@ defmodule Screens.V2.CandidateGenerator.Elevator.ClosuresTest do
 
       expect(@alert, :fetch, fn @alert_opts ->
         alerts = [
-          build_alert(
-            informed_entities: [
-              %{stop: "place-haecl", facility: build_facility("f1", short_name: "Test 1")}
-            ]
+          build_facility_alert("f1", "place-haecl",
+            facility_name: "Test 1",
+            station_name: "Haymarket"
           ),
-          build_alert(
-            informed_entities: [
-              %{stop: "place-haecl", facility: build_facility("f2", short_name: "Test 2")}
-            ]
+          build_facility_alert("f2", "place-haecl",
+            facility_name: "Test 2",
+            station_name: "Haymarket"
           )
         ]
 
@@ -249,13 +237,7 @@ defmodule Screens.V2.CandidateGenerator.Elevator.ClosuresTest do
       end)
 
       expect(@alert, :fetch, fn @alert_opts ->
-        alerts = [
-          build_alert(
-            informed_entities: [%{stop: "place-other", facility: build_facility("222")}]
-          )
-        ]
-
-        {:ok, alerts}
+        {:ok, [build_facility_alert("222", "place-other")]}
       end)
 
       assert [%ElevatorClosures{stations_with_closures: :nearby_redundancy} | _] =
@@ -265,11 +247,11 @@ defmodule Screens.V2.CandidateGenerator.Elevator.ClosuresTest do
     test "filters out alerts with no facilities or more than one facility", %{now: now} do
       expect(@alert, :fetch, fn @alert_opts ->
         alerts = [
-          build_alert(informed_entities: [%{stop: "place-haecl", facility: nil}]),
+          build_alert(informed_entities: [%{facility: nil}]),
           build_alert(
             informed_entities: [
-              %{stop: "place-haecl", facility: build_facility("f1")},
-              %{stop: "place-haecl", facility: build_facility("f2")}
+              %{facility: build_facility("f1")},
+              %{facility: build_facility("f2")}
             ]
           )
         ]
@@ -287,15 +269,6 @@ defmodule Screens.V2.CandidateGenerator.Elevator.ClosuresTest do
     end
 
     test "filters out alerts at other stations with nearby exiting redundancy", %{now: now} do
-      expect(@stop, :fetch_parent_station_name_map, fn ->
-        {:ok,
-         %{
-           "place-test" => "This Station",
-           "place-test-redundancy" => "Other With Redundancy",
-           "place-test-no-redundancy" => "Other No Redundancy"
-         }}
-      end)
-
       stub(@route, :fetch, fn _ -> {:ok, [%Route{id: "Red", type: :subway}]} end)
 
       stub(@elevator, :get, fn
@@ -306,30 +279,9 @@ defmodule Screens.V2.CandidateGenerator.Elevator.ClosuresTest do
 
       expect(@alert, :fetch, fn @alert_opts ->
         alerts = [
-          build_alert(
-            informed_entities: [
-              %{
-                stop: "place-test",
-                facility: build_facility("112", short_name: "In Station Elevator")
-              }
-            ]
-          ),
-          build_alert(
-            informed_entities: [
-              %{
-                stop: "place-test-redundancy",
-                facility: build_facility("222", short_name: "Other With Redundancy")
-              }
-            ]
-          ),
-          build_alert(
-            informed_entities: [
-              %{
-                stop: "place-test-no-redundancy",
-                facility: build_facility("333", short_name: "Other Without Redundancy")
-              }
-            ]
-          )
+          build_facility_alert("112", "place-test", station_name: "This Station"),
+          build_facility_alert("222", "place-test-with", station_name: "Other With Redundancy"),
+          build_facility_alert("333", "place-test-without", station_name: "Other No Redundancy")
         ]
 
         {:ok, alerts}
@@ -341,14 +293,12 @@ defmodule Screens.V2.CandidateGenerator.Elevator.ClosuresTest do
                    %ElevatorClosures.Station{
                      id: "place-test",
                      name: "This Station",
-                     route_icons: [%{type: :text, text: "RL", color: :red}],
-                     closures: [%Closure{id: "112", name: "In Station Elevator"}]
+                     closures: [%Closure{id: "112"}]
                    },
                    %ElevatorClosures.Station{
-                     id: "place-test-no-redundancy",
+                     id: "place-test-without",
                      name: "Other No Redundancy",
-                     route_icons: [%{type: :text, text: "RL", color: :red}],
-                     closures: [%Closure{id: "333", name: "Other Without Redundancy"}]
+                     closures: [%Closure{id: "333"}]
                    }
                  ]
                }
@@ -364,28 +314,18 @@ defmodule Screens.V2.CandidateGenerator.Elevator.ClosuresTest do
         "alt" -> build_elevator("alt", exiting_redundancy: :nearby)
       end)
 
-      expect(@stop, :fetch_parent_station_name_map, fn ->
-        {:ok,
-         %{
-           "place-1" => "one",
-           "place-2" => "two",
-           "place-3" => "three",
-           "place-4" => "four"
-         }}
-      end)
-
       expect(@alert, :fetch, fn @alert_opts ->
         alerts = [
           # backup in station
-          build_alert(informed_entities: [%{stop: "place-1", facility: build_facility("1")}]),
+          build_facility_alert("1", "place-1"),
           # other with exiting summary
-          build_alert(informed_entities: [%{stop: "place-2", facility: build_facility("2")}]),
+          build_facility_alert("2", "place-2"),
           # despite having "nearby" redundancy, should not be filtered out, because its alternate
           # elevator is also down
-          build_alert(informed_entities: [%{stop: "place-3", facility: build_facility("3")}]),
+          build_facility_alert("3", "place-3"),
           # somewhat unrealistically, place elevator 3's "nearby" alternate at a different
           # station, so they aren't combined
-          build_alert(informed_entities: [%{stop: "place-4", facility: build_facility("alt")}])
+          build_facility_alert("alt", "place-4")
         ]
 
         {:ok, alerts}
@@ -432,10 +372,6 @@ defmodule Screens.V2.CandidateGenerator.Elevator.ClosuresTest do
           build_elevator("alt")
       end)
 
-      expect(@stop, :fetch_parent_station_name_map, fn ->
-        {:ok, %{"place-1" => "one", "place-2" => "two"}}
-      end)
-
       stub(@facility, :fetch_by_id, fn id ->
         {
           :ok,
@@ -454,9 +390,9 @@ defmodule Screens.V2.CandidateGenerator.Elevator.ClosuresTest do
 
       expect(@alert, :fetch, fn @alert_opts ->
         alerts = [
-          build_alert(informed_entities: [%{stop: "place-1", facility: build_facility("1")}]),
+          build_facility_alert("1", "place-1"),
           # don't use special text when "this" is the backup for a closure at another station
-          build_alert(informed_entities: [%{stop: "place-2", facility: build_facility("2")}])
+          build_facility_alert("2", "place-2")
         ]
 
         {:ok, alerts}
@@ -487,21 +423,13 @@ defmodule Screens.V2.CandidateGenerator.Elevator.ClosuresTest do
       expect(@route, :fetch, fn %{stop_id: "place-test"} -> :error end)
 
       expect(@alert, :fetch, fn @alert_opts ->
-        alerts = [
-          build_alert(informed_entities: [%{stop: "place-test", facility: build_facility("f1")}])
-        ]
-
-        {:ok, alerts}
+        {:ok, [build_facility_alert("f1", "place-test")]}
       end)
 
       assert [
                %ElevatorClosures{
                  stations_with_closures: [
-                   %ElevatorClosures.Station{
-                     id: "place-test",
-                     name: "Place Test",
-                     closures: [%Closure{id: "f1"}]
-                   }
+                   %ElevatorClosures.Station{id: "place-test", closures: [%Closure{id: "f1"}]}
                  ]
                }
                | _
@@ -517,12 +445,11 @@ defmodule Screens.V2.CandidateGenerator.Elevator.ClosuresTest do
 
       expect(@alert, :fetch, fn @alert_opts ->
         alerts = [
-          build_alert(
+          build_facility_alert("111", "place-test",
             active_period: [
               {dt(~D[2025-01-05], ~T[03:00:00]), dt(~D[2025-01-07], ~T[02:59:00])},
               {dt(~D[2025-02-01], ~T[03:00:00]), dt(~D[2025-02-02], ~T[02:59:00])}
-            ],
-            informed_entities: [%{stop: "place-test", facility: build_facility("111")}]
+            ]
           )
         ]
 
@@ -549,9 +476,8 @@ defmodule Screens.V2.CandidateGenerator.Elevator.ClosuresTest do
 
       expect(@alert, :fetch, fn @alert_opts ->
         alerts = [
-          build_alert(
-            active_period: [{dt(~D[2025-01-05], ~T[03:00:00]), dt(~D[2025-01-07], ~T[02:59:00])}],
-            informed_entities: [%{stop: "place-test", facility: build_facility("111")}]
+          build_facility_alert("111", "place-test",
+            active_period: [{dt(~D[2025-01-05], ~T[03:00:00]), dt(~D[2025-01-07], ~T[02:59:00])}]
           )
         ]
 


### PR DESCRIPTION
Generating elevator screen closures requires, among other things, the ID and name of the elevator's station.

Previously the ID was obtained from the `stop` field of the same `informed_entity` that referenced the elevator (assuming the alerts feed would have to populate this, given "facilities" are a non-standard extension), and the name from a separate API fetch that collected the names of all parent stations in the system.

We can now populate the facilities associated with an alert and the stops associated with those facilities as part of the alert fetch, so this information can be gotten directly from the Stop resources. In particular this removes the need for the separate "station name map" to be fetched, passed around, and stubbed in tests.

Fetching alerts with the full Facility relationship graph populated (`include_all?: true`) will also enable more easily determining which child stop IDs within a station are affected by an elevator closure, which we need to enable "downstream" closure summaries.