### PR TITLE
Modify Subway Status logic to match website widget

### DIFF
--- a/lib/screens/v2/candidate_generator/widgets/subway_status.ex
+++ b/lib/screens/v2/candidate_generator/widgets/subway_status.ex
@@ -29,6 +29,8 @@ defmodule Screens.V2.CandidateGenerator.Widgets.SubwayStatus do
   # Omit up to 10 minute delays.
   defp relevant_effect?(%Alert{effect: :delay, severity: severity}), do: severity >= 3
 
+  defp relevant_effect?(%Alert{effect: :service_change, severity: severity}), do: severity >= 3
+
   defp relevant_effect?(%Alert{effect: effect}),
     do: effect in [:suspension, :shuttle, :station_closure]
 

--- a/lib/screens/v2/widget_instance/subway_status.ex
+++ b/lib/screens/v2/widget_instance/subway_status.ex
@@ -471,6 +471,19 @@ defmodule Screens.V2.WidgetInstance.SubwayStatus do
     }
   end
 
+  defp serialize_alert(
+         %{
+           alert: %Alert{
+             effect: :service_change,
+             informed_entities: informed_entities
+           }
+         },
+         route_id
+       ) do
+    location = get_location(informed_entities, route_id)
+    %{status: "Service Change", location: location}
+  end
+
   @spec serialize_green_line_branch_alert(%{alert: Alert.t(), context: %{}}, list(String.t())) ::
           alert()
   defp serialize_green_line_branch_alert(alert, route_ids)

--- a/test/screens/v2/widget_instance/subway_status_test.exs
+++ b/test/screens/v2/widget_instance/subway_status_test.exs
@@ -1402,6 +1402,68 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
       assert expected == WidgetInstance.serialize(instance)
     end
 
+    test "handles 1 service change alert" do
+      instance = %SubwayStatus{
+        subway_alerts: [
+          %{
+            alert: %Alert{
+              effect: :service_change,
+              informed_entities: [
+                %{route: "Red", stop: "place-portr", route_type: 1},
+                %{route: "Red", stop: "70065", route_type: 1}
+              ]
+            },
+            context: %{
+              all_platforms_at_informed_station: [
+                %{id: "70065", platform_name: "Ashmont/Braintree"},
+                %{id: "70066", platform_name: "Alewife"}
+              ]
+            }
+          }
+        ]
+      }
+
+      expected = %{
+        blue: %{
+          type: :contracted,
+          alerts: [
+            %{
+              route_pill: %{type: :text, text: "BL", color: :blue},
+              status: "Normal Service"
+            }
+          ]
+        },
+        orange: %{
+          type: :contracted,
+          alerts: [
+            %{
+              route_pill: %{type: :text, text: "OL", color: :orange},
+              status: "Normal Service"
+            }
+          ]
+        },
+        red: %{
+          type: :extended,
+          alert: %{
+            status: "Service Change",
+            location: %{full: "Porter", abbrev: "Porter"},
+            route_pill: %{type: :text, text: "RL", color: :red}
+          }
+        },
+        green: %{
+          type: :contracted,
+          alerts: [
+            %{
+              route_pill: %{type: :text, text: "GL", color: :green},
+              status: "Normal Service"
+            }
+          ]
+        }
+      }
+
+      assert expected == WidgetInstance.serialize(instance)
+    end
+
     test "handles alert closing multiple platforms at one station" do
       instance = %SubwayStatus{
         subway_alerts: [


### PR DESCRIPTION
**Asana task**: [Modify Subway Status logic to match website widget](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1209950740101100?focus=true)

Description
- match the website subway status by allowing service_change alerts with severity > 3 to appear on the widget
- there will be a separate PR coming up shortly for switching mbta.com/alerts to mbta.com/status

- [x] Tests added?

<img width="488" alt="Screenshot 2025-05-13 at 8 40 18 AM" src="https://github.com/user-attachments/assets/9e47528e-fcba-4b90-9399-a5a50b6e93d4" />
