### PR TITLE
test: increase timeout in flaky test

### DIFF
--- a/test/screens/v2/screen_data_test.exs
+++ b/test/screens/v2/screen_data_test.exs
@@ -99,7 +99,8 @@ defmodule Screens.V2.ScreenDataTest do
         receive do
           {:crash_running, pid} ->
             ref = Process.monitor(pid)
-            assert_receive({:DOWN, ^ref, :process, _pid, _reason})
+            # Wait a bit longer than the default 100ms to avoid occasional timeouts
+            assert_receive({:DOWN, ^ref, :process, _pid, _reason}, 200)
         end
       end)
     end


### PR DESCRIPTION
This has been a minor annoyance for a while, but so minor it wasn't worth the equally minor effort of fixing it. I have spare time and this just failed a main branch build again, though, so it has Failed Me For The Last Time™.