### PR TITLE
fix: crash in elevator screen logic

### DIFF
--- a/lib/screens/v2/candidate_generator/elevator/closures.ex
+++ b/lib/screens/v2/candidate_generator/elevator/closures.ex
@@ -263,7 +263,7 @@ defmodule Screens.V2.CandidateGenerator.Elevator.Closures do
         %Stop{parent_station: %Stop{id: ^screen_station_id}}, :unseen ->
           @empty_set
 
-        %Stop{parent_station: %Stop{id: _other}}, :unseen ->
+        _other, :unseen ->
           :unseen
 
         %Stop{id: stop_id}, %MapSet{} = downstream_facility_ids ->


### PR DESCRIPTION
Due to a quirk of our data, shuttle bus stops that are considered child stops of the parent stations they "replace" are incorrectly implied to be served by elevators within the parent station. As a result, shuttle bus route patterns (which have some stops with no parent station) ended up in our "downstream" elevator closures logic (which assumed all stops would have a parent station).

We did not need to match on the full structure of the stop in this case, so it can be simplified.
