### PR TITLE
Single-tracking messaging for Subway Status

### DIFF
--- a/lib/screens/alerts/alert.ex
+++ b/lib/screens/alerts/alert.ex
@@ -35,20 +35,18 @@ defmodule Screens.Alerts.Alert do
 
   @type cause ::
           :accident
-          | :amtrak
-          | :an_earlier_mechanical_problem
-          | :an_earlier_signal_problem
-          | :autos_impeding_service
+          | :amtrak_train_traffic
           | :coast_guard_restriction
-          | :congestion
           | :construction
-          | :crossing_malfunction
+          | :crossing_issue
           | :demonstration
           | :disabled_bus
           | :disabled_train
           | :drawbridge_being_raised
           | :electrical_work
           | :fire
+          | :fire_department_activity
+          | :flooding
           | :fog
           | :freight_train_interference
           | :hazmat_condition
@@ -58,56 +56,63 @@ defmodule Screens.Alerts.Alert do
           | :hurricane
           | :ice_in_harbor
           | :maintenance
+          | :mechanical_issue
           | :mechanical_problem
           | :medical_emergency
           | :parade
           | :police_action
+          | :police_activity
           | :power_problem
+          | :rail_defect
           | :severe_weather
+          | :signal_issue
           | :signal_problem
+          | :single_tracking
           | :slippery_rail
           | :snow
           | :special_event
           | :speed_restriction
+          | :switch_issue
           | :switch_problem
           | :tie_replacement
           | :track_problem
           | :track_work
           | :traffic
+          | :train_traffic
           | :unruly_passenger
           | :weather
-          | :unknown
 
   @type effect ::
           :access_issue
+          | :additional_service
           | :amber_alert
           | :bike_issue
           | :cancellation
           | :delay
           | :detour
-          | :dock_issue
           | :dock_closure
+          | :dock_issue
           | :elevator_closure
           | :escalator_closure
           | :extra_service
           | :facility_issue
+          | :modified_service
           | :no_service
           | :parking_closure
           | :parking_issue
           | :policy_change
+          | :schedule_change
           | :service_change
           | :shuttle
-          | :suspension
-          | :station_closure
-          | :stop_closure
-          | :stop_moved
-          | :schedule_change
           | :snow_route
+          | :station_closure
           | :station_issue
-          | :stop_shoveling
+          | :stop_closure
+          | :stop_move
+          | :stop_moved
           | :summary
+          | :suspension
           | :track_change
-          | :unknown
 
   @type active_period :: {DateTime.t(), DateTime.t() | nil}
 
