### PR TITLE
feat: Omit no-data section if an alert is present

### DIFF
--- a/docs/tech_specs/dup_v2_alert_widget_backend.md
+++ b/docs/tech_specs/dup_v2_alert_widget_backend.md
@@ -10,7 +10,7 @@
 
 Our DUP app requires a unique approach to alerts and how they are displayed. DUPs contain one screen with three different pages (rotations). When an alert affecting the stops serving the DUP is active, each page displays the alert in a different way depending on how impactful the alert is to the screen.
 
-[DUP alert spec](https://www.notion.so/mbta-downtown-crossing/DUP-Alert-Widget-Specification-a82acff850ed4f2eb98a04e5f3e0fe52)
+[DUP alert spec](https://www.notion.so/mbta-downtown-crossing/DUP-Alert-Widget-Specification-17cf5d8d11ea80399a7fe3c4f13a511f)
 
 # Motivation
 

--- a/lib/screens/alerts/informed_entity.ex
+++ b/lib/screens/alerts/informed_entity.ex
@@ -3,9 +3,9 @@ defmodule Screens.Alerts.InformedEntity do
   Functions to query alert informed entities.
   """
 
-  alias Screens.Trips.Trip
-  alias Screens.Routes.Route
   alias Screens.Alerts.Alert
+  alias Screens.Routes.Route
+  alias Screens.Trips.Trip
 
   @type t :: Alert.informed_entity()
 

--- a/lib/screens/alerts/informed_entity.ex
+++ b/lib/screens/alerts/informed_entity.ex
@@ -32,21 +32,13 @@ defmodule Screens.Alerts.InformedEntity do
     match?(%{stop: "place-" <> _}, ie)
   end
 
-  @spec all_routes_represented?([Route.id()], Trip.direction() | :both | nil, [t()]) :: boolean()
-  def all_routes_represented?(route_ids, direction_id, informed_entities) do
-    Enum.all?(route_ids, fn route_id ->
-      Enum.any?(informed_entities, fn entity ->
-        entity_matches?(entity, route_id, direction_id)
-      end)
-    end)
-  end
-
-  defp entity_matches?(
-         %{route: entity_route, direction_id: entity_direction},
-         route_id,
-         direction_id
-       )
-       when entity_route.id == route_id do
+  @spec present_alert_for_route?(t(), Route.id(), Trip.direction() | nil) :: boolean()
+  def present_alert_for_route?(
+        %{route: entity_route, direction_id: entity_direction},
+        route_id,
+        direction_id
+      )
+      when entity_route.id == route_id do
     case entity_direction do
       ^direction_id -> true
       nil -> true
@@ -54,5 +46,5 @@ defmodule Screens.Alerts.InformedEntity do
     end
   end
 
-  defp entity_matches?(_, _, _), do: false
+  def present_alert_for_route?(_, _, _), do: false
 end

--- a/lib/screens/alerts/informed_entity.ex
+++ b/lib/screens/alerts/informed_entity.ex
@@ -3,6 +3,8 @@ defmodule Screens.Alerts.InformedEntity do
   Functions to query alert informed entities.
   """
 
+  alias Screens.Trips.Trip
+  alias Screens.Routes.Route
   alias Screens.Alerts.Alert
 
   @type t :: Alert.informed_entity()
@@ -29,4 +31,28 @@ defmodule Screens.Alerts.InformedEntity do
   def parent_station?(ie) do
     match?(%{stop: "place-" <> _}, ie)
   end
+
+  @spec all_routes_represented?([Route.id()], Trip.direction() | :both | nil, [t()]) :: boolean()
+  def all_routes_represented?(route_ids, direction_id, informed_entities) do
+    Enum.all?(route_ids, fn route_id ->
+      Enum.any?(informed_entities, fn entity ->
+        entity_matches?(entity, route_id, direction_id)
+      end)
+    end)
+  end
+
+  defp entity_matches?(
+         %{route: entity_route, direction_id: entity_direction},
+         route_id,
+         direction_id
+       )
+       when entity_route.id == route_id do
+    case entity_direction do
+      ^direction_id -> true
+      nil -> true
+      _ -> false
+    end
+  end
+
+  defp entity_matches?(_, _, _), do: false
 end


### PR DESCRIPTION
**Asana task**: [DUP screens: Omit no-data section if an alert is present](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1210227886153331?focus=true)

This essentially adds logic to not show a `NoDataSection` for routes with closure alerts for all routes in section
Some pieces to note: 
- This is not explicitly tied to the alerts widget, since those candidate generators run in parallel. However, if we have no departures for a given section and alerts tied to each, it's a fair assumption that we don't want to show a `NoDataSection` regardless.
- In this alerts scenario, behavior on the FE depends on the number of routes in a section, but returning an empty list of departures works for both:
  - If a page contains only one section of routes and they are closed, the alerts widget will override the entire screen with a full page alert. Returning an empty list of departures here works b/c it will be overridden anyway.
  - If a page contains multiple sections and only one has closed routes, the alerts widget will place a partial alert on the bottom of the screen. In this case, returning an empty list of departures works b/c it will take up no screen space.
- Testing this manually beyond unit tests is a bit messy and required overriding the V3 API and stubbing a few different scenarios. Namely returning no departures for a specific route and different variants of alerts. Happy to run through that with a reviewer if desired!


- [X] Tests added?
