### PR TITLE
chore: disable unneeded telemetry logging

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -38,7 +38,7 @@ config :ex_aws, json_codec: Jason
 config :elixir, :time_zone_database, Tzdata.TimeZoneDatabase
 
 config :hackney, mod_metrics: :hackney_telemetry
-config :hackney_telemetry, report_interval: 5_000
+config :hackney_telemetry, report_interval: 10_000
 
 config :screens,
   redirect_http?: true,

--- a/lib/screens/alerts/alert.ex
+++ b/lib/screens/alerts/alert.ex
@@ -159,29 +159,27 @@ defmodule Screens.Alerts.Alert do
 
   @callback fetch(options()) :: result()
   def fetch(opts \\ [], get_json_fn \\ &V3Api.get_json/2) do
-    Screens.Telemetry.span([:screens, :alerts, :alert, :fetch], fn ->
-      includes =
-        if Keyword.get(opts, :include_all?, false),
-          do: @all_includes,
-          else: @base_includes
+    includes =
+      if Keyword.get(opts, :include_all?, false),
+        do: @all_includes,
+        else: @base_includes
 
-      params =
-        opts
-        |> Enum.flat_map(&format_query_param/1)
-        |> Map.new()
-        |> Map.put("include", Enum.join(includes, ","))
+    params =
+      opts
+      |> Enum.flat_map(&format_query_param/1)
+      |> Map.new()
+      |> Map.put("include", Enum.join(includes, ","))
 
-      case get_json_fn.("alerts", params) do
-        {:ok, response} ->
-          {:ok,
-           response
-           |> V3Api.Parser.parse()
-           |> normalize_informed_entities_for_direction_id()}
+    case get_json_fn.("alerts", params) do
+      {:ok, response} ->
+        {:ok,
+         response
+         |> V3Api.Parser.parse()
+         |> normalize_informed_entities_for_direction_id()}
 
-        _ ->
-          :error
-      end
-    end)
+      _ ->
+        :error
+    end
   end
 
   @doc """

--- a/lib/screens/stops/stop.ex
+++ b/lib/screens/stops/stop.ex
@@ -83,12 +83,10 @@ defmodule Screens.Stops.Stop do
 
   @callback fetch_stop_name(id()) :: String.t() | nil
   def fetch_stop_name(stop_id) do
-    Screens.Telemetry.span(~w[screens stops stop fetch_stop_name]a, %{stop_id: stop_id}, fn ->
-      case fetch(%{ids: [stop_id]}) do
-        {:ok, [%__MODULE__{name: name}]} -> name
-        _ -> nil
-      end
-    end)
+    case fetch(%{ids: [stop_id]}) do
+      {:ok, [%__MODULE__{name: name}]} -> name
+      _ -> nil
+    end
   end
 
   @spec fetch_subway_platforms_for_stop(id()) :: [t()]

--- a/lib/screens/telemetry.ex
+++ b/lib/screens/telemetry.ex
@@ -11,31 +11,11 @@ defmodule Screens.Telemetry do
   @impl Supervisor
   def init(_) do
     handlers = [
-      # V3 API
-      log_span(~w[screens v3_api get_json]a, metadata: ~w[path query cache]a),
-      # Stops
-      log_span(~w[screens stops stop fetch_stop_name]a, metadata: ~w[stop_id]),
-      # Location Context
-      log_span(~w[screens location_context fetch]a, metadata: ~w[app stop_id]),
-      # Alerts
-      log_span(~w[screens alerts alert fetch]a),
-      # Routes
-      log_span(~w[screens routes route fetch_routes_by_stop]a,
-        metadata: ~w[stop_id type_filters]a
-      ),
-      # DUP Candidate Generator
-      log_span(~w[screens v2 candidate_generator dup]a),
-      log_span(~w[screens v2 candidate_generator dup departures_instances]a),
-      log_span(~w[screens v2 candidate_generator dup departures get_section_data]a),
-      log_span(~w[screens v2 candidate_generator dup departures get_sections_data]a),
-      log_span(~w[screens v2 candidate_generator dup header_instances]a),
-      log_span(~w[screens v2 candidate_generator dup alerts_instances]a),
-      log_span(~w[screens v2 candidate_generator dup evergreen_content_instances]a),
-      # New DUP Candidate Generator
-      log_span(~w[screens v2 candidate_generator dup_new]a),
-      log_span(~w[screens v2 candidate_generator dup_new departures_instances]a),
-      log_span(~w[screens v2 candidate_generator dup_new evergreen_instances]a),
-      log_span(~w[screens v2 candidate_generator dup_new header_instances]a),
+      # example span to avoid unused function warnings; nothing emits this
+      log_span(~w[screens example_event]a),
+
+      # enable V3 API span logging (WARNING: high log volume)
+      # log_span(~w[screens v3_api get_json]a, metadata: ~w[path query cache]a),
 
       # events
       log_event(~w[hackney_pool]a,
@@ -59,7 +39,8 @@ defmodule Screens.Telemetry do
         measurements: [
           {Screens.V3Api.Cache.Realtime, :dispatch_stats, []},
           {Screens.V3Api.Cache.Static, :dispatch_stats, []}
-        ]
+        ],
+        period: 10_000
       }
     ]
 

--- a/lib/screens/v2/candidate_generator/dup_new.ex
+++ b/lib/screens/v2/candidate_generator/dup_new.ex
@@ -1,7 +1,6 @@
 defmodule Screens.V2.CandidateGenerator.DupNew do
   @moduledoc false
 
-  alias Screens.Telemetry
   alias Screens.V2.CandidateGenerator
   alias Screens.V2.CandidateGenerator.Widgets
 
@@ -9,28 +8,20 @@ defmodule Screens.V2.CandidateGenerator.DupNew do
 
   @behaviour CandidateGenerator
 
-  @telemetry_name ~w[screens v2 candidate_generator dup_new]a
   @instance_generators [
-                         header_instances: &Widgets.Header.instances/2,
-                         departures_instances: &Departures.instances/2,
-                         evergreen_instances: &Widgets.Evergreen.evergreen_content_instances/2
-                       ]
-                       |> Enum.map(fn {name, func} -> {@telemetry_name ++ [name], func} end)
+    &Widgets.Header.instances/2,
+    &Departures.instances/2,
+    &Widgets.Evergreen.evergreen_content_instances/2
+  ]
 
   @impl CandidateGenerator
   defdelegate screen_template(screen), to: Screens.V2.CandidateGenerator.Dup
 
   @impl CandidateGenerator
   def candidate_instances(config, now \\ DateTime.utc_now()) do
-    Telemetry.span(@telemetry_name, fn ->
-      context = Telemetry.context()
-
-      @instance_generators
-      |> Task.async_stream(fn {name, func} ->
-        Telemetry.span(name, context, fn -> func.(config, now) end)
-      end)
-      |> Enum.flat_map(fn {:ok, instances} -> instances end)
-    end)
+    @instance_generators
+    |> Task.async_stream(& &1.(config, now))
+    |> Enum.flat_map(fn {:ok, instances} -> instances end)
   end
 
   @impl CandidateGenerator


### PR DESCRIPTION
This method of sending telemetry was regularly overloading the Splunk log handler and causing more important logs to be dropped (in particular DeviceMonitor, which we rely on for alerting us to screen outages). We have not actually used these log spans to investigate anything in a long time, so we'll remove them until we may need them again.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211123747782268