@@ -122,8 +127,8 @@ defmodule Screens.Alerts.Alert do
 
   @type t :: %__MODULE__{
           id: String.t(),
-          cause: cause,
-          effect: effect,
+          cause: cause() | :unknown,
+          effect: effect() | :unknown,
           severity: integer,
           header: String.t(),
           informed_entities: list(informed_entity()),

--- a/lib/screens/alerts/parser.ex
+++ b/lib/screens/alerts/parser.ex
@@ -84,52 +84,20 @@ defmodule Screens.Alerts.Parser do
     time
   end
 
-  defp parse_effect("AMBER_ALERT"), do: :amber_alert
-  defp parse_effect("CANCELLATION"), do: :cancellation
-  defp parse_effect("DELAY"), do: :delay
-  defp parse_effect("SUSPENSION"), do: :suspension
-  defp parse_effect("TRACK_CHANGE"), do: :track_change
-  defp parse_effect("DETOUR"), do: :detour
-  defp parse_effect("SHUTTLE"), do: :shuttle
-  defp parse_effect("STOP_CLOSURE"), do: :stop_closure
-  defp parse_effect("DOCK_CLOSURE"), do: :dock_closure
-  defp parse_effect("STATION_CLOSURE"), do: :station_closure
-  defp parse_effect("STOP_MOVE"), do: :stop_moved
-  defp parse_effect("STOP_MOVED"), do: :stop_moved
-  defp parse_effect("EXTRA_SERVICE"), do: :extra_service
-  defp parse_effect("SCHEDULE_CHANGE"), do: :schedule_change
-  defp parse_effect("SERVICE_CHANGE"), do: :service_change
-  defp parse_effect("SNOW_ROUTE"), do: :snow_route
-  defp parse_effect("STATION_ISSUE"), do: :station_issue
-  defp parse_effect("DOCK_ISSUE"), do: :dock_issue
-  defp parse_effect("ACCESS_ISSUE"), do: :access_issue
-  defp parse_effect("FACILITY_ISSUE"), do: :facility_issue
-  defp parse_effect("BIKE_ISSUE"), do: :bike_issue
-  defp parse_effect("PARKING_ISSUE"), do: :parking_issue
-  defp parse_effect("PARKING_CLOSURE"), do: :parking_closure
-  defp parse_effect("ELEVATOR_CLOSURE"), do: :elevator_closure
-  defp parse_effect("ESCALATOR_CLOSURE"), do: :escalator_closure
-  defp parse_effect("POLICY_CHANGE"), do: :policy_change
-  defp parse_effect("STOP_SHOVELING"), do: :stop_shoveling
-  defp parse_effect("SUMMARY"), do: :summary
-  defp parse_effect(_), do: :unknown
-
   @causes %{
     "ACCIDENT" => :accident,
-    "AMTRAK" => :amtrak,
-    "AN_EARLIER_MECHANICAL_PROBLEM" => :an_earlier_mechanical_problem,
-    "AN_EARLIER_SIGNAL_PROBLEM" => :an_earlier_signal_problem,
-    "AUTOS_IMPEDING_SERVICE" => :autos_impeding_service,
+    "AMTRAK_TRAIN_TRAFFIC" => :amtrak_train_traffic,
     "COAST_GUARD_RESTRICTION" => :coast_guard_restriction,
-    "CONGESTION" => :congestion,
     "CONSTRUCTION" => :construction,
-    "CROSSING_MALFUNCTION" => :crossing_malfunction,
+    "CROSSING_ISSUE" => :crossing_issue,
     "DEMONSTRATION" => :demonstration,
     "DISABLED_BUS" => :disabled_bus,
     "DISABLED_TRAIN" => :disabled_train,
     "DRAWBRIDGE_BEING_RAISED" => :drawbridge_being_raised,
     "ELECTRICAL_WORK" => :electrical_work,
     "FIRE" => :fire,
+    "FIRE_DEPARTMENT_ACTIVITY" => :fire_department_activity,
+    "FLOODING" => :flooding,
     "FOG" => :fog,
     "FREIGHT_TRAIN_INTERFERENCE" => :freight_train_interference,
     "HAZMAT_CONDITION" => :hazmat_condition,
@@ -139,27 +107,67 @@ defmodule Screens.Alerts.Parser do
     "HURRICANE" => :hurricane,
     "ICE_IN_HARBOR" => :ice_in_harbor,
     "MAINTENANCE" => :maintenance,
+    "MECHANICAL_ISSUE" => :mechanical_issue,
     "MECHANICAL_PROBLEM" => :mechanical_problem,
     "MEDICAL_EMERGENCY" => :medical_emergency,
     "PARADE" => :parade,
     "POLICE_ACTION" => :police_action,
+    "POLICE_ACTIVITY" => :police_activity,
     "POWER_PROBLEM" => :power_problem,
+    "RAIL_DEFECT" => :rail_defect,
     "SEVERE_WEATHER" => :severe_weather,
+    "SIGNAL_ISSUE" => :signal_issue,
     "SIGNAL_PROBLEM" => :signal_problem,
+    "SINGLE_TRACKING" => :single_tracking,
     "SLIPPERY_RAIL" => :slippery_rail,
     "SNOW" => :snow,
     "SPECIAL_EVENT" => :special_event,
     "SPEED_RESTRICTION" => :speed_restriction,
+    "SWITCH_ISSUE" => :switch_issue,
     "SWITCH_PROBLEM" => :switch_problem,
     "TIE_REPLACEMENT" => :tie_replacement,
     "TRACK_PROBLEM" => :track_problem,
     "TRACK_WORK" => :track_work,
     "TRAFFIC" => :traffic,
+    "TRAIN_TRAFFIC" => :train_traffic,
     "UNRULY_PASSENGER" => :unruly_passenger,
     "WEATHER" => :weather
   }
 
-  defp parse_cause(cause) do
-    Map.get(@causes, cause, :unknown)
-  end
+  @effects %{
+    "ACCESS_ISSUE" => :access_issue,
+    "ADDITIONAL_SERVICE" => :additional_service,
+    "AMBER_ALERT" => :amber_alert,
+    "BIKE_ISSUE" => :bike_issue,
+    "CANCELLATION" => :cancellation,
+    "DELAY" => :delay,
+    "DETOUR" => :detour,
+    "DOCK_CLOSURE" => :dock_closure,
+    "DOCK_ISSUE" => :dock_issue,
+    "ELEVATOR_CLOSURE" => :elevator_closure,
+    "ESCALATOR_CLOSURE" => :escalator_closure,
+    "EXTRA_SERVICE" => :extra_service,
+    "FACILITY_ISSUE" => :facility_issue,
+    "MODIFIED_SERVICE" => :modified_service,
+    "NO_SERVICE" => :no_service,
+    "OTHER_EFFECT" => :other_effect,
+    "PARKING_CLOSURE" => :parking_closure,
+    "PARKING_ISSUE" => :parking_issue,
+    "POLICY_CHANGE" => :policy_change,
+    "SCHEDULE_CHANGE" => :schedule_change,
+    "SERVICE_CHANGE" => :service_change,
+    "SHUTTLE" => :shuttle,
+    "SNOW_ROUTE" => :snow_route,
+    "STATION_CLOSURE" => :station_closure,
+    "STATION_ISSUE" => :station_issue,
+    "STOP_CLOSURE" => :stop_closure,
+    "STOP_MOVE" => :stop_move,
+    "STOP_MOVED" => :stop_moved,
+    "SUMMARY" => :summary,
+    "SUSPENSION" => :suspension,
+    "TRACK_CHANGE" => :track_change
+  }
+
+  defp parse_cause(cause), do: Map.get(@causes, cause, :unknown)
+  defp parse_effect(effect), do: Map.get(@effects, effect, :unknown)
 end

--- a/lib/screens/v2/widget_instance/dup_alert/serialize.ex
+++ b/lib/screens/v2/widget_instance/dup_alert/serialize.ex
@@ -133,13 +133,16 @@ defmodule Screens.V2.WidgetInstance.DupAlert.Serialize do
 
           no_trains ++ [bold("to #{headsign}")]
         else
-          no_trains ++ [Alert.get_cause_string(t.alert.cause)]
+          no_trains ++ cause_description(t.alert)
         end
 
       [line_pill1, line_pill2] ->
         ["No", line_pill1, "or", line_pill2, "trains"]
     end
   end
+
+  defp cause_description(%Alert{cause: :unknown}), do: []
+  defp cause_description(alert), do: ["due to", Alert.cause_description(alert)]
 
   defp remedy_free_text_line(t) do
     icon = remedy_icon(t)

--- a/lib/screens/v2/widget_instance/subway_status.ex
+++ b/lib/screens/v2/widget_instance/subway_status.ex
@@ -366,7 +366,7 @@ defmodule Screens.V2.WidgetInstance.SubwayStatus do
     Map.merge(%{route_pill: serialize_route_pill(route_id)}, serialize_alert(alert, route_id))
   end
 
-  @spec serialize_alert(Alert.t() | nil, Route.id()) :: alert()
+  @spec serialize_alert(SubwayStatusAlert.t() | nil, Route.id()) :: alert()
   defp serialize_alert(alert, route_id)
 
   defp serialize_alert(nil, _route_id) do
@@ -422,23 +422,9 @@ defmodule Screens.V2.WidgetInstance.SubwayStatus do
   end
 
   defp serialize_alert(
-         %{
-           alert: %Alert{
-             effect: :delay,
-             severity: severity,
-             informed_entities: informed_entities
-           }
-         },
+         %{alert: %Alert{effect: :delay, informed_entities: informed_entities} = alert},
          route_id
        ) do
-    {delay_description, delay_minutes} = Alert.interpret_severity(severity)
-
-    duration_text =
-      case delay_description do
-        :up_to -> "up to #{delay_minutes} minutes"
-        :more_than -> "over #{delay_minutes} minutes"
-      end
-
     location =
       case get_location(informed_entities, route_id) do
         # Most delays apply to the whole line. It's not necessary to specify it.
@@ -447,7 +433,7 @@ defmodule Screens.V2.WidgetInstance.SubwayStatus do
       end
 
     %{
-      status: "Delays #{duration_text}",
+      status: "Delays #{Alert.delay_description(alert)}",
       location: location
     }
   end

--- a/lib/screens_web/views/v2/audio/reconstructed_alert_single_screen_view.ex
+++ b/lib/screens_web/views/v2/audio/reconstructed_alert_single_screen_view.ex
@@ -1,7 +1,6 @@
 defmodule ScreensWeb.V2.Audio.ReconstructedAlertSingleScreenView do
   use ScreensWeb, :view
 
-  alias Screens.Alerts.Alert
   alias Screens.Util
 
   def render("_widget.ssml", alert) do
@@ -35,13 +34,8 @@ defmodule ScreensWeb.V2.Audio.ReconstructedAlertSingleScreenView do
   def render_banner(_), do: nil
 
   # Delay
-  def render_alert(
-        %{
-          effect: :delay,
-          issue: issue
-        } = alert
-      ) do
-    ~E|<%= issue %><%= render_cause(alert.cause) %>.|
+  def render_alert(%{cause: cause, effect: :delay, issue: issue}) do
+    ~E|<%= issue %> <%= cause %>.|
   end
 
   # Downstream closure
@@ -52,7 +46,7 @@ defmodule ScreensWeb.V2.Audio.ReconstructedAlertSingleScreenView do
         cause: cause,
         stations: stations
       }) do
-    ~E|<%= get_line_name(route_svg_names) %> trains are skipping <%= Util.format_name_list_to_string_audio(stations) %><%= render_cause(cause) %>. Please seek an alternate route.|
+    ~E|<%= get_line_name(route_svg_names) %> trains are skipping <%= Util.format_name_list_to_string_audio(stations) %> <%= cause %>. Please seek an alternate route.|
   end
 
   # Downstream shuttle
@@ -63,7 +57,7 @@ defmodule ScreensWeb.V2.Audio.ReconstructedAlertSingleScreenView do
         endpoints: {left_endpoint, right_endpoint},
         cause: cause
       }) do
-    ~E|Shuttle buses replace <%= get_line_name(route_svg_names) %> trains between <%= left_endpoint %> and <%= right_endpoint %><%= render_cause(cause) %>. All shuttle buses are accessible.|
+    ~E|Shuttle buses replace <%= get_line_name(route_svg_names) %> trains between <%= left_endpoint %> and <%= right_endpoint %> <%= cause %>. All shuttle buses are accessible.|
   end
 
   # Downstream suspension
@@ -74,7 +68,7 @@ defmodule ScreensWeb.V2.Audio.ReconstructedAlertSingleScreenView do
         endpoints: {left_endpoint, right_endpoint},
         cause: cause
       }) do
-    ~E|There are no <%= get_line_name(route_svg_names) %> trains between <%= left_endpoint %> and <%= right_endpoint %><%= render_cause(cause) %>. Please seek an alternate route.|
+    ~E|There are no <%= get_line_name(route_svg_names) %> trains between <%= left_endpoint %> and <%= right_endpoint %> <%= cause %>. Please seek an alternate route.|
   end
 
   # Boundary shuttle
@@ -86,7 +80,7 @@ defmodule ScreensWeb.V2.Audio.ReconstructedAlertSingleScreenView do
         endpoints: {left_endpoint, right_endpoint},
         cause: cause
       }) do
