### PR TITLE
chore: update Sentry client package

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -7,12 +7,12 @@
       "license": "MIT",
       "dependencies": {
         "@fullstory/browser": "^1.7.1",
+        "@sentry/react": "^10.5.0",
         "classnames": "^2.5.1",
         "core-js": "^3.15.2",
         "lodash": "^4.17.21",
         "moment": "^2.30.1",
         "moment-timezone": "^0.5.47",
-        "raven-js": "^3.27.2",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-dropzone": "^11.3.4",
@@ -2877,6 +2877,56 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@sentry-internal/browser-utils": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.5.0.tgz",
+      "integrity": "sha512-4KIJdEj/8Ip9yqJleVSFe68r/U5bn5o/lYUwnFNEnDNxmpUbOlr7x3DXYuRFi1sfoMUxK9K1DrjnBkR7YYF00g==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.5.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/feedback": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.5.0.tgz",
+      "integrity": "sha512-x79P4VZwUxb1EGZb9OQ5EEgrDWFCUlrbzHBwV/oocQA5Ss1SFz5u6cP5Ak7yJtILiJtdGzAyAoQOy4GKD13D4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.5.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/replay": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.5.0.tgz",
+      "integrity": "sha512-Dp4coE/nPzhFrYH3iVrpVKmhNJ1m/jGXMEDBCNg3wJZRszI41Hrj0jCAM0Y2S3Q4IxYOmFYaFbGtVpAznRyOHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "10.5.0",
+        "@sentry/core": "10.5.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.5.0.tgz",
+      "integrity": "sha512-5nrRKd5swefd9+sFXFZ/NeL3bz/VxBls3ubAQ3afak15FikkSyHq3oKRKpMOtDsiYKXE3Bc0y3rF5A+y3OXjIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/replay": "10.5.0",
+        "@sentry/core": "10.5.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@sentry/babel-plugin-component-annotate": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/@sentry/babel-plugin-component-annotate/-/babel-plugin-component-annotate-4.1.1.tgz",
@@ -2885,6 +2935,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/@sentry/browser": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.5.0.tgz",
+      "integrity": "sha512-o5pEJeZ/iZ7Fmaz2sIirThfnmSVNiP5ZYhacvcDi0qc288TmBbikCX3fXxq3xiSkhXfe1o5QIbNyovzfutyuVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "10.5.0",
+        "@sentry-internal/feedback": "10.5.0",
+        "@sentry-internal/replay": "10.5.0",
+        "@sentry-internal/replay-canvas": "10.5.0",
+        "@sentry/core": "10.5.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@sentry/bundler-plugin-core": {
@@ -3189,6 +3255,32 @@
       ],
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.5.0.tgz",
+      "integrity": "sha512-jTJ8NhZSKB2yj3QTVRXfCCngQzAOLThQUxCl9A7Mv+XF10tP7xbH/88MVQ5WiOr2IzcmrB9r2nmUe36BnMlLjA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/react": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.5.0.tgz",
+      "integrity": "sha512-UHanvg+oIAvE/Hm76QCCdxYgb+tIuF0JszQoROApl5C5RxRfJJcU643pASQs6BDvrtxbuMQ/AHTacLTYpsn0cg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser": "10.5.0",
+        "@sentry/core": "10.5.0",
+        "hoist-non-react-statics": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || 17.x || 18.x || 19.x"
       }
     },
     "node_modules/@sentry/webpack-plugin": {
@@ -11440,10 +11532,6 @@
       "dependencies": {
         "safe-buffer": "^5.1.0"
       }
-    },
-    "node_modules/raven-js": {
-      "version": "3.27.2",
-      "license": "BSD-2-Clause"
     },
     "node_modules/react": {
       "version": "17.0.2",

--- a/assets/package.json
+++ b/assets/package.json
@@ -21,12 +21,12 @@
   },
   "dependencies": {
     "@fullstory/browser": "^1.7.1",
+    "@sentry/react": "^10.5.0",
     "classnames": "^2.5.1",
     "core-js": "^3.15.2",
     "lodash": "^4.17.21",
     "moment": "^2.30.1",
     "moment-timezone": "^0.5.47",
-    "raven-js": "^3.27.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-dropzone": "^11.3.4",

--- a/assets/src/components/v2/departures.tsx
+++ b/assets/src/components/v2/departures.tsx
@@ -10,7 +10,7 @@ import weakKey from "weak-key";
 import NormalSection from "./departures/normal_section";
 import { Section, trimSections, toFoldedSection } from "./departures/section";
 
-import { warn } from "Util/sentry";
+import { report } from "Util/sentry";
 import { hasOverflowY } from "Util/utils";
 
 type Departures = {
@@ -36,7 +36,7 @@ const Departures: ComponentType<Departures> = ({ sections }) => {
       if (foldedSections != newSections) {
         setFoldedSections(newSections);
       } else {
-        warn("layout failed: departures will overflow");
+        report("warning", "layout failed: departures will overflow");
       }
     }
   }, [foldedSections]);

