### PR TITLE
Update Asana workflow to only attach PR to ticket

### DIFF
--- a/.github/workflows/asana.yml
+++ b/.github/workflows/asana.yml
@@ -1,7 +1,7 @@
 name: Asana integration
 on: 
   pull_request:
-    types: [opened, reopened]
+    types: [edited, opened]
 
 jobs:
   asana:


### PR DESCRIPTION
**Asana task**: [Asana integrations: Attach PR to story but don't move ticket](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1210237684564478?focus=true)

Update the Asana workflow to only trigger attaching the Github PR to the Asana ticket.
