### PR TITLE
dev: fix Dependabot config for `eslint` group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,7 +33,7 @@ updates:
       eslint:
         patterns:
           - "eslint*"
-          - "@typescript-eslint*"
+          - "*-eslint"
           - "@eslint*"
       react:
         patterns:


### PR DESCRIPTION
We have no packages with the prefix `@typescript-eslint`. This pattern was likely meant to target the package `typescript-eslint` (no "@").