### PR TITLE
feat: admin image manager improvements

### DIFF
--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -115,39 +115,10 @@
     margin-left: 8px;
   }
 
-  &__thumbnail-container {
-    display: flex;
-    flex-flow: row wrap;
-    margin-top: 16px;
-  }
-
   &__thumbnail {
-    box-sizing: border-box;
-    display: inline-flex;
-    width: 100px;
-    height: 100px;
-    padding: 4px;
-    margin-right: 8px;
+    max-width: 640px;
+    max-height: 480px;
     margin-bottom: 8px;
-    border: 1px solid #eaeaea;
-    border-radius: 2px;
-
-    & &--full-size {
-      width: unset;
-      height: unset;
-    }
-  }
-
-  &__thumbnail-inner {
-    display: flex;
-    min-width: 0;
-    overflow: hidden;
-  }
-
-  &__thumbnail-image {
-    display: block;
-    width: auto;
-    height: 100%;
   }
 
   &__dropzone {
@@ -177,6 +148,6 @@
   }
 
   &__preview-container {
-    margin-top: 8px;
+    padding: 8px;
   }
 }

--- a/assets/src/util/admin.tsx
+++ b/assets/src/util/admin.tsx
@@ -39,7 +39,13 @@ const fetch = {
     });
   },
 
-  delete: (path) => doFetch(path, { method: "DELETE" }),
+  delete: (path) =>
+    doFetch(path, {
+      method: "DELETE",
+      headers: {
+        "x-csrf-token": getCsrfToken(),
+      },
+    }),
 
   text: (path) => doFetch(path, {}, (response) => response.text()),
 

--- a/lib/screens/image.ex
+++ b/lib/screens/image.ex
@@ -4,79 +4,51 @@ defmodule Screens.Image do
   alias ExAws.S3
 
   @bucket "mbta-screens"
-  @s3_base_url "https://#{@bucket}.s3.amazonaws.com/"
+  @base_uri "https://#{@bucket}.s3.amazonaws.com/"
 
-  # Matches all non-delimiter characters located after the last delimiter.
-  # screens/images/psa/some-image_file-3.png
-  #                    ^^^^^^^^^^^^^^^^^^^^^
-  @image_filename_pattern ~r|([^/]*)$|
-
-  @typep s3_object :: %{
-           e_tag: String.t(),
-           key: String.t(),
-           last_modified: String.t(),
-           owner: %{display_name: String.t(), id: String.t()},
-           size: String.t(),
-           storage_class: String.t()
-         }
-
-  @spec fetch_image_filenames() :: list(String.t())
-  def fetch_image_filenames do
-    list_operation = S3.list_objects(@bucket, prefix: psa_images_prefix())
-
-    list_operation
+  @spec list() :: list(%{key: String.t(), url: String.t()})
+  def list do
+    @bucket
+    |> S3.list_objects_v2(prefix: images_prefix())
     |> ExAws.stream!()
-    |> Stream.reject(&directory?/1)
-    |> Stream.map(&get_image_filename/1)
+    |> Stream.map(& &1.key)
+    |> Stream.reject(&prefix?/1)
+    |> Stream.map(
+      &%{
+        key: String.replace(&1, images_prefix() <> "/", ""),
+        url: @base_uri |> URI.merge(&1) |> URI.to_string()
+      }
+    )
     |> Enum.to_list()
   end
 
-  @spec get_s3_url(String.t()) :: String.t()
-  def get_s3_url(filename), do: @s3_base_url <> get_s3_path(filename)
-
-  @spec upload_image(Plug.Upload.t()) :: {:ok, String.t()} | :error
-  def upload_image(%Plug.Upload{filename: filename, path: local_path, content_type: content_type}) do
-    filename = String.downcase(filename)
-    s3_path = get_s3_path(filename)
-
+  @spec upload(String.t(), Plug.Upload.t()) :: :ok | :error
+  def upload(key, %Plug.Upload{path: local_path, content_type: content_type}) do
     result =
       local_path
       |> S3.Upload.stream_file()
-      |> S3.upload(@bucket, s3_path, acl: :public_read, content_type: content_type)
+      |> S3.upload(@bucket, image_path(key), acl: :public_read, content_type: content_type)
       |> ExAws.request()
 
     case result do
-      {:ok, %{status_code: 200}} -> {:ok, filename}
+      {:ok, %{status_code: 200}} -> :ok
       _ -> :error
     end
   end
 
-  @spec delete_image(String.t()) :: :ok | :error
-  def delete_image(filename) do
-    s3_path = psa_images_prefix() <> filename
-    delete_operation = S3.delete_object(@bucket, s3_path)
-
-    case ExAws.request(delete_operation) do
+  @spec delete(String.t()) :: :ok | :error
+  def delete(key) do
+    case @bucket |> S3.delete_object(image_path(key)) |> ExAws.request() do
       {:ok, %{status_code: 204}} -> :ok
       _ -> :error
     end
   end
 
-  @spec get_image_filename(s3_object) :: String.t()
-  defp get_image_filename(obj) do
-    @image_filename_pattern
-    |> Regex.run(obj.key, capture: :all_but_first)
-    |> hd()
+  defp images_prefix do
+    Path.join(Application.get_env(:screens, :environment_name, "screens-dev"), "images")
   end
 
