### PR TITLE
doc: centralize Mercury-specific API docs

### DIFF
--- a/docs/mercury_api.md
+++ b/docs/mercury_api.md
@@ -1,0 +1,83 @@
+# Mercury E-ink APIs
+
+[Mercury] is our vendor for E-ink screens. Unlike our other screens, Mercury
+screens do not use an on-device web browser to request and display our "screen
+app" web pages. Instead, a central system directly requests the JSON widget
+data from our API and ultimately transforms this into screenshots of individual
+widgets, with this image data then being sent to the E-ink devices.
+
+This has a couple of important consequences:
+
+1. Our widget API is *not* purely internal to the Screens app. Mercury is a
+   client of this API and changes to how layouts or widgets are serialized can
+   affect them.
+
+2. Our API includes fields that appear "unused" from the perspective of our own
+   client, but are required by the Mercury client.
+
+This document collects in one place our "API contract" with Mercury,
+specifically with regard to the second point. It should be updated if this
+contract changes.
+
+[Mercury]: https://www.notion.so/mbta-downtown-crossing/Mercury-e-ink-8ee536ab5ffe46e482d5359f443d74ed#8ee536ab5ffe46e482d5359f443d74ed
+
+
+## Widget endpoint
+
+The `/widget/:app_id` endpoint is used only by the Mercury client. This accepts
+a `widget` parameter containing the JSON data of a single widget (as returned
+from the screen data API), and renders a web page containing only that widget.
+[[#1909]]
+
+See [`tech_specs/0005_eink_widget_endpoint.md`][spec] for additional background.
+
+[spec]: tech_specs/0005_eink_widget_endpoint.md
+
+
+## Top-level fields
+
+The screen data API returns a JSON object. Normally the only interesting field
+here is `data`, the screen's root layout (which then contains other layouts and
+widgets, [and so on](architecture/widget_framework.md)). For Mercury screens,
+we include the following additional fields:
+
+* `audio_data` *(string)* — The SSML of the screen's audio readout. Mercury
+  uses this to produce their own audio readouts; the E-ink screens do not use
+  our MP3 audio API. [[#1913]]
+
+* `flex_zone` *(array)* — All of the widgets selected for display in paged
+  slots (normally paging is resolved on the server and only the current page
+  is sent to the client). Uses the same logic as "Screenplay simulations", but
+  not the same response structure. [[#2317]]
+
+* `last_deploy_timestamp` *(string)* — The datetime the app was last deployed,
+  in ISO8601 format. [[#1909]]
+
+
+## `Departures` widget
+
+For E-ink screens, each of `sections[].rows[].times_with_crowding[]` has a
+`time_in_epoch` *(integer)* field, which is the predicted departure time as a
+Unix timestamp. This allows the conversion to a number of minutes or "Now" to
+be done "just in time", independent of data fetching. [[#1911]]
+
+
+## `LineMap` widget
+
+Each of `vehicles[]` has a `time_in_epoch` *(integer)* field, which has the
+same meaning and purpose as above. [[#1970]]
+
+
+## `NormalHeader` widget
+
+For Mercury screens, the `time` field is omitted. This hides the clock that
+normally appears in screen headers, allowing the Mercury system to dynamically
+add its own clock independent of data fetching and widget rendering. [[#1943]]
+
+
+[#1909]: https://github.com/mbta/screens/pull/1909
+[#1911]: https://github.com/mbta/screens/pull/1911
+[#1913]: https://github.com/mbta/screens/pull/1913
+[#1943]: https://github.com/mbta/screens/pull/1943
+[#1970]: https://github.com/mbta/screens/pull/1970
+[#2317]: https://github.com/mbta/screens/pull/2317

--- a/lib/screens/v2/widget_instance/departures.ex
+++ b/lib/screens/v2/widget_instance/departures.ex
@@ -457,8 +457,7 @@ defmodule Screens.V2.WidgetInstance.Departures do
           serialize_timestamp(departure_time, now)
       end
 
-    # time_in_epoch is used by Mercury so they can calculate timestamps on their own.
-    # https://app.asana.com/0/1176097567827729/1205730972991228/f
+    # See `docs/mercury_api.md`
     %{time: time, time_in_epoch: DateTime.to_unix(departure_time)}
   end
 

--- a/lib/screens/v2/widget_instance/line_map.ex
+++ b/lib/screens/v2/widget_instance/line_map.ex
@@ -240,8 +240,7 @@ defmodule Screens.V2.WidgetInstance.LineMap do
       if index < 0 do
         []
       else
-        # time_in_epoch is used by Mercury so they can calculate times on their own.
-        # https://app.asana.com/0/1176097567827729/1205730972991228/f
+        # See `docs/mercury_api.md`
         departure_time_epoch = d |> Departure.time() |> DateTime.to_unix()
         [%{id: vehicle_id, index: index, label: label, time_in_epoch: departure_time_epoch}]
       end

--- a/lib/screens/v2/widget_instance/normal_header.ex
+++ b/lib/screens/v2/widget_instance/normal_header.ex
@@ -20,8 +20,7 @@ defmodule Screens.V2.WidgetInstance.NormalHeader do
           variant: atom() | nil
         }
 
-  # Mercury adds their own time so we omit the time in the response.
-  # https://app.asana.com/0/1185117109217413/1206070378353406/f
+  # See `docs/mercury_api.md`
   def serialize(%__MODULE__{screen: %Screen{vendor: :mercury}, icon: icon, text: text} = t) do
     %{icon: icon, text: text, show_to: showing_destination?(t)}
   end

--- a/lib/screens_web/controllers/v2/screen_api_controller.ex
+++ b/lib/screens_web/controllers/v2/screen_api_controller.ex
@@ -99,6 +99,7 @@ defmodule ScreensWeb.V2.ScreenApiController do
     Map.put(%{@base_response | data: default}, :variants, variants)
   end
 
+  # See `docs/mercury_api.md`
   defp screen_response(screen_id, %Screen{vendor: :mercury}, variant, opts) do
     %{full_page: data, flex_zone: flex_zone} =
       ScreenData.simulation(screen_id, merge_options(variant, opts))
@@ -116,14 +117,10 @@ defmodule ScreensWeb.V2.ScreenApiController do
     |> Keyword.put(:generator_variant, variant)
   end
 
-  # Add extra fields used by the Mercury E-ink client
+  # See `docs/mercury_api.md`
   defp put_extra_fields(response, screen_id, %Screen{vendor: :mercury}) do
     response
-    # Used to enable audio readout without additional network requests
-    # https://app.asana.com/0/1176097567827729/1205748798471858/f
     |> Map.put(:audio_data, fetch_ssml(screen_id))
-    # Used to help optimize data refreshes
-    # https://app.asana.com/0/1185117109217413/1205234924224431/f
     |> Map.put(:last_deploy_timestamp, Cache.last_deploy_timestamp())
   end
 

--- a/lib/screens_web/controllers/v2/screen_controller.ex
+++ b/lib/screens_web/controllers/v2/screen_controller.ex
@@ -140,8 +140,6 @@ defmodule ScreensWeb.V2.ScreenController do
   end
 
   # Handles widget page GET requests with widget data as a query param.
-  # Primarily used by Mercury so not all requests need to run through the framework.
-  # https://app.asana.com/0/1185117109217413/1205234924224431/f
   def widget(conn, %{"app_id" => app_id, "widget" => json_data}) when is_binary(json_data) do
     # Phoenix does not automatically decode JSON received in query params.
     case Jason.decode(json_data) do

--- a/lib/screens_web/router.ex
+++ b/lib/screens_web/router.ex
@@ -79,6 +79,7 @@ defmodule ScreensWeb.Router do
 
   scope "/v2", ScreensWeb.V2 do
     scope "/widget" do
+      # See `docs/mercury_api.md`
       pipe_through [:redirect_prod_http, :browser_no_csrf]
       post "/:app_id", ScreenController, :widget
       get "/:app_id", ScreenController, :widget


### PR DESCRIPTION
**Asana task**: https://app.asana.com/1/15492006741476/project/1185117109217413/task/1208162809395312

As per the task this included a review of past Mercury-related tasks to see whether we were missing anything else, but it doesn't look like we were.

This task is very old (created August 2024) and now that we've finally gotten around to it, I'm not actually sure whether this approach is better than purely "inline" documentation, though I think leaving little "pointers" behind to the central document still works to remind us to update the docs if the code changes. Depending on how others feel about this I would be open to this PR being "rejected" and not merged.

One thing I do think is an improvement is linking to implementation PRs rather than Asana tasks, since the former should be more durable over time. And in all cases, the PRs link back to the Asana task.