### PR TITLE
Reintroduce OvernightSection for DUPs

### DIFF
--- a/test/screens/v2/candidate_generator/dup/departures_test.exs
+++ b/test/screens/v2/candidate_generator/dup/departures_test.exs
@@ -2133,7 +2133,6 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
       assert Enum.all?(expected_instances, &Enum.member?(actual_instances, &1))
     end
 
-    @tag :skip
     test "returns OvernightDepartures if all routes in section are overnight",
          %{
            config: config,
@@ -2243,7 +2242,6 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
       assert Enum.all?(expected_departures, &Enum.member?(actual_instances, &1))
     end
 
-    @tag :skip
     test "returns OvernightDepartures with no routes if all rotations are overnight",
          %{
            config: config,
@@ -2314,7 +2312,6 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
       assert Enum.all?(expected_departures, &Enum.member?(actual_instances, &1))
     end
 
-    @tag :skip
     test "returns OvernightDepartures for rail sections with active alert and no active vehicles",
          %{
            config: config,


### PR DESCRIPTION
- We previously disabled OvernightSections due to a bug dealing with it during the day for stations that had predictions suppressed.
- This was due to the previous logic handling, which checked if we have any active routes (which would be false due to prediction suppressions) and any scheduled trains for tomorrow (which would be true) and we would default to showing the overnight section.
- This new logic adds a check to see if our current time is past the last scheduled trip for today OR before the first scheduled trip for today (which would indicate that we're inbetween schedules and overnight). It also adds the overnight check for alerts, so we're not showing alert headways in cases where it's overnight.
- As a note, this is very similar to some logic we're already using today to calculate for overnight_departures, and also is similar to some of the overnight logic we're using in RTS with the exception of the is_last_trip checks (which is omitted here)

**Asana task**: [Follow-up on temporary disabling of DUP overnight mode](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1210998350896155?focus=true)

Description

- [X] Tests (re)added?
