### PR TITLE
fix: improve directional no-data messages

### DIFF
--- a/lib/screens/routes/parser.ex
+++ b/lib/screens/routes/parser.ex
@@ -9,6 +9,7 @@ defmodule Screens.Routes.Parser do
           "attributes" => %{
             "short_name" => short_name,
             "long_name" => long_name,
+            "direction_names" => direction_names,
             "direction_destinations" => direction_destinations,
             "type" => route_type
           },
@@ -20,6 +21,7 @@ defmodule Screens.Routes.Parser do
       id: id,
       short_name: short_name,
       long_name: long_name,
+      direction_names: direction_names,
       direction_destinations: direction_destinations,
       type: RouteType.from_id(route_type),
       line: V3Api.Parser.included!(line, included)

--- a/lib/screens/routes/route.ex
+++ b/lib/screens/routes/route.ex
@@ -11,6 +11,7 @@ defmodule Screens.Routes.Route do
   defstruct id: nil,
             short_name: nil,
             long_name: nil,
+            direction_names: nil,
             direction_destinations: nil,
             type: nil,
             line: nil
@@ -21,7 +22,8 @@ defmodule Screens.Routes.Route do
           id: id,
           short_name: String.t(),
           long_name: String.t(),
-          direction_destinations: list(String.t()),
+          direction_names: [String.t()],
+          direction_destinations: [String.t()],
           type: RouteType.t(),
           line: Line.t()
         }
@@ -139,4 +141,15 @@ defmodule Screens.Routes.Route do
   @spec name(t()) :: String.t()
   def name(%__MODULE__{type: :bus, short_name: short_name}), do: short_name
   def name(%__MODULE__{long_name: long_name}), do: long_name
+
+  @doc """
+  Normalizes direction names to include the "bound" suffix (e.g. "Northbound" instead of "North").
+  """
+  @spec normalized_direction_names(t()) :: [String.t()]
+  def normalized_direction_names(%__MODULE__{direction_names: direction_names}) do
+    Enum.map(direction_names, fn
+      name when name in ~w[North South East West] -> name <> "bound"
+      other -> other
+    end)
+  end
 end

--- a/test/screens/route_patterns/route_pattern_test.exs
+++ b/test/screens/route_patterns/route_pattern_test.exs
@@ -52,6 +52,7 @@ defmodule Screens.RoutePatterns.RoutePatternTest do
                   "type" => "route",
                   "attributes" => %{
                     "direction_destinations" => ["Bowdoin", "Wonderland"],
+                    "direction_names" => ["South", "North"],
                     "long_name" => "Blue Line",
                     "short_name" => "",
                     "type" => 1
@@ -147,6 +148,7 @@ defmodule Screens.RoutePatterns.RoutePatternTest do
         id: "Blue",
         short_name: "",
         long_name: "Blue Line",
+        direction_names: ["South", "North"],
         direction_destinations: ["Bowdoin", "Wonderland"],
         type: :subway,
         line: blue_line
@@ -254,6 +256,7 @@ defmodule Screens.RoutePatterns.RoutePatternTest do
                   "type" => "route",
                   "attributes" => %{
                     "direction_destinations" => ["Bowdoin", "Wonderland"],
+                    "direction_names" => ["South", "North"],
                     "long_name" => "Blue Line",
                     "short_name" => "",
                     "type" => 1
@@ -276,6 +279,7 @@ defmodule Screens.RoutePatterns.RoutePatternTest do
                   "type" => "route",
                   "attributes" => %{
                     "direction_destinations" => ["Harvard Square", "Nubian Station"],
+                    "direction_names" => ["Outbound", "Inbound"],
                     "long_name" => "Harvard Square - Nubian Station",
                     "short_name" => "1",
                     "type" => 3

--- a/test/screens/routes/route_test.exs
+++ b/test/screens/routes/route_test.exs
@@ -14,6 +14,7 @@ defmodule Screens.Routes.RouteTest do
             "attributes" => %{
               "short_name" => nil,
               "long_name" => nil,
+              "direction_names" => nil,
               "direction_destinations" => nil,
               "type" => 1
             },


### PR DESCRIPTION
When configuring departures, we sometimes use a pattern where each direction of service gets its own dedicated section. When this is the case, and (only) one direction has no departures available, this meant live predictions were confusingly preceded/followed by a "no departures available" message using the same route pill — the screen apparently contradicting itself.

Improve support for this scenario by including a direction name in the no-data message of "directional" sections.

**Asana task**: https://app.asana.com/1/15492006741476/project/1185117109217413/task/1210825667877923

<img width="542" height="337" alt="Screenshot 2025-08-11 at 2 56 10 PM" src="https://github.com/user-attachments/assets/13383f08-6899-4a61-88fc-eb6d85da69de" />
