### PR TITLE
bugfix: Only show overnight screen on DUP if every route in the section is overnight

### DIFF
--- a/lib/screens/v2/candidate_generator/dup/departures.ex
+++ b/lib/screens/v2/candidate_generator/dup/departures.ex
@@ -294,7 +294,9 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
         # For subway, each route will have its own section.
         # If the stop is served by two different subway/light rail routes, route_ids must be populated for each section
         # Otherwise, we only need the first route in the list of routes serving the stop.
+
         primary_route_for_section = List.first(routes)
+
         disabled_modes = Screens.Config.Cache.disabled_modes()
         # If we know the predictions are unreliable, don't even bother fetching them.
         if is_nil(primary_route_for_section) or
@@ -525,6 +527,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
     |> Enum.reject(&is_nil/1)
     |> Enum.sort_by(fn %Departure{schedule: schedule} -> schedule.departure_time end)
     |> Enum.split_with(fn
+      # Split up the upcoming departures for each route into a tuple of lists, {todays_schedules, overnight_schedules}
       %{schedule: %{departure_time: nil}} ->
         # If a departure_time is nil, then there are no scheduled trips remaining for today or tomorrow
         # Return as an overnight schedule so it can be displayed with a moon 'overnight' icon if applicable

--- a/lib/screens/v2/candidate_generator/dup/departures.ex
+++ b/lib/screens/v2/candidate_generator/dup/departures.ex
@@ -470,6 +470,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
          fetch_vehicles_fn
        )
 