-    ~E|There are <%= issue %>. Please use the shuttle bus. Shuttle buses are replacing <%= get_line_name(route_svg_names) %> trains between <%= left_endpoint %> and <%= right_endpoint %><%= render_cause(cause) %>. All shuttle buses are accessible.|
+    ~E|There are <%= issue %>. Please use the shuttle bus. Shuttle buses are replacing <%= get_line_name(route_svg_names) %> trains between <%= left_endpoint %> and <%= right_endpoint %> <%= cause %>. All shuttle buses are accessible.|
   end
 
   # Boundary suspension
@@ -98,7 +92,7 @@ defmodule ScreensWeb.V2.Audio.ReconstructedAlertSingleScreenView do
         endpoints: {left_endpoint, right_endpoint},
         cause: cause
       }) do
-    ~E|There are <%= issue %>. Please seek an alternate route. Please note that there are no <%= get_line_name(route_svg_names) %> trains between <%= left_endpoint %> and <%= right_endpoint %><%= render_cause(cause) %>.|
+    ~E|There are <%= issue %>. Please seek an alternate route. Please note that there are no <%= get_line_name(route_svg_names) %> trains between <%= left_endpoint %> and <%= right_endpoint %> <%= cause %>.|
   end
 
   # Closure here - three cases
@@ -111,7 +105,7 @@ defmodule ScreensWeb.V2.Audio.ReconstructedAlertSingleScreenView do
         other_closures: other_closures
       })
       when other_closures != [] do
-    ~E|This station is closed<%= render_cause(cause) %>. Please seek an alternate route. <%= get_line_name(route_svg_names) %> trains are skipping this station and <%= Util.format_name_list_to_string_audio(other_closures) %>.|
+    ~E|This station is closed <%= cause %>. Please seek an alternate route. <%= get_line_name(route_svg_names) %> trains are skipping this station and <%= Util.format_name_list_to_string_audio(other_closures) %>.|
   end
 
   # Case 2: Single line impacted at transfer station
@@ -121,7 +115,7 @@ defmodule ScreensWeb.V2.Audio.ReconstructedAlertSingleScreenView do
         cause: cause,
         unaffected_routes: [_ | _] = unaffected_routes
       }) do
-    ~E|<%= get_line_name(route_svg_names) %> trains are skipping this station<%= render_cause(cause) %>. Please seek an alternate route. <%= get_line_name(unaffected_routes) %> trains are stopping here as usual.|
+    ~E|<%= get_line_name(route_svg_names) %> trains are skipping this station <%= cause %>. Please seek an alternate route. <%= get_line_name(unaffected_routes) %> trains are stopping here as usual.|
   end
 
   # Case 3: Single station, single line impacted
@@ -132,7 +126,7 @@ defmodule ScreensWeb.V2.Audio.ReconstructedAlertSingleScreenView do
         routes: route_svg_names,
         cause: cause
       }) do
-    ~E|This station is closed<%= render_cause(cause) %>. Please seek an alternate route. <%= get_line_name(route_svg_names) %> trains are skipping this station.|
+    ~E|This station is closed <%= cause %>. Please seek an alternate route. <%= get_line_name(route_svg_names) %> trains are skipping this station.|
   end
 
   # Shuttle here
@@ -145,9 +139,9 @@ defmodule ScreensWeb.V2.Audio.ReconstructedAlertSingleScreenView do
         } = alert
       ) do
     if Map.has_key?(alert, :is_transfer_station) do
-      ~E|There are no <%= get_line_name(route_svg_names) %> trains. Please use the shuttle bus. Shuttle buses are replacing <%= get_line_name(route_svg_names) %> trains between <%= left_endpoint %> and <%= right_endpoint %><%= render_cause(cause) %>. All shuttle buses are accessible.|
+      ~E|There are no <%= get_line_name(route_svg_names) %> trains. Please use the shuttle bus. Shuttle buses are replacing <%= get_line_name(route_svg_names) %> trains between <%= left_endpoint %> and <%= right_endpoint %> <%= cause %>. All shuttle buses are accessible.|
     else
-      ~E|This station is closed. Please use the shuttle bus. Shuttle buses are replacing <%= get_line_name(route_svg_names) %> trains between <%= left_endpoint %> and <%= right_endpoint %><%= render_cause(cause) %>. All shuttle buses are accessible.|
+      ~E|This station is closed. Please use the shuttle bus. Shuttle buses are replacing <%= get_line_name(route_svg_names) %> trains between <%= left_endpoint %> and <%= right_endpoint %> <%= cause %>. All shuttle buses are accessible.|
     end
   end
 
@@ -161,9 +155,9 @@ defmodule ScreensWeb.V2.Audio.ReconstructedAlertSingleScreenView do
         } = alert
       ) do
     if Map.has_key?(alert, :is_transfer_station) do
-      ~E|There are no <%= get_line_name(route_svg_names) %> trains<%= render_cause(cause) %>. Please seek an alternate route. Please note that there are no <%= get_line_name(route_svg_names) %> trains between <%= left_endpoint %> and <%= right_endpoint %>.|
+      ~E|There are no <%= get_line_name(route_svg_names) %> trains <%= cause %>. Please seek an alternate route. Please note that there are no <%= get_line_name(route_svg_names) %> trains between <%= left_endpoint %> and <%= right_endpoint %>.|
     else
-      ~E|This station is closed<%= render_cause(cause) %>. Please seek an alternate route. Please note that there are no <%= get_line_name(route_svg_names) %> trains between <%= left_endpoint %> and <%= right_endpoint %>.|
+      ~E|This station is closed <%= cause %>. Please seek an alternate route. Please note that there are no <%= get_line_name(route_svg_names) %> trains between <%= left_endpoint %> and <%= right_endpoint %>.|
     end
   end
 
@@ -227,7 +221,4 @@ defmodule ScreensWeb.V2.Audio.ReconstructedAlertSingleScreenView do
 
     ~E|<%= list_of_lines %>|
   end
-
-  defp render_cause(nil), do: nil
-  defp render_cause(cause), do: " #{Alert.get_cause_string(cause)}"
 end

--- a/lib/screens_web/views/v2/audio/subway_status_view.ex
+++ b/lib/screens_web/views/v2/audio/subway_status_view.ex
@@ -159,13 +159,15 @@ defmodule ScreensWeb.V2.Audio.SubwayStatusView do
     #
     # alert.status                   ||| possible values of location_string
     # -------------------------------|||-----------------------------------
-    # Shuttle Bus                    ||| "" | Xbound | $STATION | $STATION ↔ $STATION | Entire line
     # SERVICE SUSPENDED              ||| Entire line
     # Suspension                     ||| "" | Xbound | $STATION | $STATION ↔ $STATION
-    # Delays (up to|over) $N minutes ||| "" | Xbound | $STATION | $STATION ↔ $STATION
+    # Service Change                 ||| "" | Xbound | $STATION | $STATION ↔ $STATION | Entire line
+    # Shuttle Bus                    ||| "" | Xbound | $STATION | $STATION ↔ $STATION | Entire line
+    # Delays (up to|over) $N minutes ||| "" | Xbound | $STATION | $STATION ↔ $STATION | Due to $CAUSE
     # Bypassing                      ||| "" | $STOP | $STOP and $STOP | $STOP, $STOP, and $STOP
     # Bypassing $N stops             ||| ""
     # $N current alerts              ||| ""
+    # Single Tracking                ||| Due to $CAUSE
     verb_atom = get_verb_atom(status)
     article = get_article(status, location_string)
     content = get_content(status, location_string)
@@ -173,9 +175,9 @@ defmodule ScreensWeb.V2.Audio.SubwayStatusView do
     {verb_atom, ~E|<%= article %><%= content %>|}
   end
 
