### PR TITLE
fix: incorrect time range for audio being enabled

### DIFF
--- a/lib/screens/v2/screen_data/parameters.ex
+++ b/lib/screens/v2/screen_data/parameters.ex
@@ -62,7 +62,7 @@ defmodule Screens.V2.ScreenData.Parameters do
         false
 
       %Static{audio_active_time: {start_time, end_time}} ->
-        Util.time_in_range?(now, start_time, end_time)
+        now |> Util.to_eastern() |> Util.time_in_range?(start_time, end_time)
     end
   end
 

--- a/test/screens/v2/screen_data/parameters_test.exs
+++ b/test/screens/v2/screen_data/parameters_test.exs
@@ -44,7 +44,9 @@ defmodule Screens.V2.ScreenData.ParametersTest do
     }
   end
 
-  defp local_time(time), do: DateTime.new!(~D[2024-01-01], time, "America/New_York")
+  # actual "now" passed into these functions may not already be in the Eastern time zone
+  defp local_time(time),
+    do: DateTime.new!(~D[2024-01-01], time, "America/New_York") |> DateTime.shift_zone!("Etc/UTC")
 
   describe "audio_enabled?/2" do
     test "is false for a screen type with no audio schedule" do


### PR DESCRIPTION
The time in which audio would be enabled/disabled for screens with an "audio active time" (Bus Shelters and Pre-Fares) was incorrectly offset due to a missing time zone conversion.

**Asana task**: https://app.asana.com/1/15492006741476/project/1185117109217413/task/1210766710341656