+  # No predictions AND no active alerts for the section
   defp get_overnight_schedules_for_section(
          routes_with_live_departures,
          params,

--- a/lib/screens/v2/candidate_generator/dup/departures.ex
+++ b/lib/screens/v2/candidate_generator/dup/departures.ex
@@ -294,9 +294,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
         # For subway, each route will have its own section.
         # If the stop is served by two different subway/light rail routes, route_ids must be populated for each section
         # Otherwise, we only need the first route in the list of routes serving the stop.
-
         primary_route_for_section = List.first(routes)
-
         disabled_modes = Screens.Config.Cache.disabled_modes()
         # If we know the predictions are unreliable, don't even bother fetching them.
         if is_nil(primary_route_for_section) or
@@ -527,7 +525,6 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
     |> Enum.reject(&is_nil/1)
     |> Enum.sort_by(fn %Departure{schedule: schedule} -> schedule.departure_time end)
     |> Enum.split_with(fn
-      # Split up the upcoming departures for each route into a tuple of lists, {todays_schedules, overnight_schedules}
       %{schedule: %{departure_time: nil}} ->
         # If a departure_time is nil, then there are no scheduled trips remaining for today or tomorrow
         # Return as an overnight schedule so it can be displayed with a moon 'overnight' icon if applicable

--- a/lib/screens/v2/candidate_generator/dup/departures.ex
+++ b/lib/screens/v2/candidate_generator/dup/departures.ex
@@ -194,7 +194,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
 
     cond do
       # All routes in section are overnight
-      departures == [] and overnight_schedules_for_section != [] ->
+      departures == [] and Enum.count(overnight_schedules_for_section) == Enum.count(routes) ->
         %OvernightSection{routes: routes}
 
       # Headway mode

--- a/lib/screens/v2/candidate_generator/dup/departures.ex
+++ b/lib/screens/v2/candidate_generator/dup/departures.ex
@@ -175,11 +175,11 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
       |> Enum.uniq()
 
     # Check if there is any room for overnight rows before running the logic.
-    {todays_schedules_for_section, overnight_schedules_for_section} =
+    overnight_schedules_for_section =
       if (is_only_section and length(departures) >= 4) or length(departures) >= 2 do
-        {[], []}
+        []
       else
-        get_next_scheduled_trips_for_section(
+        get_overnight_schedules_for_section(
           routes_with_live_departures,
           params,
           routes,
@@ -194,8 +194,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
 
     cond do
       # All routes in section are overnight
-      departures == [] and todays_schedules_for_section == [] and
-          overnight_schedules_for_section != [] ->
+      departures == [] and overnight_schedules_for_section != [] ->
         %OvernightSection{routes: routes}
 
       # Headway mode
@@ -214,9 +213,9 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
 
       # Normal departures mode
       true ->
-        # Add trips scheduled for later today and overnight departures to the end.
+        # Add overnight departures to the end.
         # This allows overnight departures to appear as we start to run out of predictions to show.
-        departures = departures ++ todays_schedules_for_section ++ overnight_schedules_for_section
+        departures = departures ++ overnight_schedules_for_section
 
         visible_departures =
           if is_only_section do
@@ -295,7 +294,9 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
         # If the stop is served by two different subway/light rail routes, route_ids must be populated for each section
         # Otherwise, we only need the first route in the list of routes serving the stop.
         primary_route_for_section = List.first(routes)
+
         disabled_modes = Screens.Config.Cache.disabled_modes()
+
         # If we know the predictions are unreliable, don't even bother fetching them.
         if is_nil(primary_route_for_section) or
              primary_route_for_section.type in disabled_modes do
@@ -459,7 +460,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
 
   # If we are currently overnight, returns the first schedule of the day for each route_id and direction for each stop.
   # Otherwise, return an empty list.
-  defp get_next_scheduled_trips_for_section(
+  defp get_overnight_schedules_for_section(
          routes_with_live_departures,
          stop_ids,
          routes_serving_section,
@@ -469,8 +470,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
          fetch_vehicles_fn
        )
 
-  # No predictions AND no active alerts for the section
-  defp get_next_scheduled_trips_for_section(
+  defp get_overnight_schedules_for_section(
          routes_with_live_departures,
          params,
          routes,
@@ -488,59 +488,53 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
       )
 
     # Get schedules for each route_id in config
-    today_schedules
-    |> Enum.map(&{&1.route.id, &1.direction_id})
-    |> Enum.uniq()
-    |> Enum.reject(&(&1 in routes_with_live_departures))
-    |> Enum.map(fn {route_id, direction_id} ->
-      # This variable will be used when now is after 3am.
-      first_schedule_today =
-        Enum.find(
-          today_schedules,
-          &(&1.route.id == route_id and &1.direction_id == direction_id)
+    results =
+      today_schedules
+      |> Enum.map(&{&1.route.id, &1.direction_id})
+      |> Enum.uniq()
+      |> Enum.reject(&(&1 in routes_with_live_departures))
+      |> Enum.map(fn {route_id, direction_id} ->
+        # This variable will be used when now is after 3am.
+        first_schedule_today =
+          Enum.find(
+            today_schedules,
+            &(&1.route.id == route_id and &1.direction_id == direction_id)
+          )
+
+        last_schedule_today =
+          Enum.find(
+            Enum.reverse(today_schedules),
+            &(&1.route.id == route_id and &1.direction_id == direction_id)
+          )
+
+        first_schedule_tomorrow =
+          Enum.find(
+            tomorrow_schedules,
+            &(&1.route.id == route_id and &1.direction_id == direction_id)
+          )
+
+        get_overnight_departure_for_route(
+          first_schedule_today,
+          last_schedule_today,
+          first_schedule_tomorrow,
+          route_id,
+          direction_id,
+          now
         )
+      end)
 
-      last_schedule_today =
-        Enum.find(
-          Enum.reverse(today_schedules),
-          &(&1.route.id == route_id and &1.direction_id == direction_id)
-        )
-
-      first_schedule_tomorrow =
-        Enum.find(
-          tomorrow_schedules,
-          &(&1.route.id == route_id and &1.direction_id == direction_id)
-        )
-
-      get_next_schedule_for_route(
-        first_schedule_today,
-        last_schedule_today,
-        first_schedule_tomorrow,
-        route_id,
-        direction_id,
-        now
-      )
-    end)
-    # Routes not in overnight mode will be nil. Can ignore those.
-    |> Enum.reject(&is_nil/1)
-    |> Enum.sort_by(fn %Departure{schedule: schedule} -> schedule.departure_time end)
-    |> Enum.split_with(fn
-      %{schedule: %{departure_time: nil}} ->
-        # If a departure_time is nil, then there are no scheduled trips remaining for today or tomorrow
-        # Return as an overnight schedule so it can be displayed with a moon 'overnight' icon if applicable
-        false
-
-      %{schedule: %{departure_time: departure_time}} ->
-        Util.service_date(departure_time) == Util.service_date(now)
-
-      departure ->
-        # Defensive fallback that we should never reach.
-        Report.warning("dup_overnight_schedule_without_departure_time", departure: departure)
-        false
-    end)
+    # If any routes have a :departure_scheduled_today, then do not return tomorrow's schedules for any route
+    if Enum.any?(results, &(&1 == :departure_scheduled_today)) do
+      []
+    else
+      results
+      # Routes not in overnight mode will be nil. Can ignore those.
+      |> Enum.reject(&is_nil/1)
+      |> Enum.sort_by(fn %Departure{schedule: %Schedule{departure_time: dt}} -> dt end)
+    end
   end
 
-  defp get_next_scheduled_trips_for_section(
+  defp get_overnight_schedules_for_section(
          routes_with_live_departures,
          params,
          [%{type: type} | _] = routes,
@@ -553,7 +547,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
     informed_route = get_section_route_from_entities(params.stop_ids, alert_informed_entities)
     # If there are no vehicles operating on the route, assume we are overnight.
     if not is_nil(informed_route) and fetch_vehicles_fn.(informed_route, nil) == [] do
-      get_next_scheduled_trips_for_section(
+      get_overnight_schedules_for_section(
         routes_with_live_departures,
         params,
         routes,
@@ -563,14 +557,14 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
         fetch_vehicles_fn
       )
     else
-      {[], []}
+      []
     end
   end
 
-  defp get_next_scheduled_trips_for_section(_, _, _, _, _, _, _), do: {[], []}
+  defp get_overnight_schedules_for_section(_, _, _, _, _, _, _), do: []
 
   # Verifies we are meeting the timeframe conditions for overnight mode and generates the departure widget
-  defp get_next_schedule_for_route(
+  defp get_overnight_departure_for_route(
          first_schedule_today,
          last_schedule_today,
          _first_schedule_tomorrow,
@@ -587,9 +581,8 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
     nil
   end
 
-  # If now is after today's last schedule and there are no schedules tomorrow,
-  # we still want a departure row without a time (will show a moon icon)
-  defp get_next_schedule_for_route(
+  # If there are no schedules for the route tomorrow
+  defp get_overnight_departure_for_route(
          first_schedule_today,
          last_schedule_today,
          nil,
@@ -597,20 +590,29 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
          _direction_id,
          now
        ) do
-    if DateTime.compare(now, last_schedule_today.departure_time) == :gt or
-         DateTime.compare(now, first_schedule_today.departure_time) == :lt do
-      # nil/nil acts as a flag for the serializer to produce an `overnight` departure time
-      %Departure{
-        schedule: %{last_schedule_today | departure_time: nil, arrival_time: nil}
-      }
-    else
-      nil
+    cond do
+      # If current time is in between the first and last schedule of the day, signal that this route is still running
+      # We later use this atom to avoid displaying Overnight mode for this route
+      DateTime.compare(now, first_schedule_today.departure_time) == :gt and
+          DateTime.compare(now, last_schedule_today.departure_time) == :lt ->
+        :departure_scheduled_today
+
+      # If current time is before the first scheduled trip of the day, then return that schedule
+      DateTime.compare(now, first_schedule_today.departure_time) == :lt ->
+        %Departure{
+          schedule: first_schedule_today
+        }
+
+      # Only reach here if time is past all scheduled trips for the day.
+      # Return nil, b/c we do not want to show Overnight mode for a route that is not running more today or tomorrow.
+      true ->
+        nil
     end
   end
 
   # If now is before any of today's schedules or after any of tomorrow's (should never happen but just in case)
   # we do not display overnight mode.
-  defp get_next_schedule_for_route(
+  defp get_overnight_departure_for_route(
          first_schedule_today,
          last_schedule_today,
          first_schedule_tomorrow,
@@ -638,8 +640,12 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
         %Departure{schedule: first_schedule_today}
 
       # Before 3am and before the last scheduled trip of the day.
+      # Return an atom so we can track that there is still a departure for this route during today's service.
+      DateTime.compare(now, last_schedule_today.departure_time) == :lt ->
+        :departure_scheduled_today
+
       true ->
-        %Departure{schedule: last_schedule_today}
+        nil
     end
   end
 
@@ -672,7 +678,10 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
     {today, tomorrow}
   end
 
-  defp get_routes_serving_section(%{route_ids: route_ids, stop_ids: stop_ids}, fetch_routes_fn) do
+  defp get_routes_serving_section(
+         %{route_ids: route_ids, stop_ids: stop_ids},
+         fetch_routes_fn
+       ) do
     routes =
       case fetch_routes_fn.(%{stop_ids: stop_ids}) do
         {:ok, routes} -> routes

--- a/lib/screens/v2/candidate_generator/dup/departures.ex
+++ b/lib/screens/v2/candidate_generator/dup/departures.ex
@@ -460,8 +460,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
       MapSet.disjoint?(not_informed, informed_stop_ids)
   end
 
-  # For sections configured only to show predictions and not schedules, we may override
-  # by returning a list of scheduled Departures from `get_overnight_schedules_for_section`
+  # Return 'overnight' Departures from `get_overnight_schedules_for_section` to potentially show
   # if one of the following is true for a given route_id/direction_id combo:
   # 1. Service for the route is done for the day, so we may display the first departure of tomorrow.
   # 2. Service for the route has not started for the day, so we may display the first departure of today.
@@ -536,7 +535,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
         )
       end)
 
-    # We flag if any routes have a :route_service_ongoing, so the section is not fully overnight
+    # We flag if any routes have service ongoing so the section doesn't show as fully overnight
     is_sections_service_active = Enum.any?(overnight_schedules, &(&1 == :route_service_ongoing))
 
     {is_sections_service_active,

--- a/test/screens/v2/candidate_generator/dup/departures_test.exs
+++ b/test/screens/v2/candidate_generator/dup/departures_test.exs
@@ -2597,16 +2597,17 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
       now = ~U[2020-04-06T10:00:00Z]
 
       fetch_schedules_fn = fn
-        _, now ->
+        %{direction_id: :both, route_ids: [], route_type: nil, stop_ids: ["bus-C+D"]},
+        ~D[2020-04-07] ->
           {:ok,
            [
              %Schedule{
-               departure_time: ~U[2020-04-06T09:00:00Z],
+               departure_time: ~U[2020-04-07T09:00:00Z],
                route: %Route{id: "Bus C"},
                stop: struct(Stop, id: "bus-C+D")
              },
              %Schedule{
-               departure_time: ~U[2020-04-06T11:00:00Z],
+               departure_time: ~U[2020-04-07T09:00:00Z],
                route: %Route{id: "Bus D"},
                stop: struct(Stop, id: "bus-C+D")
              }
@@ -2616,12 +2617,17 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
           {:ok,
            [
              %Schedule{
-               departure_time: ~U[2020-04-07T09:00:00Z],
+               departure_time: ~U[2020-04-06T09:00:00Z],
                route: %Route{id: "Bus C"},
                stop: struct(Stop, id: "bus-C+D")
              },
              %Schedule{
-               departure_time: ~U[2020-04-07T09:00:00Z],
+               departure_time: ~U[2020-04-06T09:00:00Z],
+               route: %Route{id: "Bus D"},
+               stop: struct(Stop, id: "bus-C+D")
+             },
+             %Schedule{
+               departure_time: ~U[2020-04-06T11:01:00Z],
                route: %Route{id: "Bus D"},
                stop: struct(Stop, id: "bus-C+D")
              }

--- a/test/screens/v2/candidate_generator/dup/departures_test.exs
+++ b/test/screens/v2/candidate_generator/dup/departures_test.exs
@@ -2066,7 +2066,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
       assert Enum.all?(expected_departures, &Enum.member?(actual_instances, &1))
     end
 
-    test "returns normal sections with normal rows and overnight rows with nil scheduled times for routes in overnight mode with no scheduled trips tomorrow",
+    test "returns normal sections with normal rows of primary routes for secondary routes in overnight mode with no scheduled trips tomorrow",
          %{
            config: config,
            fetch_departures_fn: fetch_departures_fn,
@@ -2161,26 +2161,17 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
                 %Screens.V2.Departure{
                   prediction:
                     struct(Prediction,
-                      id: "Bus A",
-                      route: %Route{id: "Bus A", type: :bus},
+                      id: "A",
+                      route: %Route{id: "Test"},
                       stop: struct(Stop),
                       trip: struct(Trip)
                     ),
                   schedule: nil
-                },
-                %Screens.V2.Departure{
-                  prediction: nil,
-                  schedule:
-                    struct(Schedule,
-                      departure_time: nil,
-                      route: %Route{id: "Bus B"},
-                      stop: struct(Stop, id: "bus-B")
-                    )
                 }
               ]
             }
           ],
-          slot_names: [:main_content_two],
+          slot_names: [:main_content_one],
           now: now
         }
       ]

--- a/test/screens/v2/candidate_generator/dup/departures_test.exs
+++ b/test/screens/v2/candidate_generator/dup/departures_test.exs
@@ -2066,7 +2066,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
       assert Enum.all?(expected_departures, &Enum.member?(actual_instances, &1))
     end
 
-    test "returns normal sections with normal rows of primary routes for secondary routes in overnight mode with no scheduled trips tomorrow",
+    test "returns normal sections with normal rows and overnight rows with nil scheduled times for routes in overnight mode with no scheduled trips tomorrow",
          %{
            config: config,
            fetch_departures_fn: fetch_departures_fn,
@@ -2161,17 +2161,26 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
                 %Screens.V2.Departure{
                   prediction:
                     struct(Prediction,
-                      id: "A",
-                      route: %Route{id: "Test"},
+                      id: "Bus A",
+                      route: %Route{id: "Bus A", type: :bus},
                       stop: struct(Stop),
                       trip: struct(Trip)
                     ),
                   schedule: nil
+                },
+                %Screens.V2.Departure{
+                  prediction: nil,
+                  schedule:
+                    struct(Schedule,
+                      departure_time: nil,
+                      route: %Route{id: "Bus B"},
+                      stop: struct(Stop, id: "bus-B")
+                    )
                 }
               ]
             }
           ],
-          slot_names: [:main_content_one],
+          slot_names: [:main_content_two],
           now: now
         }
       ]

--- a/test/screens/v2/candidate_generator/dup/departures_test.exs
+++ b/test/screens/v2/candidate_generator/dup/departures_test.exs
@@ -2432,7 +2432,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
         config
         |> put_primary_departures([
           %Section{
-            query: %Query{params: %Query.Params{stop_ids: ["bus-B"]}}
+            query: %Query{params: %Query.Params{stop_ids: ["bus-B", "bus-C"]}}
           }
         ])
 
@@ -2446,6 +2446,11 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
                departure_time: ~U[2020-04-06T09:00:00Z],
                route: %Route{id: "Bus B"},
                stop: struct(Stop, id: "bus-B")
+             },
+             %Schedule{
+               departure_time: ~U[2020-04-06T09:30:00Z],
+               route: %Route{id: "Bus C"},
+               stop: struct(Stop, id: "bus-C")
              }
            ]}
 
@@ -2456,6 +2461,11 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
                departure_time: ~U[2020-04-07T09:00:00Z],
                route: %Route{id: "Bus B"},
                stop: struct(Stop, id: "bus-B")
+             },
+             %Schedule{
+               departure_time: ~U[2020-04-07T09:00:00Z],
+               route: %Route{id: "Bus C"},
+               stop: struct(Stop, id: "bus-C")
              }
            ]}
       end
@@ -2547,6 +2557,147 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
         %OvernightDepartures{screen: config, routes: [], slot_names: [:main_content_zero]},
         %OvernightDepartures{screen: config, routes: [], slot_names: [:main_content_one]},
         %OvernightDepartures{screen: config, routes: [], slot_names: [:main_content_two]}
+      ]
+
+      actual_instances =
+        Dup.Departures.departures_instances(
+          config,
+          now,
+          fetch_departures_fn,
+          fetch_alerts_fn,
+          fetch_schedules_fn,
+          fetch_routes_fn,
+          fetch_vehicles_fn
+        )
+
+      assert Enum.all?(expected_departures, &Enum.member?(actual_instances, &1))
+    end
+
+    test "returns primary section Departures if not all routes in secondary section are overnight, but none have upcoming predictions",
+         %{
+           config: config,
+           fetch_departures_fn: fetch_departures_fn,
+           fetch_alerts_fn: fetch_alerts_fn,
+           fetch_routes_fn: fetch_routes_fn,
+           fetch_vehicles_fn: fetch_vehicles_fn
+         } do
+      config =
+        config
+        |> put_primary_departures([
+          %Section{
+            query: %Query{params: %Query.Params{stop_ids: ["place-A"]}}
+          }
+        ])
+        |> put_secondary_departures_sections([
+          %Section{
+            query: %Query{params: %Query.Params{stop_ids: ["bus-B", "bus-C"]}}
+          }
+        ])
+
+      now = ~U[2020-04-06T10:00:00Z]
+
+      fetch_schedules_fn = fn
+        _, nil ->
+          {:ok,
+           [
+             %Schedule{
+               departure_time: ~U[2020-04-06T09:00:00Z],
+               route: %Route{id: "Bus B"},
+               stop: struct(Stop, id: "bus-B")
+             },
+             %Schedule{
+               departure_time: ~U[2020-04-06T11:00:00Z],
+               route: %Route{id: "Bus C"},
+               stop: struct(Stop, id: "bus-C")
+             }
+           ]}
+
+        _, _ ->
+          {:ok,
+           [
+             %Schedule{
+               departure_time: ~U[2020-04-07T09:00:00Z],
+               route: %Route{id: "Bus B"},
+               stop: struct(Stop, id: "bus-B")
+             },
+             %Schedule{
+               departure_time: ~U[2020-04-07T09:00:00Z],
+               route: %Route{id: "Bus C"},
+               stop: struct(Stop, id: "bus-C")
+             }
+           ]}
+      end
+
+      expected_departures = [
+        %DeparturesWidget{
+          screen: config,
+          sections: [
+            %NormalSection{
+              layout: %Layout{},
+              header: %SectionHeader{},
+              rows: [
+                %Screens.V2.Departure{
+                  prediction:
+                    struct(Prediction,
+                      id: "A",
+                      route: %Route{id: "Test"},
+                      stop: struct(Stop),
+                      trip: struct(Trip)
+                    ),
+                  schedule: nil
+                }
+              ]
+            }
+          ],
+          slot_names: [:main_content_zero],
+          now: now
+        },
+        %DeparturesWidget{
+          screen: config,
+          sections: [
+            %NormalSection{
+              layout: %Layout{},
+              header: %SectionHeader{},
+              rows: [
+                %Screens.V2.Departure{
+                  prediction:
+                    struct(Prediction,
+                      id: "A",
+                      route: %Route{id: "Test"},
+                      stop: struct(Stop),
+                      trip: struct(Trip)
+                    ),
+                  schedule: nil
+                }
+              ]
+            }
+          ],
+          slot_names: [:main_content_one],
+          now: now
+        },
+        %DeparturesWidget{
+          screen: config,
+          sections: [
+            %NormalSection{
+              layout: %Layout{},
+              header: %SectionHeader{},
+              rows: [
+                %Screens.V2.Departure{
+                  prediction:
+                    struct(Prediction,
+                      id: "A",
+                      route: %Route{id: "Test"},
+                      stop: struct(Stop),
+                      trip: struct(Trip)
+                    ),
+                  schedule: nil
+                }
+              ]
+            }
+          ],
+          slot_names: [:main_content_two],
+          now: now
+        }
       ]
 
       actual_instances =

--- a/test/screens/v2/candidate_generator/dup/departures_test.exs
+++ b/test/screens/v2/candidate_generator/dup/departures_test.exs
@@ -267,6 +267,8 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
           "place-A" -> [%{id: "Orange", type: :subway}, %{id: "Green", type: :light_rail}]
           "bus-A" -> [%{id: "Bus A", type: :bus}]
           "bus-B" -> [%{id: "Bus B", type: :bus}]
+          "bus-C" -> [%{id: "Bus C", type: :bus}]
+          "bus-C+D" -> [%{id: "Bus C", type: :bus}, %{id: "Bus D", type: :bus}]
           "place-overnight" -> [%{id: "Red", type: :subway}]
           _ -> [%{id: "test", type: :test}]
         end)
@@ -2589,26 +2591,24 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
           }
         ])
         |> put_secondary_departures_sections([
-          %Section{
-            query: %Query{params: %Query.Params{stop_ids: ["bus-B", "bus-C"]}}
-          }
+          %Section{query: %Query{params: %Query.Params{stop_ids: ["bus-C+D"]}}}
         ])
 
       now = ~U[2020-04-06T10:00:00Z]
 
       fetch_schedules_fn = fn
