### PR TITLE
fix: DUP departures no-data states

### DIFF
--- a/test/screens/v2/candidate_generator/dup/departures_test.exs
+++ b/test/screens/v2/candidate_generator/dup/departures_test.exs
@@ -1801,46 +1801,6 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
 
       assert Enum.all?(expected_departures, &Enum.member?(actual_instances, &1))
     end
-
-    test "returns empty departures list if sections have no departures", %{
-      config: config,
-      fetch_departures_fn: fetch_departures_fn,
-      fetch_alerts_fn: fetch_alerts_fn,
-      fetch_schedules_fn: fetch_schedules_fn,
-      fetch_routes_fn: fetch_routes_fn,
-      fetch_vehicles_fn: fetch_vehicles_fn
-    } do
-      config =
-        config
-        |> put_primary_departures([
-          %Section{
-            query: %Query{params: %Query.Params{stop_ids: ["place-E"], route_ids: []}}
-          }
-        ])
-        |> put_secondary_departures_sections([
-          %Section{query: %Query{params: %Query.Params{stop_ids: ["Boat"]}}},
-          %Section{
-            query: %Query{params: %Query.Params{stop_ids: ["place-A"], route_ids: ["Green"]}}
-          }
-        ])
-
-      now = ~U[2020-04-06T10:00:00Z]
-
-      expected_departures = []
-
-      actual_instances =
-        Dup.Departures.departures_instances(
-          config,
-          now,
-          fetch_departures_fn,
-          fetch_alerts_fn,
-          fetch_schedules_fn,
-          fetch_routes_fn,
-          fetch_vehicles_fn
-        )
-
-      assert Enum.all?(expected_departures, &Enum.member?(actual_instances, &1))
-    end
   end
 
   describe "overnight mode" do


### PR DESCRIPTION
* Fixes a gap in the logic where if a rotation's configured stops were served by at least one route, but no departures (or headways) were currently available, a "blank" departures widget would be displayed. This scenario now correctly generates a `NoDataSection`.

* Only consolidate rotations that consist entirely of `NoDataSection`s into a `DeparturesNoData` widget if this is true of *all* rotations. The presentation of `DeparturesNoData` is very generic and suggests something is wrong with our data or the screen's connection, when in reality we may have succeeded in fetching data and simply have no departures to show right now. `NoDataSection` at least has a route icon indicating which "mode" we don't have data for, so this is more informative when e.g. one rotation has subway departures and one has (an absence of) bus departures.

![Screen Shot 2025-04-28 at 17 43 12](https://github.com/user-attachments/assets/0e2c8e68-b42b-420d-8bdc-ab746dbe9aee)