### PR TITLE
Suppress Alert 636777 for Transit Data

### DIFF
--- a/lib/screens/v2/widget_instance/reconstructed_alert.ex
+++ b/lib/screens/v2/widget_instance/reconstructed_alert.ex
@@ -1241,7 +1241,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
 
   def alert_ids(%__MODULE__{} = t), do: [t.alert.id]
 
-  @suppressed_alert_ids ~w[623609]
+  @suppressed_alert_ids ~w[636777]
 
   def valid_candidate?(%__MODULE__{alert: %{id: alert_id}}) do
     alert_id not in @suppressed_alert_ids

--- a/test/screens/v2/widget_instance/reconstructed_alert_test.exs
+++ b/test/screens/v2/widget_instance/reconstructed_alert_test.exs
@@ -3292,7 +3292,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
       assert WidgetInstance.valid_candidate?(widget)
     end
 
-    suppressed_alerts = ~w[623609]
+    suppressed_alerts = ~w[636777]
 
     for alert_id <- suppressed_alerts do
       @tag alert_id: alert_id


### PR DESCRIPTION
**Asana task**: [Filter Alert 636777 from Pre Fares](https://app.asana.com/0/1185117109217413/1209929226121665/f)

Description
- https://mbta.slack.com/archives/C039ARUM48H/p1744205951518679
- [This] alert is kind of a weird one-off that may be used by Transit Data to help generate predictions on the Ashmont branch during the "shuttle train" situation, but we don't want it to actually appear

- [x] Tests added?
