### PR TITLE
fix: incorrect pills in DUP no-data states

### DIFF
--- a/lib/screens/v2/candidate_generator/dup/departures.ex
+++ b/lib/screens/v2/candidate_generator/dup/departures.ex
@@ -712,19 +712,17 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
   end
 
   defp get_routes_serving_section(
-         %{route_ids: route_ids, stop_ids: stop_ids},
+         %Params{route_ids: route_ids, route_type: route_type, stop_ids: stop_ids},
          fetch_routes_fn
        ) do
-    routes =
-      case fetch_routes_fn.(%{stop_ids: stop_ids}) do
-        {:ok, routes} -> routes
-        :error -> []
-      end
+    params =
+      %{stop_ids: stop_ids}
+      |> then(&if route_ids == [], do: &1, else: Map.put(&1, :ids, route_ids))
+      |> then(&if is_nil(route_type), do: &1, else: Map.put(&1, :route_types, [route_type]))
 
-    if route_ids == [] do
-      routes
-    else
-      Enum.filter(routes, &(&1.id in route_ids))
+    case fetch_routes_fn.(params) do
+      {:ok, routes} -> routes
+      :error -> []
     end
   end
 

--- a/test/screens/v2/candidate_generator/dup/departures_test.exs
+++ b/test/screens/v2/candidate_generator/dup/departures_test.exs
@@ -258,23 +258,40 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
 
     fetch_vehicles_fn = fn _, _ -> [struct(Vehicle)] end
 
-    fetch_routes_fn = fn %{stop_ids: stop_ids} ->
-      {
-        :ok,
-        stop_ids
-        |> Enum.flat_map(fn
-          "Boat" -> [%{id: "Ferry", type: :ferry}]
-          "place-A" -> [%{id: "Orange", type: :subway}, %{id: "Green", type: :light_rail}]
-          "bus-A" -> [%{id: "Bus A", type: :bus}]
-          "bus-B" -> [%{id: "Bus B", type: :bus}]
-          "bus-C" -> [%{id: "Bus C", type: :bus}]
-          "bus-C+D" -> [%{id: "Bus C", type: :bus}, %{id: "Bus D", type: :bus}]
-          "place-overnight" -> [%{id: "Red", type: :subway}]
-          "place-closed" -> [%{id: "Red", type: :subway}, %{id: "Bus A", type: :bus}]
-          _ -> [%{id: "test", type: :test}]
-        end)
-        |> Enum.uniq()
-      }
+    fetch_routes_fn = fn
+      %{ids: ids} ->
+        {
+          :ok,
+          ids
+          |> Enum.flat_map(fn
+            "Ferry" -> [%{id: "Ferry", type: :ferry}]
+            "Orange" -> [%{id: "Orange", type: :subway}]
+            "Green" -> [%{id: "Green", type: :light_rail}]
+            "Bus A" -> [%{id: "Bus A", type: :bus}]
+            "Bus B" -> [%{id: "Bus B", type: :bus}]
+            "Bus C" -> [%{id: "Bus C", type: :bus}]
+            "Red" -> [%{id: "Red", type: :subway}]
+          end)
+          |> Enum.uniq()
+        }
+
+      %{stop_ids: stop_ids} ->
+        {
+          :ok,
+          stop_ids
+          |> Enum.flat_map(fn
+            "Boat" -> [%{id: "Ferry", type: :ferry}]
+            "place-A" -> [%{id: "Orange", type: :subway}, %{id: "Green", type: :light_rail}]
+            "bus-A" -> [%{id: "Bus A", type: :bus}]
+            "bus-B" -> [%{id: "Bus B", type: :bus}]
+            "bus-C" -> [%{id: "Bus C", type: :bus}]
+            "bus-C+D" -> [%{id: "Bus C", type: :bus}, %{id: "Bus D", type: :bus}]
+            "place-overnight" -> [%{id: "Red", type: :subway}]
+            "place-closed" -> [%{id: "Red", type: :subway}, %{id: "Bus A", type: :bus}]
+            _ -> [%{id: "test", type: :test}]
+          end)
+          |> Enum.uniq()
+        }
     end
 
     %{


### PR DESCRIPTION
When sections were filtered by route type, no-data states for those sections could have incorrect pills, since the pill was determined by a route fetching function which ignored this filter.

**Asana task**: https://app.asana.com/1/15492006741476/project/1185117109217413/task/1210964411699892

Fixed appearance of the DUP at Quincy Center when Commuter Rail departures are devops-disabled:

<img width="960" height="540" alt="Screen Shot 2025-08-11 at 13 54 34" src="https://github.com/user-attachments/assets/bf0fc35a-2c39-4cd6-9797-a8334642e448" />

