### PR TITLE
refactor: specify alert activities as atoms

### DIFF
--- a/lib/screens/alerts/alert.ex
+++ b/lib/screens/alerts/alert.ex
@@ -23,6 +23,16 @@ defmodule Screens.Alerts.Alert do
             url: nil,
             description: nil
 
+  @type activity ::
+          :board
+          | :bringing_bike
+          | :exit
+          | :park_car
+          | :ride
+          | :store_bike
+          | :using_escalator
+          | :using_wheelchair
+
   @type cause ::
           :accident
           | :amtrak
@@ -102,11 +112,12 @@ defmodule Screens.Alerts.Alert do
   @type active_period :: {DateTime.t(), DateTime.t() | nil}
 
   @type informed_entity :: %{
+          activities: nonempty_list(activity()),
+          direction_id: Trip.direction() | nil,
           facility: Facility.t() | nil,
-          stop: Stop.id() | nil,
           route: Route.id() | nil,
           route_type: non_neg_integer() | nil,
-          direction_id: Trip.direction() | nil
+          stop: Stop.id() | nil
         }
 
   @type t :: %__MODULE__{
@@ -125,7 +136,7 @@ defmodule Screens.Alerts.Alert do
         }
 
   @type options :: [
-          activity: String.t(),
+          activities: [activity()] | :all,
           fields: [String.t()],
           include_all?: boolean(),
           route_id: Route.id(),
@@ -248,8 +259,15 @@ defmodule Screens.Alerts.Alert do
     format_query_param({:route_types, [route_type]})
   end
 
-  defp format_query_param({:activity, activity}) do
-    [{"activity", activity}]
+  defp format_query_param({:activities, :all}), do: [{"activity", "ALL"}]
+
+  defp format_query_param({:activities, activities}) when is_list(activities) do
+    [
+      {
+        "activity",
+        Enum.map_join(activities, ",", fn value -> value |> to_string() |> String.upcase() end)
+      }
+    ]
   end
 
   defp format_query_param(_), do: []

--- a/lib/screens/alerts/parser.ex
+++ b/lib/screens/alerts/parser.ex
@@ -43,7 +43,8 @@ defmodule Screens.Alerts.Parser do
 
   defp parse_informed_entity(ie, included) do
     %{
-      activities: ie["activities"],
+      activities:
+        ie["activities"] |> Enum.map(&String.downcase/1) |> Enum.map(&String.to_existing_atom/1),
       direction_id: ie["direction_id"],
       facility: parse_informed_facility(ie["facility"], included),
       route: ie["route"],

--- a/lib/screens/v2/candidate_generator/elevator/closures.ex
+++ b/lib/screens/v2/candidate_generator/elevator/closures.ex
@@ -60,7 +60,7 @@ defmodule Screens.V2.CandidateGenerator.Elevator.Closures do
         %Screen{app_params: %ElevatorConfig{elevator_id: elevator_id} = app_params} = config,
         now
       ) do
-    {:ok, alerts} = @alert.fetch(activity: "USING_WHEELCHAIR")
+    {:ok, alerts} = @alert.fetch(activities: [:using_wheelchair])
     {active, upcoming} = Enum.split_with(alerts, &Alert.happening_now?/1)
     active_closures = Enum.flat_map(active, &elevator_closure/1)
     at_this_elevator? = fn %Closure{id: id} -> id == elevator_id end

--- a/lib/screens/v2/candidate_generator/widgets/elevator_closures.ex
+++ b/lib/screens/v2/candidate_generator/widgets/elevator_closures.ex
@@ -46,7 +46,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ElevatorClosures do
       ) do
     with {:ok, location_context} <- fetch_location_context_fn.(PreFare, parent_station_id, now),
          {:ok, parent_station_map} <- @stop.fetch_parent_station_name_map(),
-         {:ok, alerts} <- fetch_alerts_fn.(activity: "USING_WHEELCHAIR") do
+         {:ok, alerts} <- fetch_alerts_fn.(activities: [:using_wheelchair]) do
       elevator_closures =
         alerts
         |> elevator_alerts()

--- a/test/screens/alerts/alert_test.exs
+++ b/test/screens/alerts/alert_test.exs
@@ -49,7 +49,7 @@ defmodule Screens.Alerts.AlertTest do
             route: "1",
             direction_id: nil,
             route_type: nil,
-            activities: ~w[BOARD EXIT RIDE],
+            activities: ~w[board exit ride]a,
             facility: nil
           }
         ],

--- a/test/screens/v2/candidate_generator/elevator/closures_test.exs
+++ b/test/screens/v2/candidate_generator/elevator/closures_test.exs
@@ -37,7 +37,7 @@ defmodule Screens.V2.CandidateGenerator.Elevator.ClosuresTest do
     vendor: :mimo
   }
 
-  @alert_opts [activity: "USING_WHEELCHAIR"]
+  @alert_opts [activities: [:using_wheelchair]]
 
   setup do
     stub(@alert, :fetch, fn @alert_opts -> {:ok, []} end)

--- a/test/screens/v2/candidate_generator/widgets/elevator_closures_test.exs
+++ b/test/screens/v2/candidate_generator/widgets/elevator_closures_test.exs
@@ -18,7 +18,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ElevatorClosuresTest do
   @route injected(Route)
   @stop injected(Stop)
 
-  @alert_opts [activity: "USING_WHEELCHAIR"]
+  @alert_opts [activities: [:using_wheelchair]]
 
   setup :verify_on_exit!
 


### PR DESCRIPTION
Alert activities are an enum rather than an arbitrary string. Specify them as atoms and document the possible values as a type.