-        _, nil ->
+        _, now ->
           {:ok,
            [
              %Schedule{
                departure_time: ~U[2020-04-06T09:00:00Z],
-               route: %Route{id: "Bus B"},
-               stop: struct(Stop, id: "bus-B")
+               route: %Route{id: "Bus C"},
+               stop: struct(Stop, id: "bus-C+D")
              },
              %Schedule{
                departure_time: ~U[2020-04-06T11:00:00Z],
-               route: %Route{id: "Bus C"},
-               stop: struct(Stop, id: "bus-C")
+               route: %Route{id: "Bus D"},
+               stop: struct(Stop, id: "bus-C+D")
              }
            ]}
 
@@ -2617,13 +2617,13 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
            [
              %Schedule{
                departure_time: ~U[2020-04-07T09:00:00Z],
-               route: %Route{id: "Bus B"},
-               stop: struct(Stop, id: "bus-B")
+               route: %Route{id: "Bus C"},
+               stop: struct(Stop, id: "bus-C+D")
              },
              %Schedule{
                departure_time: ~U[2020-04-07T09:00:00Z],
-               route: %Route{id: "Bus C"},
-               stop: struct(Stop, id: "bus-C")
+               route: %Route{id: "Bus D"},
+               stop: struct(Stop, id: "bus-C+D")
              }
            ]}
       end


### PR DESCRIPTION
**Asana task**: [Investigate Kendall DUP evening bus issue](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1210196927622064?focus=true)

In the example of the bug shown in the ticket, this occurred because only 2/3 routes shown on this section of the Kendall DUP was in overnight mode. However, there was still one bus that had trips scheduled for later in the night.

To solve this, I added a check that there are as many overnight trips as there are total routes available.

This also changes, and I believe improves, the following case
- When there are no trips scheduled for the next day, as in the case of the Kendall buses on Friday, then we will show a duplicate of the `primary_departures` screen instead of an Overnight screen


- [ ] Tests added?