-  defp get_verb_atom(status) do
-    if String.starts_with?(status, "Bypassing"), do: :is, else: :has
-  end
+  defp get_verb_atom("Bypassing" <> _), do: :is
+  defp get_verb_atom("Single Tracking" <> _), do: :is
+  defp get_verb_atom(_other), do: :has
 
   defp conjugate(verb_atom, multi_branch_alert?)
 
@@ -188,7 +190,7 @@ defmodule ScreensWeb.V2.Audio.SubwayStatusView do
   defp get_article(status, location_string) do
     cond do
       location_string == "Eastbound" -> "an "
-      status =~ ~r/^(?:Delays|Bypassing|SERVICE SUSPENDED|\d)/ -> ""
+      status =~ ~r/^(?:Delays|Bypassing|Single Tracking|SERVICE SUSPENDED|\d)/ -> ""
       true -> "a "
     end
   end
@@ -199,17 +201,21 @@ defmodule ScreensWeb.V2.Audio.SubwayStatusView do
         # E.g. "3 current alerts", "Bypassing 5 stops", "Suspension"
         ~E|<%= status %>|
 
+      # Location is actually a cause (single tracking)
+      String.starts_with?(location_string, "Due to") ->
+        ~E|<%= status %> <%= location_string %>|
+
       # Shuttle Bus/Suspension/Delays + Xbound
       location_string =~ ~r/^(?:North|East|South|West)bound$/ ->
         # E.g. "Southbound Shuttle bus", "Northbound Suspension", "Eastbound Delays up to 20 minutes"
         ~E|<%= location_string %> <%= status %>|
 
-      # Shuttle Bus/Suspension/Delays + $STATION ↔ $STATION
+      # Shuttle Bus/Suspension/Delays/Single Tracking + $STATION ↔ $STATION
       String.contains?(location_string, " ↔ ") ->
         # E.g. "Suspension between Back Bay and North Station", "Shuttle Bus between Ashmont and JFK/UMass"
         ~E|<%= status %> between <%= String.replace(location_string, " ↔ ", " and ") %>|
 
-      # Shuttle Bus/SERVICE SUSPENDED + Entire line
+      # Shuttle Bus/Service Change/SERVICE SUSPENDED + Entire line
       location_string == "Entire line" ->
         # "SERVICE SUSPENDED on the Entire line"
         ~E|<%= status %> on the <%= location_string %>|

--- a/lib/screens_web/views/v2/audio/subway_status_view.ex
+++ b/lib/screens_web/views/v2/audio/subway_status_view.ex
@@ -159,10 +159,10 @@ defmodule ScreensWeb.V2.Audio.SubwayStatusView do
     #
     # alert.status                   ||| possible values of location_string
     # -------------------------------|||-----------------------------------
-    # Shuttle Bus                    ||| "" | Xbound | $STATION | $STATION to $STATION | Entire line
+    # Shuttle Bus                    ||| "" | Xbound | $STATION | $STATION ↔ $STATION | Entire line
     # SERVICE SUSPENDED              ||| Entire line
-    # Suspension                     ||| "" | Xbound | $STATION | $STATION to $STATION
-    # Delays (up to|over) $N minutes ||| "" | Xbound | $STATION | $STATION to $STATION
+    # Suspension                     ||| "" | Xbound | $STATION | $STATION ↔ $STATION
+    # Delays (up to|over) $N minutes ||| "" | Xbound | $STATION | $STATION ↔ $STATION
     # Bypassing                      ||| "" | $STOP | $STOP and $STOP | $STOP, $STOP, and $STOP
     # Bypassing $N stops             ||| ""
     # $N current alerts              ||| ""
@@ -204,10 +204,10 @@ defmodule ScreensWeb.V2.Audio.SubwayStatusView do
         # E.g. "Southbound Shuttle bus", "Northbound Suspension", "Eastbound Delays up to 20 minutes"
         ~E|<%= location_string %> <%= status %>|
 
-      # Shuttle Bus/Suspension/Delays + $STATION to $STATION
-      String.contains?(location_string, " to ") ->
-        # E.g. "Suspension from Back Bay to North Station", "Shuttle Bus from Ashmont to JFK/UMass"
-        ~E|<%= status %> from <%= location_string %>|
+      # Shuttle Bus/Suspension/Delays + $STATION ↔ $STATION
+      String.contains?(location_string, " ↔ ") ->
+        # E.g. "Suspension between Back Bay and North Station", "Shuttle Bus between Ashmont and JFK/UMass"
+        ~E|<%= status %> between <%= String.replace(location_string, " ↔ ", " and ") %>|
 
       # Shuttle Bus/SERVICE SUSPENDED + Entire line
       location_string == "Entire line" ->

--- a/test/screens/v2/widget_instance/subway_status_test.exs
+++ b/test/screens/v2/widget_instance/subway_status_test.exs
@@ -936,6 +936,72 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
       assert expected == WidgetInstance.serialize(instance)
     end
 
+    test "handles an informational single-tracking alert" do
+      instance = %SubwayStatus{
+        subway_alerts: [
+          %{
+            alert: %Alert{
+              cause: :single_tracking,
+              effect: :delay,
+              severity: 1,
+              informed_entities: [
+                %{route: "Orange", stop: "place-ogmnl"},
+                %{route: "Orange", stop: "place-mlmnl"},
+                %{route: "Orange", stop: "place-welln"}
+              ]
+            }
+          }
+        ]
+      }
+
+      expected = %{
+        @normal_service
+        | orange: %{
+            type: :extended,
+            alert: %{
+              status: "Single Tracking",
+              location: %{full: "Oak Grove ↔ Wellington", abbrev: "Oak Grove ↔ Wellington"},
+              route_pill: @ol_pill
+            }
+          }
+      }
+
+      assert expected == WidgetInstance.serialize(instance)
+    end
+
+    test "handles a non-informational single-tracking alert" do
+      instance = %SubwayStatus{
+        subway_alerts: [
+          %{
+            alert: %Alert{
+              cause: :single_tracking,
+              effect: :delay,
+              severity: 4,
+              informed_entities: [
+                %{route: "Orange", stop: "place-ogmnl"},
+                %{route: "Orange", stop: "place-mlmnl"},
+                %{route: "Orange", stop: "place-welln"}
+              ]
+            }
+          }
+        ]
+      }
+
+      expected = %{
+        @normal_service
+        | orange: %{
+            type: :extended,
+            alert: %{
+              status: "Delays up to 15 minutes",
+              location: %{full: "Due to Single Tracking", abbrev: "Single Tracking"},
+              route_pill: @ol_pill
+            }
+          }
+      }
+
+      assert expected == WidgetInstance.serialize(instance)
+    end
+
     test "handles alert closing multiple platforms at one station" do
       instance = %SubwayStatus{
         subway_alerts: [

--- a/test/screens/v2/widget_instance/subway_status_test.exs
+++ b/test/screens/v2/widget_instance/subway_status_test.exs
@@ -18,51 +18,24 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
   end
 
   describe "serialize/1" do
+    @bl_pill %{type: :text, text: "BL", color: :blue}
+    @gl_pill %{type: :text, text: "GL", color: :green}
+    @ol_pill %{type: :text, text: "OL", color: :orange}
+    @rl_pill %{type: :text, text: "RL", color: :red}
+
+    @normal_service %{
+      blue: %{type: :contracted, alerts: [%{route_pill: @bl_pill, status: "Normal Service"}]},
+      green: %{type: :contracted, alerts: [%{route_pill: @gl_pill, status: "Normal Service"}]},
+      orange: %{type: :contracted, alerts: [%{route_pill: @ol_pill, status: "Normal Service"}]},
+      red: %{type: :contracted, alerts: [%{route_pill: @rl_pill, status: "Normal Service"}]}
+    }
+
+    defp gl_pill(branches), do: Map.put(@gl_pill, :branches, branches)
+
     test "returns normal service when there are no alerts" do
-      instance = %SubwayStatus{
-        subway_alerts: []
-      }
+      instance = %SubwayStatus{subway_alerts: []}
 
-      expected = %{
-        blue: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "BL", color: :blue},
-              status: "Normal Service"
-            }
-          ]
-        },
-        orange: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "OL", color: :orange},
-              status: "Normal Service"
-            }
-          ]
-        },
-        red: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "RL", color: :red},
-              status: "Normal Service"
-            }
-          ]
-        },
-        green: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "GL", color: :green},
-              status: "Normal Service"
-            }
-          ]
-        }
-      }
-
-      assert expected == WidgetInstance.serialize(instance)
+      assert @normal_service == WidgetInstance.serialize(instance)
     end
 
     test "handles station closure alert with 4+ stops" do
