### PR TITLE
chore: use new Mercury device monitoring APIs

### DIFF
--- a/lib/screens/device_monitor/fetch.ex
+++ b/lib/screens/device_monitor/fetch.ex
@@ -3,8 +3,16 @@ defmodule Screens.DeviceMonitor.Fetch do
 
   require Logger
 
-  def make_and_parse_request(url, headers \\ [], parse_fn, vendor_name) do
-    with {:http_request, {:ok, response}} <- {:http_request, HTTPoison.get(url, headers)},
+  @spec make_and_parse_request(
+          url :: binary(),
+          HTTPoison.headers(),
+          http_opts :: Keyword.t(),
+          parse_fn :: (binary() -> {:ok, parsed} | {:error, term()}),
+          vendor_name :: atom()
+        ) :: {:ok, parsed} | :error
+        when parsed: any()
+  def make_and_parse_request(url, headers, opts, parse_fn, vendor_name) do
+    with {:http_request, {:ok, response}} <- {:http_request, HTTPoison.get(url, headers, opts)},
          {:response_success, %{status_code: 200, body: body}} <- {:response_success, response},
          {:parse, {:ok, parsed}} <- {:parse, parse_fn.(body)} do
       {:ok, parsed}

--- a/lib/screens/device_monitor/gds.ex
+++ b/lib/screens/device_monitor/gds.ex
@@ -16,10 +16,10 @@ defmodule Screens.DeviceMonitor.Gds do
 
   @impl true
   def log({_from_dt, to_dt}) do
-    Screens.DeviceMonitor.Logger.log_data(fn -> fetch(to_dt) end, :gds, "GDS_DMS_PASSWORD")
+    Screens.DeviceMonitor.Logger.log_data(fn -> do_log(to_dt) end, :gds, "GDS_DMS_PASSWORD")
   end
 
-  defp fetch(now) do
+  defp do_log(now) do
     with {:ok, token} <- get_token(),
          {:ok, devices_data} <- fetch_devices_data(token, now) do
       sns = Map.keys(devices_data)
@@ -45,7 +45,7 @@ defmodule Screens.DeviceMonitor.Gds do
 
     @token_url_base
     |> build_url(params)
-    |> Fetch.make_and_parse_request(&parse_token/1, @vendor_name)
+    |> Fetch.make_and_parse_request([], [], &parse_token/1, @vendor_name)
   end
 
   defp parse_token(xml) do
@@ -68,7 +68,7 @@ defmodule Screens.DeviceMonitor.Gds do
 
     @device_list_url_base
     |> build_url(params)
-    |> Fetch.make_and_parse_request(&parse_devices_data(&1, now), @vendor_name)
+    |> Fetch.make_and_parse_request([], [], &parse_devices_data(&1, now), @vendor_name)
   end
 
   defp parse_devices_data(xml, now) do

--- a/lib/screens/device_monitor/mercury.ex
+++ b/lib/screens/device_monitor/mercury.ex
@@ -1,6 +1,8 @@
 defmodule Screens.DeviceMonitor.Mercury do
   @moduledoc false
 
+  # Docs: https://mercuryinnovation.notion.site/Nexus-MBTA-API-192a7568977c8082a879f47b5adbbab1
+
   @behaviour Screens.DeviceMonitor.Vendor
 
   alias Screens.DeviceMonitor.Fetch
@@ -13,117 +15,86 @@ defmodule Screens.DeviceMonitor.Mercury do
   @impl true
   def log(log_range) do
     Screens.DeviceMonitor.Logger.log_data(
-      fn -> fetch(log_range) end,
+      fn -> do_log(log_range) end,
       @vendor_name,
       "MERCURY_API_KEY"
     )
   end
 
-  defp fetch(log_range) do
-    headers = [{"apiKey", get_api_key()}]
-
-    with {:ok, parsed} <-
-           Fetch.make_and_parse_request(
-             @api_url_base <> "/devices",
-             headers,
-             &Jason.decode/1,
-             @vendor_name
-           ) do
-      prod_screens =
-        Enum.filter(parsed, &match?(%{"stop" => %{"agency_id" => "mbta_prod"}}, &1))
-
-      button_press_event_counts = fetch_button_press_events(prod_screens, log_range)
-
-      {:ok,
-       Enum.map(
-         prod_screens,
-         &fetch_device_info(&1, Map.get(button_press_event_counts, &1["device_id"], 0))
-       )}
-    end
-  end
-
-  defp fetch_device_info(device, num_button_presses) do
-    device_id = device["device_id"]
-    headers = [{"apiKey", get_api_key()}]
-
-    info =
-      case Fetch.make_and_parse_request(
-             @api_url_base <> "/devices/#{device_id}",
-             headers,
-             &Jason.decode/1,
-             @vendor_name
-           ) do
-        {:ok, parsed} -> fetch_relevant_fields(parsed)
-        :error -> %{device_id: device_id, state: :error}
-      end
-
-    Map.put(info, :button_presses, num_button_presses)
-  end
-
-  defp fetch_relevant_fields(device) do
-    %{
-      "device_id" => device_id,
-      "screens" => [screen],
-      "battery_level" => battery,
-      "stop" => %{"stop_id" => stop_id}
-    } = device
-
-    screen_fields = fetch_relevant_screen_fields(screen)
-
-    Map.merge(screen_fields, %{device_id: device_id, stop_id: stop_id, battery: battery})
-  end
-
-  defp fetch_relevant_screen_fields(status) do
-    %{
-      "latest_logs" => %{
-        "GSMStatus" => %{"rssi" => signal_strength},
-        "status" => %{"internal_temp" => temperature, "battery_reading" => battery_voltage},
-        "GSMBoot" => %{"serial" => connectivity_used},
-        "boot" => %{"reset_cause" => connect_reason}
-      },
-      "State" => state,
-      "Options" => %{"Name" => name},
-      "last_heartbeat" => last_heartbeat
-    } = status
-
-    %{
-      state: state,
-      name: name,
-      battery_voltage: battery_voltage,
-      connect_reason: connect_reason,
-      connectivity_used: connectivity_used,
-      last_heartbeat: last_heartbeat,
-      signal_strength: signal_strength,
-      temperature: temperature
-    }
-  end
-
-  defp fetch_button_press_events(devices, {from_dt, to_dt}) do
+  defp do_log({from_dt, to_dt}) do
     from_unix = DateTime.to_unix(from_dt)
     to_unix = DateTime.to_unix(to_dt)
