### PR TITLE
chore: suppress ReconstructedAlerts for 645336

### DIFF
--- a/lib/screens/v2/widget_instance/reconstructed_alert.ex
+++ b/lib/screens/v2/widget_instance/reconstructed_alert.ex
@@ -1211,7 +1211,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
 
   def alert_ids(%__MODULE__{} = t), do: [t.alert.id]
 
-  @suppressed_alert_ids ~w[636777]
+  @suppressed_alert_ids ~w[645336]
 
   def valid_candidate?(%__MODULE__{alert: %{id: alert_id}}) do
     alert_id not in @suppressed_alert_ids

--- a/test/screens/v2/widget_instance/reconstructed_alert_test.exs
+++ b/test/screens/v2/widget_instance/reconstructed_alert_test.exs
@@ -3342,7 +3342,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
       assert WidgetInstance.valid_candidate?(widget)
     end
 
-    suppressed_alerts = ~w[636777]
+    suppressed_alerts = ~w[645336]
 
     for alert_id <- suppressed_alerts do
       @tag alert_id: alert_id


### PR DESCRIPTION
This alert is a "mixed" shuttle/suspension represented in the data as only a suspension, so ReconstructedAlert content will not give the full picture. We will instead be scheduling custom content on Pre-Fares.

**Asana task**: https://app.asana.com/1/15492006741476/project/1185117109217413/task/1210534397902318
