### PR TITLE
fix: Pre-Fare audio consistency with takeovers

### DIFF
--- a/lib/screens/v2/candidate_generator/pre_fare.ex
+++ b/lib/screens/v2/candidate_generator/pre_fare.ex
@@ -6,6 +6,7 @@ defmodule Screens.V2.CandidateGenerator.PreFare do
   alias Screens.V2.CandidateGenerator
   alias Screens.V2.CandidateGenerator.Widgets
   alias Screens.V2.Template.Builder
+  alias Screens.V2.WidgetInstance
   alias Screens.V2.WidgetInstance.AudioOnly.{AlertsIntro, AlertsOutro, ContentSummary}
   alias Screens.V2.WidgetInstance.NormalHeader
   alias Screens.V2.WidgetInstance.ShuttleBusInfo, as: ShuttleBusInfoWidget
@@ -97,25 +98,23 @@ defmodule Screens.V2.CandidateGenerator.PreFare do
   end
 
   @impl CandidateGenerator
-  def audio_only_instances(
-        widgets,
-        config,
-        routes_fetch_fn \\ &Route.fetch/1
-      ) do
-    [
-      fn -> content_summary_instances(widgets, config, routes_fetch_fn) end,
-      fn -> alerts_intro_instances(widgets, config) end,
-      fn -> alerts_outro_instances(widgets, config) end
-    ]
+  def audio_only_instances(widgets, config, routes_fetch_fn \\ &Route.fetch/1) do
+    # If there is any kind of full-screen takeover or evergreen content configured for a full-body
+    # takeover slot, certain audio widgets may not be applicable or would give inaccurate info.
+    non_takeover_instance_fns =
+      if has_takeover?(widgets),
+        do: [],
+        else: [
+          fn -> content_summary_instances(widgets, config, routes_fetch_fn) end,
+          fn -> alerts_intro_instances(widgets, config) end
+        ]
+
+    (non_takeover_instance_fns ++ [fn -> alerts_outro_instances(widgets, config) end])
     |> Task.async_stream(& &1.(), timeout: 20_000)
     |> Enum.flat_map(fn {:ok, instances} -> instances end)
   end
 
-  def header_instances(
-        config,
-        now,
-        fetch_stop_name_fn \\ &Stop.fetch_stop_name/1
-      ) do
+  def header_instances(config, now, fetch_stop_name_fn \\ &Stop.fetch_stop_name/1) do
     %Screen{app_params: %PreFare{header: %CurrentStopId{stop_id: stop_id}}} = config
 
     stop_name = fetch_stop_name_fn.(stop_id)
@@ -123,27 +122,25 @@ defmodule Screens.V2.CandidateGenerator.PreFare do
     [%NormalHeader{screen: config, text: stop_name, time: now}]
   end
 
-  def shuttle_bus_info_instances(
-        %Screen{
-          app_params: %PreFare{
-            shuttle_bus_info: %ShuttleBusInfo{
-              enabled: false
-            }
-          }
-        },
-        _now
-      ) do
+  defp shuttle_bus_info_instances(
+         %Screen{
+           app_params: %PreFare{
+             shuttle_bus_info: %ShuttleBusInfo{
+               enabled: false
+             }
+           }
+         },
+         _now
+       ) do
     []
   end
 
-  def shuttle_bus_info_instances(config, now) do
+  defp shuttle_bus_info_instances(config, now) do
     [%ShuttleBusInfoWidget{screen: config, now: now}]
   end
 
   defp content_summary_instances(widgets, config, routes_fetch_fn) do
-    %{stop_id: config.app_params.content_summary.parent_station_id}
-    |> routes_fetch_fn.()
-    |> case do
+    case routes_fetch_fn.(%{stop_id: config.app_params.content_summary.parent_station_id}) do
       {:ok, routes_at_station} ->
         subway_lines_at_station =
           routes_at_station
@@ -158,16 +155,17 @@ defmodule Screens.V2.CandidateGenerator.PreFare do
           |> Enum.reject(&is_nil/1)
           |> Enum.uniq()
 
