### PR TITLE
bugfix: Hide DUP's NoDataSection during alerts, match IE route with section's route properly

### DIFF
--- a/lib/screens/alerts/informed_entity.ex
+++ b/lib/screens/alerts/informed_entity.ex
@@ -34,11 +34,11 @@ defmodule Screens.Alerts.InformedEntity do
 
   @spec present_alert_for_route?(t(), Route.id(), Trip.direction() | nil) :: boolean()
   def present_alert_for_route?(
-        %{route: entity_route, direction_id: entity_direction},
+        %{route: entity_route_id, direction_id: entity_direction},
         route_id,
         direction_id
       )
-      when entity_route.id == route_id do
+      when entity_route_id == route_id do
     case entity_direction do
       ^direction_id -> true
       nil -> true

--- a/lib/screens/v2/candidate_generator/dup/alerts.ex
+++ b/lib/screens/v2/candidate_generator/dup/alerts.ex
@@ -145,7 +145,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Alerts do
   defp directional_shuttle_or_suspension?(alert) do
     directional =
       alert.effect in [:shuttle, :suspension] and
-        Enum.any?(alert.informed_entities, &(&1.direction_id in 0..1))
+        not Enum.any?(alert.informed_entities, &is_nil(&1.direction_id))
 
     if directional do
       Report.warning(

--- a/lib/screens/v2/candidate_generator/dup/departures.ex
+++ b/lib/screens/v2/candidate_generator/dup/departures.ex
@@ -174,14 +174,6 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
       |> Enum.map(&{Departure.route(&1).id, Departure.direction_id(&1)})
       |> Enum.uniq()
 
-    # TODO: Here for testing
-    departures =
-      departures
-      |> Enum.reject(
-        &(&1.prediction != nil and
-            (&1.prediction.route.id == "Orange" or &1.prediction.route.id == "Red"))
-      )
-
     # Check if there is any room for overnight rows before running the logic.
     {section_contains_active_route, overnight_schedules_for_section} =
       if (is_only_section and length(departures) >= 4) or length(departures) >= 2 do

--- a/test/screens/v2/candidate_generator/dup/departures_test.exs
+++ b/test/screens/v2/candidate_generator/dup/departures_test.exs
@@ -2916,7 +2916,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
               effect: :suspension,
               informed_entities: [
                 %{
-                  route: %{id: "Red"},
+                  route: "Red",
                   route_type: 0,
                   stop: "place-closed",
                   direction_id: nil


### PR DESCRIPTION
**Asana task**: [DUP "omit no-data with alerts" feature not working](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1210675381138609?focus=true)

Fixes the DUP handling of the No Data Section when there are active alerts. 
- Root cause of the issue was that the stubbed `Informed Entity` values I used for testing had the route as a struct, when this is supposed to just be a string, the `route_id`. You can see this modified data in the unit test and how this was testing the code with incorrect data.
- Reordered so that the Alert handling comes before Overnight section logic. This Overnight check could be true for an alert case, i.e. if there is a suspension for the rest of the day and thus nothing scheduled until tomorrow. In this case, we still want return an empty departures section. 