### PR TITLE
Fix bus berth pronounciation

### DIFF
--- a/lib/screens_web/views/v2/audio/departures_view.ex
+++ b/lib/screens_web/views/v2/audio/departures_view.ex
@@ -103,6 +103,12 @@ defmodule ScreensWeb.V2.Audio.DeparturesView do
   end
 
   defp render_track_number(nil, _), do: ~E""
+
+  defp render_track_number(<<letter, digit>>, :bus)
+       when letter in ?A..?Z and digit in ?0..?9 do
+    ~E|at berth <say-as interpret-as="spell-out"><%= <<letter::utf8>> %></say-as><%= <<digit::utf8>> %><break/>|
+  end
+
   defp render_track_number(track_number, :bus), do: ~E|at berth <%= track_number %><break/>|
   defp render_track_number(track_number, _), do: ~E|on track <%= track_number %><break/>|
 

--- a/lib/screens_web/views/v2/audio/departures_view.ex
+++ b/lib/screens_web/views/v2/audio/departures_view.ex
@@ -106,7 +106,7 @@ defmodule ScreensWeb.V2.Audio.DeparturesView do
 
   defp render_track_number(<<letter, digit>>, :bus)
        when letter in ?A..?Z and digit in ?0..?9 do
-    ~E|at berth <say-as interpret-as="spell-out"><%= <<letter::utf8>> %></say-as><%= <<digit::utf8>> %><break/>|
+    ~E|at berth <break strength="weak"/><say-as interpret-as="spell-out"><%= <<letter::utf8>> %></say-as><%= <<digit::utf8>> %><break/>|
   end
 
   defp render_track_number(track_number, :bus), do: ~E|at berth <%= track_number %><break/>|

--- a/lib/screens_web/views/v2/audio/departures_view.ex
+++ b/lib/screens_web/views/v2/audio/departures_view.ex
@@ -104,12 +104,17 @@ defmodule ScreensWeb.V2.Audio.DeparturesView do
 
   defp render_track_number(nil, _), do: ~E""
 
-  defp render_track_number(<<letter, digit>>, :bus)
-       when letter in ?A..?Z and digit in ?0..?9 do
-    ~E|at berth <break strength="weak"/><say-as interpret-as="spell-out"><%= <<letter::utf8>> %></say-as><%= <<digit::utf8>> %><break/>|
+  defp render_track_number(track_number, :bus) do
+    track_number =
+      String.replace(
+        track_number,
+        ~r/\D+/,
+        ~S(<break strength="weak"/><say-as interpret-as="spell-out">\0</say-as>)
+      )
+
+    ~E|at berth <%= raw(track_number) %><break/>|
   end
 
-  defp render_track_number(track_number, :bus), do: ~E|at berth <%= track_number %><break/>|
   defp render_track_number(track_number, _), do: ~E|on track <%= track_number %><break/>|
 
   defp render_route(route_text) do

--- a/test/screens_web/views/v2/audio/departures_view_test.exs
+++ b/test/screens_web/views/v2/audio/departures_view_test.exs
@@ -161,7 +161,7 @@ defmodule ScreensWeb.V2.Audio.DeparturesViewTest do
       }
 
       assert render(assigns) =~
-               "The next <say-as interpret-as=\"address\">73</say-as> bus to Waverley at berth E"
+               "The next <say-as interpret-as=\"address\">73</say-as> bus to Waverley at berth <break strength=\"weak\"/><say-as interpret-as=\"spell-out\">E</say-as>"
 
       assert render(assigns) =~
                "The next Needham Line train to South Station on track 5"


### PR DESCRIPTION
**Asana task**: [Fix pronunciation of bus berths on screen audio](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1210077353559487?focus=true)

Description
Unfortunately, wrapping the berth identifier in a single SSML `say-as` tag and indicating to pronounce it as an address or any other option still results in the pronounciation "ah-two" or "ay tee double u oh".

The best option I could find was adding a slight break between "Berth" and the identifier to improve clarity, and then only specifying to "spell-out" the letter.
