### PR TITLE
Fixed issue where CR alerts weren't hiding appropriate departures

### DIFF
--- a/lib/screens/predictions/prediction.ex
+++ b/lib/screens/predictions/prediction.ex
@@ -32,14 +32,8 @@ defmodule Screens.Predictions.Prediction do
   @includes ~w[route.line stop trip.route_pattern.representative_trip trip.stops vehicle]
 
   @spec fetch(Departure.params()) :: {:ok, list(t())} | :error
-  def fetch(%{} = params) do
-    result = Departure.do_fetch("predictions", Map.put(params, :include, @includes))
-
-    case result do
-      {:ok, predictions} -> {:ok, Enum.reject(predictions, &is_nil(&1.departure_time))}
-      :error -> :error
-    end
-  end
+  def fetch(%{} = params),
+    do: Departure.do_fetch("predictions", Map.put(params, :include, @includes))
 
   def stop_for_vehicle(%__MODULE__{vehicle: %Vehicle{stop_id: stop_id}}), do: stop_id
   def stop_for_vehicle(_), do: nil

--- a/lib/screens/v2/departure.ex
+++ b/lib/screens/v2/departure.ex
@@ -114,6 +114,14 @@ defmodule Screens.V2.Departure do
     end
   end
 
+  def departure_time(%__MODULE__{prediction: p}) when not is_nil(p) do
+    select_departure_time(p)
+  end
+
+  def departure_time(%__MODULE__{prediction: nil, schedule: s}) do
+    select_departure_time(s)
+  end
+
   def headsign(%__MODULE__{prediction: p, schedule: s}) when not is_nil(p) do
     %Prediction{trip: %Trip{headsign: headsign}} = p
 
@@ -193,6 +201,14 @@ defmodule Screens.V2.Departure do
 
   def track_number(_), do: nil
 
+  def trip_id(%__MODULE__{prediction: %Prediction{trip: %Trip{id: trip_id}}}) do
+    trip_id
+  end
+
+  def trip_id(%__MODULE__{schedule: %Schedule{trip: %Trip{id: trip_id}}}) do
+    trip_id
+  end
+
   def vehicle_status(%__MODULE__{
         prediction: %Prediction{vehicle: %Vehicle{current_status: current_status}}
       }) do
@@ -220,6 +236,9 @@ defmodule Screens.V2.Departure do
 
   defp select_arrival_time(%{arrival_time: nil, departure_time: t}), do: t
   defp select_arrival_time(%{arrival_time: t, departure_time: _}), do: t
+
+  defp select_departure_time(%{arrival_time: t, departure_time: nil}), do: t
+  defp select_departure_time(%{arrival_time: _, departure_time: t}), do: t
 
   defp identify_stop_type_from_times(arrival_time, departure_time)
   defp identify_stop_type_from_times(nil, _), do: :first_stop

--- a/test/screens/v2/departure/builder_test.exs
+++ b/test/screens/v2/departure/builder_test.exs
@@ -21,21 +21,33 @@ defmodule Screens.V2.Departure.BuilderTest do
     end
 
     test "filters out departures with both arrival_time and departure_time nil" do
-      p1 = %Prediction{id: "arrival", arrival_time: ~U[2020-02-01T01:00:00Z], departure_time: nil}
+      p1 = %Prediction{
+        id: "arrival",
+        trip: %Trip{id: "t1", stops: ["1", "2", "3"]},
+        arrival_time: ~U[2020-02-01T01:00:00Z],
+        departure_time: nil
+      }
 
       p2 = %Prediction{
         id: "departure",
+        trip: %Trip{id: "t2", stops: ["1", "2", "3"]},
         arrival_time: nil,
         departure_time: ~U[2020-02-01T01:00:00Z]
       }
 
       p3 = %Prediction{
         id: "both",
+        trip: %Trip{id: "t3", stops: ["1", "2", "3"]},
         arrival_time: ~U[2020-02-01T01:00:00Z],
         departure_time: ~U[2020-02-01T01:00:00Z]
       }
 
-      p4 = %Prediction{id: "neither", arrival_time: nil, departure_time: nil}
+      p4 = %Prediction{
+        id: "neither",
+        trip: %Trip{id: "t4", stops: ["1", "2", "3"]},
+        arrival_time: nil,
+        departure_time: nil
+      }
 
       actual = Builder.build([p1, p2, p3, p4], [], @now)
       expected = to_departures([p1, p2, p3])
@@ -44,17 +56,36 @@ defmodule Screens.V2.Departure.BuilderTest do
     end
 
     test "filters out departures in the past" do
