### PR TITLE
fix: incorrect pattern match in device monitor

### DIFF
--- a/lib/screens/device_monitor/store.ex
+++ b/lib/screens/device_monitor/store.ex
@@ -72,7 +72,7 @@ defmodule Screens.DeviceMonitor.Store do
 
         {:error, "Key not found"} ->
           case Memcache.add(server, @key, value) do
-            {:ok, _version} -> {:ok, nil}
+            {:ok} -> {:ok, nil}
             # someone else created it between the `get` and the `add`
             {:error, "Key exists"} -> get_and_update(server, value, retries_left - 1)
             {:error, _} = error -> error


### PR DESCRIPTION
This pattern was from an earlier version of the code that used the `cas: true` option for `Memcache.add`, which changes the shape of the `:ok` return value. Fortunately this didn't cause any problems since it caused the DeviceMonitor to crash and restart one time only (when the key was initially created), in a situation where it would have done nothing anyway.
