### PR TITLE
fix: add Mercury device logging fallback

### DIFF
--- a/lib/screens/device_monitor/mercury.ex
+++ b/lib/screens/device_monitor/mercury.ex
@@ -97,5 +97,9 @@ defmodule Screens.DeviceMonitor.Mercury do
     }
   end
 
+  defp device_info(%{"device_id" => device_id, "stop" => %{"stop_id" => stop_id}}, _count) do
+    %{device_id: device_id, state: "error", stop_id: stop_id}
+  end
+
   defp get_api_key, do: System.fetch_env!("MERCURY_API_KEY")
 end


### PR DESCRIPTION
If the format of Mercury API device data isn't exactly what we expect, log the device anyway with an `error` state instead of crashing the entire report. This fixes an observed issue where devices may have an empty `screens` array.

**Asana task**: https://app.asana.com/1/15492006741476/project/1185117109217413/task/1210950010649580