### PR TITLE
DUP Headway Logic Update

### DIFF
--- a/lib/screens/headways.ex
+++ b/lib/screens/headways.ex
@@ -117,16 +117,17 @@ defmodule Screens.Headways do
     },
     red_ashmont: {~w[Red], ~w[shmnl fldcr smmnl asmnl]},
     red_braintree: {~w[Red], ~w[nqncy wlsta qnctr qamnl brntn]},
-    silver_seaport: {~w[741 742 746], ~w[conrd wtcst crtst sstat]},
-    silver_chelsea: {~w[743], ~w[conrd wtcst crtst sstat aport estav boxdt belsq chels]}
+    # combining 743 with the other three for the common stops
+    silver_seaport: {~w[741 742 743 746], ~w[conrd wtcst crtst sstat]},
+    silver_chelsea: {~w[743], ~w[aport estav boxdt belsq chels]}
   }
 
   # Mapping of stops and route IDs to headway keys for the Silver Line,
   # for stops which serve more than one route.
   @sl_stops %{
     # congress_st_at_wtc 17_096
-    silver_seaport: {~w[741 742 746], ~w[17096]},
-    silver_chelsea: {~w[743], ~w[17096]}
+    # combining 743 with the other three for the common stops
+    silver_seaport: {~w[741 742 743 746], ~w[17096]}
   }
 
   @type range :: {low :: pos_integer(), high :: pos_integer()}

--- a/test/screens/headways_test.exs
+++ b/test/screens/headways_test.exs
@@ -57,9 +57,9 @@ defmodule Screens.HeadwaysTest do
     test "returns the correct value for a combination of station id and route for the Silver Line" do
       assert Headways.get_with_route("place-chels", "743", local_dt()) == {7, 9}
       assert Headways.get_with_route("place-crtst", "746", local_dt()) == {1, 3}
-      assert Headways.get_with_route("place-crtst", "743", local_dt()) == {7, 9}
+      assert Headways.get_with_route("place-crtst", "743", local_dt()) == {1, 3}
       assert Headways.get_with_route(@congress_st_at_wtc, "742", local_dt()) == {1, 3}
-      assert Headways.get_with_route(@congress_st_at_wtc, "743", local_dt()) == {7, 9}
+      assert Headways.get_with_route(@congress_st_at_wtc, "743", local_dt()) == {1, 3}
       assert Headways.get_with_route("place-crtst", "751", local_dt()) == nil
     end
   end

