### PR TITLE
feat: Add CapeFlyer route pill color

### DIFF
--- a/assets/css/colors.scss
+++ b/assets/css/colors.scss
@@ -6,6 +6,7 @@ $line-silver: #7c878e;
 $line-cr: #80276c;
 $line-bus: #ffc72c;
 $line-ferry: #008eaa;
+$line-capeflyer: #006595;
 
 $alert-yellow: #fd0;
 

--- a/assets/css/v2/dup/departures/route_pill.scss
+++ b/assets/css/v2/dup/departures/route_pill.scss
@@ -38,7 +38,7 @@
   &--ocean_blue {
     background-color: colors.$line-capeflyer;
   }
-  
+
   &--yellow {
     width: 280px;
     height: 168px;

--- a/assets/css/v2/dup/departures/route_pill.scss
+++ b/assets/css/v2/dup/departures/route_pill.scss
@@ -35,7 +35,7 @@
     background-color: colors.$line-ferry;
   }
 
-  &--cape_blue {
+  &--ocean_blue {
     background-color: colors.$line-capeflyer;
   }
   

--- a/assets/css/v2/dup/departures/route_pill.scss
+++ b/assets/css/v2/dup/departures/route_pill.scss
@@ -35,6 +35,10 @@
     background-color: colors.$line-ferry;
   }
 
+  &--cape_blue {
+    background-color: colors.$line-capeflyer;
+  }
+  
   &--yellow {
     width: 280px;
     height: 168px;

--- a/assets/css/v2/lcd_common/route_pill.scss
+++ b/assets/css/v2/lcd_common/route_pill.scss
@@ -34,6 +34,10 @@
     background-color: colors.$line-ferry;
   }
 
+  &--ocean_blue {
+    background-color: colors.$line-capeflyer;
+  }
+
   &--yellow {
     background-color: colors.$line-bus;
     box-shadow: 2px 4px 2px 0 rgb(0 0 0 / 25%);

--- a/assets/src/components/v2/departures/route_pill.tsx
+++ b/assets/src/components/v2/departures/route_pill.tsx
@@ -35,6 +35,7 @@ type Color =
   | "purple"
   | "yellow"
   | "teal"
+  | "cape_blue"
   | "silver";
 
 type PillIcon = "bus" | "light_rail" | "rail" | "boat";

--- a/assets/src/components/v2/departures/route_pill.tsx
+++ b/assets/src/components/v2/departures/route_pill.tsx
@@ -35,7 +35,7 @@ type Color =
   | "purple"
   | "yellow"
   | "teal"
-  | "cape_blue"
+  | "ocean_blue"
   | "silver";
 
 type PillIcon = "bus" | "light_rail" | "rail" | "boat";

--- a/assets/src/util/svg_utils.tsx
+++ b/assets/src/util/svg_utils.tsx
@@ -86,6 +86,7 @@ const STRING_TO_COLOR: { [key: string]: string } = {
   red: "#DA291C",
   green: "#00843D",
   purple: "#80276C",
+  cape_blue: "#006595"
 };
 
 export const getHexColor = (color: string) => STRING_TO_COLOR[color];

--- a/assets/src/util/svg_utils.tsx
+++ b/assets/src/util/svg_utils.tsx
@@ -86,7 +86,6 @@ const STRING_TO_COLOR: { [key: string]: string } = {
   red: "#DA291C",
   green: "#00843D",
   purple: "#80276C",
-  cape_blue: "#006595"
 };
 
 export const getHexColor = (color: string) => STRING_TO_COLOR[color];

--- a/lib/screens/routes/route.ex
+++ b/lib/screens/routes/route.ex
@@ -36,8 +36,8 @@ defmodule Screens.Routes.Route do
         }
 
   @typep name_colors :: :blue | :green | :orange | :red | :silver
-  @type color :: name_colors() | :purple | :teal | :yellow
-  @type icon :: name_colors() | :bus | :cr | :ferry | :mattapan
+  @type color :: name_colors() | :purple | :teal | :yellow | :ocean_blue
+  @type icon :: name_colors() | :bus | :cr | :ferry | :mattapan | :capeflyer
 
   @spec by_id(id()) :: {:ok, t()} | :error
   def by_id(id) do
@@ -110,6 +110,7 @@ defmodule Screens.Routes.Route do
   def color("Blue", _), do: :blue
   def color("CR-" <> _, _), do: :purple
   def color("Boat-" <> _, _), do: :teal
+  def color("CapeFlyer", _), do: :ocean_blue
   def color(route_id, _) when route_id in @sl_route_ids, do: :silver
   def color(_, :rail), do: :purple
   def color(_, :ferry), do: :teal
@@ -128,6 +129,7 @@ defmodule Screens.Routes.Route do
   def icon(%{id: "Mattapan"}), do: :mattapan
   def icon(%{id: "Orange"}), do: :orange
   def icon(%{id: "Red"}), do: :red
+  def icon(%{id: "CapeFlyer"}), do: :capeflyer
   def icon(%{id: id}) when id in @sl_route_ids, do: :silver
   def icon(%{short_name: "SL" <> _}), do: :silver
   def icon(%{type: :bus}), do: :bus

--- a/lib/screens/v2/widget_instance/serializer/route_pill.ex
+++ b/lib/screens/v2/widget_instance/serializer/route_pill.ex
@@ -167,6 +167,9 @@ defmodule Screens.V2.WidgetInstance.Serializer.RoutePill do
       :silver ->
         %{type: :text, text: "SL", color: :silver}
 
+      :capeflyer ->
+        %{type: :icon, icon: :rail, color: :ocean_blue}
+
       route_color ->
         pill = route_color |> to_string |> String.capitalize() |> do_serialize(%{})
         Map.merge(pill, %{color: route_color})
@@ -224,6 +227,8 @@ defmodule Screens.V2.WidgetInstance.Serializer.RoutePill do
   defp do_serialize("Boat-" <> _line, _) do
     %{type: :icon, icon: :boat}
   end
+
+  defp do_serialize("CapeFlyer", _), do: %{type: :icon, icon: :rail}
 
   for {route_id, name} <- @special_bus_route_names do
     defp do_serialize(unquote(route_id), _) do

--- a/test/screens/v2/widget_instance/serializer/route_pill_test.exs
+++ b/test/screens/v2/widget_instance/serializer/route_pill_test.exs
@@ -30,6 +30,11 @@ defmodule Screens.V2.WidgetInstance.Serializer.RoutePillTest do
                serialize_for_departure("Boat-F1", "", :ferry, nil)
     end
 
+    test "Returns ocean_blue rail icon for CapeFlyer" do
+      assert %{type: :icon, icon: :rail, color: :ocean_blue} ==
+               serialize_for_departure("CapeFlyer", "", :rail, nil)
+    end
+
     test "Returns slashed route pill if route name contains `/`" do
       assert %{type: :slashed, part1: "34", part2: "35", color: :yellow} ==
                serialize_for_departure("3435", "34/35", :bus, nil)


### PR DESCRIPTION
**Asana task**: [Fix incorrect route pill for Cape Flyer](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1210794505820587?focus=true)

Add the route pill color for the CapeFlyer. According to the V3 API, this route's color is #006595. See [route data here](https://api-v3.mbta.com/routes/CapeFlyer).
<img width="1100" height="156" alt="image" src="https://github.com/user-attachments/assets/ac30d704-155a-4a21-afd8-85e08e202d70" />


- [X] Tests added?
