### PR TITLE
fix: `bidirectional` crash with no departures

### DIFF
--- a/lib/screens/v2/candidate_generator/widgets/departures.ex
+++ b/lib/screens/v2/candidate_generator/widgets/departures.ex
@@ -262,6 +262,8 @@ defmodule Screens.V2.CandidateGenerator.Widgets.Departures do
 
   # "Bidirectional" mode: take only the first departure, and the next departure in the opposite
   # direction from the first, if one exists.
+  defp make_bidirectional([]), do: []
+
   defp make_bidirectional([first | rest]) do
     first_direction = Departure.direction_id(first)
 


### PR DESCRIPTION
Previously, *whether* to perform the `bidirectional` logic was also handled by this function's pattern-matching, in a way that also covered the empty list:

```
defp make_bidirectional([first | rest], true), do: # ...
defp make_bidirectional(departures, _enabled), do: departures
```

In c18c8bf this condition was moved elsewhere and the second argument removed, leaving the only pattern for departures to match as `[first | rest]`, which crashes when there are no departures.
