### PR TITLE
build: use automatic JSX transform

### DIFF
--- a/assets/eslint.config.mjs
+++ b/assets/eslint.config.mjs
@@ -32,6 +32,8 @@ export default [
       "no-empty": ["error", { allowEmptyCatch: true }],
       "react/display-name": "warn",
       "react/prop-types": "warn",
+      // not valid when using the "automatic" JSX transform
+      "react/react-in-jsx-scope": "off",
       "@typescript-eslint/ban-ts-comment": "warn",
       "@typescript-eslint/no-explicit-any": "warn",
       "@typescript-eslint/no-unused-vars": [

--- a/assets/src/apps/admin.tsx
+++ b/assets/src/apps/admin.tsx
@@ -1,6 +1,6 @@
 import "../../css/admin.scss";
 
-import React, { ComponentType } from "react";
+import type { ComponentType } from "react";
 import ReactDOM from "react-dom";
 import {
   BrowserRouter as Router,

--- a/assets/src/apps/v2/bus_eink.tsx
+++ b/assets/src/apps/v2/bus_eink.tsx
@@ -6,7 +6,6 @@ initFullstory();
 
 import "../../../css/bus_eink_v2.scss";
 
-import React from "react";
 import ReactDOM from "react-dom";
 import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
 import ScreenPage from "Components/v2/screen_page";

--- a/assets/src/apps/v2/bus_shelter.tsx
+++ b/assets/src/apps/v2/bus_shelter.tsx
@@ -6,7 +6,6 @@ initFullstory();
 
 import "../../../css/bus_shelter_v2.scss";
 
-import React from "react";
 import ReactDOM from "react-dom";
 import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
 import ScreenPage from "Components/v2/screen_page";

--- a/assets/src/apps/v2/busway.tsx
+++ b/assets/src/apps/v2/busway.tsx
@@ -6,7 +6,6 @@ initFullstory();
 
 import "../../../css/busway_v2.scss";
 
-import React from "react";
 import ReactDOM from "react-dom";
 import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
 import ScreenPage from "Components/v2/screen_page";

--- a/assets/src/apps/v2/dup.tsx
+++ b/assets/src/apps/v2/dup.tsx
@@ -6,7 +6,6 @@ initFullstory();
 
 import "../../../css/dup_v2.scss";
 
-import React from "react";
 import ReactDOM from "react-dom";
 import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
 import ScreenPage from "Components/v2/screen_page";

--- a/assets/src/apps/v2/elevator.tsx
+++ b/assets/src/apps/v2/elevator.tsx
@@ -6,7 +6,6 @@ initFullstory();
 
 import "../../../css/elevator_v2.scss";
 
-import React from "react";
 import ReactDOM from "react-dom";
 import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
 import NormalScreen from "Components/v2/elevator/normal_screen";

--- a/assets/src/apps/v2/gl_eink.tsx
+++ b/assets/src/apps/v2/gl_eink.tsx
@@ -6,7 +6,6 @@ initFullstory();
 
 import "../../../css/gl_eink_v2.scss";
 
-import React from "react";
 import ReactDOM from "react-dom";
 import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
 import ScreenPage from "Components/v2/screen_page";

--- a/assets/src/apps/v2/pre_fare.tsx
+++ b/assets/src/apps/v2/pre_fare.tsx
@@ -6,7 +6,6 @@ initFullstory();
 
 import "../../../css/pre_fare_v2.scss";
 
-import React from "react";
 import ReactDOM from "react-dom";
 import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
 import ScreenPage from "Components/v2/screen_page";

--- a/assets/src/components/admin/admin_add_modal.tsx
+++ b/assets/src/components/admin/admin_add_modal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import _ from "lodash";
 
 import {

--- a/assets/src/components/admin/admin_cells.tsx
+++ b/assets/src/components/admin/admin_cells.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useMemo, useEffect } from "react";
+import { useRef, useMemo, useEffect } from "react";
 import { Link } from "react-router-dom";
 import _ from "lodash";
 

--- a/assets/src/components/admin/admin_edit_modal.tsx
+++ b/assets/src/components/admin/admin_edit_modal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import _ from "lodash";
 
 const EditModal = ({

--- a/assets/src/components/admin/admin_filters.tsx
+++ b/assets/src/components/admin/admin_filters.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import { useMemo } from "react";
 
 import { gatherSelectOptions } from "Util/admin";
 

--- a/assets/src/components/admin/admin_form.tsx
+++ b/assets/src/components/admin/admin_form.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef } from "react";
 import { fetch } from "Util/admin";
 
 const validateJson = (json) => {

--- a/assets/src/components/admin/admin_form_cells.tsx
+++ b/assets/src/components/admin/admin_form_cells.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 const FormStaticCell = ({ value }) => {
   return <input defaultValue={value} disabled={true} />;
 };

--- a/assets/src/components/admin/admin_image_manager.tsx
+++ b/assets/src/components/admin/admin_image_manager.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useDropzone } from "react-dropzone";
 import _ from "lodash";
 

--- a/assets/src/components/admin/admin_screen_config_form.tsx
+++ b/assets/src/components/admin/admin_screen_config_form.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import _ from "lodash";
 
 import AdminForm from "Components/admin/admin_form";

--- a/assets/src/components/admin/admin_table.tsx
+++ b/assets/src/components/admin/admin_table.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 import { useTable, useFilters, useRowSelect } from "react-table";
 import _ from "lodash";
 import weakKey from "weak-key";

--- a/assets/src/components/admin/admin_tables.tsx
+++ b/assets/src/components/admin/admin_tables.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import AdminTable from "Components/admin/admin_table";
 
 import {

--- a/assets/src/components/admin/devops.tsx
+++ b/assets/src/components/admin/devops.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 
 import { fetch } from "Util/admin";
 

--- a/assets/src/components/admin/inspector.tsx
+++ b/assets/src/components/admin/inspector.tsx
@@ -1,4 +1,4 @@
-import React, {
+import {
   type ComponentType,
   type RefObject,
   useEffect,

--- a/assets/src/components/v2/alert.tsx
+++ b/assets/src/components/v2/alert.tsx
@@ -1,4 +1,11 @@
-import React, { ComponentType, useState, useLayoutEffect, useRef } from "react";
+import {
+  type ComponentType,
+  type ReactNode,
+  useState,
+  useLayoutEffect,
+  useRef,
+} from "react";
+
 import { classWithModifier, imagePath } from "Util/utils";
 
 import RoutePill, {
@@ -24,7 +31,7 @@ interface BaseAlertProps {
 }
 
 interface AlertCardProps {
-  children: React.ReactNode;
+  children: ReactNode;
 }
 
 type AlertIcon = "bus" | "x" | "warning" | "snowflake";

--- a/assets/src/components/v2/arrow.tsx
+++ b/assets/src/components/v2/arrow.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { imagePath } from "Util/utils";
 
 /*

--- a/assets/src/components/v2/bundled_svg/link_arrow.tsx
+++ b/assets/src/components/v2/bundled_svg/link_arrow.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType } from "react";
+import type { ComponentType } from "react";
 
 interface Props {
   width: number;

--- a/assets/src/components/v2/bus_eink/bottom_takeover_body.tsx
+++ b/assets/src/components/v2/bus_eink/bottom_takeover_body.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-
+import type { ComponentType } from "react";
 import Widget, { WidgetData } from "Components/v2/widget";
 
 interface Props {
@@ -7,7 +6,7 @@ interface Props {
   full_body_bottom_screen: WidgetData;
 }
 
-const BottomTakeoverBody: React.ComponentType<Props> = ({
+const BottomTakeoverBody: ComponentType<Props> = ({
   main_content: mainContent,
   full_body_bottom_screen: fullBodyBottomScreen,
 }) => {

--- a/assets/src/components/v2/bus_eink/flex_zone_takeover.tsx
+++ b/assets/src/components/v2/bus_eink/flex_zone_takeover.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-
+import type { ComponentType } from "react";
 import Widget, { WidgetData } from "Components/v2/widget";
 
 interface Props {
@@ -8,7 +7,7 @@ interface Props {
   footer: WidgetData;
 }
 
-const FlexZoneTakeoverBody: React.ComponentType<Props> = ({
+const FlexZoneTakeoverBody: ComponentType<Props> = ({
   footer,
   main_content: mainContent,
   flex_zone_takeover: flexZoneTakeover,

--- a/assets/src/components/v2/bus_eink/normal_body.tsx
+++ b/assets/src/components/v2/bus_eink/normal_body.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-
+import type { ComponentType } from "react";
 import Widget, { WidgetData } from "Components/v2/widget";
 
 interface Props {
@@ -8,7 +7,7 @@ interface Props {
   footer: WidgetData;
 }
 
-const NormalBody: React.ComponentType<Props> = ({
+const NormalBody: ComponentType<Props> = ({
   footer,
   main_content: mainContent,
   flex_zone: flexZone,

--- a/assets/src/components/v2/bus_eink/normal_screen.tsx
+++ b/assets/src/components/v2/bus_eink/normal_screen.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-
+import type { ComponentType } from "react";
 import Widget, { WidgetData } from "Components/v2/widget";
 
 interface Props {
@@ -7,7 +6,7 @@ interface Props {
   body: WidgetData;
 }
 
-const NormalScreen: React.ComponentType<Props> = ({ header, body }) => {
+const NormalScreen: ComponentType<Props> = ({ header, body }) => {
   return (
     <div className="screen-normal">
       <div className="screen-normal__header">

--- a/assets/src/components/v2/bus_shelter/alert.tsx
+++ b/assets/src/components/v2/bus_shelter/alert.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType } from "react";
+import type { ComponentType } from "react";
 
 import BaseAlert, {
   Props,

--- a/assets/src/components/v2/bus_shelter/flex/one_large.tsx
+++ b/assets/src/components/v2/bus_shelter/flex/one_large.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-
+import type { ComponentType } from "react";
 import Widget, { WidgetData } from "Components/v2/widget";
 import FlexZonePageIndicator from "Components/v2/flex/page_indicator";
 
@@ -9,7 +8,7 @@ interface Props {
   num_pages: number;
 }
 
-const OneLarge: React.ComponentType<Props> = ({
+const OneLarge: ComponentType<Props> = ({
   large,
   num_pages: numPages,
   page_index: pageIndex,

--- a/assets/src/components/v2/bus_shelter/flex/one_medium_two_small.tsx
+++ b/assets/src/components/v2/bus_shelter/flex/one_medium_two_small.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-
+import type { ComponentType } from "react";
 import Widget, { WidgetData } from "Components/v2/widget";
 import FlexZonePageIndicator from "Components/v2/flex/page_indicator";
 
@@ -11,7 +10,7 @@ interface Props {
   num_pages: number;
 }
 
-const OneMediumTwoSmall: React.ComponentType<Props> = ({
+const OneMediumTwoSmall: ComponentType<Props> = ({
   medium_left: mediumLeft,
   small_upper_right: smallUpperRight,
   small_lower_right: smallLowerRight,

--- a/assets/src/components/v2/bus_shelter/flex/two_medium.tsx
+++ b/assets/src/components/v2/bus_shelter/flex/two_medium.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-
+import type { ComponentType } from "react";
 import Widget, { WidgetData } from "Components/v2/widget";
 import FlexZonePageIndicator from "Components/v2/flex/page_indicator";
 
@@ -10,7 +9,7 @@ interface Props {
   num_pages: number;
 }
 
-const TwoMedium: React.ComponentType<Props> = ({
+const TwoMedium: ComponentType<Props> = ({
   medium_left: mediumLeft,
   medium_right: mediumRight,
   page_index: pageIndex,

--- a/assets/src/components/v2/bus_shelter/link_footer.tsx
+++ b/assets/src/components/v2/bus_shelter/link_footer.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import DefaultLinkFooter from "Components/v2/link_footer";
 
 const LinkFooter = ({ text, url }) => {

--- a/assets/src/components/v2/bus_shelter/normal_body.tsx
+++ b/assets/src/components/v2/bus_shelter/normal_body.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-
+import type { ComponentType } from "react";
 import Widget, { WidgetData } from "Components/v2/widget";
 
 interface Props {
@@ -8,7 +7,7 @@ interface Props {
   footer: WidgetData;
 }
 
-const NormalBody: React.ComponentType<Props> = ({
+const NormalBody: ComponentType<Props> = ({
   main_content: mainContent,
   flex_zone: flexZone,
   footer,

--- a/assets/src/components/v2/bus_shelter/normal_screen.tsx
+++ b/assets/src/components/v2/bus_shelter/normal_screen.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-
+import type { ComponentType } from "react";
 import Widget, { WidgetData } from "Components/v2/widget";
 
 interface Props {
@@ -7,7 +6,7 @@ interface Props {
   body: WidgetData;
 }
 
-const NormalScreen: React.ComponentType<Props> = ({ header, body }) => {
+const NormalScreen: ComponentType<Props> = ({ header, body }) => {
   return (
     <div className="screen-normal">
       <div className="screen-normal__header">

--- a/assets/src/components/v2/bus_shelter/takeover_body.tsx
+++ b/assets/src/components/v2/bus_shelter/takeover_body.tsx
@@ -1,12 +1,11 @@
-import React from "react";
-
+import type { ComponentType } from "react";
 import Widget, { WidgetData } from "Components/v2/widget";
 
 interface Props {
   full_body: WidgetData;
 }
 
-const TakeoverBody: React.ComponentType<Props> = ({ full_body: fullBody }) => {
+const TakeoverBody: ComponentType<Props> = ({ full_body: fullBody }) => {
   return (
     <div className="body-takeover">
       <div className="body-takeover__full-body">

--- a/assets/src/components/v2/busway/normal_screen.tsx
+++ b/assets/src/components/v2/busway/normal_screen.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-
+import type { ComponentType } from "react";
 import Widget, { WidgetData } from "Components/v2/widget";
 
 interface Props {
@@ -7,7 +6,7 @@ interface Props {
   main_content: WidgetData;
 }
 
-const NormalScreen: React.ComponentType<Props> = ({
+const NormalScreen: ComponentType<Props> = ({
   header: header,
   main_content: mainContent,
 }) => {

--- a/assets/src/components/v2/departures.tsx
+++ b/assets/src/components/v2/departures.tsx
@@ -1,4 +1,4 @@
-import React, {
+import {
   ComponentType,
   useLayoutEffect,
   useMemo,

--- a/assets/src/components/v2/departures/departure_crowding.tsx
+++ b/assets/src/components/v2/departures/departure_crowding.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType } from "react";
+import type { ComponentType } from "react";
 
 import { classWithModifier } from "Util/utils";
 

--- a/assets/src/components/v2/departures/departure_row.tsx
+++ b/assets/src/components/v2/departures/departure_row.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType } from "react";
+import type { ComponentType } from "react";
 
 import RoutePill, { Pill } from "./route_pill";
 import Destination from "./destination";

--- a/assets/src/components/v2/departures/departure_time.tsx
+++ b/assets/src/components/v2/departures/departure_time.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType } from "react";
+import type { ComponentType } from "react";
 import { classWithModifier } from "Util/utils";
 
 const TextDepartureTime = ({ text }) => {

--- a/assets/src/components/v2/departures/departure_times.tsx
+++ b/assets/src/components/v2/departures/departure_times.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType } from "react";
+import type { ComponentType } from "react";
 
 import DepartureTime from "./departure_time";
 import DepartureCrowding, { CrowdingLevel } from "./departure_crowding";

--- a/assets/src/components/v2/departures/destination.tsx
+++ b/assets/src/components/v2/departures/destination.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType } from "react";
+import type { ComponentType } from "react";
 
 const abbreviate = (headsign: string): string => {
   if (headsign === "Government Center") return "Government Ctr";

--- a/assets/src/components/v2/departures/header.tsx
+++ b/assets/src/components/v2/departures/header.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import cx from "classnames";
 import Arrow45 from "Images/Arrow-45-no-padding.svg";
 

--- a/assets/src/components/v2/departures/later_departures.tsx
+++ b/assets/src/components/v2/departures/later_departures.tsx
@@ -1,4 +1,5 @@
-import React, {
+import {
+  type CSSProperties,
   useEffect,
   useLayoutEffect,
   useMemo,
@@ -83,7 +84,7 @@ const LaterDepatures = ({ rows }: { rows: DepartureRow[] }) => {
         style={
           {
             "--later-departures-offset": currentDepartureIdx,
-          } as React.CSSProperties
+          } as CSSProperties
         }
       >
         {departures.map((departure) => (

--- a/assets/src/components/v2/departures/normal_section.tsx
+++ b/assets/src/components/v2/departures/normal_section.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType } from "react";
+import type { ComponentType } from "react";
 import weakKey from "weak-key";
 
 import DepartureRow from "./departure_row";

--- a/assets/src/components/v2/departures/notice_row.tsx
+++ b/assets/src/components/v2/departures/notice_row.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType } from "react";
+import type { ComponentType } from "react";
 import FreeText, { FreeTextType } from "Components/v2/free_text";
 
 type NoticeRow = {

--- a/assets/src/components/v2/departures/route_pill.tsx
+++ b/assets/src/components/v2/departures/route_pill.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType } from "react";
+import type { ComponentType } from "react";
 
 import { imagePath, classWithModifiers } from "Util/utils";
 

--- a/assets/src/components/v2/disruption_diagram/disruption_diagram.tsx
+++ b/assets/src/components/v2/disruption_diagram/disruption_diagram.tsx
@@ -1,7 +1,7 @@
 // SPECIFICATION: https://www.notion.so/mbta-downtown-crossing/Disruption-Diagram-Specification-a779027385b545abbff6fb4b4fd0adc1
 
-import React, {
-  ComponentType,
+import {
+  type ComponentType,
   useCallback,
   useEffect,
   useRef,

--- a/assets/src/components/v2/dup/departures.tsx
+++ b/assets/src/components/v2/dup/departures.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType } from "react";
+import type { ComponentType } from "react";
 
 import { type Section as SectionBase } from "Components/v2/departures/section";
 import NormalSection from "./departures/normal_section";

--- a/assets/src/components/v2/dup/departures/departure_row.tsx
+++ b/assets/src/components/v2/dup/departures/departure_row.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType } from "react";
+import type { ComponentType } from "react";
 
 import type DepartureRowBase from "Components/v2/departures/departure_row";
 import RoutePill from "Components/v2/departures/route_pill";

--- a/assets/src/components/v2/dup/departures/departure_time.tsx
+++ b/assets/src/components/v2/dup/departures/departure_time.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType } from "react";
+import type { ComponentType } from "react";
 import { classWithModifier, classWithModifiers, imagePath } from "Util/utils";
 
 import type DepartureTimeBase from "Components/v2/departures/departure_time";

--- a/assets/src/components/v2/dup/departures/departure_times.tsx
+++ b/assets/src/components/v2/dup/departures/departure_times.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType } from "react";
+import type { ComponentType } from "react";
 
 import { type TimeWithCrowding } from "Components/v2/departures/departure_times";
 import DepartureTime from "./departure_time";

--- a/assets/src/components/v2/dup/departures/destination.tsx
+++ b/assets/src/components/v2/dup/departures/destination.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType, useLayoutEffect, useRef, useState } from "react";
+import { type ComponentType, useLayoutEffect, useRef, useState } from "react";
 
 import type DestinationBase from "Components/v2/departures/destination";
 

--- a/assets/src/components/v2/dup/departures/headway_section.tsx
+++ b/assets/src/components/v2/dup/departures/headway_section.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType } from "react";
+import type { ComponentType } from "react";
 import FreeText, { FreeTextType } from "Components/v2/free_text";
 import { classWithModifier } from "Util/utils";
 

--- a/assets/src/components/v2/dup/departures/no_data_section.tsx
+++ b/assets/src/components/v2/dup/departures/no_data_section.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType } from "react";
+import type { ComponentType } from "react";
 
 import NoConnection from "Images/live-data-none.svg";
 import FreeText, { FreeTextType } from "Components/v2/free_text";

--- a/assets/src/components/v2/dup/departures/normal_section.tsx
+++ b/assets/src/components/v2/dup/departures/normal_section.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType } from "react";
+import type { ComponentType } from "react";
 
 import { type NormalSection as Props } from "Components/v2/departures/normal_section";
 import DepartureRow from "./departure_row";

--- a/assets/src/components/v2/dup/departures/overnight_section.tsx
+++ b/assets/src/components/v2/dup/departures/overnight_section.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType } from "react";
+import type { ComponentType } from "react";
 
 import FreeText, { FreeTextType } from "Components/v2/free_text";
 

--- a/assets/src/components/v2/dup/departures_no_data.tsx
+++ b/assets/src/components/v2/dup/departures_no_data.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType } from "react";
+import type { ComponentType } from "react";
 import { imagePath } from "Util/utils";
 import LinkArrow from "../bundled_svg/link_arrow";
 

--- a/assets/src/components/v2/dup/dup_rotation_wrapper.tsx
+++ b/assets/src/components/v2/dup/dup_rotation_wrapper.tsx
@@ -1,8 +1,8 @@
 import _ from "lodash";
-import React from "react";
+import type { ElementType } from "react";
 
 export const splitRotationFromPropNames = (
-  WrappedComponent: React.ElementType,
+  WrappedComponent: ElementType,
   rotation: string,
 ) => {
   return (props: any) => {

--- a/assets/src/components/v2/dup/no_data.tsx
+++ b/assets/src/components/v2/dup/no_data.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType } from "react";
+import type { ComponentType } from "react";
 import NormalHeader from "./normal_header";
 import DeparturesNoData from "./departures_no_data";
 import { useStationName } from "Hooks/outfront";

--- a/assets/src/components/v2/dup/normal_body.tsx
+++ b/assets/src/components/v2/dup/normal_body.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-
+import type { ComponentType } from "react";
 import Widget, { WidgetData } from "Components/v2/widget";
 
 interface Props {
@@ -8,9 +7,7 @@ interface Props {
   rotation: string;
 }
 
-const NormalBody: React.ComponentType<Props> = ({
-  main_content: mainContent,
-}) => {
+const NormalBody: ComponentType<Props> = ({ main_content: mainContent }) => {
   return (
     <div className="body-normal">
       <div className="widget-slot body-normal__main-content">

--- a/assets/src/components/v2/dup/normal_header.tsx
+++ b/assets/src/components/v2/dup/normal_header.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import DefaultNormalHeader, { Icon } from "Components/v2/normal_header";
 import { DUP_VERSION } from "./version";
 import { usePlayerName } from "Hooks/outfront";

--- a/assets/src/components/v2/dup/normal_screen.tsx
+++ b/assets/src/components/v2/dup/normal_screen.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-
+import type { ComponentType } from "react";
 import Widget, { WidgetData } from "Components/v2/widget";
 
 interface Props {
@@ -8,7 +7,7 @@ interface Props {
   rotation_two: WidgetData;
 }
 
-const NormalScreen: React.ComponentType<Props> = ({
+const NormalScreen: ComponentType<Props> = ({
   rotation_zero: rotationZero,
   rotation_one: rotationOne,
   rotation_two: rotationTwo,
@@ -22,7 +21,7 @@ const NormalScreen: React.ComponentType<Props> = ({
   );
 };
 
-export const NormalSimulation: React.ComponentType<Props> = ({
+export const NormalSimulation: ComponentType<Props> = ({
   rotation_zero: rotationZero,
   rotation_one: rotationOne,
   rotation_two: rotationTwo,

--- a/assets/src/components/v2/dup/overnight_departures.tsx
+++ b/assets/src/components/v2/dup/overnight_departures.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType } from "react";
+import type { ComponentType } from "react";
 import { classWithModifier, imagePath } from "Util/utils";
 import RoutePill, { Pill } from "Components/v2/departures/route_pill";
 

--- a/assets/src/components/v2/dup/page_load_no_data.tsx
+++ b/assets/src/components/v2/dup/page_load_no_data.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType } from "react";
+import type { ComponentType } from "react";
 import LinkArrow from "../bundled_svg/link_arrow";
 import Loading from "Images/loading.svg";
 import NormalHeader from "./normal_header";

--- a/assets/src/components/v2/dup/partial_alert.tsx
+++ b/assets/src/components/v2/dup/partial_alert.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import { classWithModifier } from "Util/utils";
 import FreeText, { FreeTextType } from "Components/v2/free_text";
 

--- a/assets/src/components/v2/dup/rotation_normal.tsx
+++ b/assets/src/components/v2/dup/rotation_normal.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-
+import type { ComponentType } from "react";
 import Widget, { WidgetData } from "Components/v2/widget";
 
 interface Props {
@@ -8,7 +7,7 @@ interface Props {
   rotation: string;
 }
 
-const RotationNormal: React.ComponentType<Props> = ({
+const RotationNormal: ComponentType<Props> = ({
   header: header,
   body: body,
   rotation: rotation,

--- a/assets/src/components/v2/dup/rotation_takeover.tsx
+++ b/assets/src/components/v2/dup/rotation_takeover.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-
+import type { ComponentType } from "react";
 import Widget, { WidgetData } from "Components/v2/widget";
 
 interface Props {
@@ -7,7 +6,7 @@ interface Props {
   rotation: string;
 }
 
-const RotationTakeover: React.ComponentType<Props> = ({
+const RotationTakeover: ComponentType<Props> = ({
   full_rotation: fullRotation,
   rotation: rotation,
 }) => {

--- a/assets/src/components/v2/dup/split_body.tsx
+++ b/assets/src/components/v2/dup/split_body.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-
+import type { ComponentType } from "react";
 import Widget, { WidgetData } from "Components/v2/widget";
 
 interface Props {
@@ -9,7 +8,7 @@ interface Props {
   rotation: string;
 }
 
-const SplitBody: React.ComponentType<Props> = ({
+const SplitBody: ComponentType<Props> = ({
   main_content_reduced: mainContentReduced,
   bottom_pane: bottomPane,
 }) => {

--- a/assets/src/components/v2/dup/takeover_alert.tsx
+++ b/assets/src/components/v2/dup/takeover_alert.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import LinkArrow from "../bundled_svg/link_arrow";
 import FreeText, { FreeTextType } from "Components/v2/free_text";
 

--- a/assets/src/components/v2/dup/viewport.tsx
+++ b/assets/src/components/v2/dup/viewport.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-
+import type { ComponentType } from "react";
 import { getRotationIndex } from "Util/outfront";
 
 /**
@@ -8,7 +7,7 @@ import { getRotationIndex } from "Util/outfront";
  * If the param is missing, this will show the full
  * screen content (5760px x 1080px).
  */
-const Viewport: React.ComponentType = ({ children }) => {
+const Viewport: ComponentType = ({ children }) => {
   let viewportClassName = "dup-screen-viewport";
   let shifterClassName = "dup-shifter";
   switch (getRotationIndex()) {

--- a/assets/src/components/v2/eink/alert.tsx
+++ b/assets/src/components/v2/eink/alert.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType } from "react";
+import type { ComponentType } from "react";
 
 import BaseAlert, {
   Props,

--- a/assets/src/components/v2/eink/bottom_screen_filler.tsx
+++ b/assets/src/components/v2/eink/bottom_screen_filler.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType } from "react";
+import type { ComponentType } from "react";
 import HandWithPhone from "Images/hand-with-phone.svg";
 
 const BottomScreenFiller: ComponentType = () => (

--- a/assets/src/components/v2/eink/bus_normal_header.tsx
+++ b/assets/src/components/v2/eink/bus_normal_header.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType } from "react";
+import type { ComponentType } from "react";
 
 import DefaultNormalHeader, { Icon } from "Components/v2/normal_header";
 

--- a/assets/src/components/v2/eink/departures_no_data.tsx
+++ b/assets/src/components/v2/eink/departures_no_data.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType } from "react";
+import type { ComponentType } from "react";
 import NoConnection from "Images/live-data-none.svg";
 
 interface Props {

--- a/assets/src/components/v2/eink/departures_no_service.tsx
+++ b/assets/src/components/v2/eink/departures_no_service.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType } from "react";
+import type { ComponentType } from "react";
 import { imagePath } from "Util/utils";
 
 const DeparturesNoService: ComponentType = () => {

--- a/assets/src/components/v2/eink/fare_info_footer.tsx
+++ b/assets/src/components/v2/eink/fare_info_footer.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import { imagePath } from "Util/utils";
 import LinkFooter from "Components/v2/eink/link_footer";
 

--- a/assets/src/components/v2/eink/flex/one_medium.tsx
+++ b/assets/src/components/v2/eink/flex/one_medium.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-
+import type { ComponentType } from "react";
 import Widget, { WidgetData } from "Components/v2/widget";
 import FlexZonePageIndicator from "Components/v2/flex/page_indicator";
 
@@ -9,7 +8,7 @@ interface Props {
   num_pages: number;
 }
 
-const OneMedium: React.ComponentType<Props> = ({
+const OneMedium: ComponentType<Props> = ({
   medium,
   num_pages: numPages,
   page_index: pageIndex,

--- a/assets/src/components/v2/eink/gl_normal_header.tsx
+++ b/assets/src/components/v2/eink/gl_normal_header.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType } from "react";
+import type { ComponentType } from "react";
 
 import DefaultNormalHeader, { Icon } from "Components/v2/normal_header";
 

--- a/assets/src/components/v2/eink/link_footer.tsx
+++ b/assets/src/components/v2/eink/link_footer.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import DefaultLinkFooter from "Components/v2/link_footer";
 
 const LinkFooter = ({ text, url }) => {

--- a/assets/src/components/v2/eink/no_data.tsx
+++ b/assets/src/components/v2/eink/no_data.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType } from "react";
+import type { ComponentType } from "react";
 import { imagePath } from "Util/utils";
 import NoConnection from "Images/live-data-none.svg";
 import BottomScreenFiller from "Components/v2/eink/bottom_screen_filler";

--- a/assets/src/components/v2/eink/overnight_departures.tsx
+++ b/assets/src/components/v2/eink/overnight_departures.tsx
@@ -1,5 +1,5 @@
 import moment from "moment";
-import React, { ComponentType } from "react";
+import type { ComponentType } from "react";
 import { imagePath } from "Util/utils";
 
 const OvernightDepartures: ComponentType = () => {

--- a/assets/src/components/v2/eink/page_load_no_data.tsx
+++ b/assets/src/components/v2/eink/page_load_no_data.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType } from "react";
+import type { ComponentType } from "react";
 import { imagePath } from "Util/utils";
 import BottomScreenFiller from "Components/v2/eink/bottom_screen_filler";
 import Loading from "Images/loading.svg";

--- a/assets/src/components/v2/eink/takeover_body.tsx
+++ b/assets/src/components/v2/eink/takeover_body.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-
+import type { ComponentType } from "react";
 import Widget, { WidgetData } from "Components/v2/widget";
 
 interface Props {
@@ -7,7 +6,7 @@ interface Props {
   full_body_bottom_screen: WidgetData;
 }
 
-const TakeoverBody: React.ComponentType<Props> = ({
+const TakeoverBody: ComponentType<Props> = ({
   full_body_top_screen: fullBodyTopScreen,
   full_body_bottom_screen: fullBodyBottomScreen,
 }) => {

--- a/assets/src/components/v2/eink/top_and_flex_takeover.tsx
+++ b/assets/src/components/v2/eink/top_and_flex_takeover.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-
+import type { ComponentType } from "react";
 import Widget, { WidgetData } from "Components/v2/widget";
 
 interface Props {
@@ -8,7 +7,7 @@ interface Props {
   footer: WidgetData;
 }
 
-const TopAndFlexTakeoverBody: React.ComponentType<Props> = ({
+const TopAndFlexTakeoverBody: ComponentType<Props> = ({
   full_body_top_screen: fullBodyTopScreen,
   flex_zone_takeover: flexZoneTakeover,
   footer,

--- a/assets/src/components/v2/elevator/alternate_path.tsx
+++ b/assets/src/components/v2/elevator/alternate_path.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType } from "react";
+import type { ComponentType } from "react";
 import cx from "classnames";
 import Arrow, { Direction, LineWeight } from "Components/v2/arrow";
 import makePersistent, {

--- a/assets/src/components/v2/elevator/closures.tsx
+++ b/assets/src/components/v2/elevator/closures.tsx
@@ -1,4 +1,10 @@
-import React, { ComponentType, useLayoutEffect, useRef, useState } from "react";
+import {
+  type ComponentType,
+  type CSSProperties,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 import cx from "classnames";
 import _ from "lodash";
 import RoutePill, {
@@ -314,7 +320,7 @@ const Closures = ({
 
   const listOffsetStyle = {
     "--closure-list-offset": listPageIndex,
-  } as React.CSSProperties;
+  } as CSSProperties;
 
   const numRowsOffPage = pageRowCounts
     .filter((_, index) => index != listPageIndex)

--- a/assets/src/components/v2/elevator/footer.tsx
+++ b/assets/src/components/v2/elevator/footer.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { classWithModifier } from "Util/utils";
 
 const Footer = ({ variant }: { variant: string | null }) => {

--- a/assets/src/components/v2/elevator/no_data.tsx
+++ b/assets/src/components/v2/elevator/no_data.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType } from "react";
+import type { ComponentType } from "react";
 import { imagePath } from "Util/utils";
 
 const NoData: ComponentType = () => {

--- a/assets/src/components/v2/elevator/normal_screen.tsx
+++ b/assets/src/components/v2/elevator/normal_screen.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import Widget, { WidgetData } from "Components/v2/widget";
 
 interface Props {

--- a/assets/src/components/v2/elevator/paging_indicators.tsx
+++ b/assets/src/components/v2/elevator/paging_indicators.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import PagingDotUnselected from "Images/paging_dot_unselected.svg";
 import PagingDotSelected from "Images/paging_dot_selected.svg";
 

--- a/assets/src/components/v2/elevator_status.tsx
+++ b/assets/src/components/v2/elevator_status.tsx
@@ -1,6 +1,6 @@
 import useTextResizer from "Hooks/v2/use_text_resizer";
 import moment from "moment";
-import React, { ComponentType } from "react";
+import type { ComponentType } from "react";
 import { classWithModifier, imagePath } from "Util/utils";
 import FlexZonePageIndicator from "./flex/page_indicator";
 import makePersistentCarousel, {

--- a/assets/src/components/v2/evergreen_content.tsx
+++ b/assets/src/components/v2/evergreen_content.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType } from "react";
+import type { ComponentType } from "react";
 
 import LoopingVideoPlayer from "Components/v2/looping_video_player";
 

--- a/assets/src/components/v2/flex/page_indicator.tsx
+++ b/assets/src/components/v2/flex/page_indicator.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType } from "react";
+import type { ComponentType } from "react";
 
 import { classWithModifier } from "Util/utils";
 

--- a/assets/src/components/v2/free_text.tsx
+++ b/assets/src/components/v2/free_text.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import _ from "lodash";
 
 import { classWithModifier, classWithModifiers, imagePath } from "Util/utils";

--- a/assets/src/components/v2/full_line_map.tsx
+++ b/assets/src/components/v2/full_line_map.tsx
@@ -1,7 +1,7 @@
 import makePersistentCarousel, {
   PageRendererProps,
 } from "Components/v2/persistent_carousel";
-import React, { ComponentType } from "react";
+import type { ComponentType } from "react";
 
 interface Page {
   asset_url: string;

--- a/assets/src/components/v2/gl_eink/bottom_takeover_body.tsx
+++ b/assets/src/components/v2/gl_eink/bottom_takeover_body.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-
+import type { ComponentType } from "react";
 import Widget, { WidgetData } from "Components/v2/widget";
 
 interface Props {
@@ -8,7 +7,7 @@ interface Props {
   full_body_bottom_screen: WidgetData;
 }
 
-const BottomTakeoverBody: React.ComponentType<Props> = ({
+const BottomTakeoverBody: ComponentType<Props> = ({
   left_sidebar: leftSidebar,
   main_content: mainContent,
   full_body_bottom_screen: fullBodyBottomScreen,

--- a/assets/src/components/v2/gl_eink/flex_zone_takeover.tsx
+++ b/assets/src/components/v2/gl_eink/flex_zone_takeover.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-
+import type { ComponentType } from "react";
 import Widget, { WidgetData } from "Components/v2/widget";
 
 interface Props {
@@ -9,7 +8,7 @@ interface Props {
   footer: WidgetData;
 }
 
-const FlexZoneTakeoverBody: React.ComponentType<Props> = ({
+const FlexZoneTakeoverBody: ComponentType<Props> = ({
   left_sidebar: leftSidebar,
   main_content: mainContent,
   flex_zone_takeover: flexZoneTakeover,

--- a/assets/src/components/v2/gl_eink/line_map.tsx
+++ b/assets/src/components/v2/gl_eink/line_map.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { Fragment } from "react";
 
 import { classWithModifier } from "Util/utils";
 
@@ -204,10 +204,10 @@ const BaseMapStops = ({ stops }) => {
         }
 
         return (
-          <React.Fragment key={i}>
+          <Fragment key={i}>
             {stopIcon}
             {stopLabel}
-          </React.Fragment>
+          </Fragment>
         );
       })}
     </>

--- a/assets/src/components/v2/gl_eink/normal_body.tsx
+++ b/assets/src/components/v2/gl_eink/normal_body.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-
+import type { ComponentType } from "react";
 import Widget, { WidgetData } from "Components/v2/widget";
 
 interface Props {
@@ -9,7 +8,7 @@ interface Props {
   footer: WidgetData;
 }
 
-const NormalBody: React.ComponentType<Props> = ({
+const NormalBody: ComponentType<Props> = ({
   left_sidebar: leftSidebar,
   main_content: mainContent,
   flex_zone: flexZone,

--- a/assets/src/components/v2/gl_eink/normal_screen.tsx
+++ b/assets/src/components/v2/gl_eink/normal_screen.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-
+import type { ComponentType } from "react";
 import Widget, { WidgetData } from "Components/v2/widget";
 
 interface Props {
@@ -7,7 +6,7 @@ interface Props {
   body: WidgetData;
 }
 
-const NormalScreen: React.ComponentType<Props> = ({ header, body }) => {
+const NormalScreen: ComponentType<Props> = ({ header, body }) => {
   return (
     <div className="screen-normal">
       <div className="screen-normal__header">

--- a/assets/src/components/v2/gl_eink/top_takeover_body.tsx
+++ b/assets/src/components/v2/gl_eink/top_takeover_body.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-
+import type { ComponentType } from "react";
 import Widget, { WidgetData } from "Components/v2/widget";
 
 interface Props {
@@ -9,7 +8,7 @@ interface Props {
   footer: WidgetData;
 }
 
-const TopTakeoverBody: React.ComponentType<Props> = ({
+const TopTakeoverBody: ComponentType<Props> = ({
   full_body_top_screen: fullBodyTopScreen,
   flex_zone: flexZone,
   footer,

--- a/assets/src/components/v2/lcd/departures_no_data.tsx
+++ b/assets/src/components/v2/lcd/departures_no_data.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType } from "react";
+import type { ComponentType } from "react";
 import NoConnection from "Images/live-data-none.svg";
 
 interface Props {

--- a/assets/src/components/v2/lcd/no_data.tsx
+++ b/assets/src/components/v2/lcd/no_data.tsx
@@ -1,5 +1,5 @@
 import NoConnection from "Images/live-data-none.svg";
-import React, { ComponentType } from "react";
+import type { ComponentType } from "react";
 import TLogo from "Images/logo.svg";
 
 interface Props {

--- a/assets/src/components/v2/lcd/normal_header.tsx
+++ b/assets/src/components/v2/lcd/normal_header.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import DefaultNormalHeader from "Components/v2/normal_header";
 import { getScreenSide } from "Util/utils";
 

--- a/assets/src/components/v2/lcd/page_load_no_data.tsx
+++ b/assets/src/components/v2/lcd/page_load_no_data.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType } from "react";
+import type { ComponentType } from "react";
 import Loading from "Images/loading.svg";
 
 const coolBlack = "#171F26";

--- a/assets/src/components/v2/link_footer.tsx
+++ b/assets/src/components/v2/link_footer.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import { imagePath } from "Util/utils";
 
 const LinkFooter = ({ text, url, logoPath }) => {

--- a/assets/src/components/v2/looping_video_player.tsx
+++ b/assets/src/components/v2/looping_video_player.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType, useEffect, useRef, useState } from "react";
+import { type ComponentType, useEffect, useRef, useState } from "react";
 
 interface Props {
   src: string;

--- a/assets/src/components/v2/multi_screen_page.tsx
+++ b/assets/src/components/v2/multi_screen_page.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import ScreenContainer, {
   defaultResponseMapper,
   ResponseMapper,

--- a/assets/src/components/v2/normal_header.tsx
+++ b/assets/src/components/v2/normal_header.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, ComponentType } from "react";
+import { forwardRef, ComponentType } from "react";
 
 import LiveDataSvg from "Images/live-data-small.svg";
 import { getDatasetValue } from "Util/dataset";

--- a/assets/src/components/v2/persistent_carousel.tsx
+++ b/assets/src/components/v2/persistent_carousel.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType, ReactNode } from "react";
+import { type ComponentType, ReactNode } from "react";
 import makePersistent, { WrappedComponentProps } from "./persistent_wrapper";
 import useRefreshPaging from "Hooks/v2/use_refresh_paging";
 

--- a/assets/src/components/v2/persistent_wrapper.tsx
+++ b/assets/src/components/v2/persistent_wrapper.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType, useState } from "react";
+import { type ComponentType, useState } from "react";
 
 interface WrappedComponentProps {
   updateVisibleData: () => void;

--- a/assets/src/components/v2/placeholder.tsx
+++ b/assets/src/components/v2/placeholder.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-
+import type { ComponentType } from "react";
 import { classWithModifier } from "Util/utils";
 
 interface Props {
@@ -7,7 +6,7 @@ interface Props {
   text?: string;
 }
 
-const Placeholder: React.ComponentType<Props> = ({ color, text }) => {
+const Placeholder: ComponentType<Props> = ({ color, text }) => {
   return (
     <div className={classWithModifier("placeholder", color)}>
       <div className="placeholder__text">

--- a/assets/src/components/v2/pre_fare/body_left_flex.tsx
+++ b/assets/src/components/v2/pre_fare/body_left_flex.tsx
@@ -1,12 +1,11 @@
-import React from "react";
-
+import type { ComponentType } from "react";
 import Widget, { WidgetData } from "Components/v2/widget";
 
 interface Props {
   paged_main_content_left: WidgetData;
 }
 
-const BodyLeftFlex: React.ComponentType<Props> = ({
+const BodyLeftFlex: ComponentType<Props> = ({
   paged_main_content_left: pagedMainContentLeft,
 }) => {
   return (

--- a/assets/src/components/v2/pre_fare/body_left_takeover.tsx
+++ b/assets/src/components/v2/pre_fare/body_left_takeover.tsx
@@ -1,12 +1,11 @@
-import React from "react";
-
+import type { ComponentType } from "react";
 import Widget, { WidgetData } from "Components/v2/widget";
 
 interface Props {
   full_body_left: WidgetData;
 }
 
-const BodyLeftTakeover: React.ComponentType<Props> = ({
+const BodyLeftTakeover: ComponentType<Props> = ({
   full_body_left: fullBodyLeft,
 }) => {
   return (

--- a/assets/src/components/v2/pre_fare/body_right_takeover.tsx
+++ b/assets/src/components/v2/pre_fare/body_right_takeover.tsx
@@ -1,12 +1,11 @@
-import React from "react";
-
+import type { ComponentType } from "react";
 import Widget, { WidgetData } from "Components/v2/widget";
 
 interface Props {
   full_body_right: WidgetData;
 }
 
-const BodyRightTakeover: React.ComponentType<Props> = ({
+const BodyRightTakeover: ComponentType<Props> = ({
   full_body_right: fullBodyRight,
 }) => {
   return (

--- a/assets/src/components/v2/pre_fare/body_takeover.tsx
+++ b/assets/src/components/v2/pre_fare/body_takeover.tsx
@@ -1,14 +1,11 @@
-import React from "react";
-
+import type { ComponentType } from "react";
 import Widget, { WidgetData } from "Components/v2/widget";
 
 interface Props {
   full_body_duo: WidgetData;
 }
 
-const BodyTakeover: React.ComponentType<Props> = ({
-  full_body_duo: fullBodyDuo,
-}) => {
+const BodyTakeover: ComponentType<Props> = ({ full_body_duo: fullBodyDuo }) => {
   return (
     <div className="body-takeover">
       <div className="body-takeover__full-body">

--- a/assets/src/components/v2/pre_fare/flex/one_large.tsx
+++ b/assets/src/components/v2/pre_fare/flex/one_large.tsx
@@ -1,12 +1,11 @@
-import React from "react";
-
+import type { ComponentType } from "react";
 import Widget, { WidgetData } from "Components/v2/widget";
 
 interface Props {
   large: WidgetData;
 }
 
-const OneLarge: React.ComponentType<Props> = ({ large }) => {
+const OneLarge: ComponentType<Props> = ({ large }) => {
   return (
     <div className="flex-one-large">
       <div className="flex-one-large__large">

--- a/assets/src/components/v2/pre_fare/flex/two_medium.tsx
+++ b/assets/src/components/v2/pre_fare/flex/two_medium.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-
+import type { ComponentType } from "react";
 import Widget, { WidgetData } from "Components/v2/widget";
 
 interface Props {
@@ -7,7 +6,7 @@ interface Props {
   medium_right: WidgetData;
 }
 
-const TwoMedium: React.ComponentType<Props> = ({
+const TwoMedium: ComponentType<Props> = ({
   medium_left: mediumLeft,
   medium_right: mediumRight,
 }) => {

--- a/assets/src/components/v2/pre_fare/no_data.tsx
+++ b/assets/src/components/v2/pre_fare/no_data.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType } from "react";
+import type { ComponentType } from "react";
 import LcdNoData from "Components/v2/lcd/no_data";
 
 interface Props {

--- a/assets/src/components/v2/pre_fare/normal_body.tsx
+++ b/assets/src/components/v2/pre_fare/normal_body.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-
+import type { ComponentType } from "react";
 import Widget, { WidgetData } from "Components/v2/widget";
 
 interface Props {
@@ -7,7 +6,7 @@ interface Props {
   body_right: WidgetData;
 }
 
-const NormalBody: React.ComponentType<Props> = ({
+const NormalBody: ComponentType<Props> = ({
   body_left: bodyLeft,
   body_right: bodyRight,
 }) => {

--- a/assets/src/components/v2/pre_fare/normal_body_left.tsx
+++ b/assets/src/components/v2/pre_fare/normal_body_left.tsx
@@ -1,12 +1,11 @@
-import React from "react";
-
+import type { ComponentType } from "react";
 import Widget, { WidgetData } from "Components/v2/widget";
 
 interface Props {
   main_content_left: WidgetData;
 }
 
-const NormalBodyLeft: React.ComponentType<Props> = ({
+const NormalBodyLeft: ComponentType<Props> = ({
   main_content_left: mainContentLeft,
 }) => {
   return (

--- a/assets/src/components/v2/pre_fare/normal_body_right.tsx
+++ b/assets/src/components/v2/pre_fare/normal_body_right.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-
+import type { ComponentType } from "react";
 import Widget, { WidgetData } from "Components/v2/widget";
 
 interface Props {
@@ -7,7 +6,7 @@ interface Props {
   lower_right: WidgetData;
 }
 
-const NormalBodyRight: React.ComponentType<Props> = ({
+const NormalBodyRight: ComponentType<Props> = ({
   upper_right: upperRight,
   lower_right: lowerRight,
 }) => {

--- a/assets/src/components/v2/pre_fare/normal_screen.tsx
+++ b/assets/src/components/v2/pre_fare/normal_screen.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-
+import type { ComponentType } from "react";
 import Widget, { WidgetData } from "Components/v2/widget";
 
 interface Props {
@@ -7,7 +6,7 @@ interface Props {
   body: WidgetData;
 }
 
-const NormalScreen: React.ComponentType<Props> = ({ header, body }) => {
+const NormalScreen: ComponentType<Props> = ({ header, body }) => {
   return (
     <div className="screen-normal">
       <div className="screen-normal__header">

--- a/assets/src/components/v2/pre_fare/page_load_no_data.tsx
+++ b/assets/src/components/v2/pre_fare/page_load_no_data.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType } from "react";
+import type { ComponentType } from "react";
 import LcdPageLoadNoData from "Components/v2/lcd/page_load_no_data";
 
 const PageLoadNoData: ComponentType = () => {

--- a/assets/src/components/v2/pre_fare/screen_split_takeover.tsx
+++ b/assets/src/components/v2/pre_fare/screen_split_takeover.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-
+import type { ComponentType } from "react";
 import Widget, { WidgetData } from "Components/v2/widget";
 
 interface Props {
@@ -7,7 +6,7 @@ interface Props {
   full_right_screen: WidgetData;
 }
 
-const ScreenSplitTakeover: React.ComponentType<Props> = ({
+const ScreenSplitTakeover: ComponentType<Props> = ({
   full_left_screen: fullLeftScreen,
   full_right_screen: fullRightScreen,
 }) => {

--- a/assets/src/components/v2/pre_fare/screen_takeover.tsx
+++ b/assets/src/components/v2/pre_fare/screen_takeover.tsx
@@ -1,12 +1,11 @@
-import React from "react";
-
+import type { ComponentType } from "react";
 import Widget, { WidgetData } from "Components/v2/widget";
 
 interface Props {
   full_duo_screen: WidgetData;
 }
 
-const ScreenTakeover: React.ComponentType<Props> = ({
+const ScreenTakeover: ComponentType<Props> = ({
   full_duo_screen: fullDuoScreen,
 }) => {
   return (

--- a/assets/src/components/v2/pre_fare/simulation_screen_container.tsx
+++ b/assets/src/components/v2/pre_fare/simulation_screen_container.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType, useContext } from "react";
+import { type ComponentType, useContext } from "react";
 import {
   LastFetchContext,
   ResponseMapperContext,

--- a/assets/src/components/v2/pre_fare/simulation_screen_page.tsx
+++ b/assets/src/components/v2/pre_fare/simulation_screen_page.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useParams } from "react-router-dom";
 import SimulationScreenContainer from "Components/v2/pre_fare/simulation_screen_container";
 

--- a/assets/src/components/v2/pre_fare_single_screen_alert.tsx
+++ b/assets/src/components/v2/pre_fare_single_screen_alert.tsx
@@ -1,5 +1,6 @@
+import type { ComponentType } from "react";
+
 import useTextResizer from "Hooks/v2/use_text_resizer";
-import React from "react";
 import { getHexColor, STRING_TO_SVG } from "Util/svg_utils";
 import DisruptionDiagram, {
   DisruptionDiagramData,
@@ -51,7 +52,7 @@ interface StandardLayoutProps {
 // - issue font is size large
 // - "Seek alternate route" remedy is medium
 // - "Use shuttle bus" remedy is large
-const StandardLayout: React.ComponentType<StandardLayoutProps> = ({
+const StandardLayout: ComponentType<StandardLayoutProps> = ({
   issue,
   remedy,
   effect,
@@ -98,7 +99,7 @@ interface DownstreamLayoutProps {
 }
 
 // In the downstream layout, the map is at the top, and the font size stays constant
-const DownstreamLayout: React.ComponentType<DownstreamLayoutProps> = ({
+const DownstreamLayout: ComponentType<DownstreamLayoutProps> = ({
   endpoints,
   effect,
   remedy,
@@ -120,7 +121,7 @@ interface PartialClosureLayoutProps {
 // Covers the case where a station_closure only affects one line at a transfer station.
 // In the even rarer case that there are multiple branches in the routes list or unaffected routes list
 // the font size may need to shrink to accommodate.
-const PartialClosureLayout: React.ComponentType<PartialClosureLayoutProps> = ({
+const PartialClosureLayout: ComponentType<PartialClosureLayoutProps> = ({
   routes,
   unaffected_routes,
   disruptionDiagram,
@@ -179,7 +180,7 @@ const fallbackLayoutIcons = {
   shuttle: ShuttleBusIcon,
 };
 
-const FallbackLayout: React.ComponentType<FallbackLayoutProps> = ({
+const FallbackLayout: ComponentType<FallbackLayoutProps> = ({
   issue,
   remedy,
   remedyBold,
@@ -223,7 +224,7 @@ interface StandardIssueSectionProps {
   contentTextSize: string;
 }
 
-const StandardIssueSection: React.ComponentType<StandardIssueSectionProps> = ({
+const StandardIssueSection: ComponentType<StandardIssueSectionProps> = ({
   issue,
   location,
   contentTextSize,
@@ -250,9 +251,9 @@ interface DownstreamIssueSectionProps {
   endpoints: [string, string];
 }
 
-const DownstreamIssueSection: React.ComponentType<
-  DownstreamIssueSectionProps
-> = ({ endpoints }) => (
+const DownstreamIssueSection: ComponentType<DownstreamIssueSectionProps> = ({
+  endpoints,
+}) => (
   <div className="alert-card__issue">
     <div
       className={classWithModifier("alert-card__content-block__text", "medium")}
@@ -267,7 +268,7 @@ interface RemedySectionProps {
   remedy: string | null;
   contentTextSize: string;
 }
-const RemedySection: React.ComponentType<RemedySectionProps> = ({
+const RemedySection: ComponentType<RemedySectionProps> = ({
   effect,
   remedy,
   contentTextSize,
@@ -306,9 +307,7 @@ interface MapSectionProps {
   disruptionDiagram: DisruptionDiagramData;
 }
 
-const MapSection: React.ComponentType<MapSectionProps> = ({
-  disruptionDiagram,
-}) => {
+const MapSection: ComponentType<MapSectionProps> = ({ disruptionDiagram }) => {
   return (
     <div
       id="disruption-diagram-container"
@@ -328,9 +327,9 @@ const isPartialClosure = ({
   region === "here" &&
   unaffected_routes.length > 0;
 
-const PreFareSingleScreenAlert: React.ComponentType<
-  PreFareSingleScreenAlertProps
-> = (alert) => {
+const PreFareSingleScreenAlert: ComponentType<PreFareSingleScreenAlertProps> = (
+  alert,
+) => {
   const {
     cause,
     region,
@@ -496,7 +495,7 @@ const getAlertColor = (routes: EnrichedRoute[]) => {
   return uniqueColors == 1 ? colors[0] : "yellow";
 };
 
-const PreFareAlertBanner: React.ComponentType<{ routes: EnrichedRoute[] }> = ({
+const PreFareAlertBanner: ComponentType<{ routes: EnrichedRoute[] }> = ({
   routes,
 }) => {
   let banner;

--- a/assets/src/components/v2/reconstructed_alert.tsx
+++ b/assets/src/components/v2/reconstructed_alert.tsx
@@ -1,13 +1,13 @@
-import React, { ComponentType } from "react";
-import { classWithModifier, classWithModifiers, imagePath } from "Util/utils";
+import type { ComponentType, ReactNode } from "react";
 
+import { classWithModifier, classWithModifiers, imagePath } from "Util/utils";
 import RoutePill, { routePillKey } from "Components/v2/departures/route_pill";
 import { ReconAlertProps } from "./reconstructed_takeover";
 import useTextResizer from "Hooks/v2/use_text_resizer";
 
 interface AlertCardProps {
   urgent: boolean;
-  children: React.ReactNode;
+  children: ReactNode;
 }
 
 // Corresponds to cases where on the server this widget is generated with an

--- a/assets/src/components/v2/reconstructed_takeover.tsx
+++ b/assets/src/components/v2/reconstructed_takeover.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-
+import type { ComponentType } from "react";
 import { classWithModifiers, imagePath } from "Util/utils";
 import DisruptionDiagram, {
   DisruptionDiagramData,
@@ -18,7 +17,7 @@ interface ReconAlertProps {
   urgent: boolean;
 }
 
-const ReconstructedTakeover: React.ComponentType<ReconAlertProps> = (alert) => {
+const ReconstructedTakeover: ComponentType<ReconAlertProps> = (alert) => {
   const {
     cause,
     effect,

--- a/assets/src/components/v2/screen_container.tsx
+++ b/assets/src/components/v2/screen_container.tsx
@@ -1,4 +1,4 @@
-import React, {
+import {
   createContext,
   useContext,
   ComponentType,

--- a/assets/src/components/v2/screen_page.tsx
+++ b/assets/src/components/v2/screen_page.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useParams } from "react-router-dom";
 import ScreenContainer from "Components/v2/screen_container";
 import { ScreenIDProvider } from "Hooks/v2/use_screen_id";

--- a/assets/src/components/v2/simulation_screen_container.tsx
+++ b/assets/src/components/v2/simulation_screen_container.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType, useContext } from "react";
+import { type ComponentType, useContext } from "react";
 import {
   LastFetchContext,
   ResponseMapperContext,

--- a/assets/src/components/v2/simulation_screen_page.tsx
+++ b/assets/src/components/v2/simulation_screen_page.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useParams } from "react-router-dom";
 import SimulationScreenContainer from "./simulation_screen_container";
 

--- a/assets/src/components/v2/subway_status/eink_subway_status.tsx
+++ b/assets/src/components/v2/subway_status/eink_subway_status.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType, forwardRef } from "react";
+import { type ComponentType, forwardRef } from "react";
 import { classWithModifier, firstWord } from "Util/utils";
 import { STRING_TO_SVG } from "Util/svg_utils";
 import {

--- a/assets/src/components/v2/subway_status/lcd_subway_status.tsx
+++ b/assets/src/components/v2/subway_status/lcd_subway_status.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType, forwardRef } from "react";
+import { type ComponentType, forwardRef } from "react";
 import { classWithModifier, classWithModifiers, firstWord } from "Util/utils";
 import { STRING_TO_SVG, getHexColor } from "Util/svg_utils";
 import {

--- a/assets/src/components/v2/survey.tsx
+++ b/assets/src/components/v2/survey.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType } from "react";
+import type { ComponentType } from "react";
 import EvergreenContent from "Components/v2/evergreen_content";
 
 interface Props {

--- a/assets/src/components/v2/takeover_screen.tsx
+++ b/assets/src/components/v2/takeover_screen.tsx
@@ -1,14 +1,11 @@
-import React from "react";
-
+import type { ComponentType } from "react";
 import Widget, { WidgetData } from "Components/v2/widget";
 
 interface Props {
   full_screen: WidgetData;
 }
 
-const TakeoverScreen: React.ComponentType<Props> = ({
-  full_screen: fullScreen,
-}) => {
+const TakeoverScreen: ComponentType<Props> = ({ full_screen: fullScreen }) => {
   return (
     <div className="screen-takeover">
       <div className="screen-takeover__full-screen">

--- a/assets/src/components/v2/widget.tsx
+++ b/assets/src/components/v2/widget.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from "react";
+import { type ComponentType, createContext, useContext } from "react";
 
 type WidgetData = { type: string } & Record<string, any>;
 
@@ -6,9 +6,9 @@ interface Props {
   data: WidgetData;
 }
 
-const MappingContext = React.createContext({});
+const MappingContext = createContext({});
 
-const Widget: React.ComponentType<Props> = ({ data }) => {
+const Widget: ComponentType<Props> = ({ data }) => {
   if (data == null) {
     return null;
   }

--- a/assets/src/components/v2/widget_page.tsx
+++ b/assets/src/components/v2/widget_page.tsx
@@ -1,5 +1,4 @@
 import { getDatasetValue } from "Util/dataset";
-import React from "react";
 import Widget from "./widget";
 
 const WidgetPage = () => {

--- a/assets/src/components/v2/widget_tree_error_boundary.tsx
+++ b/assets/src/components/v2/widget_tree_error_boundary.tsx
@@ -1,4 +1,4 @@
-import React, { ErrorInfo, useContext } from "react";
+import { type ComponentType, Component, ErrorInfo, useContext } from "react";
 import { RouteComponentProps, withRouter } from "react-router-dom";
 import getCsrfToken from "Util/csrf";
 import { getDataset } from "Util/dataset";
@@ -41,7 +41,7 @@ interface State {
  * Whenever we receive new data from the backend, this component gives the
  * normal render another try, even if an error was previously thrown.
  */
-class WidgetTreeErrorBoundary extends React.Component<Props, State> {
+class WidgetTreeErrorBoundary extends Component<Props, State> {
   state = { hasError: false, prevLastFetch: this.props.lastFetch };
 
   // When an error is thrown during render, log it.
@@ -122,7 +122,7 @@ class WidgetTreeErrorBoundary extends React.Component<Props, State> {
  * The component renders whatever layout is configured for the screen type
  * when it fails to fetch API data.
  */
-const FallbackLayout: React.ComponentType = () => {
+const FallbackLayout: ComponentType = () => {
   const responseMapper = useContext(ResponseMapperContext);
 
   return <Widget data={responseMapper({ state: "failure" }) as WidgetData} />;
@@ -155,7 +155,7 @@ const LogTimeRecorder = (() => {
 // It's necessary to get the context separately and pass it to the component
 // as a prop because we need this value in getDerivedStateFromProps, which
 // does not receive context as an argument.
-const WrappedWithLastFetch: React.ComponentType<Omit<Props, "lastFetch">> = (
+const WrappedWithLastFetch: ComponentType<Omit<Props, "lastFetch">> = (
   props,
 ) => {
   const lastFetch = useContext(LastFetchContext);

--- a/assets/src/hooks/v2/use_api_response.tsx
+++ b/assets/src/hooks/v2/use_api_response.tsx
@@ -1,6 +1,13 @@
+import {
+  type Dispatch,
+  type SetStateAction,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+
 import { WidgetData } from "Components/v2/widget";
 import useDriftlessInterval from "Hooks/use_driftless_interval";
-import React, { useEffect, useMemo, useState } from "react";
 import { getDatasetValue } from "Util/dataset";
 import { sendToInspector, useReceiveFromInspector } from "Util/inspector";
 import { isDup } from "Util/outfront";
@@ -82,7 +89,7 @@ const parseSimulationResponse = ({
 
 const doFailureBuffer = (
   lastSuccess: number | null,
-  setApiResponse: React.Dispatch<React.SetStateAction<ApiResponse>>,
+  setApiResponse: Dispatch<SetStateAction<ApiResponse>>,
   apiResponse: ApiResponse = FAILURE_RESPONSE,
 ) => {
   if (lastSuccess == null) {

--- a/assets/src/hooks/v2/use_screen_id.tsx
+++ b/assets/src/hooks/v2/use_screen_id.tsx
@@ -1,13 +1,13 @@
-import React, { useContext } from "react";
+import { type ReactNode, createContext, useContext } from "react";
 
-const ScreenIDContext = React.createContext<string>("");
+const ScreenIDContext = createContext<string>("");
 
 export const ScreenIDProvider = ({
   id,
   children,
 }: {
   id: string;
-  children: React.ReactNode;
+  children: ReactNode;
 }) => (
   <ScreenIDContext.Provider value={id}>{children}</ScreenIDContext.Provider>
 );

--- a/assets/src/hooks/v2/use_text_resizer.tsx
+++ b/assets/src/hooks/v2/use_text_resizer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { type RefObject, useEffect, useRef, useState } from "react";
 
 interface UseTextResizerArgs<T> {
   sizes: T[];
@@ -7,7 +7,7 @@ interface UseTextResizerArgs<T> {
 }
 
 interface UseTextResizerReturn<T> {
-  ref: React.RefObject<HTMLDivElement>;
+  ref: RefObject<HTMLDivElement>;
   size: T;
   isDone: boolean;
 }

--- a/assets/tsconfig.json
+++ b/assets/tsconfig.json
@@ -11,7 +11,7 @@
     ] /* Specify library files to be included in the compilation. */,
     // "allowJs": true,                    /* Allow javascript files to be compiled. */
     // "checkJs": true,                    /* Report errors in .js files. */
-    "jsx": "react" /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */,
+    "jsx": "react-jsx" /* Specify JSX code generation. */,
     // "declaration": true,                /* Generates corresponding '.d.ts' file. */
     // "declarationMap": true,             /* Generates a sourcemap for each corresponding '.d.ts' file. */
     "sourceMap": true /* Generates corresponding '.map' file. */,

--- a/assets/webpack.config.js
+++ b/assets/webpack.config.js
@@ -59,7 +59,8 @@ module.exports = (env, argv) => {
                     corejs: require("core-js/package.json").version,
                   },
                 ],
-                "@babel/preset-react",
+                // "automatic" will be the default in Babel 8
+                ["@babel/preset-react", { runtime: "automatic" }],
                 "@babel/preset-typescript",
               ],
             },


### PR DESCRIPTION
Babel 7.9.0 and up support an alternate method of transforming JSX (to become the default in Babel 8) which does not require using `import React from "react"` for JSX element syntax to be "available". Instead, it automatically inserts a more targeted import statement. See:

https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html

This switches to the new method and eliminates now-unnecessary import statements.