-      p1 = %Prediction{id: "1", arrival_time: ~U[2020-01-01T00:00:00Z]}
+      p1 = %Prediction{
+        id: "1",
+        trip: %Trip{id: "t1", stops: ["1", "2", "3"]},
+        arrival_time: ~U[2020-01-01T00:00:00Z]
+      }
 
       p2 = %Prediction{
         id: "2",
+        trip: %Trip{id: "t2", stops: ["1", "2", "3"]},
         arrival_time: ~U[2020-01-01T00:00:00Z],
         departure_time: ~U[2020-01-01T02:00:00Z]
       }
 
-      p3 = %Prediction{id: "3", departure_time: ~U[2020-01-01T00:00:00Z]}
-      p4 = %Prediction{id: "4", departure_time: ~U[2020-01-01T02:00:00Z]}
-      p5 = %Prediction{id: "5", arrival_time: ~U[2020-02-01T00:00:00Z]}
+      p3 = %Prediction{
+        id: "3",
+        trip: %Trip{id: "t3", stops: ["1", "2", "3"]},
+        departure_time: ~U[2020-01-01T00:00:00Z]
+      }
+
+      p4 = %Prediction{
+        id: "4",
+        trip: %Trip{id: "t4", stops: ["1", "2", "3"]},
+        departure_time: ~U[2020-01-01T02:00:00Z]
+      }
+
+      p5 = %Prediction{
+        id: "5",
+        trip: %Trip{id: "t5", stops: ["1", "2", "3"]},
+        arrival_time: ~U[2020-02-01T00:00:00Z]
+      }
 
       assert Builder.build([p1, p2, p3, p4, p5], [], @now) == to_departures([p2, p4, p5])
     end
@@ -83,7 +114,7 @@ defmodule Screens.V2.Departure.BuilderTest do
 
       p4 = %Prediction{
         id: "4",
-        trip: nil,
+        trip: %Trip{id: "47610993", route_id: "214216"},
         route: %Route{id: "214216"},
         departure_time: ~U[2020-01-01T01:00:00Z]
       }
@@ -150,8 +181,8 @@ defmodule Screens.V2.Departure.BuilderTest do
       p2 = %Prediction{id: "2", trip: %Trip{id: "t1"}, departure_time: ~U[2020-02-01T00:01:00Z]}
       p3 = %Prediction{id: "3", trip: %Trip{id: "t2"}, departure_time: ~U[2020-02-01T01:01:00Z]}
       p4 = %Prediction{id: "4", trip: %Trip{id: "t2"}, departure_time: ~U[2020-02-01T01:00:00Z]}
-      p5 = %Prediction{id: "5", trip: %Trip{id: nil}, departure_time: ~U[2020-02-01T00:00:00Z]}
-      p6 = %Prediction{id: "6", trip: nil, departure_time: ~U[2020-02-01T00:00:00Z]}
+      p5 = %Prediction{id: "5", trip: %Trip{id: "t3"}, departure_time: ~U[2020-02-01T00:00:00Z]}
+      p6 = %Prediction{id: "6", trip: %Trip{id: "t4"}, departure_time: ~U[2020-02-01T00:00:00Z]}
 
       actual = Builder.build([p1, p2, p3, p4, p5, p6], [], @now)
       expected = to_departures([p1, p4, p5, p6])
@@ -163,6 +194,7 @@ defmodule Screens.V2.Departure.BuilderTest do
       # arrives earlier, departs later
       p1 = %Prediction{
         id: "1",
+        trip: %Trip{id: "t1", stops: ["1", "2", "3"]},
         arrival_time: ~U[2020-02-01T01:00:01Z],
         departure_time: ~U[2020-02-01T01:00:05Z]
       }
@@ -170,6 +202,7 @@ defmodule Screens.V2.Departure.BuilderTest do
       # arrives later, departs earlier
       p2 = %Prediction{
         id: "2",
+        trip: %Trip{id: "t2", stops: ["1", "2", "3"]},
         arrival_time: ~U[2020-02-01T01:00:02Z],
         departure_time: ~U[2020-02-01T01:00:03Z]
       }
@@ -270,7 +303,7 @@ defmodule Screens.V2.Departure.BuilderTest do
 
       p2 = %Prediction{
         id: "p2",
-        departure_time: ~U[2020-02-01T01:00:00Z],
+        departure_time: nil,
         trip: %Trip{id: "t3"},
         schedule_relationship: :cancelled
       }


### PR DESCRIPTION
**Asana task**: [[Investigation] CR Test Alerts > Screenplay dev-green Displays](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1210793900723819?focus=true)

- For Commuter Rail Alerts, we weren't taking into consideration the cancelled/skipped prediction when showing the scheduled departure
- New logic moves some of the relevancy checks to after we combine the predictions and scheduled departures, to allow for proper cross checking of scheduled trips to predicted trips
- Also removed a departure_time nil check within the Prediction fetch, which will allow us to properly get all predictions within the Builder


- [x] Tests modified?