-        %ContentSummary{
-          screen: config,
-          widgets_snapshot: widgets,
-          lines_at_station: subway_lines_at_station
-        }
+        [
+          %ContentSummary{
+            screen: config,
+            widgets_snapshot: widgets,
+            lines_at_station: subway_lines_at_station
+          }
+        ]
 
       :error ->
-        nil
+        []
     end
-    |> List.wrap()
   end
 
   defp alerts_intro_instances(widgets, config) do
@@ -176,5 +174,20 @@ defmodule Screens.V2.CandidateGenerator.PreFare do
 
   defp alerts_outro_instances(widgets, config) do
     [%AlertsOutro{screen: config, widgets_snapshot: widgets}]
+  end
+
+  @takeover_slots MapSet.new(~w[
+      full_body_duo
+      full_body_left
+      full_body_right
+      full_duo_screen
+      full_left_screen
+      full_right_screen
+    ]a)
+
+  defp has_takeover?(widgets) do
+    widgets
+    |> Enum.flat_map(&WidgetInstance.slot_names/1)
+    |> Enum.any?(&(&1 in @takeover_slots))
   end
 end

--- a/lib/screens/v2/widget_instance/audio_only/alerts_intro.ex
+++ b/lib/screens/v2/widget_instance/audio_only/alerts_intro.ex
@@ -54,32 +54,14 @@ defmodule Screens.V2.WidgetInstance.AudioOnly.AlertsIntro do
     end
   end
 
-  def audio_valid_candidate?(t, slot_names_fn \\ &WidgetInstance.slot_names/1)
-
-  def audio_valid_candidate?(
-        %__MODULE__{screen: %Screen{app_id: :pre_fare_v2}} = t,
-        slot_names_fn
-      ) do
-    # On pre-fare screens, we only include this widget when
-    # there's no takeover content and at least one service alert widget in the readout queue.
-    takeover_slots = MapSet.new(~w[full_body_left full_body_right full_body full_screen]a)
-
-    no_takeover_content? =
-      Enum.all?(t.widgets_snapshot, fn widget ->
-        widget
-        |> slot_names_fn.()
-        |> MapSet.new()
-        |> MapSet.disjoint?(takeover_slots)
-      end)
-
-    at_least_one_service_alert_widget? = Enum.any?(t.widgets_snapshot, &service_alert_widget?/1)
-
-    no_takeover_content? and at_least_one_service_alert_widget?
+  def audio_valid_candidate?(%__MODULE__{
+        screen: %Screen{app_id: :pre_fare_v2},
+        widgets_snapshot: widgets
+      }) do
+    Enum.any?(widgets, &service_alert_widget?/1)
   end
 
-  def audio_valid_candidate?(_t, _slot_names_fn) do
-    false
-  end
+  def audio_valid_candidate?(_t), do: false
 
   def audio_view(_instance), do: ScreensWeb.V2.Audio.AlertsIntroView
 

--- a/lib/screens/v2/widget_instance/audio_only/content_summary.ex
+++ b/lib/screens/v2/widget_instance/audio_only/content_summary.ex
@@ -58,36 +58,15 @@ defmodule Screens.V2.WidgetInstance.AudioOnly.ContentSummary do
     end
   end
 
-  @pre_fare_takeover_slots MapSet.new(~w[
-      full_body_duo
-      full_body_left
-      full_body_right
-      full_duo_screen
-      full_left_screen
-      full_right_screen
-    ]a)
-
-  def audio_valid_candidate?(
-        %__MODULE__{
-          screen: %Screen{
-            app_id: :pre_fare_v2,
-            app_params: %PreFare{header: %CurrentStopId{stop_id: stop_id}}
-          },
-          widgets_snapshot: widgets
-        } = t
-      ) do
+  def audio_valid_candidate?(%__MODULE__{
+        screen: %Screen{
+          app_id: :pre_fare_v2,
+          app_params: %PreFare{header: %CurrentStopId{stop_id: stop_id}}
+        },
+        widgets_snapshot: widgets
+      }) do
     # Need to skip this readout for Wellington during the OL Surge