@@ -82,45 +55,16 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
       }
 
       expected = %{
-        blue: %{
-          type: :extended,
-          alert: %{
-            route_pill: %{type: :text, text: "BL", color: :blue},
-            status: "Bypassing 4 stops",
-            location: %{
-              abbrev: "mbta.com/status",
-              full: "mbta.com/status"
-            },
-            station_count: 4
+        @normal_service
+        | blue: %{
+            type: :extended,
+            alert: %{
+              route_pill: @bl_pill,
+              status: "Bypassing 4 stops",
+              location: %{abbrev: "mbta.com/status", full: "mbta.com/status"},
+              station_count: 4
+            }
           }
-        },
-        orange: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "OL", color: :orange},
-              status: "Normal Service"
-            }
-          ]
-        },
-        red: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "RL", color: :red},
-              status: "Normal Service"
-            }
-          ]
-        },
-        green: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "GL", color: :green},
-              status: "Normal Service"
-            }
-          ]
-        }
       }
 
       assert expected == WidgetInstance.serialize(instance)
@@ -142,45 +86,19 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
       }
 
       expected = %{
-        blue: %{
-          type: :extended,
-          alert: %{
-            route_pill: %{type: :text, text: "BL", color: :blue},
-            status: "Bypassing",
-            location: %{
-              abbrev: "Airport, Maverick & Aquarium",
-              full: "Airport, Maverick & Aquarium"
-            },
-            station_count: 3
+        @normal_service
+        | blue: %{
+            type: :extended,
+            alert: %{
+              route_pill: @bl_pill,
+              status: "Bypassing",
+              location: %{
+                abbrev: "Airport, Maverick & Aquarium",
+                full: "Airport, Maverick & Aquarium"
+              },
+              station_count: 3
+            }
           }
-        },
-        orange: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "OL", color: :orange},
-              status: "Normal Service"
-            }
-          ]
-        },
-        red: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "RL", color: :red},
-              status: "Normal Service"
-            }
-          ]
-        },
-        green: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "GL", color: :green},
-              status: "Normal Service"
-            }
-          ]
-        }
       }
 
       assert expected == WidgetInstance.serialize(instance)
@@ -201,42 +119,16 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
       }
 
       expected = %{
-        blue: %{
-          type: :extended,
-          alert: %{
-            route_pill: %{type: :text, text: "BL", color: :blue},
-            status: "Bypassing",
-            location: %{abbrev: "Airport and Maverick", full: "Airport and Maverick"},
-            station_count: 2
+        @normal_service
+        | blue: %{
+            type: :extended,
+            alert: %{
+              route_pill: @bl_pill,
+              status: "Bypassing",
+              location: %{abbrev: "Airport and Maverick", full: "Airport and Maverick"},
+              station_count: 2
+            }
           }
-        },
-        orange: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "OL", color: :orange},
-              status: "Normal Service"
-            }
-          ]
-        },
-        red: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "RL", color: :red},
-              status: "Normal Service"
-            }
-          ]
-        },
-        green: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "GL", color: :green},
-              status: "Normal Service"
-            }
-          ]
-        }
       }
 
       assert expected == WidgetInstance.serialize(instance)
@@ -268,40 +160,19 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
       }
 
       expected = %{
-        blue: %{
-          type: :extended,
-          alert: %{
-            route_pill: %{type: :text, text: "BL", color: :blue},
-            status: "Suspension",
-            location: %{abbrev: "Airport ↔ Aquarium", full: "Airport ↔ Aquarium"}
-          }
-        },
-        orange: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "OL", color: :orange},
-              status: "Normal Service"
+        @normal_service
+        | blue: %{
+            type: :extended,
+            alert: %{
+              route_pill: @bl_pill,
+              status: "Suspension",
+              location: %{abbrev: "Airport ↔ Aquarium", full: "Airport ↔ Aquarium"}
             }
-          ]
-        },
-        red: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "RL", color: :red},
-              status: "Normal Service"
-            }
-          ]
-        },
-        green: %{
-          type: :extended,
-          alert: %{
-            route_pill: %{type: :text, text: "GL", color: :green},
-            status: "Delays up to 20 minutes",
-            location: nil
+          },
+          green: %{
+            type: :extended,
+            alert: %{route_pill: @gl_pill, status: "Delays up to 20 minutes", location: nil}
           }
-        }
       }
 
       assert expected == WidgetInstance.serialize(instance)
@@ -330,47 +201,21 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
       }
 
       expected = %{
-        blue: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "BL", color: :blue},
-              status: "Suspension",
-              location: %{abbrev: "Airport", full: "Airport"}
-            },
-            %{
-              status: "Delays up to 20 minutes",
-              location: %{abbrev: "Airport ↔ Aquarium", full: "Airport ↔ Aquarium"}
-            }
-          ]
-        },
-        orange: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "OL", color: :orange},
-              status: "Normal Service"
-            }
-          ]
-        },
-        red: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "RL", color: :red},
-              status: "Normal Service"
-            }
-          ]
-        },
-        green: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "GL", color: :green},
-              status: "Normal Service"
-            }
-          ]
-        }
+        @normal_service
+        | blue: %{
+            type: :contracted,
+            alerts: [
+              %{
+                route_pill: @bl_pill,
+                status: "Suspension",
+                location: %{abbrev: "Airport", full: "Airport"}
+              },
+              %{
+                status: "Delays up to 20 minutes",
+                location: %{abbrev: "Airport ↔ Aquarium", full: "Airport ↔ Aquarium"}
+              }
+            ]
+          }
       }
 
       assert expected == WidgetInstance.serialize(instance)
@@ -418,44 +263,19 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
       }
 
       expected = %{
-        blue: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "BL", color: :blue},
-              status: "2 current alerts",
-              location: "mbta.com/status"
-            }
-          ]
-        },
-        orange: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "OL", color: :orange},
-              status: "2 current alerts",
-              location: "mbta.com/status"
-            }
-          ]
-        },
-        red: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "RL", color: :red},
-              status: "Normal Service"
-            }
-          ]
-        },
-        green: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "GL", color: :green},
-              status: "Normal Service"
-            }
-          ]
-        }
+        @normal_service
+        | blue: %{
+            type: :contracted,
+            alerts: [
+              %{route_pill: @bl_pill, status: "2 current alerts", location: "mbta.com/status"}
+            ]
+          },
+          orange: %{
+            type: :contracted,
+            alerts: [
+              %{route_pill: @ol_pill, status: "2 current alerts", location: "mbta.com/status"}
+            ]
+          }
       }
 
       assert expected == WidgetInstance.serialize(instance)
