### PR TITLE
fix: positioning of long headers on `lcd` screens

### DIFF
--- a/assets/css/v2/lcd_common/normal_header.scss
+++ b/assets/css/v2/lcd_common/normal_header.scss
@@ -15,7 +15,6 @@
 
 .normal-header-title {
   position: absolute;
-  bottom: 40px;
   left: 40px;
   display: flex;
   align-content: end;
@@ -40,10 +39,12 @@
   }
 
   &--large {
+    bottom: 40px;
     font-size: 104px;
   }
 
   &--small {
+    bottom: 24px;
     font-size: 72px;
   }
 }


### PR DESCRIPTION
On `lcd_common` screens (Bus Shelter, Sectional, Pre-Fare), headers with text long enough to trigger the "small" sizing and run onto two lines were awkwardly positioned.

| Before | After |
|---|---|
| <img width="1080" height="200" alt="Screen Shot 2025-07-18 at 15 00 03" src="https://github.com/user-attachments/assets/8e9a5315-3cb6-4a7b-b58f-2a80379cc8b3" /> | <img width="1080" height="200" alt="Screen Shot 2025-07-18 at 15 01 11" src="https://github.com/user-attachments/assets/5b143cec-ffe2-4f9d-b16a-d432482805a6" /> |
