### PR TITLE
feat: DUP secondary departures no-data fallback

### DIFF
--- a/lib/screens/alerts/alert.ex
+++ b/lib/screens/alerts/alert.ex
@@ -146,10 +146,13 @@ defmodule Screens.Alerts.Alert do
           stop_ids: [Stop.id()]
         ]
 
+  @type result :: {:ok, [t()]} | :error
+  @type fetch :: (options() -> result())
+
   @base_includes ~w[facilities]
   @all_includes ~w[facilities.stop.child_stops facilities.stop.parent_station.child_stops]
 
-  @callback fetch(options()) :: {:ok, list(t())} | :error
+  @callback fetch(options()) :: result()
   def fetch(opts \\ [], get_json_fn \\ &V3Api.get_json/2) do
     Screens.Telemetry.span([:screens, :alerts, :alert, :fetch], fn ->
       includes =

--- a/lib/screens/routes/route.ex
+++ b/lib/screens/routes/route.ex
@@ -47,7 +47,10 @@ defmodule Screens.Routes.Route do
     end
   end
 
-  @callback fetch() :: {:ok, [t()]} | :error
+  @type result :: {:ok, [t()]} | :error
+  @type fetch :: (params() -> result())
+
+  @callback fetch() :: result()
   @callback fetch(params()) :: {:ok, [t()]} | :error
   def fetch(opts \\ %{}, get_json_fn \\ &V3Api.get_json/2) do
     params =

--- a/lib/screens/schedules/schedule.ex
+++ b/lib/screens/schedules/schedule.ex
@@ -29,9 +29,13 @@ defmodule Screens.Schedules.Schedule do
 
   @includes ~w[route.line stop trip.route_pattern.representative_trip trip.stops]
 
-  @spec fetch(Departure.params()) :: {:ok, list(t())} | :error
-  @spec fetch(Departure.params(), DateTime.t() | Date.t() | String.t() | nil) ::
-          {:ok, list(t())} | :error
+  @type date_param :: DateTime.t() | Date.t() | String.t() | nil
+
+  @type result :: {:ok, [t()]} | :error
+  @type fetch_with_date :: (Departure.params(), date_param() -> result())
+
+  @spec fetch(Departure.params()) :: result()
+  @spec fetch(Departure.params(), date_param()) :: result()
   def fetch(%{} = params, date \\ nil) do
     params = if is_nil(date), do: params, else: Map.put(params, :date, date)
     result = Departure.do_fetch("schedules", Map.put(params, :include, @includes))

--- a/lib/screens/vehicles/vehicle.ex
+++ b/lib/screens/vehicles/vehicle.ex
@@ -1,6 +1,7 @@
 defmodule Screens.Vehicles.Vehicle do
   @moduledoc false
 
+  alias Screens.Routes.Route
   alias Screens.Trips.Trip
   alias Screens.V3Api.Parser
   alias Screens.Vehicles.Carriage
@@ -36,6 +37,9 @@ defmodule Screens.Vehicles.Vehicle do
           carriages: list(Carriage.t())
         }
 
+  @type by_route_and_direction :: (Route.id(), Trip.direction() -> [t()])
+
+  @spec by_route_and_direction(Route.id(), Trip.direction()) :: [t()]
   def by_route_and_direction(route_id, direction_id) do
     case Screens.V3Api.get_json("vehicles", %{
            "filter[route]" => route_id,


### PR DESCRIPTION
When no sections were configured for DUP secondary departures, the secondary rotation would be a copy of the primary departures. This extends that behavior to also occur when sections *are* configured but there are currently no departures to display. The primary use case is DUPs that display subway (primary) and bus (secondary) departures, where the relevant bus stops have no service on weekends.

Also restructure logic to reduce redundant data fetching, and add some typespecs.

**Asana task**: https://app.asana.com/1/15492006741476/project/1185117109217413/task/1210098606381697