@@ -492,49 +312,32 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
       }
 
       expected = %{
-        blue: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "BL", color: :blue},
-              status: "Bypassing",
-              location: %{abbrev: "Airport", full: "Airport"},
-              station_count: 1
-            }
-          ]
-        },
-        orange: %{
-          type: :contracted,
-          alerts: [
-            %{
-              location: %{abbrev: "Oak Grove ↔ Wellington", full: "Oak Grove ↔ Wellington"},
-              route_pill: %{color: :orange, text: "OL", type: :text},
-              status: "Suspension"
-            },
-            %{
-              location: %{abbrev: "Oak Grove ↔ Wellington", full: "Oak Grove ↔ Wellington"},
-              status: "Delays up to 20 minutes"
-            }
-          ]
-        },
-        red: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "RL", color: :red},
-              status: "Normal Service"
-            }
-          ]
-        },
-        green: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "GL", color: :green},
-              status: "Normal Service"
-            }
-          ]
-        }
+        @normal_service
+        | blue: %{
+            type: :contracted,
+            alerts: [
+              %{
+                route_pill: @bl_pill,
+                status: "Bypassing",
+                location: %{abbrev: "Airport", full: "Airport"},
+                station_count: 1
+              }
+            ]
+          },
+          orange: %{
+            type: :contracted,
+            alerts: [
+              %{
+                location: %{abbrev: "Oak Grove ↔ Wellington", full: "Oak Grove ↔ Wellington"},
+                route_pill: @ol_pill,
+                status: "Suspension"
+              },
+              %{
+                location: %{abbrev: "Oak Grove ↔ Wellington", full: "Oak Grove ↔ Wellington"},
+                status: "Delays up to 20 minutes"
+              }
+            ]
+          }
       }
 
       assert expected == WidgetInstance.serialize(instance)
@@ -563,55 +366,29 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
       }
 
       expected = %{
-        blue: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "BL", color: :blue},
-              status: "Normal Service"
-            }
-          ]
-        },
-        orange: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "OL", color: :orange},
-              status: "Normal Service"
-            }
-          ]
-        },
-        red: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "RL", color: :red},
-              status: "Normal Service"
-            }
-          ]
-        },
-        green: %{
-          type: :contracted,
-          alerts: [
-            %{
-              location: %{
-                abbrev: "Gov't Ctr and Riverside",
-                full: "Government Center and Riverside"
+        @normal_service
+        | green: %{
+            type: :contracted,
+            alerts: [
+              %{
+                location: %{
+                  abbrev: "Gov't Ctr and Riverside",
+                  full: "Government Center and Riverside"
+                },
+                route_pill: @gl_pill,
+                station_count: 2,
+                status: "Bypassing"
               },
-              route_pill: %{color: :green, text: "GL", type: :text},
-              station_count: 2,
-              status: "Bypassing"
-            },
-            %{
-              location: %{
-                abbrev: "Hawes St ↔ St. Paul St",
-                full: "Hawes Street ↔ Saint Paul Street"
-              },
-              route_pill: %{branches: [:c], color: :green, text: "GL", type: :text},
-              status: "Suspension"
-            }
-          ]
-        }
+              %{
+                location: %{
+                  abbrev: "Hawes St ↔ St. Paul St",
+                  full: "Hawes Street ↔ Saint Paul Street"
+                },
+                route_pill: gl_pill([:c]),
+                status: "Suspension"
+              }
+            ]
+          }
       }
 
       assert expected == WidgetInstance.serialize(instance)
@@ -650,48 +427,18 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
       }
 
       expected = %{
-        blue: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "BL", color: :blue},
-              status: "Normal Service"
-            }
-          ]
-        },
-        orange: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "OL", color: :orange},
-              status: "Normal Service"
-            }
-          ]
-        },
-        red: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "RL", color: :red},
-              status: "Normal Service"
-            }
-          ]
-        },
-        green: %{
-          type: :contracted,
-          alerts: [
-            %{
-              location: nil,
-              route_pill: %{color: :green, text: "GL", type: :text},
-              status: "Delays up to 25 minutes"
-            },
-            %{
-              route_pill: %{type: :text, text: "GL", color: :green, branches: [:b, :c]},
-              status: "2 current alerts",
-              location: "mbta.com/status"
-            }
-          ]
-        }
+        @normal_service
+        | green: %{
+            type: :contracted,
+            alerts: [
+              %{location: nil, route_pill: @gl_pill, status: "Delays up to 25 minutes"},
+              %{
+                route_pill: gl_pill([:b, :c]),
+                status: "2 current alerts",
+                location: "mbta.com/status"
+              }
+            ]
+          }
       }
 
       assert expected == WidgetInstance.serialize(instance)
@@ -722,51 +469,21 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
       }
 
       expected = %{
-        blue: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "BL", color: :blue},
-              status: "Normal Service"
-            }
-          ]
-        },
-        orange: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "OL", color: :orange},
-              status: "Normal Service"
-            }
-          ]
-        },
-        red: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "RL", color: :red},
-              status: "Normal Service"
-            }
-          ]
-        },
-        green: %{
-          type: :contracted,
-          alerts: [
-            %{
-              location: nil,
-              route_pill: %{color: :green, text: "GL", type: :text},
-              status: "Delays up to 20 minutes"
-            },
-            %{
-              location: %{
-                abbrev: "Gov't Ctr ↔ Park St",
-                full: "Government Center ↔ Park Street"
-              },
-              route_pill: %{color: :green, text: "GL", type: :text},
-              status: "Suspension"
-            }
-          ]
-        }
+        @normal_service
+        | green: %{
+            type: :contracted,
+            alerts: [
+              %{location: nil, route_pill: @gl_pill, status: "Delays up to 20 minutes"},
+              %{
+                location: %{
+                  abbrev: "Gov't Ctr ↔ Park St",
+                  full: "Government Center ↔ Park Street"
+                },
+                route_pill: @gl_pill,
+                status: "Suspension"
+              }
+            ]
+          }
       }
 
       assert expected == WidgetInstance.serialize(instance)
@@ -794,48 +511,14 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
       }
 
       expected = %{
-        blue: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "BL", color: :blue},
-              status: "Normal Service"
-            }
-          ]
-        },
-        orange: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "OL", color: :orange},
-              status: "Normal Service"
-            }
-          ]
-        },
-        red: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "RL", color: :red},
-              status: "Normal Service"
-            }
-          ]
-        },
-        green: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "GL", color: :green, branches: [:b]},
-              status: "Delays up to 20 minutes",
-              location: nil
-            },
-            %{
-              route_pill: %{type: :text, text: "GL", color: :green, branches: [:c]},
-              status: "Delays over 60 minutes",
-              location: nil
-            }
-          ]
-        }
+        @normal_service
+        | green: %{
+            type: :contracted,
+            alerts: [
+              %{route_pill: gl_pill([:b]), status: "Delays up to 20 minutes", location: nil},
+              %{route_pill: gl_pill([:c]), status: "Delays over 60 minutes", location: nil}
+            ]
+          }
       }
 
       assert expected == WidgetInstance.serialize(instance)
@@ -870,43 +553,17 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
       }
 
       expected = %{
-        blue: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "BL", color: :blue},
-              status: "Normal Service"
-            }
-          ]
-        },
-        orange: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "OL", color: :orange},
-              status: "Normal Service"
-            }
-          ]
-        },
-        red: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "RL", color: :red},
-              status: "Normal Service"
-            }
-          ]
-        },
-        green: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "GL", color: :green, branches: [:b, :c, :e]},
-              status: "3 current alerts",
-              location: "mbta.com/status"
-            }
-          ]
-        }
+        @normal_service
+        | green: %{
+            type: :contracted,
+            alerts: [
+              %{
+                route_pill: gl_pill([:b, :c, :e]),
+                status: "3 current alerts",
+                location: "mbta.com/status"
+              }
+            ]
+          }
       }
 
       assert expected == WidgetInstance.serialize(instance)
@@ -940,50 +597,25 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
       }
 
       expected = %{
-        blue: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "BL", color: :blue},
-              status: "Normal Service"
-            }
-          ]
-        },
-        orange: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "OL", color: :orange},
-              status: "Bypassing",
-              location: %{abbrev: "Oak Grove", full: "Oak Grove"},
-              station_count: 1
-            }
-          ]
-        },
-        red: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "RL", color: :red},
-              status: "Normal Service"
-            }
-          ]
-        },
-        green: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "GL", color: :green, branches: [:b]},
-              status: "Delays up to 20 minutes",
-              location: nil
-            },
-            %{
-              route_pill: %{type: :text, text: "GL", color: :green, branches: [:c]},
-              status: "Delays over 60 minutes",
-              location: nil
-            }
-          ]
-        }
+        @normal_service
+        | orange: %{
+            type: :contracted,
+            alerts: [
+              %{
+                route_pill: @ol_pill,
+                status: "Bypassing",
+                location: %{abbrev: "Oak Grove", full: "Oak Grove"},
+                station_count: 1
+              }
+            ]
+          },
+          green: %{
+            type: :contracted,
+            alerts: [
+              %{route_pill: gl_pill([:b]), status: "Delays up to 20 minutes", location: nil},
+              %{route_pill: gl_pill([:c]), status: "Delays over 60 minutes", location: nil}
+            ]
+          }
       }
 
       assert expected == WidgetInstance.serialize(instance)
