### PR TITLE
Changed mbta.com/alerts to mbta.com/status for SubwayStatus widgets

### DIFF
--- a/assets/src/components/v2/subway_status/eink_subway_status.tsx
+++ b/assets/src/components/v2/subway_status/eink_subway_status.tsx
@@ -97,7 +97,7 @@ interface AlertRowProps extends Alert {
   showInlineBranches: boolean;
 }
 
-const ALERTS_URL = "mbta.com/alerts";
+const STATUS_URL = "mbta.com/status";
 const ALERT_FITTING_STEPS = [
   FittingStep.PerAlertEffect,
   FittingStep.Abbrev,
@@ -119,7 +119,7 @@ const AlertRow: ComponentType<AlertRowProps> = ({
 
   let locationText: string | null;
   if (replaceLocationWithUrl) {
-    locationText = ALERTS_URL;
+    locationText = STATUS_URL;
   } else if (isAlertLocationMap(location)) {
     locationText = abbrev ? location.abbrev : location.full;
   } else {

--- a/assets/src/components/v2/subway_status/lcd_subway_status.tsx
+++ b/assets/src/components/v2/subway_status/lcd_subway_status.tsx
@@ -115,7 +115,7 @@ const CONTRACTED_ALERT_FITTING_STEPS = [
 ];
 const EXTENDED_ALERT_FITTING_STEPS = [FittingStep.Abbrev, FittingStep.FullSize];
 
-const ALERTS_URL = "mbta.com/alerts";
+const STATUS_URL = "mbta.com/status";
 
 const ContractedAlert: ComponentType<AlertWithID> = ({
   route_pill: routePill,
@@ -134,7 +134,7 @@ const ContractedAlert: ComponentType<AlertWithID> = ({
 
   let locationText: string | null;
   if (replaceLocationWithUrl) {
-    locationText = ALERTS_URL;
+    locationText = STATUS_URL;
   } else if (isAlertLocationMap(location)) {
     locationText = abbrev ? location.abbrev : location.full;
   } else {

--- a/lib/screens/v2/widget_instance/subway_status.ex
+++ b/lib/screens/v2/widget_instance/subway_status.ex
@@ -86,6 +86,8 @@ defmodule Screens.V2.WidgetInstance.SubwayStatus do
 
   @green_line_branches ["Green-B", "Green-C", "Green-D", "Green-E"]
 
+  @mbta_status_url "mbta.com/status"
+
   defimpl Screens.V2.WidgetInstance do
     alias ScreensConfig.Audio
     alias ScreensConfig.Screen.BusShelter
@@ -426,7 +428,7 @@ defmodule Screens.V2.WidgetInstance.SubwayStatus do
                                 other {# stops}}",
             num_informed_platforms: length(informed_platforms)
           ),
-        location: %{full: "mbta.com/alerts", abbrev: "mbta.com/alerts"}
+        location: %{full: @mbta_status_url, abbrev: @mbta_status_url}
       }
     else
       # Get closed station names from informed entities
@@ -646,7 +648,7 @@ defmodule Screens.V2.WidgetInstance.SubwayStatus do
     %{
       route_pill: route_pill,
       status: "#{alert_count} current alerts",
-      location: "mbta.com/alerts"
+      location: @mbta_status_url
     }
   end
 
@@ -769,7 +771,7 @@ defmodule Screens.V2.WidgetInstance.SubwayStatus do
 
       stop_names ->
         {"Bypassing #{length(stop_names)} stops",
-         %{full: "mbta.com/alerts", abbrev: "mbta.com/alerts"}}
+         %{full: @mbta_status_url, abbrev: @mbta_status_url}}
     end
   end
 

--- a/lib/screens_web/views/v2/audio/subway_status_view.ex
+++ b/lib/screens_web/views/v2/audio/subway_status_view.ex
@@ -229,8 +229,8 @@ defmodule ScreensWeb.V2.Audio.SubwayStatusView do
   defp get_location_string(nil), do: ""
 
   # We never read out the alerts URL.
-  defp get_location_string(%{full: "mbta.com/alerts"}), do: ""
-  defp get_location_string("mbta.com/alerts"), do: ""
+  defp get_location_string(%{full: "mbta.com" <> _}), do: ""
+  defp get_location_string("mbta.com" <> _), do: ""
 
   defp get_location_string(%{full: full}), do: full
   defp get_location_string(location_string), do: location_string

--- a/test/screens/v2/widget_instance/subway_status_test.exs
+++ b/test/screens/v2/widget_instance/subway_status_test.exs
@@ -88,8 +88,8 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
             route_pill: %{type: :text, text: "BL", color: :blue},
             status: "Bypassing 4 stops",
             location: %{
-              abbrev: "mbta.com/alerts",
-              full: "mbta.com/alerts"
+              abbrev: "mbta.com/status",
+              full: "mbta.com/status"
             },
             station_count: 4
           }
@@ -424,7 +424,7 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
             %{
               route_pill: %{type: :text, text: "BL", color: :blue},
               status: "2 current alerts",
-              location: "mbta.com/alerts"
+              location: "mbta.com/status"
             }
           ]
         },
@@ -434,7 +434,7 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
             %{
               route_pill: %{type: :text, text: "OL", color: :orange},
               status: "2 current alerts",
-              location: "mbta.com/alerts"
+              location: "mbta.com/status"
             }
           ]
         },
@@ -688,7 +688,7 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
             %{
               route_pill: %{type: :text, text: "GL", color: :green, branches: [:b, :c]},
               status: "2 current alerts",
-              location: "mbta.com/alerts"
+              location: "mbta.com/status"
             }
           ]
         }
@@ -903,7 +903,7 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
             %{
               route_pill: %{type: :text, text: "GL", color: :green, branches: [:b, :c, :e]},
               status: "3 current alerts",
-              location: "mbta.com/alerts"
+              location: "mbta.com/status"
             }
           ]
         }
@@ -1053,7 +1053,7 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
             %{
               route_pill: %{type: :text, text: "GL", color: :green},
               status: "3 current alerts",
-              location: "mbta.com/alerts"
+              location: "mbta.com/status"
             }
           ]
         }
@@ -1112,7 +1112,7 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
             %{
               route_pill: %{type: :text, text: "OL", color: :orange},
               status: "2 current alerts",
-              location: "mbta.com/alerts"
+              location: "mbta.com/status"
             }
           ]
         },
@@ -1384,7 +1384,7 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
           type: :extended,
           alert: %{
             status: "Bypassing 1 stop",
-            location: %{full: "mbta.com/alerts", abbrev: "mbta.com/alerts"},
+            location: %{full: "mbta.com/status", abbrev: "mbta.com/status"},
             route_pill: %{type: :text, text: "RL", color: :red}
           }
         },
@@ -1449,7 +1449,7 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
           type: :extended,
           alert: %{
             status: "Bypassing 2 stops",
-            location: %{full: "mbta.com/alerts", abbrev: "mbta.com/alerts"},
+            location: %{full: "mbta.com/status", abbrev: "mbta.com/status"},
             route_pill: %{type: :text, text: "RL", color: :red}
           }
         },


### PR DESCRIPTION
**Asana task**: [Modify Subway Status logic to match website widget](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1209950740101100?focus=true)

Description
Changed mbta.com/alerts to mbta.com/status for SubwayStatus widgets
Let me know if I missed any places, I know there a few places where we might concat the actual URL but I couldn't 100% find them.

- [X] Tests modified