### PR TITLE
feat: downstream elevator closure summaries

### DIFF
--- a/lib/screens/facilities/facility.ex
+++ b/lib/screens/facilities/facility.ex
@@ -71,4 +71,16 @@ defmodule Screens.Facilities.Facility do
       _ -> :error
     end
   end
+
+  @doc """
+  Given a facility whose `stop` field is loaded, returns the inverse of `excludes_stop_ids`, i.e.
+  the child stops that *are* served by the facility.
+  """
+  @spec served_stop_ids(t()) :: [Stop.id()]
+  def served_stop_ids(%__MODULE__{
+        excludes_stop_ids: excludes_stop_ids,
+        stop: %Stop{child_stops: child_stops, location_type: 1}
+      })
+      when is_list(child_stops),
+      do: Enum.map(child_stops, & &1.id) -- excludes_stop_ids
 end

--- a/lib/screens/route_patterns/route_pattern.ex
+++ b/lib/screens/route_patterns/route_pattern.ex
@@ -43,7 +43,10 @@ defmodule Screens.RoutePatterns.RoutePattern do
       fetch_params
       |> Enum.flat_map(&encode_param/1)
       |> Map.new()
-      |> Map.put("include", Enum.join(~w[route.line representative_trip.stops], ","))
+      |> Map.put(
+        "include",
+        Enum.join(~w[route.line representative_trip.stops.parent_station], ",")
+      )
 
     case get_json_fn.("route_patterns", encoded_params) do
       {:ok, response} ->

--- a/test/screens/facilities/facility_test.exs
+++ b/test/screens/facilities/facility_test.exs
@@ -56,6 +56,13 @@ defmodule Screens.Facilities.FacilityTest do
     type: :elevator
   }
 
+  defp build(fields) do
+    struct!(
+      %Facility{id: "test", long_name: "L", short_name: "S", stop: :unloaded, type: :elevator},
+      fields
+    )
+  end
+
   describe "fetch/2" do
     test "fetches and parses facilities" do
       get_json_fn = fn "facilities",
@@ -79,6 +86,21 @@ defmodule Screens.Facilities.FacilityTest do
       end
 
       assert Facility.fetch_by_id("954", get_json_fn) == {:ok, @expected}
+    end
+  end
+
+  describe "served_stop_ids/1" do
+    test "determines which child stop IDs the facility serves based on its excluded stop IDs" do
+      facility =
+        build(
+          excludes_stop_ids: ~w[2 3],
+          stop: %Stop{
+            location_type: 1,
+            child_stops: [%Stop{id: "1"}, %Stop{id: "2"}, %Stop{id: "3"}, %Stop{id: "4"}]
+          }
+        )
+
+      assert Facility.served_stop_ids(facility) == ~w[1 4]
     end
   end
 end

--- a/test/screens/route_patterns/route_pattern_test.exs
+++ b/test/screens/route_patterns/route_pattern_test.exs
@@ -9,7 +9,8 @@ defmodule Screens.RoutePatterns.RoutePatternTest do
   describe "fetch/2" do
     test "fetches and parses route patterns" do
       get_json_fn =
-        fn "route_patterns", %{"include" => "route.line,representative_trip.stops"} ->
+        fn "route_patterns",
+           %{"include" => "route.line,representative_trip.stops.parent_station"} ->
           {
             :ok,
             %{
@@ -210,7 +211,8 @@ defmodule Screens.RoutePatterns.RoutePatternTest do
 
     test "filters by route type or typicality" do
       get_json_fn =
-        fn "route_patterns", %{"include" => "route.line,representative_trip.stops"} ->
+        fn "route_patterns",
+           %{"include" => "route.line,representative_trip.stops.parent_station"} ->
           {
             :ok,
             %{

--- a/test/screens/v2/candidate_generator/elevator/closures_test.exs
+++ b/test/screens/v2/candidate_generator/elevator/closures_test.exs
@@ -183,12 +183,8 @@ defmodule Screens.V2.CandidateGenerator.Elevator.ClosuresTest do
     end
 
     test "groups multiple outside closures by station", %{now: now} do
-      expect(@route, :fetch, 2, fn
-        %{stop_id: "place-haecl"} ->
-          {:ok, [%Route{id: "Orange", type: :subway}]}
-
-        %{stop_id: "place-test"} ->
-          {:ok, [%Route{id: "Red", type: :subway}]}
+      expect(@route, :fetch, fn %{stop_id: "place-haecl"} ->
+        {:ok, [%Route{id: "Orange", type: :subway}]}
       end)
 
       expect(@alert, :fetch, fn @alert_opts ->


### PR DESCRIPTION
Reintroduces hand-authored exiting summaries for closed elevators with redundancy that requires travel outside their station (e.g. "Exit at Harvard, request shuttle bus back to Davis"). This involves determining whether a rider looking at a given elevator screen could encounter a given closed elevator, if they traveled to its station from where they are and attempted to exit that station.

For now, this does not take transfers into account: a custom exiting summary only appears when the closed elevator is on the same line as the elevator screen.

**Asana task**: https://app.asana.com/1/15492006741476/project/1185117109217413/task/1209537234084964

## Example

The below test screen is associated with elevator 804 at Park Street station. From here, the Heath Street platform at Prudential station is "downstream", so the custom exiting summary is displayed for a closure of elevator 920 which serves that platform.

<img src="https://github.com/user-attachments/assets/1f99bf28-5ddb-44e9-b469-b64ee2198216" width="400" />