### PR TITLE
Add additional logging for API responses

### DIFF
--- a/assets/src/hooks/v2/use_api_response.tsx
+++ b/assets/src/hooks/v2/use_api_response.tsx
@@ -192,6 +192,9 @@ const useBaseApiResponse = ({
         SentryLogger.info("Request failed.", { json });
         doFailureBuffer(lastSuccess, setApiResponse, response);
       } else {
+        if (!isSuccess(response)) {
+          SentryLogger.info("Non-success API response", { json });
+        }
         setApiResponse((prevApiResponse) => {
           if (!isSuccess(prevApiResponse)) {
             SentryLogger.info("Exiting no-data state.");


### PR DESCRIPTION
- Currently, our Sentry logging logs exceptions thrown and Exiting the no data state when parsing an API response. For whatever reason, Sentry seems to not be reporting all of what should be caught errors from network problems.
- This adds a bit of additional logging for checking the other non-success responses, assuming failures will still be logged as Request failed and success will just pass through regularly.
- My thought here is that if Sentry isn't catching errors, it must be going through properly. If the request isn't just outright failing, then it must be going through the success flow, in which case these new logs should catch it. 
