### PR TITLE
Single-tracking messaging for DUP Alerts

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -92,6 +92,14 @@ config :screens,
     ]
   },
   dup_alert_headsign_matchers: %{
+    "place-r1" => [
+      %{
+        informed: "place-r2",
+        not_informed: "N/A",
+        alert_headsign: "Test R1",
+        headway_headsign: "N/A"
+      }
+    ],
     "place-B" => [
       %{
         informed: "place-A",

--- a/lib/screens/v2/candidate_generator/dup/alerts.ex
+++ b/lib/screens/v2/candidate_generator/dup/alerts.ex
@@ -94,12 +94,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Alerts do
 
   defp create_alert_widgets({:special, widgets}, _, _, _), do: widgets
 
-  defp create_alert_widgets(
-         {:normal, alerts},
-         %Screen{app_params: %Dup{primary_departures: %{sections: sections}}} = config,
-         location_context,
-         stop_name
-       ) do
+  defp create_alert_widgets({:normal, alerts}, config, location_context, stop_name) do
     alert = choose_alert(alerts)
 
     if is_nil(alert) do
@@ -110,7 +105,6 @@ defmodule Screens.V2.CandidateGenerator.Dup.Alerts do
           screen: config,
           alert: alert,
           location_context: location_context,
-          primary_section_count: length(sections),
           rotation_index: rotation_index,
           stop_name: stop_name
         }

--- a/lib/screens/v2/candidate_generator/dup/alerts.ex
+++ b/lib/screens/v2/candidate_generator/dup/alerts.ex
@@ -112,19 +112,22 @@ defmodule Screens.V2.CandidateGenerator.Dup.Alerts do
     end
   end
 
-  defp relevant_effect?(%{effect: :delay, severity: severity}, _) do
+  # Always include single-tracking alerts regardless of severity.
+  defp relevant_effect?(%Alert{effect: :delay, cause: :single_tracking}, _screen), do: true
+
+  defp relevant_effect?(%Alert{effect: :delay, severity: severity}, _screen) do
     severity >= 5
   end
 
   # WTC special case
-  defp relevant_effect?(%{effect: effect}, %Screen{
+  defp relevant_effect?(%Alert{effect: effect}, %Screen{
          app_params: %Dup{alerts: %AlertsConfig{stop_id: "place-wtcst"}}
        }) do
     effect in [:detour]
   end
 
-  defp relevant_effect?(%{effect: effect}, _) do
-    effect in [:station_closure, :shuttle, :suspension]
+  defp relevant_effect?(%Alert{effect: effect}, _screen) do
+    effect in [:station_closure, :shuttle, :suspension, :delay]
   end
 
   @spec relevant_location?(Alert.t(), LocationContext.t()) :: boolean()

--- a/lib/screens/v2/widget_instance/dup_alert.ex
+++ b/lib/screens/v2/widget_instance/dup_alert.ex
@@ -113,6 +113,18 @@ defmodule Screens.V2.WidgetInstance.DupAlert do
        else: :some
   end
 
+  # Treat being inside a "severe" single-tracking disruption the same as "some" service being
+  # eliminated, even though service is still running. We expect live predictions to not be fully
+  # available within single-tracked segments, so it's okay for this message to take up more space
+  # when the severity warrants it.
+  defp eliminated_service_type(
+         %__MODULE__{alert: %Alert{cause: :single_tracking, effect: :delay, severity: severity}} =
+           t
+       )
+       when severity >= 5 do
+    if LocalizedAlert.location(t) == :inside, do: :some, else: :none
+  end
+
   defp eliminated_service_type(_other), do: :none
 
   def get_affected_lines(t) do

--- a/lib/screens/v2/widget_instance/dup_alert.ex
+++ b/lib/screens/v2/widget_instance/dup_alert.ex
@@ -10,21 +10,13 @@ defmodule Screens.V2.WidgetInstance.DupAlert do
   alias Screens.V2.WidgetInstance.DupAlert.Serialize
   alias ScreensConfig.Screen
 
-  @enforce_keys [
-    :screen,
-    :alert,
-    :location_context,
-    :primary_section_count,
-    :rotation_index,
-    :stop_name
-  ]
+  @enforce_keys [:screen, :alert, :location_context, :rotation_index, :stop_name]
   defstruct @enforce_keys
 
   @type t :: %__MODULE__{
           screen: Screen.t(),
           alert: Alert.t(),
           location_context: LocationContext.t(),
-          primary_section_count: pos_integer(),
           rotation_index: rotation_index,
           stop_name: String.t()
         }
@@ -155,7 +147,7 @@ defmodule Screens.V2.WidgetInstance.DupAlert do
       effect: t.alert.effect,
       location: LocalizedAlert.location(t),
       affected_line_count: length(get_affected_lines(t)),
-      primary_section_count: t.primary_section_count
+      primary_section_count: length(t.screen.app_params.primary_departures.sections)
     }
   end
 

--- a/lib/screens/v2/widget_instance/dup_alert.ex
+++ b/lib/screens/v2/widget_instance/dup_alert.ex
@@ -5,10 +5,9 @@ defmodule Screens.V2.WidgetInstance.DupAlert do
 
   alias Screens.Alerts.Alert
   alias Screens.LocationContext
-  alias Screens.Report
   alias Screens.V2.LocalizedAlert
   alias Screens.V2.WidgetInstance.DupAlert.Serialize
-  alias ScreensConfig.Screen
+  alias ScreensConfig.{Departures, Screen, Screen.Dup}
 
   @enforce_keys [:screen, :alert, :location_context, :rotation_index, :stop_name]
   defstruct @enforce_keys
@@ -27,13 +26,11 @@ defmodule Screens.V2.WidgetInstance.DupAlert do
 
   @spec priority(t()) :: Screens.V2.WidgetInstance.priority()
   def priority(t) do
-    # For DUP alerts, priority is based on layout.
     # Overnight mode should take priority over partial alerts but not full_screen.
     # Giving full_screen the highest priority so it will always show over overnight.
-    if alert_layout(t) == :full_screen do
-      [1]
-    else
-      [1, 2]
+    case alert_layout(t) do
+      :full_screen -> [1]
+      :partial -> [1, 2]
     end
   end
 
@@ -42,9 +39,6 @@ defmodule Screens.V2.WidgetInstance.DupAlert do
     case alert_layout(t) do
       :full_screen -> Serialize.serialize_full_screen(t)
       :partial -> Serialize.serialize_partial(t)
-      # This case will never match since it would be filtered out at `valid_candidate?`,
-      # but Dialyzer doesn't know that.
-      :no_render -> %{}
     end
   end
 
@@ -54,9 +48,6 @@ defmodule Screens.V2.WidgetInstance.DupAlert do
       case alert_layout(t) do
         :full_screen -> "full_rotation"
         :partial -> "bottom_pane"
-        # This case will never match since it would be filtered out at `valid_candidate?`,
-        # but Dialyzer doesn't know that.
-        :no_render -> "bottom_pane"
       end
 
     # Returns e.g. [:full_rotation_zero], [:bottom_pane_one], ...
@@ -68,160 +59,61 @@ defmodule Screens.V2.WidgetInstance.DupAlert do
     case alert_layout(t) do
       :full_screen -> :takeover_alert
       :partial -> :partial_alert
-      # This case will never match since it would be filtered out at `valid_candidate?`,
-      # but Dialyzer doesn't know that.
-      :no_render -> :partial_alert
     end
   end
 
   @spec valid_candidate?(t()) :: boolean()
-  def valid_candidate?(%__MODULE__{} = t), do: alert_layout(t) != :no_render
+  def valid_candidate?(%__MODULE__{}), do: true
 
-  # Inputs/output are stored as a table for readability.
-  # Table is adapted from the one in the product spec: https://www.notion.so/mbta-downtown-crossing/DUP-Alert-Widget-Specification-a82acff850ed4f2eb98a04e5f3e0fe52
-  # Compile-time code converts each table row to a key-value pair in a map.
-  # PrimarySections refers to the number of sections in `primary_departures` of DUP config.
-  #
-  # Delay alerts are handled separately, see `delay_alert_layout` below.
-  # Layouts for rotations one and two are derived from the layout for rotation zero, see `non_delay_alert_layout` below.
-  layout_zero_table = """
-  # INPUTS                                                            || OUTPUT
-  # Effect          Location            AffectedLines PrimarySections || LayoutZero
-    station_closure inside              1             1                  full_screen
-    station_closure inside              1             2                  partial
-    station_closure inside              2             2                  full_screen
-  # "Boundary" location is not possible for station closures.
-    shuttle         inside              1             1                  full_screen
-    shuttle         inside              1             2                  partial
-    shuttle         inside              2             2                  full_screen
-    shuttle         boundary_upstream   1             1                  partial
-    shuttle         boundary_downstream 1             1                  partial
-    shuttle         boundary_upstream   1             2                  partial
-    shuttle         boundary_downstream 1             2                  partial
-    suspension      inside              1             1                  full_screen
-    suspension      inside              1             2                  partial
-    suspension      inside              2             2                  full_screen
-    suspension      boundary_upstream   1             1                  partial
-    suspension      boundary_downstream 1             1                  partial
-    suspension      boundary_upstream   1             2                  partial
-    suspension      boundary_downstream 1             2                  partial
-  """
+  # Determine the desired layout for this alert. Follows the rules documented here:
+  # https://www.notion.so/mbta-downtown-crossing/DUP-Alert-Widget-Specification-17cf5d8d11ea80399a7fe3c4f13a511f
+  @spec alert_layout(t()) :: :full_screen | :partial
+  defp alert_layout(%__MODULE__{rotation_index: :zero} = t), do: rotation_zero_layout(t)
 
-  @parameters_to_layout_zero layout_zero_table
-                             |> String.split("\n", trim: true)
-                             |> Enum.reject(&String.starts_with?(&1, "#"))
-                             |> Enum.into(%{}, fn line ->
-                               [
-                                 effect,
-                                 location,
-                                 affected_line_count,
-                                 primary_section_count,
-                                 layout_zero
-                               ] = String.split(line, ~r/\s+/, trim: true)
-
-                               # Convert strings to appropriate types
-                               [effect, location, layout_zero] =
-                                 Enum.map(
-                                   [effect, location, layout_zero],
-                                   &String.to_atom/1
-                                 )
-
-                               [affected_line_count, primary_section_count] =
-                                 Enum.map(
-                                   [affected_line_count, primary_section_count],
-                                   &String.to_integer/1
-                                 )
-
-                               parameters = %{
-                                 effect: effect,
-                                 location: location,
-                                 affected_line_count: affected_line_count,
-                                 primary_section_count: primary_section_count
-                               }
-
-                               {parameters, layout_zero}
-                             end)
-
-  defp get_layout_parameters(t) do
-    %{
-      effect: t.alert.effect,
-      location: LocalizedAlert.location(t),
-      affected_line_count: length(get_affected_lines(t)),
-      primary_section_count: length(t.screen.app_params.primary_departures.sections)
-    }
+  defp alert_layout(%__MODULE__{rotation_index: :one} = t) do
+    if eliminated_service_type(t) == :none, do: :partial, else: :full_screen
   end
 
-  @spec alert_layout(t()) :: :full_screen | :partial | :no_render
-  defp alert_layout(t) do
-    if t.alert.effect == :delay,
-      do: delay_alert_layout(t),
-      else: non_delay_alert_layout(t)
+  # When no secondary departures are configured, departures in this rotation will be the same as
+  # those in rotation zero, so use the same layout.
+  defp alert_layout(
+         %__MODULE__{
+           rotation_index: :two,
+           screen: %Screen{app_params: %Dup{secondary_departures: %Departures{sections: []}}}
+         } = t
+       ),
+       do: rotation_zero_layout(t)
+
+  defp alert_layout(%__MODULE__{rotation_index: :two}), do: :partial
+
+  defp rotation_zero_layout(t) do
+    if eliminated_service_type(t) == :all, do: :full_screen, else: :partial
   end
 
-  defp delay_alert_layout(t) do
-    delay_severity = t.alert.severity
-
-    if delay_severity >= 5 do
-      # All delays >= 20 minutes get a partial alert on all 3 rotations
-      :partial
-    else
-      # We don't show delays < 20 minutes
-      log_layout_mismatch(t, delay_severity)
-      :no_render
-    end
+  # Determine whether this alert "eliminates service" entirely, partially, or not at all, at the
+  # screen's station, for the routes in primary departures.
+  @spec eliminated_service_type(t()) :: :all | :some | :none
+  defp eliminated_service_type(
+         %__MODULE__{
+           alert: %Alert{effect: effect},
+           screen: %Screen{
+             app_params: %Dup{primary_departures: %Departures{sections: primary_sections}}
+           }
+         } = t
+       )
+       when effect in [:shuttle, :station_closure, :suspension] do
+    # Assume primary departures is always configured with a section for each subway line at the
+    # screen's station. So if we're `inside` a disruption and it affects the same number of lines
+    # as the number we show departures for, that means all service is eliminated. Otherwise, only
+    # some is (either we're at a boundary and there's still service in one direction, or we're at
+    # a transfer station and the alert only affects one line).
+    if LocalizedAlert.location(t) == :inside and
+         length(get_affected_lines(t)) == length(primary_sections),
+       do: :all,
+       else: :some
   end
 
-  defp non_delay_alert_layout(t) do
-    parameters = get_layout_parameters(t)
-
-    lookup_result = Map.fetch(@parameters_to_layout_zero, parameters)
-
-    case {t.rotation_index, lookup_result} do
-      {:zero, {:ok, layout_zero}} ->
-        # The first page's layout maps directly from `parameters`.
-        layout_zero
-
-      {:one, {:ok, _layout_zero}} ->
-        # The second page always uses full-screen layout, as long as the alert is relevant.
-        :full_screen
-
-      {:two, {:ok, layout_zero}} ->
-        # The third page's layout depends on whether or not the screen has secondary departures configured.
-        #
-        # If the screen has secondary departures configured, it always gets a partial alert.
-        # If the screen does not have secondary departures configured, it gets the same layout as the first page.
-        #
-        # This is because we do not want to hide secondary departures (e.g. bus, CR) if they exist.
-        has_secondary_departures = t.screen.app_params.secondary_departures.sections != []
-
-        if has_secondary_departures,
-          do: :partial,
-          else: layout_zero
-
-      {_rotation_index, :error} ->
-        # We don't know what to do under these conditions.
-        # Log it, and prevent the alert from appearing.
-        log_layout_mismatch(t, :not_applicable)
-        :no_render
-    end
-  end
-
-  # The widget _should_ always be valid given the constraints of what alerts
-  # we generate DUP alert widgets for, but in case one slips through, we
-  # should know about it!
-  defp log_layout_mismatch(t, delay_severity) do
-    Report.warning(
-      "dup_alert_no_matching_layout",
-      t
-      |> get_layout_parameters()
-      |> Map.merge(%{
-        delay_severity: delay_severity,
-        rotation_index: t.rotation_index,
-        alert_id: t.alert.id,
-        stop_id: t.screen.app_params.alerts.stop_id
-      })
-    )
-  end
+  defp eliminated_service_type(_other), do: :none
 
   def get_affected_lines(t) do
     t

--- a/lib/screens/v2/widget_instance/dup_alert.ex
+++ b/lib/screens/v2/widget_instance/dup_alert.ex
@@ -83,14 +83,7 @@ defmodule Screens.V2.WidgetInstance.DupAlert do
   end
 
   @spec valid_candidate?(t()) :: boolean()
-  def valid_candidate?(%__MODULE__{} = t) do
-    # Suppress alerts 519314 and 529291, at all stations served by the Red Line.
-    suppressed =
-      t.alert.id in ["519314", "529291"] and
-        Enum.any?(t.location_context.routes, &(&1[:route_id] == "Red"))
-
-    not suppressed and alert_layout(t) != :no_render
-  end
+  def valid_candidate?(%__MODULE__{} = t), do: alert_layout(t) != :no_render
 
   # Inputs/output are stored as a table for readability.
   # Table is adapted from the one in the product spec: https://www.notion.so/mbta-downtown-crossing/DUP-Alert-Widget-Specification-a82acff850ed4f2eb98a04e5f3e0fe52

--- a/test/screens/v2/widget_instance/dup_alert_test.exs
+++ b/test/screens/v2/widget_instance/dup_alert_test.exs
@@ -189,6 +189,61 @@ defmodule Screens.V2.WidgetInstance.DupAlertTest do
       assert serialized(screen, context, alert) == [banner, banner, banner]
     end
 
+    test "inside non-severe single-tracking" do
+      screen = build_screen()
+      context = build_location_context("place-r2")
+
+      alert =
+        build_alert(
+          cause: :single_tracking,
+          effect: :delay,
+          severity: 4,
+          informed_entities: route_informed_entities(~w[Red])
+        )
+
+      banner = %{
+        color: :red,
+        text: %FreeTextLine{icon: :delay, text: [bold("Red Line"), "delays"]}
+      }
+
+      assert serialized(screen, context, alert) == [banner, banner, banner]
+    end
+
+    test "inside severe single-tracking" do
+      screen = build_screen()
+      context = build_location_context("place-r2")
+
+      alert =
+        build_alert(
+          cause: :single_tracking,
+          effect: :delay,
+          severity: 5,
+          informed_entities: stop_informed_entities("Red", ~w[place-r1 place-r2 place-r3])
+        )
+
+      banner = %{
+        color: :red,
+        text: %FreeTextLine{icon: :delay, text: [bold("Red Line"), "delays"]}
+      }
+
+      takeover = %{
+        header: %{color: :red, text: "Test Stop"},
+        text: %FreeTextLine{
+          icon: :delay,
+          text: [
+            pill(:red),
+            bold("delays"),
+            bold("up to 20 minutes"),
+            "due to",
+            "single tracking"
+          ]
+        },
+        remedy: %FreeTextLine{icon: nil, text: []}
+      }
+
+      assert serialized(screen, context, alert) == [banner, takeover, banner]
+    end
+
     test "single-line inside shuttle" do
       screen = build_screen()
       context = build_location_context("place-r2")

--- a/test/screens/v2/widget_instance/dup_alert_test.exs
+++ b/test/screens/v2/widget_instance/dup_alert_test.exs
@@ -1,5 +1,308 @@
 defmodule Screens.V2.WidgetInstance.DupAlertTest do
   use ExUnit.Case, async: true
 
-  # alias Screens.V2.WidgetInstance.DupAlert
+  alias Screens.Alerts.Alert
+  alias Screens.LocationContext
+  alias Screens.V2.WidgetInstance.DupAlert
+  alias ScreensConfig.{Departures, FreeTextLine, Screen}
+
+  defp build_alert(fields) do
+    struct!(%Alert{cause: :construction, effect: :suspension, severity: 5}, fields)
+  end
+
+  defp route_informed_entities(route_ids) do
+    Enum.map(route_ids, &%{route_type: 1, route: &1, stop: nil, direction_id: nil})
+  end
+
+  defp stop_informed_entities(route_id, stop_ids) do
+    Enum.map(stop_ids, &%{route_type: 1, route: route_id, stop: &1, direction_id: nil})
+  end
+
+  @tagged_stop_sequences %{
+    "Blue" => [~w[place-b1 place-x place-b2 place-b3 place-b4]],
+    "Red" => [~w[place-r1 place-r2 place-r3 place-x place-r4]]
+  }
+
+  defp build_location_context(home_stop) do
+    stop_sequences = LocationContext.untag_stop_sequences(@tagged_stop_sequences)
+
+    %LocationContext{
+      home_stop: home_stop,
+      tagged_stop_sequences: @tagged_stop_sequences,
+      upstream_stops: LocationContext.upstream_stop_id_set([home_stop], stop_sequences),
+      downstream_stops: LocationContext.downstream_stop_id_set([home_stop], stop_sequences),
+      routes: @tagged_stop_sequences |> Map.keys() |> Enum.map(&%{active?: true, route_id: &1}),
+      alert_route_types: LocationContext.route_type_filter(Screen.Dup, [home_stop])
+    }
+  end
+
+  defp build_screen(primary_sections_count \\ 1, has_secondary_departures? \\ false) do
+    struct(Screen,
+      app_id: :dup_v2,
+      app_params:
+        struct(Screen.Dup,
+          primary_departures: %Departures{
+            sections: List.duplicate(struct(Departures.Section), primary_sections_count)
+          },
+          secondary_departures: %Departures{
+            sections: if(has_secondary_departures?, do: [struct(Departures.Section)], else: [])
+          }
+        )
+    )
+  end
+
+  defp all_rotations(screen, context, alert) do
+    Enum.map(
+      [:zero, :one, :two],
+      &%DupAlert{
+        screen: screen,
+        location_context: context,
+        alert: alert,
+        rotation_index: &1,
+        stop_name: "Test Stop"
+      }
+    )
+  end
+
+  describe "layout selection" do
+    defp widget_types(screen, context, alert) do
+      all_rotations(screen, context, alert) |> Enum.map(&DupAlert.widget_type/1)
+    end
+
+    test "all service eliminated at a single-line stop with only primary departures" do
+      screen = build_screen()
+      context = build_location_context("place-r2")
+
+      alert =
+        build_alert(
+          informed_entities: stop_informed_entities("Red", ~w[place-r1 place-r2 place-r3])
+        )
+
+      assert widget_types(screen, context, alert) ==
+               [:takeover_alert, :takeover_alert, :takeover_alert]
+    end
+
+    test "all service eliminated at a single-line stop with secondary departures" do
+      screen = build_screen(1, true)
+      context = build_location_context("place-r2")
+
+      alert =
+        build_alert(
+          informed_entities: stop_informed_entities("Red", ~w[place-r1 place-r2 place-r3])
+        )
+
+      assert widget_types(screen, context, alert) ==
+               [:takeover_alert, :takeover_alert, :partial_alert]
+    end
+
+    test "all service eliminated for both lines at a transfer stop" do
+      screen = build_screen(2)
+      context = build_location_context("place-x")
+
+      alert =
+        build_alert(
+          informed_entities:
+            stop_informed_entities("Red", ~w[place-r3 place-x place-r4]) ++
+              stop_informed_entities("Blue", ~w[place-b1 place-x place-b2])
+        )
+
+      assert widget_types(screen, context, alert) ==
+               [:takeover_alert, :takeover_alert, :takeover_alert]
+    end
+
+    test "all service eliminated for one line at a transfer stop" do
+      screen = build_screen(2)
+      context = build_location_context("place-x")
+
+      alert =
+        build_alert(
+          informed_entities: stop_informed_entities("Red", ~w[place-r3 place-x place-r4])
+        )
+
+      assert widget_types(screen, context, alert) ==
+               [:partial_alert, :takeover_alert, :partial_alert]
+    end
+
+    test "one direction of service eliminated" do
+      screen = build_screen()
+      context = build_location_context("place-r1")
+
+      alert =
+        build_alert(
+          informed_entities: stop_informed_entities("Red", ~w[place-r1 place-r2 place-r3])
+        )
+
+      assert widget_types(screen, context, alert) ==
+               [:partial_alert, :takeover_alert, :partial_alert]
+    end
+
+    test "alert effect does not eliminate service" do
+      screen = build_screen()
+      context = build_location_context("place-r2")
+      alert = build_alert(effect: :delay, informed_entities: route_informed_entities(~w[Red]))
+
+      assert widget_types(screen, context, alert) ==
+               [:partial_alert, :partial_alert, :partial_alert]
+    end
+  end
+
+  describe "layout serialization" do
+    defp serialized(screen, context, alert) do
+      all_rotations(screen, context, alert) |> Enum.map(&DupAlert.serialize/1)
+    end
+
+    defmacrop bold(text) do
+      quote do
+        %{format: :bold, text: unquote(text)}
+      end
+    end
+
+    defmacrop pill(route) do
+      quote do
+        %{route: unquote(route)}
+      end
+    end
+
+    test "single-line delays" do
+      screen = build_screen()
+      context = build_location_context("place-r2")
+      alert = build_alert(effect: :delay, informed_entities: route_informed_entities(~w[Red]))
+
+      banner = %{
+        color: :red,
+        text: %FreeTextLine{icon: :delay, text: [bold("Red Line"), "delays"]}
+      }
+
+      assert serialized(screen, context, alert) == [banner, banner, banner]
+    end
+
+    test "multi-line delays" do
+      screen = build_screen(2, false)
+      context = build_location_context("place-x")
+
+      alert =
+        build_alert(effect: :delay, informed_entities: route_informed_entities(~w[Red Blue]))
+
+      # BUG: shows a white delay icon on a yellow background, need an inverse delay icon
+      banner = %{color: :yellow, text: %FreeTextLine{icon: :delay, text: ["Train delays"]}}
+
+      assert serialized(screen, context, alert) == [banner, banner, banner]
+    end
+
+    test "single-line inside shuttle" do
+      screen = build_screen()
+      context = build_location_context("place-r2")
+
+      alert =
+        build_alert(
+          effect: :shuttle,
+          informed_entities: stop_informed_entities("Red", ~w[place-r1 place-r2 place-r3])
+        )
+
+      takeover = %{
+        header: %{color: :red, text: "Test Stop"},
+        text: %FreeTextLine{
+          icon: :warning,
+          text: [bold("No"), pill(:red), bold("trains"), "due to", "construction"]
+        },
+        remedy: %FreeTextLine{icon: :shuttle, text: [bold("Use shuttle bus")]}
+      }
+
+      assert serialized(screen, context, alert) == [takeover, takeover, takeover]
+    end
+
+    test "single-line inside non-shuttle" do
+      screen = build_screen()
+      context = build_location_context("place-r2")
+
+      alert =
+        build_alert(
+          effect: :station_closure,
+          informed_entities: stop_informed_entities("Red", ~w[place-r2])
+        )
+
+      takeover = %{
+        header: %{color: :red, text: "Test Stop"},
+        text: %FreeTextLine{
+          icon: :warning,
+          text: [bold("No"), pill(:red), bold("trains"), "due to", "construction"]
+        },
+        remedy: %FreeTextLine{icon: nil, text: ["Seek alternate route"]}
+      }
+
+      assert serialized(screen, context, alert) == [takeover, takeover, takeover]
+    end
+
+    test "boundary" do
+      screen = build_screen()
+      context = build_location_context("place-r1")
+
+      alert =
+        build_alert(
+          informed_entities: stop_informed_entities("Red", ~w[place-r1 place-r2 place-r3])
+        )
+
+      banner = %{
+        color: :red,
+        text: %FreeTextLine{icon: :warning, text: ["No", bold("Test R1"), "trains"]}
+      }
+
+      takeover = %{
+        header: %{color: :red, text: "Test Stop"},
+        text: %FreeTextLine{
+          icon: :warning,
+          text: [bold("No"), pill(:red), bold("trains"), bold("to Test R1")]
+        },
+        remedy: %FreeTextLine{icon: nil, text: ["Seek alternate route"]}
+      }
+
+      assert serialized(screen, context, alert) == [banner, takeover, banner]
+    end
+
+    test "multi-line inside single-line disruption" do
+      screen = build_screen(2)
+      context = build_location_context("place-x")
+
+      alert =
+        build_alert(
+          informed_entities: stop_informed_entities("Red", ~w[place-r3 place-x place-r4])
+        )
+
+      banner = %{
+        color: :red,
+        text: %FreeTextLine{icon: :warning, text: ["No", bold("Red Line"), "trains"]}
+      }
+
+      takeover = %{
+        header: %{color: :red, text: "Test Stop"},
+        text: %FreeTextLine{
+          icon: :warning,
+          text: [bold("No"), pill(:red), bold("trains"), "due to", "construction"]
+        },
+        remedy: %FreeTextLine{icon: nil, text: ["Seek alternate route"]}
+      }
+
+      assert serialized(screen, context, alert) == [banner, takeover, banner]
+    end
+
+    test "multi-line disruption" do
+      screen = build_screen(2)
+      context = build_location_context("place-x")
+
+      alert =
+        build_alert(
+          informed_entities:
+            stop_informed_entities("Red", ~w[place-r3 place-x place-r4]) ++
+              stop_informed_entities("Blue", ~w[place-b1 place-x place-b2])
+        )
+
+      takeover = %{
+        header: %{color: :yellow, text: "Test Stop"},
+        text: %FreeTextLine{icon: :warning, text: ["No", pill(:blue), "or", pill(:red), "trains"]},
+        remedy: %FreeTextLine{icon: nil, text: ["Seek alternate route"]}
+      }
+
+      assert serialized(screen, context, alert) == [takeover, takeover, takeover]
+    end
+  end
 end

--- a/test/screens/v2/widget_instance/dup_special_case_alert_test.exs
+++ b/test/screens/v2/widget_instance/dup_special_case_alert_test.exs
@@ -9,59 +9,17 @@ defmodule Screens.V2.WidgetInstance.DupSpecialCaseAlertTest do
 
   defp routes("place-kencl") do
     [
-      %{
-        active?: true,
-        direction_destinations: ["Boston College", "Government Center"],
-        long_name: "Green Line B",
-        route_id: "Green-B",
-        short_name: "B",
-        type: :light_rail
-      },
-      %{
-        active?: true,
-        direction_destinations: ["Cleveland Circle", "Government Center"],
-        long_name: "Green Line C",
-        route_id: "Green-C",
-        short_name: "C",
-        type: :light_rail
-      },
-      %{
-        active?: true,
-        direction_destinations: ["Riverside", "Union Square"],
-        long_name: "Green Line D",
-        route_id: "Green-D",
-        short_name: "D",
-        type: :light_rail
-      }
+      %{active?: true, route_id: "Green-B"},
+      %{active?: true, route_id: "Green-C"},
+      %{active?: true, route_id: "Green-D"}
     ]
   end
 
   defp routes("place-wtcst") do
     [
-      %{
-        active?: true,
-        direction_destinations: ["Logan Airport Terminals", "South Station"],
-        long_name: "Logan Airport Terminals - South Station",
-        route_id: "741",
-        short_name: "SL1",
-        type: :bus
-      },
-      %{
-        active?: true,
-        direction_destinations: ["Drydock Avenue", "South Station"],
-        long_name: "Drydock Avenue - South Station",
-        route_id: "742",
-        short_name: "SL2",
-        type: :bus
-      },
-      %{
-        active?: true,
-        direction_destinations: ["Chelsea Station", "South Station"],
-        long_name: "Chelsea Station - South Station",
-        route_id: "743",
-        short_name: "SL3",
-        type: :bus
-      }
+      %{active?: true, route_id: "741"},
+      %{active?: true, route_id: "742"},
+      %{active?: true, route_id: "743"}
     ]
   end
 


### PR DESCRIPTION
Most widgets technically already support single-tracking alerts since these have an effect of `DELAY`. However, when the cause of a delay is single-tracking specifically, we want to make this info more prominent, including showing the alert at severity levels we otherwise wouldn't. This updates the handling of DUP alerts accordingly.

---

Includes several distinct but related commits, best reviewed per-commit.

**Asana task**: https://app.asana.com/1/15492006741476/project/1185117109217413/task/1210603551669549