### PR TITLE
fix: elevator screen no-data state serialization

### DIFF
--- a/lib/screens/v2/widget_instance/elevator_closures.ex
+++ b/lib/screens/v2/widget_instance/elevator_closures.ex
@@ -137,10 +137,15 @@ defmodule Screens.V2.WidgetInstance.ElevatorClosures do
       }),
       do: %{
         id: id,
-        stations_with_closures: Enum.map(stations_with_closures, &Station.serialize/1),
+        stations_with_closures: serialize_stations(stations_with_closures),
         station_id: station_id,
         upcoming_closure: if(upcoming_closure, do: Upcoming.serialize(upcoming_closure, now))
       }
+
+  defp serialize_stations(stations) when is_list(stations),
+    do: Enum.map(stations, &Station.serialize/1)
+
+  defp serialize_stations(other), do: other
 
   defimpl Screens.V2.WidgetInstance do
     alias Screens.V2.WidgetInstance.ElevatorClosures

--- a/test/screens/v2/widget_instance/elevator_closures_test.exs
+++ b/test/screens/v2/widget_instance/elevator_closures_test.exs
@@ -44,6 +44,17 @@ defmodule Screens.V2.WidgetInstance.ElevatorClosuresTest do
              }
     end
 
+    test "serializes a no-closures state" do
+      instance = %{@instance | stations_with_closures: :no_closures}
+
+      assert WidgetInstance.serialize(instance) == %{
+               id: @instance.app_params.elevator_id,
+               station_id: @instance.station_id,
+               stations_with_closures: :no_closures,
+               upcoming_closure: nil
+             }
+    end
+
     test "serializes an upcoming closure" do
       instance = %{
         @instance


### PR DESCRIPTION
The type of `stations_with_closures` is either a list of stations *or* an atom such as `:no_closures`. The recently introduced `Enum.map/2` did not account for this, so serialization [would always crash](https://mbtace.sentry.io/issues/6529369484/) if the screen was trying to display a "no data" state.