### PR TITLE
bugfix: Add nil stop_id check into DUP alerts fetcher

### DIFF
--- a/lib/screens/v2/candidate_generator/dup/alerts.ex
+++ b/lib/screens/v2/candidate_generator/dup/alerts.ex
@@ -35,27 +35,31 @@ defmodule Screens.V2.CandidateGenerator.Dup.Alerts do
     %Screen{app_params: %Dup{alerts: %AlertsConfig{stop_id: stop_id}, header: header_config}} =
       config
 
-    stop_name =
-      case header_config do
-        %{stop_id: stop_id} ->
-          case fetch_stop_name_fn.(stop_id) do
-            nil -> []
-            stop_name -> stop_name
-          end
-
-        %{stop_name: stop_name} ->
-          stop_name
-      end
-
-    with {:ok, location_context} <- fetch_location_context_fn.(Dup, stop_id, now),
-         route_ids <- Route.route_ids(location_context.routes),
-         {:ok, alerts} <- fetch_alerts_fn.(route_ids: route_ids) do
-      alerts
-      |> relevant_alerts(config, location_context, now)
-      |> alert_special_cases(config)
-      |> create_alert_widgets(config, location_context, stop_name)
+    if is_nil(stop_id) do
+      []
     else
-      :error -> []
+      stop_name =
+        case header_config do
+          %{stop_id: stop_id} ->
+            case fetch_stop_name_fn.(stop_id) do
+              nil -> []
+              stop_name -> stop_name
+            end
+
+          %{stop_name: stop_name} ->
+            stop_name
+        end
+
+      with {:ok, location_context} <- fetch_location_context_fn.(Dup, stop_id, now),
+           route_ids <- Route.route_ids(location_context.routes),
+           {:ok, alerts} <- fetch_alerts_fn.(route_ids: route_ids) do
+        alerts
+        |> relevant_alerts(config, location_context, now)
+        |> alert_special_cases(config)
+        |> create_alert_widgets(config, location_context, stop_name)
+      else
+        :error -> []
+      end
     end
   end
 


### PR DESCRIPTION
**Asana task**: [Investigate Sentry report volume](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1210072157534313?focus=true)

When the `stop_id` for Alerts is set to nil, the `LocationContext.fetch` call throws an error. We want to return an empty list from the `Alerts` fetcher before that method is ever called. 

Notes on implementation:
- This nil stop_id case is only relevant for the DUPs alert fetcher at present. 
- I included in the function instead of breaking out into a separate pattern matched function header b/c that ended up being cleaner and more concise with the default values being set.