--- a/test/screens/v2/candidate_generator/dup/departures_headway_test.exs
+++ b/test/screens/v2/candidate_generator/dup/departures_headway_test.exs
@@ -1,0 +1,629 @@
+defmodule Screens.V2.CandidateGenerator.Dup.DeparturesHeadwayTest do
+  use ExUnit.Case, async: true
+
+  alias Screens.Alerts.Alert
+  alias Screens.Predictions.Prediction
+  alias Screens.Routes.Route
+  alias Screens.Stops.Stop
+  alias Screens.Trips.Trip
+  alias Screens.Vehicles.Vehicle
+  alias Screens.V2.Departure
+  alias Screens.V2.CandidateGenerator.Dup
+  alias Screens.V2.WidgetInstance.Departures, as: DeparturesWidget
+  alias Screens.V2.WidgetInstance.Departures.{HeadwaySection, NormalSection}
+  alias ScreensConfig.{Alerts, Departures, Header}
+  alias ScreensConfig.Departures.Header, as: SectionHeader
+  alias ScreensConfig.Departures.{Layout, Query, Section}
+  alias ScreensConfig.Screen
+  alias ScreensConfig.Screen.Dup, as: DupConfig
+
+  import Screens.Inject
+  import Mox
+  setup :verify_on_exit!
+
+  @headways injected(Screens.Headways)
+
+  defp put_primary_departures(widget, primary_departures_sections) do
+    %{
+      widget
+      | app_params: %{
+          widget.app_params
+          | primary_departures: %Departures{sections: primary_departures_sections}
+        }
+    }
+  end
+
+  setup do
+    config = %Screen{
+      app_params: %DupConfig{
+        header: %Header.StopId{stop_id: "place-headway-test"},
+        primary_departures: %Departures{
+          sections: []
+        },
+        secondary_departures: %Departures{
+          sections: []
+        },
+        alerts: struct(Alerts)
+      },
+      vendor: :outfront,
+      device_id: "TEST",
+      name: "TEST",
+      app_id: :dup_v2
+    }
+
+    fetch_departures_fn = fn
+      %{stop_ids: ["place-A"]}, _opts ->
+        {:ok,
+         [
+           %Departure{
+             prediction:
+               struct(Prediction,
+                 id: "A",
+                 route: %Route{id: "Test"},
+                 stop: struct(Stop),
+                 trip: struct(Trip)
+               )
+           }
+         ]}
+
+      _, _ ->
+        {:ok, []}
+    end
+
+    fetch_alerts_fn = fn
+      _ -> []
+    end
+
+    fetch_schedules_fn = fn
+      _, _ ->
+        []
+    end
+
+    fetch_vehicles_fn = fn _, _ -> [struct(Vehicle)] end
+
+    fetch_routes_fn = fn
+      %{ids: ids} ->
+        {
+          :ok,
+          ids
+          |> Enum.flat_map(fn
+            "Ferry" ->
+              [%{id: "Ferry", type: :ferry}]
+
+            "Orange" ->
+              [%{id: "Orange", type: :subway}]
+
+            "Green" ->
+              [%{id: "Green", type: :light_rail}]
+
+            "Red" ->
+              [%{id: "Red", type: :subway}]
+
+            "Blue" ->
+              [
+                %Route{
+                  id: "Blue",
+                  type: :subway,
+                  direction_names: ["Test Direction Zero", "Test Direction One"]
+                }
+              ]
+
+            "743" ->
+              [%Route{id: "743", type: :bus, direction_names: ["Test Bus One", "Test Bus Two"]}]
+          end)
+          |> Enum.uniq()
+        }
+
+      %{stop_ids: stop_ids} ->
+        {
+          :ok,
+          stop_ids
+          |> Enum.flat_map(fn
+            "place-knncl" ->
+              [%{id: "Red", type: :subway}]
+
+            "place-A" ->
+              [%{id: "Orange", type: :subway}, %{id: "Green", type: :light_rail}]
+
+            _ ->
+              [%{id: "test", type: :test}]
+          end)
+          |> Enum.uniq()
+        }
+    end
+
+    %{
+      config: config,
+      fetch_departures_fn: fetch_departures_fn,
+      fetch_alerts_fn: fetch_alerts_fn,
+      fetch_schedules_fn: fetch_schedules_fn,
+      fetch_routes_fn: fetch_routes_fn,
+      fetch_vehicles_fn: fetch_vehicles_fn
+    }
+  end
+
+  test "returns headway section when no departures, no alert and not in overnight period", %{
+    config: config,
+    fetch_departures_fn: fetch_departures_fn,
+    fetch_alerts_fn: fetch_alerts_fn,
+    fetch_schedules_fn: fetch_schedules_fn,
+    fetch_routes_fn: fetch_routes_fn,
+    fetch_vehicles_fn: fetch_vehicles_fn
+  } do
+    config =
+      put_primary_departures(config, [
+        %Section{query: %Query{params: %Query.Params{stop_ids: ["place-knncl"]}}}
+      ])
+
+    now = ~U[2020-04-06T10:00:00Z]
+    expect(@headways, :get_with_route, fn "place-knncl", "Red", ^now -> {12, 16} end)
+
+    expected_departures = [
+      %DeparturesWidget{
+        screen: config,
+        sections: [
+          %HeadwaySection{
+            route: "Red",
+            time_range: {12, 16},
+            headsign: nil
+          }
+        ],
+        slot_names: [:main_content_zero],
+        now: now
+      },
+      %DeparturesWidget{
+        screen: config,
+        sections: [
+          %HeadwaySection{
+            route: "Red",
+            time_range: {12, 16},
+            headsign: nil
+          }
+        ],
+        slot_names: [:main_content_one],
+        now: now
+      },
+      %DeparturesWidget{
+        screen: config,
+        sections: [
+          %HeadwaySection{
+            route: "Red",
+            time_range: {12, 16},
+            headsign: nil
+          }
+        ],
+        slot_names: [:main_content_two],
+        now: now
+      }
+    ]
+
+    actual_instances =
+      Dup.Departures.departures_instances(
+        config,
+        now,
+        fetch_departures_fn,
+        fetch_alerts_fn,
+        fetch_schedules_fn,
+        fetch_routes_fn,
+        fetch_vehicles_fn
+      )
+
+    assert Enum.all?(expected_departures, &Enum.member?(actual_instances, &1))
+  end
+
+  test "returns headway sections with direction names if the sections are configured with direction_id",
+       %{
+         config: config,
+         fetch_departures_fn: fetch_departures_fn,
+         fetch_alerts_fn: fetch_alerts_fn,
+         fetch_schedules_fn: fetch_schedules_fn,
+         fetch_routes_fn: fetch_routes_fn,
+         fetch_vehicles_fn: fetch_vehicles_fn
+       } do
+    config =
+      put_primary_departures(config, [
+        %Section{
+          query: %Query{
+            params: %Query.Params{stop_ids: ["place-aport"], route_ids: ["Blue"], direction_id: 0}
+          }
+        },
+        %Section{
+          query: %Query{
+            params: %Query.Params{stop_ids: ["place-aport"], route_ids: ["743"], direction_id: 0}
+          }
+        }
+      ])
+
+    now = ~U[2020-04-06T10:00:00Z]
+    expect(@headways, :get_with_route, fn "place-aport", "Blue", ^now -> {2, 4} end)
+    expect(@headways, :get_with_route, fn "place-aport", "743", ^now -> {6, 8} end)
+
+    expected_departures = [
+      %DeparturesWidget{
+        screen: config,
+        sections: [
+          %HeadwaySection{
+            route: "Blue",
+            time_range: {2, 4},
+            headsign: "Test Direction Zero"
+          },
+          %HeadwaySection{
+            route: "743",
+            time_range: {6, 8},
+            headsign: "Test Bus One"
+          }
+        ],
+        slot_names: [:main_content_zero],
+        now: now
+      },
+      %DeparturesWidget{
+        screen: config,
+        sections: [
+          %HeadwaySection{
+            route: "Blue",
+            time_range: {2, 4},
+            headsign: "Test Direction Zero"
+          },
+          %HeadwaySection{
+            route: "743",
+            time_range: {6, 8},
+            headsign: "Test Bus One"
+          }
+        ],
+        slot_names: [:main_content_one],
+        now: now
+      },
+      %DeparturesWidget{
+        screen: config,
+        sections: [
+          %HeadwaySection{
+            route: "Blue",
+            time_range: {2, 4},
+            headsign: "Test Direction Zero"
+          },
+          %HeadwaySection{
+            route: "743",
+            time_range: {6, 8},
+            headsign: "Test Bus One"
+          }
+        ],
+        slot_names: [:main_content_two],
+        now: now
+      }
+    ]
+
+    actual_instances =
+      Dup.Departures.departures_instances(
+        config,
+        now,
+        fetch_departures_fn,
+        fetch_alerts_fn,
+        fetch_schedules_fn,
+        fetch_routes_fn,
+        fetch_vehicles_fn
+      )
+
+    assert Enum.all?(expected_departures, &Enum.member?(actual_instances, &1))
+  end
+
+  test "returns directional headway when at boundary for alerts", %{
+    config: config,
+    fetch_departures_fn: fetch_departures_fn,
+    fetch_schedules_fn: fetch_schedules_fn,
+    fetch_routes_fn: fetch_routes_fn,
+    fetch_vehicles_fn: fetch_vehicles_fn
+  } do
+    config =
+      put_primary_departures(config, [
+        %Section{query: %Query{params: %Query.Params{stop_ids: ["place-B"]}}}
+      ])
+
+    now = ~U[2020-04-06T10:00:00Z]
+    expect(@headways, :get_with_route, fn "place-B", "test", ^now -> {12, 16} end)
+
+    fetch_alerts_fn = fn
+      [
+        direction_id: :both,
+        route_ids: [],
+        stop_ids: ["place-B"],
+        route_types: [:light_rail, :subway]
+      ] ->
+        [
+          struct(Alert,
+            effect: :suspension,
+            informed_entities: [
+              %{stop: "place-B", route: "Red"}
+            ],
+            active_period: [{~U[2020-04-06T09:00:00Z], nil}]
+          )
+        ]
+    end
+
+    expected_departures = [
+      %DeparturesWidget{
+        screen: config,
+        sections: [
+          %HeadwaySection{
+            route: "Red",
+            time_range: {12, 16},
+            headsign: "Test A"
+          }
+        ],
+        slot_names: [:main_content_zero],
+        now: now
+      },
+      %DeparturesWidget{
+        screen: config,
+        sections: [
+          %HeadwaySection{
+            route: "Red",
+            time_range: {12, 16},
+            headsign: "Test A"
+          }
+        ],
+        slot_names: [:main_content_one],
+        now: now
+      },
+      %DeparturesWidget{
+        screen: config,
+        sections: [
+          %HeadwaySection{
+            route: "Red",
+            time_range: {12, 16},
+            headsign: "Test A"
+          }
+        ],
+        slot_names: [:main_content_two],
+        now: now
+      }
+    ]
+
+    actual_instances =
+      Dup.Departures.departures_instances(
+        config,
+        now,
+        fetch_departures_fn,
+        fetch_alerts_fn,
+        fetch_schedules_fn,
+        fetch_routes_fn,
+        fetch_vehicles_fn
+      )
+
+    assert Enum.all?(expected_departures, &Enum.member?(actual_instances, &1))
+  end
+
+  test "returns headway section and regular predictions when multiple departures configured but one section has headways",
+       %{
+         config: config,
+         fetch_departures_fn: fetch_departures_fn,
+         fetch_alerts_fn: fetch_alerts_fn,
+         fetch_schedules_fn: fetch_schedules_fn,
+         fetch_routes_fn: fetch_routes_fn,
+         fetch_vehicles_fn: fetch_vehicles_fn
+       } do
+    config =
+      put_primary_departures(config, [
+        %Section{query: %Query{params: %Query.Params{stop_ids: ["place-A"]}}},
+        %Section{query: %Query{params: %Query.Params{stop_ids: ["place-kencl"]}}}
+      ])
+
+    now = ~U[2020-04-06T10:00:00Z]
+    expect(@headways, :get_with_route, fn "place-A", "Orange", ^now -> nil end)
+    expect(@headways, :get_with_route, fn "place-A", "Green", ^now -> nil end)
+    expect(@headways, :get_with_route, fn "place-kencl", "test", ^now -> {7, 13} end)
+
+    expected_departures = [
+      %DeparturesWidget{
+        screen: config,
+        sections: [
+          %NormalSection{
+            layout: %Layout{},
+            header: %SectionHeader{},
+            rows: [
+              %Screens.V2.Departure{
+                prediction:
+                  struct(Prediction,
+                    id: "A",
+                    route: %Route{id: "Test"},
+                    stop: struct(Stop),
+                    trip: struct(Trip)
+                  ),
+                schedule: nil
+              }
+            ]
+          },
+          %HeadwaySection{
+            route: "test",
+            time_range: {7, 13},
+            headsign: nil
+          }
+        ],
+        slot_names: [:main_content_reduced_zero],
+        now: now
+      },
+      %DeparturesWidget{
+        screen: config,
+        sections: [
+          %NormalSection{
+            layout: %Layout{},
+            header: %SectionHeader{},
+            rows: [
+              %Screens.V2.Departure{
+                prediction:
+                  struct(Prediction,
+                    id: "A",
+                    route: %Route{id: "Test"},
+                    stop: struct(Stop),
+                    trip: struct(Trip)
+                  ),
+                schedule: nil
+              }
+            ]
+          },
+          %HeadwaySection{
+            route: "test",
+            time_range: {7, 13},
+            headsign: nil
+          }
+        ],
+        slot_names: [:main_content_reduced_one],
+        now: now
+      },
+      %DeparturesWidget{
+        screen: config,
+        sections: [
+          %NormalSection{
+            layout: %Layout{},
+            header: %SectionHeader{},
+            rows: [
+              %Screens.V2.Departure{
+                prediction:
+                  struct(Prediction,
+                    id: "A",
+                    route: %Route{id: "Test"},
+                    stop: struct(Stop),
+                    trip: struct(Trip)
+                  ),
+                schedule: nil
+              }
+            ]
+          },
+          %HeadwaySection{
+            route: "test",
+            time_range: {7, 13},
+            headsign: nil
+          }
+        ],
+        slot_names: [:main_content_reduced_two],
+        now: now
+      }
+    ]
+
+    actual_instances =
+      Dup.Departures.departures_instances(
+        config,
+        now,
+        fetch_departures_fn,
+        fetch_alerts_fn,
+        fetch_schedules_fn,
+        fetch_routes_fn,
+        fetch_vehicles_fn
+      )
+
+    assert Enum.all?(expected_departures, &Enum.member?(actual_instances, &1))
+  end
+
+  test "returns headway sections for branch station for alert with trunk headsign", %{
+    config: config,
+    fetch_departures_fn: fetch_departures_fn,
+    fetch_schedules_fn: fetch_schedules_fn,
+    fetch_routes_fn: fetch_routes_fn,
+    fetch_vehicles_fn: fetch_vehicles_fn
+  } do
+    config =
+      put_primary_departures(config, [
+        %Section{query: %Query{params: %Query.Params{stop_ids: ["place-kencl"]}}}
+      ])
+
+    now = ~U[2020-04-06T10:00:00Z]
+    expect(@headways, :get_with_route, fn "place-kencl", "test", ^now -> {7, 13} end)
+
+    fetch_alerts_fn = fn
+      [
+        direction_id: :both,
+        route_ids: [],
+        stop_ids: ["place-kencl"],
+        route_types: [:light_rail, :subway]
+      ] ->
+        [
+          # Suspension alert from Kenmore to Hynes
+          struct(Alert,
+            effect: :suspension,
+            informed_entities: [
+              %{
+                direction_id: nil,
+                facility: nil,
+                route: "Green-C",
+                route_type: 0,
+                stop: "70151"
+              },
+              %{
+                direction_id: nil,
+                facility: nil,
+                route: "Green-C",
+                route_type: 0,
+                stop: "70152"
+              },
+              %{
+                direction_id: nil,
+                facility: nil,
+                route: "Green-C",
+                route_type: 0,
+                stop: "place-kencl"
+              },
+              %{
+                direction_id: nil,
+                facility: nil,
+                route: "Green-C",
+                route_type: 0,
+                stop: "place-hymnl"
+              }
+            ],
+            active_period: [{~U[2020-04-06T09:00:00Z], nil}]
+          )
+        ]
+    end
+
+    expected_departures = [
+      %DeparturesWidget{
+        screen: config,
+        sections: [
+          %HeadwaySection{
+            route: "Green-C",
+            time_range: {7, 13},
+            headsign: "Westbound"
+          }
+        ],
+        slot_names: [:main_content_reduced_zero],
+        now: now
+      },
+      %DeparturesWidget{
+        screen: config,
+        sections: [
+          %HeadwaySection{
+            route: "Green-C",
+            time_range: {7, 13},
+            headsign: "Westbound"
+          }
+        ],
+        slot_names: [:main_content_reduced_one],
+        now: now
+      },
+      %DeparturesWidget{
+        screen: config,
+        sections: [
+          %HeadwaySection{
+            route: "Green-C",
+            time_range: {7, 13},
+            headsign: "Westbound"
+          }
+        ],
+        slot_names: [:main_content_reduced_two],
+        now: now
+      }
+    ]
+
+    actual_instances =
+      Dup.Departures.departures_instances(
+        config,
+        now,
+        fetch_departures_fn,
+        fetch_alerts_fn,
+        fetch_schedules_fn,
+        fetch_routes_fn,
+        fetch_vehicles_fn
+      )
+
+    assert Enum.all?(expected_departures, &Enum.member?(actual_instances, &1))
+  end
+end

