### PR TITLE
test: fix `Plug.Test` deprecation warning

### DIFF
--- a/test/screens/ueberauth/strategy/fake_test.exs
+++ b/test/screens/ueberauth/strategy/fake_test.exs
@@ -1,6 +1,7 @@
 defmodule Screens.Ueberauth.Strategy.FakeTest do
-  use ExUnit.Case
-  use Plug.Test
+  use ExUnit.Case, async: true
+
+  import Plug.Test
   import Screens.Ueberauth.Strategy.Fake
 
   describe "implements all the callbacks" do


### PR DESCRIPTION
`use Plug.Test` is deprecated in favor of simply importing the modules that this macro imports.