### PR TITLE
fix: ReconstructedAlert crash on Pre-Fares

### DIFF
--- a/lib/screens/v2/location_context.ex
+++ b/lib/screens/v2/location_context.ex
@@ -206,7 +206,7 @@ defmodule Screens.LocationContext do
       |> Enum.flat_map(& &1.stops)
       |> Enum.map(fn
         %Stop{id: id, parent_station: nil} -> {id, id}
-        %Stop{id: id, parent_station: parent_id} -> {id, parent_id}
+        %Stop{id: id, parent_station: %Stop{id: parent_id}} -> {id, parent_id}
       end)
       |> Map.new()
 


### PR DESCRIPTION
ba06cfa5 introduced a regression where the "stop sequences" of a `LocationContext` could be entire `Stop` structs instead of stop IDs, on screen types that use parent station sequences (DUPs and Pre-Fares). This could cause later logic to crash when it expected to find IDs.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210441937098495