### PR TITLE
fix: tolerate invalid config in no-data message

### DIFF
--- a/lib/screens/v2/candidate_generator/widgets/departures.ex
+++ b/lib/screens/v2/candidate_generator/widgets/departures.ex
@@ -160,11 +160,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.Departures do
 
   defp normal_section_rows({:ok, departures}), do: departures
 
-  defp normal_section_rows({:no_data, route, :both}) do
-    [%FreeTextLine{icon: Route.icon(route), text: [no_departures_message()]}]
-  end
-
-  defp normal_section_rows({:no_data, route, direction_id}) do
+  defp normal_section_rows({:no_data, route, direction_id}) when direction_id in [0, 1] do
     [
       %FreeTextLine{
         icon: Route.icon(route),
@@ -176,6 +172,10 @@ defmodule Screens.V2.CandidateGenerator.Widgets.Departures do
         ]
       }
     ]
+  end
+
+  defp normal_section_rows({:no_data, route, _both}) do
+    [%FreeTextLine{icon: Route.icon(route), text: [no_departures_message()]}]
   end
 
   defp normal_section_rows(:no_data) do


### PR DESCRIPTION
The logic for directional no-data messages added in b2b1ca40 encountered [a crash](https://mbtace.sentry.io/issues/6807063531/?alert_rule_id=9523677&alert_timestamp=1755060442227&alert_type=email&environment=screens-prod&notification_uuid=076671d8-80e3-47c4-b4d5-eacc60bc4d6a&project=6061747&referrer=alert_email) when screens were mistakenly configured with a `direction_id` of `null`, when the correct value to use for no direction filtering is `"both"`. This restructures the logic to check specifically for a valid direction ID, and otherwise show the generic message.