### PR TITLE
fix: github team name in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @mbta/digital-ride
+* @mbta/screens-developers


### PR DESCRIPTION
**Asana task**: N/A

Description
PR updates GitHub group name in `CODEOWNERS`

- [ ] Tests added?
