### PR TITLE
Improve audio readout admin tools

### DIFF
--- a/assets/src/components/admin/inspector.tsx
+++ b/assets/src/components/admin/inspector.tsx
@@ -143,12 +143,16 @@ const Inspector: ComponentType = () => {
                 <DataControls
                   // Reset when the iframe reloads, since the screen will no
                   // longer be aware of previously-sent inspector messages
-                  key={frameLoadedAt}
+                  key={"data-controls-" + frameLoadedAt}
                   isVariantEnabled={isVariantEnabled}
                   screen={screen}
                   sendToFrame={sendToFrame}
                 />
-                <AudioControls screen={screen} />
+                <AudioControls
+                  // Reset any active audio playback when a new screen loads
+                  key={"audio-controls-" + frameLoadedAt}
+                  screen={screen}
+                />
               </>
             )}
           </>
@@ -485,13 +489,9 @@ const AudioControls: ComponentType<{ screen: ScreenWithId }> = ({ screen }) => {
               Show SSML
             </button>
 
-            {playingAt ? (
-              <button onClick={() => setPlayingAt(null)}>⏹️ Stop Audio</button>
-            ) : (
-              <button onClick={() => setPlayingAt(new Date())}>
-                ▶️ Play Audio
-              </button>
-            )}
+            <button onClick={() => setPlayingAt(new Date())}>
+              {playingAt ? "🔄 Refresh Audio" : "▶️ Play Audio"}
+            </button>
           </div>
 
           <dialog className="inspector__modal" ref={dialogRef}>
@@ -513,6 +513,7 @@ const AudioControls: ComponentType<{ screen: ScreenWithId }> = ({ screen }) => {
 
           {playingAt && (
             <audio
+              controls
               autoPlay={true}
               onEnded={() => setPlayingAt(null)}
               src={`${audioPath}/readout.mp3?at=${playingAt.getTime()}`}


### PR DESCRIPTION
Two small Inspector features to assist with gathering info for the audio readouts epic:

* In the "Show SSML" dialog, show the count of billable and total characters in the SSML, and the limits for each.
* Show controls for the audio readout, enabling pausing and seeking the audio as well as seeing the length of the readout.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211176661292117