### PR TITLE
feat(admin): don't reload page on config update

### DIFF
--- a/assets/src/components/admin/admin_screen_config_form.tsx
+++ b/assets/src/components/admin/admin_screen_config_form.tsx
@@ -22,6 +22,7 @@ const AdminScreenConfigForm = (): JSX.Element => (
     fetchConfig={fetchConfig}
     validatePath="/api/admin/screens/validate"
     confirmPath="/api/admin/screens/confirm"
+    onUpdated={() => alert("Config updated successfully")}
   />
 );
 


### PR DESCRIPTION
The Config Editor and the "single-screen" editor used in the Inspector no longer reload the entire page when the config is updated. This was mostly unnecessary and even counter-productive in the Inspector, since the reloaded screen would most likely be built from the pre-update cached copy of the config, requiring a second manual reload after a few seconds to allow the cache to update.

Also add a reload button to the Inspector to allow manually reloading only the screen iframe, so the current zoom level is retained.