--- a/test/screens/v2/widget_instance/departures_test.exs
+++ b/test/screens/v2/widget_instance/departures_test.exs
@@ -188,11 +188,26 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
       dup_screen: dup_screen,
       now: now
     } do
-      section = %HeadwaySection{route: "Red", time_range: {1, 2}, headsign: "Test"}
+      section = %HeadwaySection{route: "Red", time_range: {1, 2}, headsign: nil}
 
       expected_text = %{
         icon: :red,
         text: ["every", %{format: :bold, text: "1-2"}, "minutes"]
+      }
+
+      assert %{type: :headway_section, text: expected_text, layout: :row} ==
+               Departures.serialize_section(section, dup_screen, now, false)
+    end
+
+    test "returns serialized headway_section for multiple configured sections with headsign", %{
+      dup_screen: dup_screen,
+      now: now
+    } do
+      section = %HeadwaySection{route: "Red", time_range: {12, 15}, headsign: "Alewife"}
+
+      expected_text = %{
+        icon: :red,
+        text: [%{format: :bold, text: "Alewife"}, %{format: :small, text: "every 12-15m"}]
       }
 
       assert %{type: :headway_section, text: expected_text, layout: :row} ==


### PR DESCRIPTION
**Asana task**: [Update how headway logic works on DUPs](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1210911817494842?focus=true)

