### PR TITLE
fix: DUP special section heights

### DIFF
--- a/assets/css/v2/dup/departures/headway_section.scss
+++ b/assets/css/v2/dup/departures/headway_section.scss
@@ -1,7 +1,9 @@
 .departures-section.headway-section {
-  height: 208px;
+  &--row {
+    height: 208px;
+  }
 
-  &.headway-section--full_screen {
+  &--full_screen {
     height: 416px;
     padding-top: 72px;
     padding-right: 64px;

--- a/assets/css/v2/dup/departures/no_data_section.scss
+++ b/assets/css/v2/dup/departures/no_data_section.scss
@@ -1,6 +1,10 @@
 .departures-section.no-data-section {
   width: 1920px;
-  height: auto;
+  height: 416px;
+
+  .body-split__main-content-reduced & {
+    height: 208px;
+  }
 
   .no-data-section__icon-container {
     display: inline-block;
@@ -18,8 +22,4 @@
   .no-data-section__row {
     height: 208px;
   }
-}
-
-.body-split__main-content-reduced .no-data-section {
-  height: 208px;
 }

--- a/assets/css/v2/dup/departures/overnight.scss
+++ b/assets/css/v2/dup/departures/overnight.scss
@@ -1,5 +1,5 @@
 .overnight-section__row {
-  height: 408px;
+  height: 416px;
 }
 
 .overnight-departures__container {

--- a/assets/css/v2/dup/departures/section.scss
+++ b/assets/css/v2/dup/departures/section.scss
@@ -1,10 +1,6 @@
 .departures-section {
   position: relative;
 
-  &:not(:only-child) {
-    height: 416px;
-  }
-
   &:not(:first-child)::before {
     position: absolute;
     left: 0;


### PR DESCRIPTION
In developer browsers, but not on real-world DUPs, no-data and headway sections would always take up two rows of height, even in the "reduced" layout where they were intended to only take up one. This was a CSS specificity issue which may not have affected real DUPs due to their very different (older) browser versions.

**Asana task**: https://app.asana.com/1/15492006741476/project/1185117109217413/task/1210675381138616

![Screen Shot 2025-07-03 at 16 38 03](https://github.com/user-attachments/assets/7716d00f-b131-4b0d-a555-4af73becde38)