-    if has_surge_widgets?(widgets) and stop_id in ["place-welln"] do
-      false
-    else
-      # On pre-fare screens, we only include a content summary when there's no takeover content.
-      Enum.all?(t.widgets_snapshot, fn widget ->
-        widget
-        |> WidgetInstance.slot_names()
-        |> MapSet.new()
-        |> MapSet.disjoint?(@pre_fare_takeover_slots)
-      end)
-    end
+    not (has_surge_widgets?(widgets) and stop_id in ["place-welln"])
   end
 
   def audio_valid_candidate?(_t) do

--- a/test/screens/v2/widget_instance/audio_only/alerts_intro_test.exs
+++ b/test/screens/v2/widget_instance/audio_only/alerts_intro_test.exs
@@ -20,12 +20,6 @@ defmodule Screens.V2.WidgetInstance.AudioOnly.AlertsIntroTest do
       audio_valid_candidate?: true
     }
 
-    takeover_widget = %MockWidget{
-      slot_names: [:full_body],
-      audio_sort_key: [0],
-      audio_valid_candidate?: true
-    }
-
     audio_sort_key_fn = fn
       %MockWidget{} = mock_widget -> WidgetInstance.audio_sort_key(mock_widget)
       %SubwayStatus{} -> [1]
@@ -53,11 +47,6 @@ defmodule Screens.V2.WidgetInstance.AudioOnly.AlertsIntroTest do
       widgets_snapshot: [subway_status, alert]
     }
 
-    instance_with_takeover_content = %AlertsIntro{
-      screen: nil,
-      widgets_snapshot: [takeover_widget, subway_status, alert, other_widget]
-    }
-
     %{
       pre_fare_config: pre_fare_config,
       other_config: other_config,
@@ -65,8 +54,7 @@ defmodule Screens.V2.WidgetInstance.AudioOnly.AlertsIntroTest do
       slot_names_fn: slot_names_fn,
       instance_without_service_alert_widgets: instance_without_service_alert_widgets,
       instance_with_subway_status_and_alerts: instance_with_subway_status_and_alerts,
-      instance_with_alert_at_start: instance_with_alert_at_start,
-      instance_with_takeover_content: instance_with_takeover_content
+      instance_with_alert_at_start: instance_with_alert_at_start
     }
   end
 
@@ -119,51 +107,25 @@ defmodule Screens.V2.WidgetInstance.AudioOnly.AlertsIntroTest do
   end
 
   describe "audio_valid_candidate?/1" do
-    # NOTE: need to call `AlertsIntro.audio_valid_candidate?/2` in order to inject a stubbed function
-    # for testing purposes. This is otherwise equivalent to `WidgetInstance.audio_valid_candidate?/1`.
-
-    test "for pre-fare, returns true if there's at least one service alert widget and no takeover content",
-         %{
-           slot_names_fn: slot_names_fn,
-           pre_fare_config: pre_fare_config,
-           instance_with_subway_status_and_alerts: widget
-         } do
+    test "for pre-fare, returns true if there's at least one service alert widget",
+         %{pre_fare_config: pre_fare_config, instance_with_subway_status_and_alerts: widget} do
       widget = put_config(widget, pre_fare_config)
 
-      assert AlertsIntro.audio_valid_candidate?(widget, slot_names_fn)
+      assert AlertsIntro.audio_valid_candidate?(widget)
     end
 
     test "for pre-fare, returns false if there's no service alert widget",
-         %{
-           slot_names_fn: slot_names_fn,
-           pre_fare_config: pre_fare_config,
-           instance_without_service_alert_widgets: widget
-         } do
+         %{pre_fare_config: pre_fare_config, instance_without_service_alert_widgets: widget} do
       widget = put_config(widget, pre_fare_config)
 
-      refute AlertsIntro.audio_valid_candidate?(widget, slot_names_fn)
-    end
-
-    test "for pre-fare, returns false if there's any takeover content",
-         %{
-           slot_names_fn: slot_names_fn,
-           pre_fare_config: pre_fare_config,
-           instance_with_takeover_content: widget
-         } do
-      widget = put_config(widget, pre_fare_config)
-
-      refute AlertsIntro.audio_valid_candidate?(widget, slot_names_fn)
+      refute AlertsIntro.audio_valid_candidate?(widget)
     end
 
     test "returns false for other screen type",
