### PR TITLE
fix: facility type atoms not existing

### DIFF
--- a/lib/screens/facilities/facility.ex
+++ b/lib/screens/facilities/facility.ex
@@ -36,7 +36,7 @@ defmodule Screens.Facilities.Facility do
           long_name: String.t(),
           short_name: String.t(),
           stop: Stop.t() | :unloaded,
-          type: type()
+          type: type() | :unknown
         }
 
   @type params :: [stop_ids: [Stop.id()], types: [type()]]

--- a/lib/screens/facilities/parser.ex
+++ b/lib/screens/facilities/parser.ex
@@ -4,6 +4,27 @@ defmodule Screens.Facilities.Parser do
   alias Screens.Facilities.Facility
   alias Screens.V3Api
 
+  @types %{
+    "BIKE_STORAGE" => :bike_storage,
+    "BRIDGE_PLATE" => :bridge_plate,
+    "ELECTRIC_CAR_CHARGERS" => :electric_car_chargers,
+    "ELEVATED_SUBPLATFORM" => :elevated_subplatform,
+    "ELEVATOR" => :elevator,
+    "ESCALATOR" => :escalator,
+    "FARE_MEDIA_ASSISTANCE_FACILITY" => :fare_media_assistance_facility,
+    "FARE_MEDIA_ASSISTANT" => :fare_media_assistant,
+    "FARE_VENDING_MACHINE" => :fare_vending_machine,
+    "FARE_VENDING_RETAILER" => :fare_vending_retailer,
+    "FULLY_ELEVATED_PLATFORM" => :fully_elevated_platform,
+    "OTHER" => :other,
+    "PARKING_AREA" => :parking_area,
+    "PICK_DROP" => :pick_drop,
+    "PORTABLE_BOARDING_LIFT" => :portable_boarding_lift,
+    "RAMP" => :ramp,
+    "TAXI_STAND" => :taxi_stand,
+    "TICKET_WINDOW" => :ticket_window
+  }
+
   def parse(
         %{
           "id" => id,
@@ -27,7 +48,7 @@ defmodule Screens.Facilities.Parser do
       long_name: long_name,
       short_name: short_name,
       stop: V3Api.Parser.included(stop, included, :unloaded),
-      type: type |> String.downcase() |> String.to_existing_atom()
+      type: Map.get(@types, type, :unknown)
     }
   end
 


### PR DESCRIPTION
As with 6bb51f0, these atoms did not reliably "exist", by virtue of only existing in a typespec.
