### PR TITLE
feat: Include subtitle in departures header audio readout

### DIFF
--- a/lib/screens/v2/widget_instance/departures.ex
+++ b/lib/screens/v2/widget_instance/departures.ex
@@ -232,9 +232,17 @@ defmodule Screens.V2.WidgetInstance.Departures do
       ) do
     header =
       case header do
-        %{read_as: header} when is_binary(header) -> header
-        %{title: header} when is_binary(header) -> header
-        _ -> nil
+        %{read_as: header} when is_binary(header) ->
+          header
+
+        %{title: title, subtitle: subtitle} when is_binary(title) and is_binary(subtitle) ->
+          "#{title}. #{String.replace(subtitle, "*", "")}"
+
+        %{title: header} when is_binary(header) ->
+          header
+
+        _ ->
+          nil
       end
 
     serialized_departure_groups =

--- a/test/screens/v2/widget_instance/departures_test.exs
+++ b/test/screens/v2/widget_instance/departures_test.exs
@@ -1051,7 +1051,7 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
     test "can serialize a :normal_section" do
       section = %NormalSection{
         rows: [],
-        header: %Header{title: "Section Header"}
+        header: %Header{title: "Section Header", subtitle: nil}
       }
 
       screen = struct(Screen, %{app_id: :gl_eink_v2})
@@ -1068,7 +1068,11 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
     test "uses the `read_as` header property if available" do
       section = %NormalSection{
         rows: [],
-        header: %Header{title: "Section Header", read_as: "A special audio-only value"}
+        header: %Header{
+          title: "Section Header",
+          read_as: "A special audio-only value",
+          subtitle: "Section Subtitle"
+        }
       }
 
       screen = struct(Screen, %{app_id: :gl_eink_v2})
@@ -1079,6 +1083,28 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
                type: :normal_section,
                departure_groups: [],
                header: "A special audio-only value"
+             } =
+               Departures.audio_serialize_section(
+                 section,
+                 screen,
+                 now
+               )
+    end
+
+    test "includes the `subtitle` header property if available, filtering out markdown" do
+      section = %NormalSection{
+        rows: [],
+        header: %Header{title: "Section Header", subtitle: "Section **Subtitle**"}
+      }
+
+      screen = struct(Screen, %{app_id: :gl_eink_v2})
+
+      now = ~U[2020-01-01T00:00:00Z]
+
+      assert %{
+               type: :normal_section,
+               departure_groups: [],
+               header: "Section Header. Section Subtitle"
              } =
                Departures.audio_serialize_section(
                  section,


### PR DESCRIPTION
**Asana task**: [Wayfinding sub-headers in departures sections](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1209972434938244?focus=true)

- Adds the subheader to the departures widget audio readout value when present

- [X] Tests added?