Description
Previously, Headway Mode would only work if there was an associated alert at the particular station.

The new changes keep the old terminal alert headway logic (along with the directional headsigns), but also checks if there are no departures, no alerts, and we're not in an overnight period and shows Headway Mode in this flow as well. This enables Headway Mode to show in cases where we have suppressed predictions at certain stations. 

Along with these display logic changes, direction_name is now being parsed from the V3 API and has been added as the headsign in cases where we have sections configured with a direction_id. This will now use the direction name associated with the direction id (e.g. Inbound, Outbound, Westbound etc.). In cases where we don't have a direction_id, we will show the generic headway text.

NB: I did see a bug at Haymarket when we had a Temporary Terminal with the orange line, and then headways for the Green Line where it would double up Orange Line headways. Going to look to see if there's a ticket in the backlog for this, but I also have a fix in a separate branch for that that I am going to spin out into a separate PR. 

- [X] Tests added?

<img width="970" height="567" alt="Screenshot 2025-08-18 at 3 04 24 PM" src="https://github.com/user-attachments/assets/92c6c04d-fcbe-44d9-976d-42a8fce44a0f" />
<img width="978" height="546" alt="Screenshot 2025-08-13 at 4 46 02 PM" src="https://github.com/user-attachments/assets/e4b4dbf3-2d5c-4197-af2b-dab930a4f9e2" />
<img width="979" height="548" alt="Screenshot 2025-08-13 at 4 47 49 PM" src="https://github.com/user-attachments/assets/1de3295c-b725-4ead-ac28-41427d1fed45" />
<img width="968" height="553" alt="Screenshot 2025-08-18 at 3 24 01 PM" src="https://github.com/user-attachments/assets/c43e2e6c-2e29-46e0-85ac-d570fa7b241d" />