-    device_ids = Enum.map_join(devices, "-", & &1["device_id"])
 
-    case Fetch.make_and_parse_request(
-           @api_url_base <> "/allEvents/#{device_ids}/#{from_unix}/#{to_unix}",
-           [{"apiKey", get_api_key()}],
-           &Jason.decode/1,
-           @vendor_name
-         ) do
-      {:ok, parsed} ->
-        for {device_id, events_map} <- parsed, into: %{} do
-          num_button_presses =
-            events_map
+    with {:ok, devices} <- fetch("/devices?verbose=true"),
+         {:ok, events} <- fetch("/allEvents/#{from_unix}/#{to_unix}") do
+      button_press_counts_by_device =
+        for {device_id, device_events} <- events, into: %{} do
+          count =
+            device_events
             |> Map.values()
             |> Enum.map(&Map.get(&1, "BUTTON_PRESS", []))
             |> Enum.concat()
             |> Enum.count()
 
-          {device_id, num_button_presses}
+          {device_id, count}
         end
 
-      _ ->
-        %{}
+      {:ok,
+       devices
+       |> Enum.filter(&match?(%{"stop" => %{"agency_id" => "mbta_prod"}}, &1))
+       |> Enum.map(&device_info(&1, Map.get(button_press_counts_by_device, &1["device_id"], 0)))}
     end
+  end
+
+  defp fetch(path) do
+    Fetch.make_and_parse_request(
+      @api_url_base <> path,
+      [{"apiKey", get_api_key()}],
+      # devices API sometimes takes longer to respond than the default timeout of 5 seconds
+      [recv_timeout: 10_000],
+      &Jason.decode/1,
+      @vendor_name
+    )
+  end
+
+  defp device_info(
+         %{
+           "device_id" => device_id,
+           "battery_level" => battery,
+           "screens" => [
+             %{
+               "last_heartbeat" => last_heartbeat,
+               "latest_logs" => %{
+                 "boot" => %{"reset_cause" => connect_reason},
+                 "GSMBoot" => %{"serial" => connectivity_used},
+                 "GSMStatus" => %{"rssi" => signal_strength},
+                 "status" => %{
+                   "battery_reading" => battery_voltage,
+                   "internal_temp" => temperature
+                 }
+               },
+               "Options" => %{"Name" => name},
+               "State" => state
+             }
+           ],
+           "stop" => %{"stop_id" => stop_id}
+         },
+         button_press_count
+       ) do
+    %{
+      device_id: device_id,
+      battery: battery,
+      battery_voltage: battery_voltage,
+      button_presses: button_press_count,
+      connect_reason: connect_reason,
+      connectivity_used: connectivity_used,
+      last_heartbeat: last_heartbeat,
+      name: name,
+      signal_strength: signal_strength,
+      state: state,
+      stop_id: stop_id,
+      temperature: temperature
+    }
   end
 
   defp get_api_key, do: System.fetch_env!("MERCURY_API_KEY")

--- a/test/screens/device_monitor_test.exs
+++ b/test/screens/device_monitor_test.exs
@@ -24,9 +24,9 @@ defmodule Screens.DeviceMonitorTest do
 
   test "calls vendor log functions with the correct time range",
        %{state: state, store: store, version: version} do
-    :ok = Store.set(store, ~U[2025-01-01 12:25:02Z], version)
+    :ok = Store.set(store, ~U[2025-01-01 12:29:02Z], version)
 
-    expect(MockVendor, :log, fn {~U[2025-01-01 12:25:00Z], ~U[2025-01-01 12:30:00Z]} ->
+    expect(MockVendor, :log, fn {~U[2025-01-01 12:29:00Z], ~U[2025-01-01 12:31:00Z]} ->
       :mock_log_done
     end)
 
@@ -44,7 +44,7 @@ defmodule Screens.DeviceMonitorTest do
 
   test "does not log again within the previous log interval",
        %{state: state, store: store, version: version} do
-    :ok = Store.set(store, ~U[2025-01-01 12:30:03Z], version)
+    :ok = Store.set(store, ~U[2025-01-01 12:31:03Z], version)
 
     assert {:noreply, ^state} = run(state)
 


### PR DESCRIPTION
Mercury introduced a `verbose` parameter for their API which allows fetching the details of all devices at once, instead of requiring N+1 requests. Using this also allows us to shorten the logging interval since we no longer have to wait multiple minutes for the N+1 requests to complete.

Also removes a `timeout` option from `Task.Supervisor.async_nolink/3` which does not actually exist.

**Asana task**: https://app.asana.com/1/15492006741476/project/1185117109217413/task/1210825464414329