### PR TITLE
chore: update Erlang and Elixir versions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-elixir 1.15.7-otp-26
-erlang 26.2
+elixir 1.17.3-otp-27
+erlang 27.3.4
 nodejs 18.20.2

--- a/lib/screens/v2/disruption_diagram/builder.ex
+++ b/lib/screens/v2/disruption_diagram/builder.ex
@@ -947,7 +947,7 @@ defmodule Screens.V2.DisruptionDiagram.Builder do
   defp gap_indices(builder) do
     home_stop = builder.metadata.home_stop
 
-    closure_left..closure_right = closure_indices(builder)
+    closure_left..closure_right//1 = closure_indices(builder)
 
     cond do
       home_stop < closure_left -> (home_stop + 1)..(closure_left - 1)//1

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Screens.MixProject do
     [
       app: :screens,
       version: "0.1.0",
-      elixir: "~> 1.13",
+      elixir: "~> 1.17",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       aliases: aliases(),

--- a/test/screens/screens_by_alert_test.exs
+++ b/test/screens/screens_by_alert_test.exs
@@ -3,8 +3,9 @@ defmodule Screens.ScreensByAlertTest do
   use ExUnit.Case
   alias Screens.ScreensByAlert
 
-  @tag :skip
   describe "get_screens_by_alert/1" do
+    @describetag :skip
+
     setup do
       ScreensByAlert.put_data(1, [1])
       on_exit(fn -> ScreensByAlert.put_data(1, []) end)
@@ -16,12 +17,10 @@ defmodule Screens.ScreensByAlertTest do
       }
     end
 
-    @tag :skip
     test "returns map with data when called before expiration" do
       assert %{1 => [1]} == ScreensByAlert.get_screens_by_alert([1])
     end
 
-    @tag :skip
     test "returns map with default empty list when called after expiration", %{
       screens_by_alert_ttl: ttl
     } do
@@ -30,7 +29,6 @@ defmodule Screens.ScreensByAlertTest do
       assert %{1 => []} == ScreensByAlert.get_screens_by_alert([1])
     end
 
-    @tag :skip
     test "returns map with no expired", %{screens_ttl: ttl} do
       assert %{1 => [1]} == ScreensByAlert.get_screens_by_alert([1])
       Process.sleep(ttl * 1000)
@@ -40,6 +38,8 @@ defmodule Screens.ScreensByAlertTest do
   end
 
   describe "get_screens_last_updated/1" do
+    @describetag :skip
+
     setup do
       ScreensByAlert.put_data(1, [1])
       on_exit(fn -> ScreensByAlert.put_data(1, []) end)
@@ -50,12 +50,10 @@ defmodule Screens.ScreensByAlertTest do
       }
     end
 
-    @tag :skip
     test "returns when screen was last updated", %{last_updated: last_updated} do
       assert %{1 => last_updated} == ScreensByAlert.get_screens_last_updated([1])
     end
 
-    @tag :skip
     test "returns map with default timestamp of 0 after expiration", %{
       last_updated: last_updated,
       ttl: ttl


### PR DESCRIPTION
* Resolve compile warnings raised by the new Elixir version.
* Use a Dockerfile approach that lets us encode all tool versions up-front and in one place.
* Use Erlang Alpine image as the base for the runtime container instead of plain Alpine, so it already has the proper packages installed and we don't have to maintain this extra setup.