### PR TITLE
ci: fix caches never being populated on main

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -12,7 +12,7 @@ runs:
     - uses: asdf-vm/actions/install@v3
       if: steps.asdf-cache.outputs.cache-hit != 'true'
     - uses: mbta/actions/reshim-asdf@v2
-
+      if: steps.asdf-cache.outputs.cache-hit == 'true'
     - name: Elixir tools
       if: steps.asdf-cache.outputs.cache-hit != 'true'
       shell: bash
@@ -26,7 +26,7 @@ runs:
         path: |
           _build
           deps
-        key: ex-deps-${{ hashFiles('**/mix.lock') }}
+        key: ex-deps-${{ hashFiles('.tool-versions', '**/mix.lock') }}
     - name: Elixir dependencies
       if: steps.ex-deps-cache.outputs.cache-hit != 'true'
       shell: bash
@@ -38,7 +38,7 @@ runs:
       id: js-deps-cache
       with:
         path: assets/node_modules
-        key: js-deps-${{ hashFiles('**/package-lock.json') }}
+        key: js-deps-${{ hashFiles('.tool-versions', '**/package-lock.json') }}
     - name: JS dependencies
       if: steps.js-deps-cache.outputs.cache-hit != 'true'
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: CI
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     paths-ignore:
       - docs/**


### PR DESCRIPTION
Because we only had CI running on `pull_request`, it was never actually running on the main branch, which is the only branch whose caches other branches are allowed to use. This resulted in builds on feature branches slowing down as the main cache became progressively less usable due to dependency changes.

Also includes a small improvement to the caching logic as a separate commit; see commit message.