--- a/assets/src/components/v2/widget_tree_error_boundary.tsx
+++ b/assets/src/components/v2/widget_tree_error_boundary.tsx
@@ -1,5 +1,7 @@
 import { type ComponentType, Component, ErrorInfo, useContext } from "react";
 import { RouteComponentProps, withRouter } from "react-router-dom";
+import { captureReactException } from "@sentry/react";
+
 import getCsrfToken from "Util/csrf";
 import { getDataset } from "Util/dataset";
 import { isRealScreen } from "Util/utils";
@@ -8,7 +10,6 @@ import {
   LastFetchContext,
 } from "Components/v2/screen_container";
 import Widget, { WidgetData } from "Components/v2/widget";
-import * as SentryLogger from "Util/sentry";
 
 // The component uses the `match` prop supplied by withRouter for error logging.
 interface Props extends RouteComponentProps<any> {
@@ -82,9 +83,7 @@ class WidgetTreeErrorBoundary extends Component<Props, State> {
       });
     } else {
       // Log directly to Sentry.
-      SentryLogger.captureException(error, {
-        extra: { componentStacktrace: errorInfo.componentStack },
-      });
+      captureReactException(error, errorInfo);
     }
   }
 

--- a/assets/src/util/sentry.tsx
+++ b/assets/src/util/sentry.tsx
@@ -1,131 +1,42 @@
+import * as Sentry from "@sentry/react";
+import type { SeverityLevel } from "@sentry/react";
+
 import { isDup } from "Util/outfront";
 import { isRealScreen } from "Util/utils";
 import { getDataset } from "Util/dataset";
-// Previously tried @sentry/react and @sentry/browser as the SDK, but the QtWeb browser on e-inks could not
-// use them. Raven is an older stable SDK that better works with older browsers.
-import Raven, { RavenOptions, RavenTransportOptions } from "raven-js";
 
