### PR TITLE
Rs/capeflyer shows cr pill

### DIFF
--- a/lib/screens/routes/route.ex
+++ b/lib/screens/routes/route.ex
@@ -123,6 +123,7 @@ defmodule Screens.Routes.Route do
   @spec icon(t()) :: icon()
   def icon(%{id: "Blue"}), do: :blue
   def icon(%{id: "Boat-" <> _}), do: :ferry
+  def icon(%{id: "CapeFlyer"}), do: :capeflyer
   def icon(%{id: "CR-" <> _}), do: :cr
   def icon(%{id: "Green" <> _}), do: :green
   def icon(%{id: "Mattapan"}), do: :mattapan

--- a/lib/screens/v2/widget_instance/serializer/route_pill.ex
+++ b/lib/screens/v2/widget_instance/serializer/route_pill.ex
@@ -155,6 +155,9 @@ defmodule Screens.V2.WidgetInstance.Serializer.RoutePill do
       :bus ->
         %{type: :icon, icon: :bus, color: :yellow}
 
+      :capeflyer ->
+        %{type: :icon, icon: :rail, color: :purple}
+
       :cr ->
         %{type: :icon, icon: :rail, color: :purple}
 
@@ -220,6 +223,8 @@ defmodule Screens.V2.WidgetInstance.Serializer.RoutePill do
       do: Map.merge(base, %{type: :text, text: "TR#{track_number}"}),
       else: Map.merge(base, %{type: :icon, icon: :rail})
   end
+
+  defp do_serialize("CapeFlyer", _), do: %{type: :icon, icon: :rail}
 
   defp do_serialize("Boat-" <> _line, _) do
     %{type: :icon, icon: :boat}

--- a/test/screens/v2/widget_instance/serializer/route_pill_test.exs
+++ b/test/screens/v2/widget_instance/serializer/route_pill_test.exs
@@ -30,6 +30,11 @@ defmodule Screens.V2.WidgetInstance.Serializer.RoutePillTest do
                serialize_for_departure("Boat-F1", "", :ferry, nil)
     end
 
+    test "Returns purple rail icon for CapeFlyer" do
+      assert %{type: :icon, icon: :rail, color: :purple} ==
+               serialize_for_departure("CapeFlyer", "", :rail, nil)
+    end
+
     test "Returns slashed route pill if route name contains `/`" do
       assert %{type: :slashed, part1: "34", part2: "35", color: :yellow} ==
                serialize_for_departure("3435", "34/35", :bus, nil)


### PR DESCRIPTION
**Asana task**: [Fix incorrect route pill for Cape Flyer](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1210794505820587?focus=true)

Updates the CapeFlyer to use the purple commuter rail color with a rail icon on DUPs.

<img width="1112" height="155" alt="image" src="https://github.com/user-attachments/assets/77b835ee-c571-4ffc-8bc4-f1439b48d2ff" />

- [X] Tests added?