@@ -1020,43 +652,13 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
       }
 
       expected = %{
-        blue: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "BL", color: :blue},
-              status: "Normal Service"
-            }
-          ]
-        },
-        orange: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "OL", color: :orange},
-              status: "Normal Service"
-            }
-          ]
-        },
-        red: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "RL", color: :red},
-              status: "Normal Service"
-            }
-          ]
-        },
-        green: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "GL", color: :green},
-              status: "3 current alerts",
-              location: "mbta.com/status"
-            }
-          ]
-        }
+        @normal_service
+        | green: %{
+            type: :contracted,
+            alerts: [
+              %{route_pill: @gl_pill, status: "3 current alerts", location: "mbta.com/status"}
+            ]
+          }
       }
 
       assert expected == WidgetInstance.serialize(instance)
@@ -1097,49 +699,24 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
       }
 
       expected = %{
-        blue: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "BL", color: :blue},
-              status: "Normal Service"
-            }
-          ]
-        },
-        orange: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "OL", color: :orange},
-              status: "2 current alerts",
-              location: "mbta.com/status"
-            }
-          ]
-        },
-        red: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "RL", color: :red},
-              status: "Normal Service"
-            }
-          ]
-        },
-        green: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "GL", color: :green, branches: [:b]},
-              status: "Delays up to 20 minutes",
-              location: nil
-            },
-            %{
-              route_pill: %{type: :text, text: "GL", color: :green, branches: [:c]},
-              status: "Delays over 60 minutes",
-              location: nil
-            }
-          ]
-        }
+        @normal_service
+        | orange: %{
+            type: :contracted,
+            alerts: [
+              %{
+                route_pill: @ol_pill,
+                status: "2 current alerts",
+                location: "mbta.com/status"
+              }
+            ]
+          },
+          green: %{
+            type: :contracted,
+            alerts: [
+              %{route_pill: gl_pill([:b]), status: "Delays up to 20 minutes", location: nil},
+              %{route_pill: gl_pill([:c]), status: "Delays over 60 minutes", location: nil}
+            ]
+          }
       }
 
       assert expected == WidgetInstance.serialize(instance)
@@ -1172,47 +749,39 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
       }
 
       expected = %{
-        blue: %{
-          alerts: [
-            %{
-              route_pill: %{color: :blue, text: "BL", type: :text},
-              status: "Suspension",
-              location: %{abbrev: "Beachmont", full: "Beachmont"}
-            }
-          ],
-          type: :contracted
-        },
-        orange: %{
-          type: :contracted,
-          alerts: [
-            %{
-              location: %{abbrev: "Oak Grove", full: "Oak Grove"},
-              route_pill: %{color: :orange, text: "OL", type: :text},
-              station_count: 1,
-              status: "Bypassing"
-            }
-          ]
-        },
-        red: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "RL", color: :red},
-              status: "Normal Service"
-            }
-          ]
-        },
-        green: %{
-          type: :contracted,
-          alerts: [
-            %{
-              location: %{abbrev: "Lechmere", full: "Lechmere"},
-              route_pill: %{color: :green, text: "GL", type: :text},
-              status: "Bypassing",
-              station_count: 1
-            }
-          ]
-        }
+        @normal_service
+        | blue: %{
+            alerts: [
+              %{
+                route_pill: @bl_pill,
+                status: "Suspension",
+                location: %{abbrev: "Beachmont", full: "Beachmont"}
+              }
+            ],
+            type: :contracted
+          },
+          orange: %{
+            type: :contracted,
+            alerts: [
+              %{
+                location: %{abbrev: "Oak Grove", full: "Oak Grove"},
+                route_pill: @ol_pill,
+                station_count: 1,
+                status: "Bypassing"
+              }
+            ]
+          },
+          green: %{
+            type: :contracted,
+            alerts: [
+              %{
+                location: %{abbrev: "Lechmere", full: "Lechmere"},
+                route_pill: @gl_pill,
+                status: "Bypassing",
+                station_count: 1
+              }
+            ]
+          }
       }
 
       assert expected == WidgetInstance.serialize(instance)
@@ -1239,41 +808,20 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
       }
 
       expected = %{
-        blue: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "BL", color: :blue},
-              status: "Normal Service"
+        @normal_service
+        | orange: %{
+            type: :extended,
+            alert: %{
+              route_pill: @ol_pill,
+              status: "Bypassing",
+              location: %{abbrev: "Oak Grove", full: "Oak Grove"},
+              station_count: 1
             }
-          ]
-        },
-        orange: %{
-          type: :extended,
-          alert: %{
-            route_pill: %{type: :text, text: "OL", color: :orange},
-            status: "Bypassing",
-            location: %{abbrev: "Oak Grove", full: "Oak Grove"},
-            station_count: 1
+          },
+          green: %{
+            type: :extended,
+            alert: %{route_pill: gl_pill([:c]), status: "Delays over 60 minutes", location: nil}
           }
-        },
-        red: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "RL", color: :red},
-              status: "Normal Service"
-            }
-          ]
-        },
-        green: %{
-          type: :extended,
-          alert: %{
-            route_pill: %{type: :text, text: "GL", color: :green, branches: [:c]},
-            status: "Delays over 60 minutes",
-            location: nil
-          }
-        }
       }
 
       assert expected == WidgetInstance.serialize(instance)
@@ -1296,45 +844,21 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
       }
 
       expected = %{
-        blue: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "BL", color: :blue},
-              status: "Delays over 60 minutes",
-              location: nil
-            }
-          ]
-        },
-        orange: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "OL", color: :orange},
-              status: "Delays over 60 minutes",
-              location: nil
-            }
-          ]
-        },
-        red: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "RL", color: :red},
-              status: "Normal Service"
-            }
-          ]
-        },
-        green: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "GL", color: :green, branches: [:c]},
-              status: "Delays over 60 minutes",
-              location: nil
-            }
-          ]
-        }
+        @normal_service
+        | blue: %{
+            type: :contracted,
+            alerts: [%{route_pill: @bl_pill, status: "Delays over 60 minutes", location: nil}]
+          },
+          orange: %{
+            type: :contracted,
+            alerts: [%{route_pill: @ol_pill, status: "Delays over 60 minutes", location: nil}]
+          },
+          green: %{
+            type: :contracted,
+            alerts: [
+              %{route_pill: gl_pill([:c]), status: "Delays over 60 minutes", location: nil}
+            ]
+          }
       }
 
       assert expected == WidgetInstance.serialize(instance)
@@ -1362,41 +886,15 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
       }
 
       expected = %{
-        blue: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "BL", color: :blue},
-              status: "Normal Service"
+        @normal_service
+        | red: %{
+            type: :extended,
+            alert: %{
+              status: "Bypassing 1 stop",
+              location: %{full: "mbta.com/status", abbrev: "mbta.com/status"},
+              route_pill: @rl_pill
             }
-          ]
-        },
-        orange: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "OL", color: :orange},
-              status: "Normal Service"
-            }
-          ]
-        },
-        red: %{
-          type: :extended,
-          alert: %{
-            status: "Bypassing 1 stop",
-            location: %{full: "mbta.com/status", abbrev: "mbta.com/status"},
-            route_pill: %{type: :text, text: "RL", color: :red}
           }
-        },
-        green: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "GL", color: :green},
-              status: "Normal Service"
-            }
-          ]
-        }
       }
 
       assert expected == WidgetInstance.serialize(instance)
