### PR TITLE
chore: clean up audio on CR Departures widget

### DIFF
--- a/lib/screens_web/views/v2/audio/cr_departures_view.ex
+++ b/lib/screens_web/views/v2/audio/cr_departures_view.ex
@@ -8,13 +8,16 @@ defmodule ScreensWeb.V2.Audio.CRDeparturesView do
 
   def render("_widget.ssml", %{
         departures: departures,
-        station: station,
-        header_pill: header_pill
+        header_pill: header_pill,
+        is_free: is_free,
+        station: station
       }) do
     ~E|
-    <p>Consider taking Commuter Rail during <%= render_route_pill(header_pill) %> delays:</p>
+    <%= if is_free do %>
+      <p>Free Commuter Rail during <%= render_route_pill(header_pill) %> disruption.</p>
+    <% end %>
+    <p>Upcoming Commuter Rail departures:</p>
     <%= render_departures(departures, station) %>
-    <p>Riders can take the Commuter Rail free of charge.</p>
     |
   end
 


### PR DESCRIPTION
The previous audio unconditionally referred to e.g. "Red Line delays" and claimed the Commuter Rail was "free of charge", even when neither of these were the case. This now correctly takes the `is_free` config field into account and changes the audio to align more closely with the visual presentation.

There are no existing tests for this view — due to the small scope of this change and CR Departures being a "legacy" widget we don't expect to change much before it is ultimately replaced, this change was manually tested using the admin inspector rather than the heavier lift of adding automated tests.

**Asana task**: https://app.asana.com/1/15492006741476/project/1185117109217413/task/1209294078164618