### PR TITLE
fix: filter out skipped/cancelled predictions

### DIFF
--- a/test/screens/v2/departure_test.exs
+++ b/test/screens/v2/departure_test.exs
@@ -399,7 +399,7 @@ defmodule Screens.V2.DepartureTest do
     end
   end
 
-  describe "fetch_predictions_and_schedules/2" do
+  describe "fetch/1" do
     test "maintains schedules even if they are in the past" do
       now = ~U[2024-08-28 17:13:14.116713Z]
       # The train is _very_ late!!
@@ -422,11 +422,12 @@ defmodule Screens.V2.DepartureTest do
       fetch_schedules_fn = fn _ -> {:ok, [schedule]} end
 
       assert {:ok, [%Departure{schedule: schedule, prediction: prediction}]} ==
-               Departure.fetch_predictions_and_schedules(
-                 [],
-                 now,
-                 fetch_predictions_fn,
-                 fetch_schedules_fn
+               Departure.fetch(
+                 %{},
+                 include_schedules: true,
+                 now: now,
+                 fetch_predictions_fn: fetch_predictions_fn,
+                 fetch_schedules_fn: fetch_schedules_fn
                )
     end
   end


### PR DESCRIPTION
This issue was partly addressed in ee539a3, but the fix was inadvertently only applied to the case where scheduled departures were being displayed; the "predictions only" code path still had the issue.

This fixes the issue more systematically by removing the separate "predictions only" code path entirely. All departure fetching now goes through the same logic; in the case where only predictions are fetched, the schedule-related logic is a no-op.

**Asana task**: https://app.asana.com/1/15492006741476/project/1185117109217413/task/1210392853396720?focus=true