### PR TITLE
fix: use correct URL for elevator status audio

### DIFF
--- a/lib/screens_web/views/v2/audio/elevator_status_view.ex
+++ b/lib/screens_web/views/v2/audio/elevator_status_view.ex
@@ -25,7 +25,7 @@ defmodule ScreensWeb.V2.Audio.ElevatorStatusView do
   end
 
   defp render_cta do
-    ~E|For a full list of elevator alerts, and directions to <w role="amazon:JJ">alternate</w> accessible paths, visit MBTA dot com slash: alerts: slash: access, or call <say-as interpret-as="telephone">617-222-2828</say-as>.|
+    ~E|For a full list of elevator alerts, and directions to <w role="amazon:JJ">alternate</w> accessible paths, visit MBTA dot com slash: elevators, or call <say-as interpret-as="telephone">617-222-2828</say-as>.|
   end
 
   defp render_active_at_home(pages) do


### PR DESCRIPTION
In 7f1b1445 we replaced existing instances of `mbta.com/alerts/access` with the preferred URL `mbta.com/elevators`, but missed this one.