### PR TITLE
[chore] Add tabular-nums to departure time CSS classes

### DIFF
--- a/assets/css/v2/bus_eink/departures/time.scss
+++ b/assets/css/v2/bus_eink/departures/time.scss
@@ -19,6 +19,7 @@
   font-family: Inter;
   color: black;
   vertical-align: middle;
+  font-variant-numeric: tabular-nums;
 }
 
 .departure-time__text {

--- a/assets/css/v2/bus_eink/departures/time.scss
+++ b/assets/css/v2/bus_eink/departures/time.scss
@@ -17,9 +17,9 @@
 .departure-time {
   display: inline-block;
   font-family: Inter;
+  font-variant-numeric: tabular-nums;
   color: black;
   vertical-align: middle;
-  font-variant-numeric: tabular-nums;
 }
 
 .departure-time__text {

--- a/assets/css/v2/dup/departures/time.scss
+++ b/assets/css/v2/dup/departures/time.scss
@@ -8,7 +8,6 @@
   color: colors.$cool-black-15;
   text-align: right;
 
-
   &:not(:first-child) {
     margin-top: 32px;
   }

--- a/assets/css/v2/dup/departures/time.scss
+++ b/assets/css/v2/dup/departures/time.scss
@@ -3,9 +3,11 @@
 .departure-time {
   font-family: Inter, sans-serif;
   font-size: 138px;
+  font-variant-numeric: tabular-nums;
   line-height: 1em;
   color: colors.$cool-black-15;
   text-align: right;
+
 
   &:not(:first-child) {
     margin-top: 32px;

--- a/assets/css/v2/gl_eink/departures/time.scss
+++ b/assets/css/v2/gl_eink/departures/time.scss
@@ -18,6 +18,7 @@
 .departure-time {
   margin-right: 32px;
   font-family: Inter;
+  font-variant-numeric: tabular-nums;
   color: black;
   text-align: right;
 }

--- a/assets/css/v2/lcd_common/departures/time.scss
+++ b/assets/css/v2/lcd_common/departures/time.scss
@@ -37,6 +37,7 @@
 .departure-time {
   display: inline-block;
   font-family: Inter, sans-serif;
+  font-variant-numeric: tabular-nums;
   color: colors.$cool-black-15;
   vertical-align: middle;
 }

--- a/assets/css/v2/on_bus/time.scss
+++ b/assets/css/v2/on_bus/time.scss
@@ -3,6 +3,7 @@
   width: 100%;
   margin-top: 25.5px;
   font-size: 47px;
+  font-variant-numeric: tabular-nums;
   vertical-align: middle;
 }
 

--- a/assets/css/v2/pre_fare/departure_time.scss
+++ b/assets/css/v2/pre_fare/departure_time.scss
@@ -3,6 +3,7 @@
 
 .departure-time {
   display: inline-block;
+  font-variant-numeric: tabular-nums;
   color: colors.$cool-black-15;
   text-align: right;
   vertical-align: middle;


### PR DESCRIPTION
**Asana task**: [Use tabular figures for departures on screens](https://app.asana.com/1/15492006741476/project/1208877354406742/task/1206945324796523?focus=true)

<img width="620" alt="• Summer @ S Sta" src="https://github.com/user-attachments/assets/5de907d7-eed8-4989-85f8-5da7bd888c22" />
