### PR TITLE
Sort overnight schedules in DUPs departures

### DIFF
--- a/lib/screens/v2/candidate_generator/dup/departures.ex
+++ b/lib/screens/v2/candidate_generator/dup/departures.ex
@@ -182,7 +182,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
       else
         get_overnight_schedules_for_section(
           routes_with_live_departures,
-          params,
+          Map.put(params, :sort, "departure_time"),
           routes,
           alert_informed_entities,
           now,

--- a/lib/screens/v2/candidate_generator/dup/departures.ex
+++ b/lib/screens/v2/candidate_generator/dup/departures.ex
@@ -182,7 +182,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
       else
         get_overnight_schedules_for_section(
           routes_with_live_departures,
-          Map.put(params, :sort, "departure_time"),
+          params,
           routes,
           alert_informed_entities,
           now,
@@ -527,7 +527,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
        ) do
     {today_schedules, tomorrow_schedules} =
       get_today_tomorrow_schedules(
-        Map.from_struct(params),
+        Map.from_struct(params) |> Map.put(:sort, "departure_time"),
         fetch_schedules_fn,
         now,
         Enum.map(routes, & &1.id)

--- a/lib/screens/v2/candidate_generator/dup/departures.ex
+++ b/lib/screens/v2/candidate_generator/dup/departures.ex
@@ -225,14 +225,9 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
       true ->
         # Add overnight departures to the end.
         # This allows overnight departures to appear as we start to run out of predictions to show.
-        all_departures =
-          if length(departures) < max_visible_departures and overnight_schedules_for_section != [] do
-            departures ++ overnight_schedules_for_section
-          else
-            departures
-          end
+        visible_departures =
+          Enum.take(departures ++ overnight_schedules_for_section, max_visible_departures)
 
-        visible_departures = Enum.take(all_departures, max_visible_departures)
         # DUPs don't support Layout or Header for now
         %NormalSection{rows: visible_departures, layout: %Layout{}, header: %Header{}}
     end

--- a/lib/screens/v2/candidate_generator/dup/departures.ex
+++ b/lib/screens/v2/candidate_generator/dup/departures.ex
@@ -522,7 +522,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
        ) do
     {today_schedules, tomorrow_schedules} =
       get_today_tomorrow_schedules(
-        Map.from_struct(params) |> Map.put(:sort, "departure_time"),
+        params |> Map.from_struct() |> Map.put(:sort, "departure_time"),
         fetch_schedules_fn,
         now,
         Enum.map(routes, & &1.id)

--- a/lib/screens/v2/candidate_generator/dup/departures.ex
+++ b/lib/screens/v2/candidate_generator/dup/departures.ex
@@ -174,9 +174,10 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
       |> Enum.map(&{Departure.route(&1).id, Departure.direction_id(&1)})
       |> Enum.uniq()
 
+    max_visible_departures = if is_only_section, do: 4, else: 2
     # Check if there is any room for overnight rows before running the logic.
     {section_contains_active_route, overnight_schedules_for_section} =
-      if (is_only_section and length(departures) >= 4) or length(departures) >= 2 do
+      if length(departures) >= max_visible_departures do
         {false, []}
       else
         get_overnight_schedules_for_section(
@@ -224,15 +225,14 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
       true ->
         # Add overnight departures to the end.
         # This allows overnight departures to appear as we start to run out of predictions to show.
-        departures = departures ++ overnight_schedules_for_section
-
-        visible_departures =
-          if is_only_section do
-            Enum.take(departures, 4)
+        all_departures =
+          if length(departures) < max_visible_departures and overnight_schedules_for_section != [] do
+            departures ++ overnight_schedules_for_section
           else
-            Enum.take(departures, 2)
+            departures
           end
 
+        visible_departures = Enum.take(all_departures, max_visible_departures)
         # DUPs don't support Layout or Header for now
         %NormalSection{rows: visible_departures, layout: %Layout{}, header: %Header{}}
     end


### PR DESCRIPTION
**Asana task**: [Investigate: DUPs showing "overnight" departures incorrectly](https://app.asana.com/1/15492006741476/project/1208877354406742/task/1210559658847355?focus=true)


To fix the incorrect overnight times being shown on DUPs, this passes the param to the v3 API to sort departures by ascending order time. This ensures that the first/last schedule of today and first schedule of tomorrow that are found are all correct.