-// https://docs.sentry.io/clients/javascript/usage/#raven-js-additional-context
-type LogLevel = "info" | "warning" | "error";
-
-const log = (message: string, level: LogLevel, extra?: any) => {
-  const options: RavenOptions = { level };
-  if (extra) {
-    options.extra = extra;
-  }
-  Raven.captureMessage(message, options);
-};
-const info = (message: string, extra?: any) => log(message, "info", extra);
-const warn = (message: string, extra?: any) => log(message, "warning", extra);
-const error = (message: string, extra?: any) => log(message, "error", extra);
-
-const captureException = (ex: unknown, options?: RavenOptions) => {
-  Raven.captureException(ex, options);
-};
-
-const OFFLINE_EVENTS_KEY = "sentry_offline_events";
-
-// Store offline Sentry events in localStorage for later retry
-function cacheEvent(options: RavenTransportOptions) {
-  try {
-    const cached = localStorage.getItem(OFFLINE_EVENTS_KEY);
-    const events = cached ? JSON.parse(cached) : [];
-
-    // Remove oldest event if limit is reached
-    if (events.length >= 30) {
-      events.shift();
-    }
-
-    events.push({
-      ...options,
-      data: {
-        ...options.data,
-        extra: {
-          ...(options.data.extra || {}),
-          cached: new Date().toISOString(),
-        },
-      },
-    });
-    localStorage.setItem(OFFLINE_EVENTS_KEY, JSON.stringify(events));
-  } catch {}
-}
-
-function buildSentryAuthHeader(auth) {
-  return `Sentry sentry_version=${auth.sentry_version}, sentry_client=${auth.sentry_client}, sentry_key=${auth.sentry_key}`;
-}
-
-async function resendCachedEvents() {
-  const cached = localStorage.getItem(OFFLINE_EVENTS_KEY);
-  if (!cached) return;
-
-  const events = JSON.parse(cached);
-
-  for (let i = 0; i < events.length; i++) {
-    try {
-      const event = events[i];
-      const response = await fetch(event.url, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "X-Sentry-Auth": buildSentryAuthHeader(event.auth),
-        },
-        body: JSON.stringify(event.data),
-      });
-
-      if (response.ok) {
-        events.splice(i, 1);
-        i--;
-      }
-    } catch {}
-  }
-
-  localStorage.setItem(OFFLINE_EVENTS_KEY, JSON.stringify(events));
-}
-
-// Once we are no longer bounded by browser constraints (old bus-eink),
-// we can migrate off of Raven to @sentry/browser and use their built-in offline caching.
-// Documentation for reference: https://docs.sentry.io/platforms/javascript/guides/react/best-practices/offline-caching/
-function customTransport(options: RavenTransportOptions) {
-  fetch(options.url, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(options.data),
-  }).catch(() => {
-    // Cache the event only if the fetch was rejected, indicating that the network was likely unavailable
-    cacheEvent(options);
-  });
-}
+const report = (
+  level: SeverityLevel,
+  message: string,
+  extra?: Record<string, unknown>,
+) => Sentry.captureMessage(message, { extra, level });
 
 /**
  * Initializes Sentry if the DSN is defined AND this client is running on
  * a real production screen.
  */
 const initSentry = (appString: string) => {
-  const { sentry: sentryDsn, environmentName: env } = getDataset();
+  const { sentry: dsn, environmentName: environment } = getDataset();
 
-  if (sentryDsn && isRealScreen()) {
-    Raven.setTransport(customTransport);
-    Raven.config(sentryDsn, { environment: env }).install();
-
-    // Set listener to retry any cached Sentry events any time the browser transitions from offline to online
-    window.addEventListener("online", resendCachedEvents);
-    // 5 minute interval for retries in case "online" event never fires
-    setInterval(resendCachedEvents, 5 * 60 * 1000);
+  if (dsn && environment && isRealScreen()) {
+    Sentry.init({
+      dsn,
+      environment,
+      transport: Sentry.makeBrowserOfflineTransport(Sentry.makeFetchTransport),
+      sendDefaultPii: true,
+    });
 
     if (isDup()) {
       const today = new Date();
       const hour = today.getHours();
       const min = today.getMinutes();
       if (hour === 8 && min >= 0 && min < 10)
-        info(`Sentry intialized for app: ${appString}`);
+        report("info", `Sentry initialized for app: ${appString}`);
     } else {
-      info(`Sentry intialized for app: ${appString}`);
+      report("info", `Sentry initialized for app: ${appString}`);
     }
   }
 };
 
 export default initSentry;
-/** @knipignore */
-export { info, warn, error, captureException };
+export { report };


### PR DESCRIPTION
Upgrading from our 6-year-old version of the Sentry client was previously blocked by having to support GDS E-ink devices. We can now upgrade to the latest version and take advantage of its native support for caching events while offline.