@@ -1424,41 +922,15 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
       }
 
       expected = %{
-        blue: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "BL", color: :blue},
-              status: "Normal Service"
+        @normal_service
+        | red: %{
+            type: :extended,
+            alert: %{
+              status: "Service Change",
+              location: %{full: "Porter", abbrev: "Porter"},
+              route_pill: @rl_pill
             }
-          ]
-        },
-        orange: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "OL", color: :orange},
-              status: "Normal Service"
-            }
-          ]
-        },
-        red: %{
-          type: :extended,
-          alert: %{
-            status: "Service Change",
-            location: %{full: "Porter", abbrev: "Porter"},
-            route_pill: %{type: :text, text: "RL", color: :red}
           }
-        },
-        green: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "GL", color: :green},
-              status: "Normal Service"
-            }
-          ]
-        }
       }
 
       assert expected == WidgetInstance.serialize(instance)
@@ -1489,41 +961,15 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
       }
 
       expected = %{
-        blue: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "BL", color: :blue},
-              status: "Normal Service"
+        @normal_service
+        | red: %{
+            type: :extended,
+            alert: %{
+              status: "Bypassing 2 stops",
+              location: %{full: "mbta.com/status", abbrev: "mbta.com/status"},
+              route_pill: @rl_pill
             }
-          ]
-        },
-        orange: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "OL", color: :orange},
-              status: "Normal Service"
-            }
-          ]
-        },
-        red: %{
-          type: :extended,
-          alert: %{
-            status: "Bypassing 2 stops",
-            location: %{full: "mbta.com/status", abbrev: "mbta.com/status"},
-            route_pill: %{type: :text, text: "RL", color: :red}
           }
-        },
-        green: %{
-          type: :contracted,
-          alerts: [
-            %{
-              route_pill: %{type: :text, text: "GL", color: :green},
-              status: "Normal Service"
-            }
-          ]
-        }
       }
 
       assert expected == WidgetInstance.serialize(instance)
@@ -1543,32 +989,11 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
       }
 
       expected = %{
-        blue: %{
-          type: :extended,
-          alert: %{
-            route_pill: %{type: :text, text: "BL", color: :blue},
-            status: "Shuttle Bus",
-            location: "Entire line"
+        @normal_service
+        | blue: %{
+            type: :extended,
+            alert: %{route_pill: @bl_pill, status: "Shuttle Bus", location: "Entire line"}
           }
-        },
-        green: %{
-          alerts: [
-            %{route_pill: %{color: :green, text: "GL", type: :text}, status: "Normal Service"}
-          ],
-          type: :contracted
-        },
-        orange: %{
-          alerts: [
-            %{route_pill: %{color: :orange, text: "OL", type: :text}, status: "Normal Service"}
-          ],
-          type: :contracted
-        },
-        red: %{
-          alerts: [
-            %{route_pill: %{color: :red, text: "RL", type: :text}, status: "Normal Service"}
-          ],
-          type: :contracted
-        }
       }
 
       assert expected == WidgetInstance.serialize(instance)
@@ -1588,32 +1013,11 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
       }
 
       expected = %{
-        blue: %{
-          type: :extended,
-          alert: %{
-            route_pill: %{type: :text, text: "BL", color: :blue},
-            status: "SERVICE SUSPENDED",
-            location: "Entire line"
+        @normal_service
+        | blue: %{
+            type: :extended,
+            alert: %{route_pill: @bl_pill, status: "SERVICE SUSPENDED", location: "Entire line"}
           }
-        },
-        green: %{
-          alerts: [
-            %{route_pill: %{color: :green, text: "GL", type: :text}, status: "Normal Service"}
-          ],
-          type: :contracted
-        },
-        orange: %{
-          alerts: [
-            %{route_pill: %{color: :orange, text: "OL", type: :text}, status: "Normal Service"}
-          ],
-          type: :contracted
-        },
-        red: %{
-          alerts: [
-            %{route_pill: %{color: :red, text: "RL", type: :text}, status: "Normal Service"}
-          ],
-          type: :contracted
-        }
       }
 
       assert expected == WidgetInstance.serialize(instance)
@@ -1636,32 +1040,11 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
       }
 
       expected = %{
-        blue: %{
-          alerts: [
-            %{route_pill: %{color: :blue, text: "BL", type: :text}, status: "Normal Service"}
-          ],
-          type: :contracted
-        },
-        green: %{
-          type: :extended,
-          alert: %{
-            route_pill: %{type: :text, text: "GL", color: :green},
-            status: "SERVICE SUSPENDED",
-            location: "Entire line"
+        @normal_service
+        | green: %{
+            type: :extended,
+            alert: %{route_pill: @gl_pill, status: "SERVICE SUSPENDED", location: "Entire line"}
           }
-        },
-        orange: %{
-          alerts: [
-            %{route_pill: %{color: :orange, text: "OL", type: :text}, status: "Normal Service"}
-          ],
-          type: :contracted
-        },
-        red: %{
-          alerts: [
-            %{route_pill: %{color: :red, text: "RL", type: :text}, status: "Normal Service"}
-          ],
-          type: :contracted
-        }
       }
 
       assert expected == WidgetInstance.serialize(instance)
@@ -1682,32 +1065,11 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
       }
 
       expected = %{
-        blue: %{
-          type: :extended,
-          alert: %{
-            route_pill: %{type: :text, text: "BL", color: :blue},
-            status: "Delays over 60 minutes",
-            location: nil
+        @normal_service
+        | blue: %{
+            type: :extended,
+            alert: %{route_pill: @bl_pill, status: "Delays over 60 minutes", location: nil}
           }
-        },
-        green: %{
-          alerts: [
-            %{route_pill: %{color: :green, text: "GL", type: :text}, status: "Normal Service"}
-          ],
-          type: :contracted
-        },
-        orange: %{
-          alerts: [
-            %{route_pill: %{color: :orange, text: "OL", type: :text}, status: "Normal Service"}
-          ],
-          type: :contracted
-        },
-        red: %{
-          alerts: [
-            %{route_pill: %{color: :red, text: "RL", type: :text}, status: "Normal Service"}
-          ],
-          type: :contracted
-        }
       }
 
       assert expected == WidgetInstance.serialize(instance)
@@ -1730,32 +1092,15 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
       }
 
       expected = %{
-        blue: %{
-          alerts: [
-            %{route_pill: %{color: :blue, text: "BL", type: :text}, status: "Normal Service"}
-          ],
-          type: :contracted
-        },
-        green: %{
-          type: :extended,
-          alert: %{
-            location: %{abbrev: "Kenmore ↔ Kent St", full: "Kenmore ↔ Kent Street"},
-            route_pill: %{color: :green, text: "GL", type: :text, branches: [:c]},
-            status: "Shuttle Bus"
+        @normal_service
+        | green: %{
+            type: :extended,
+            alert: %{
+              location: %{abbrev: "Kenmore ↔ Kent St", full: "Kenmore ↔ Kent Street"},
+              route_pill: gl_pill([:c]),
+              status: "Shuttle Bus"
+            }
           }
-        },
-        orange: %{
-          alerts: [
-            %{route_pill: %{color: :orange, text: "OL", type: :text}, status: "Normal Service"}
-          ],
-          type: :contracted
-        },
-        red: %{
-          alerts: [
-            %{route_pill: %{color: :red, text: "RL", type: :text}, status: "Normal Service"}
-          ],
-          type: :contracted
-        }
       }
 
       assert expected == WidgetInstance.serialize(instance)


### PR DESCRIPTION
Most widgets technically already support single-tracking alerts since these have an effect of `DELAY`. However, where possible we want to:

1. call out that these are "due to single tracking"
2. show them regardless of severity, allowing "informational" alerts

This change adds these aspects to the Subway Status widget.

---

Includes several distinct but related commits, best reviewed per-commit.

**Asana task**: https://app.asana.com/1/15492006741476/project/1185117109217413/task/1210764886971057