-         %{
-           slot_names_fn: slot_names_fn,
-           other_config: other_config,
-           instance_with_subway_status_and_alerts: widget
-         } do
+         %{other_config: other_config, instance_with_subway_status_and_alerts: widget} do
       widget = put_config(widget, other_config)
 
-      refute AlertsIntro.audio_valid_candidate?(widget, slot_names_fn)
+      refute AlertsIntro.audio_valid_candidate?(widget)
     end
   end
 end

--- a/test/screens/v2/widget_instance/audio_only/content_summary_test.exs
+++ b/test/screens/v2/widget_instance/audio_only/content_summary_test.exs
@@ -5,7 +5,6 @@ defmodule Screens.V2.WidgetInstance.AudioOnly.ContentSummaryTest do
   alias Screens.V2.WidgetInstance
   alias Screens.V2.WidgetInstance.AudioOnly.ContentSummary
   alias Screens.V2.WidgetInstance.Departures.NormalSection
-  alias Screens.V2.WidgetInstance.MockWidget
   alias Screens.V2.WidgetInstance.{NormalHeader, ShuttleBusInfo}
   alias ScreensConfig.Header.CurrentStopId
   alias ScreensConfig.Screen
@@ -48,19 +47,12 @@ defmodule Screens.V2.WidgetInstance.AudioOnly.ContentSummaryTest do
       lines_at_station: []
     }
 
-    instance_with_takeover_content = %ContentSummary{
-      screen: nil,
-      widgets_snapshot: [%MockWidget{slot_names: [:full_body_duo]}],
-      lines_at_station: [:red, :orange]
-    }
-
     %{
       pre_fare_config: pre_fare_config,
       departures_config: departures_config,
       other_config: other_config,
       instance_with_header: instance_with_header,
       instance_without_header: instance_without_header,
-      instance_with_takeover_content: instance_with_takeover_content,
       instance_with_surge_widgets: instance_with_surge_widgets
     }
   end
@@ -135,10 +127,8 @@ defmodule Screens.V2.WidgetInstance.AudioOnly.ContentSummaryTest do
   end
 
   describe "audio_valid_candidate?/1" do
-    test "on pre-fare screens, widget is valid if there is no takeover content", %{
-      pre_fare_config: pre_fare_config,
-      instance_with_header: widget
-    } do
+    test "widget is valid on pre-fare screens",
+         %{pre_fare_config: pre_fare_config, instance_with_header: widget} do
       widget = widget |> put_config(pre_fare_config) |> put_stop_id("place-gover")
 
       assert WidgetInstance.audio_valid_candidate?(widget)
@@ -153,19 +143,8 @@ defmodule Screens.V2.WidgetInstance.AudioOnly.ContentSummaryTest do
       refute WidgetInstance.audio_valid_candidate?(widget)
     end
 
-    test "on pre-fare screens, widget is not valid if there is any takeover content", %{
-      pre_fare_config: pre_fare_config,
-      instance_with_takeover_content: widget
-    } do
-      widget = put_config(widget, pre_fare_config)
-
-      refute WidgetInstance.audio_valid_candidate?(widget)
-    end
-
-    test "widget is not valid on screens other than pre-fare", %{
-      other_config: other_config,
-      instance_with_takeover_content: widget
-    } do
+    test "widget is not valid on screens other than pre-fare",
+         %{other_config: other_config, instance_with_header: widget} do
       widget = put_config(widget, other_config)
 
       refute WidgetInstance.audio_valid_candidate?(widget)


### PR DESCRIPTION
The `ContentSummary` and `AlertsIntro` audio-only widgets both had logic that prevented their inclusion when the screen had widgets in "takeover" slots, but these checks were duplicated and had drifted out of sync with regard to slot names. This moves the logic into the main candidate generator so it can be done in one place.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210237684564486