### PR TITLE
Decreased font size for DUP route pills text length > 3

### DIFF
--- a/assets/css/v2/dup/departures/route_pill.scss
+++ b/assets/css/v2/dup/departures/route_pill.scss
@@ -71,7 +71,8 @@
     color: black;
   }
 
-  &--green {
+  &--green,
+  &--small {
     font-size: 84px;
   }
 }

--- a/assets/src/components/v2/departures/route_pill.tsx
+++ b/assets/src/components/v2/departures/route_pill.tsx
@@ -56,7 +56,11 @@ const TextRoutePill: ComponentType<TextPill & { outline?: boolean }> = ({
     modifiers.push(size);
   } else {
     const routeNum = Number(text);
-    modifiers.push(isNaN(routeNum) || routeNum > 199 ? "small" : "large");
+    if (isNaN(routeNum)) {
+      modifiers.push(text.length > 3 ? "small" : "large");
+    } else {
+      modifiers.push(routeNum > 199 ? "small" : "large");
+    }
   }
 
   return (


### PR DESCRIPTION
- Added the small modifier for route-pill__text
- Had to change the size modifiers logic to check explicitly for TR text

**Asana task**: [Adjust font size for 2-digit CR Track Pills](https://app.asana.com/1/15492006741476/project/1185117109217422/task/1211138992434689?focus=true)

- [ ] Tests added?

<img width="755" height="98" alt="Screenshot 2025-08-27 at 2 21 43 PM" src="https://github.com/user-attachments/assets/f9ed47be-9540-49e0-8f0d-1392168b08f3" />
<img width="736" height="104" alt="Screenshot 2025-08-27 at 2 22 00 PM" src="https://github.com/user-attachments/assets/013d2dd9-cf49-4109-9b77-79fcb4332e24" />