-  @spec directory?(s3_object) :: boolean()
-  defp directory?(obj) do
-    String.ends_with?(obj.key, "/")
-  end
+  defp image_path(key), do: Path.join(images_prefix(), key)
 
-  defp psa_images_prefix do
-    Application.get_env(:screens, :environment_name, "screens-dev") <> "/images/psa/"
-  end
-
-  defp get_s3_path(filename), do: psa_images_prefix() <> filename
+  defp prefix?(key), do: String.ends_with?(key, "/")
 end

--- a/lib/screens/util/assets.ex
+++ b/lib/screens/util/assets.ex
@@ -2,7 +2,7 @@ defmodule Screens.Util.Assets do
   @moduledoc false
 
   def s3_asset_url(asset_path) do
-    env = Application.get_env(:screens, :environment_name, "screens-prod")
+    env = Application.get_env(:screens, :environment_name, "screens-dev")
     "https://mbta-screens.s3.amazonaws.com/#{env}/#{asset_path}"
   end
 end

--- a/lib/screens_web/controllers/admin_api_controller.ex
+++ b/lib/screens_web/controllers/admin_api_controller.ex
@@ -89,24 +89,23 @@ defmodule ScreensWeb.AdminApiController do
     json(conn, %{success: success})
   end
 
-  def image_filenames(conn, _params) do
-    image_filenames = Image.fetch_image_filenames()
-    json(conn, %{image_filenames: image_filenames})
+  def list_images(conn, _params) do
+    json(conn, %{images: Image.list()})
   end
 
-  def upload_image(conn, %{"image" => %Plug.Upload{} = upload_struct}) do
+  def upload_image(conn, %{"image" => %Plug.Upload{} = upload, "key" => key}) do
     response =
-      case Image.upload_image(upload_struct) do
-        {:ok, uploaded_name} -> %{success: true, uploaded_name: uploaded_name}
+      case Image.upload(key, upload) do
+        :ok -> %{success: true}
         :error -> %{success: false}
       end
 
     json(conn, response)
   end
 
-  def delete_image(conn, %{"filename" => filename}) do
+  def delete_image(conn, %{"key" => key}) do
     response =
-      case Image.delete_image(filename) do
+      case Image.delete(key) do
         :ok -> %{success: true}
         :error -> %{success: false}
       end

--- a/lib/screens_web/controllers/screen_controller.ex
+++ b/lib/screens_web/controllers/screen_controller.ex
@@ -1,7 +1,0 @@
-defmodule ScreensWeb.ScreenController do
-  use ScreensWeb, :controller
-
-  def show_image(conn, %{"filename" => filename}) do
-    redirect(conn, external: Screens.Image.get_s3_url(filename))
-  end
-end

--- a/lib/screens_web/router.ex
+++ b/lib/screens_web/router.ex
@@ -73,9 +73,9 @@ defmodule ScreensWeb.Router do
     post "/screens/confirm/:id", AdminApiController, :confirm
     post "/refresh", AdminApiController, :refresh
     post "/devops", AdminApiController, :devops
-    get "/image_filenames", AdminApiController, :image_filenames
-    post "/image", AdminApiController, :upload_image
-    delete "/image/:filename", AdminApiController, :delete_image
+    get "/images", AdminApiController, :list_images
+    post "/images", AdminApiController, :upload_image
+    delete "/images/:key", AdminApiController, :delete_image
   end
 
   scope "/v2", ScreensWeb.V2 do
@@ -121,12 +121,6 @@ defmodule ScreensWeb.Router do
       get "/:id/volume", AudioController, :show_volume
       get "/:id/debug", AudioController, :debug
     end
-  end
-
-  scope "/image", ScreensWeb do
-    pipe_through [:redirect_prod_http, :browser]
-
-    get "/:filename", ScreenController, :show_image
   end
 
   scope "/api", ScreensWeb do


### PR DESCRIPTION
A recent motivation for [making files in the assets bucket public by default](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1209486399971517) was that we often forgot to add the `public-read` ACL when manually uploading line map images. However, the admin UI already includes a file manager that allows uploading images to S3 and sets the correct ACL automatically; it's just limited to a specific prefix. This PR is a quick diversion into the idea of removing that limitation, and sprucing up the experience a bit while we're here.

👉 [Try it out on dev-green!](https://screens-dev-green.mbtace.com/admin/image-manager)

* The Image Manager can now manage all objects under the environment's `images/` prefix, rather than only in `images/psa/`. When uploading an image, admins can enter the prefix to use within `images/` (and the filename, removing the limitation that the uploaded name had to be the same as the local one).

* Uploading and deleting images no longer forces a full page reload, only a refresh of the image list. Uploading an image also selects the just-uploaded image, confirming its presence.

* The prefix of an upload defaults to the prefix of whichever file is selected for preview. This allows easily uploading images to an existing prefix without having to type it in, and combined with the above behavior, uploading multiple images to the same prefix without typing/selecting it each time.

* Limit the dimensions of the preview for the selected image to reasonable values. Provide a link to view the image at full size.

* Add a button to copy the path of the selected image to the clipboard, suitable for pasting directly into screen configuration.

* Fix an issue where deleting images was not possible due to a missing CSRF token.

* Remove an unneeded S3 "pass-through" route that was only used by the Image Manager. Instead, send the full URLs of images to the client along with their keys.