### PR TITLE
Fixed fallback alert error for ReconstructedAlertSingleScreenView

### DIFF
--- a/lib/screens_web/views/v2/audio/reconstructed_alert_single_screen_view.ex
+++ b/lib/screens_web/views/v2/audio/reconstructed_alert_single_screen_view.ex
@@ -180,6 +180,19 @@ defmodule ScreensWeb.V2.Audio.ReconstructedAlertSingleScreenView do
     end
   end
 
+  # Fallback for Dual Screen
+  def render_alert(%{
+        issue: issue,
+        remedy: remedy,
+        location: location
+      }) do
+    if is_nil(location) do
+      ~E|<%= issue %>. <%= remedy %>|
+    else
+      ~E|<%= location %>.|
+    end
+  end
+
   defp get_line_name([%{color: _color, text: _text, type: _type} | _tail] = routes) do
     routes
     |> Enum.map(fn route -> route.text end)


### PR DESCRIPTION
**Asana task**: [Crash in Pre-Fare audio readout for shuttle alert](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1208771175609374?focus=true)

- It seems like in the fallback for the Dual Screen using a Single Screen alert view we don't specify an audio readout for suspensions without endpoints or region. This causes us to crash out due to not matching any of the functions
- This adds a function that allows for a fallback use of `location` as the audio readout. In cases where we use `dual_screen_fallback_fields`, we will now readout the alert header as the readout instead of crashing. I thought about adding `remedy_bold` as a field, but in my mind it didn't make sense to have `remedy` and `remedy_bold` be different values, and I think it makes more sense to read the header rather than something like "Seek alternate route" (although maybe the audio limit might be a problem?)