### PR TITLE
fix: interpreting alerts as directional

### DIFF
--- a/lib/screens/alerts/alert.ex
+++ b/lib/screens/alerts/alert.ex
@@ -389,8 +389,13 @@ defmodule Screens.Alerts.Alert do
     )
   end
 
-  def direction_id(%__MODULE__{informed_entities: informed_entities}),
-    do: List.first(informed_entities).direction_id
+  @doc """
+  Very imperfectly determine whether an alert only affects one direction of service. Assumes this
+  is the case if any affected parent station is only affected in one direction.
+  """
+  @spec direction_id(t()) :: Trip.direction() | nil
+  def direction_id(%__MODULE__{informed_entities: entities}),
+    do: Enum.find(entities, &InformedEntity.parent_station?/1).direction_id
 
   def informed_parent_stations(%__MODULE__{
         informed_entities: informed_entities

--- a/test/screens/alerts/alert_test.exs
+++ b/test/screens/alerts/alert_test.exs
@@ -290,4 +290,64 @@ defmodule Screens.Alerts.AlertTest do
       assert :error == Alert.fetch_by_stop_and_route(stop_ids, route_ids, x_get_json_fn2)
     end
   end
+
+  describe "direction_id/1" do
+    test "returns nil when all informed parent stations are affected in both directions" do
+      alert = %Alert{
+        informed_entities: [
+          %{
+            activities: ~w[board exit ride]a,
+            direction_id: 0,
+            facility: nil,
+            route: "1",
+            route_type: nil,
+            stop: "12345"
+          },
+          %{
+            activities: ~w[board exit ride]a,
+            direction_id: nil,
+            facility: nil,
+            route: "1",
+            route_type: nil,
+            stop: "place-a"
+          }
+        ]
+      }
+
+      assert Alert.direction_id(alert) == nil
+    end
+
+    test "returns the direction ID of the first directionally-informed parent station" do
+      alert = %Alert{
+        informed_entities: [
+          %{
+            activities: ~w[board exit ride]a,
+            direction_id: 0,
+            facility: nil,
+            route: "1",
+            route_type: nil,
+            stop: "12345"
+          },
+          %{
+            activities: ~w[board exit ride]a,
+            direction_id: 1,
+            facility: nil,
+            route: "1",
+            route_type: nil,
+            stop: "place-a"
+          },
+          %{
+            activities: ~w[board exit ride]a,
+            direction_id: 0,
+            facility: nil,
+            route: "1",
+            route_type: nil,
+            stop: "place-b"
+          }
+        ]
+      }
+
+      assert Alert.direction_id(alert) == 1
+    end
+  end
 end


### PR DESCRIPTION
`Alert.direction_id/1` would incorrectly return a non-nil value if there happened to be any stopping locations (which would always have a non-nil direction) ahead of the first parent station in the informed entities. Since entities are never explicitly sorted, this could sometimes be the case and sometimes not, even for the same alert.

The immediate fix is to only consider parent stations, though this approach is still flawed, as is the entire notion that one can assign a single "direction" to an alert. It should work well enough for how alert data is currently structured and the kinds of alerts we are likely to see, though.

**Asana task**: https://app.asana.com/1/15492006741476/project/1185117109217413/task/1211317821078418

Includes a separate and unrelated refactor of informed entity normalization logic. I had a difficult time following this and wanted to simplify it to make sure it wasn't part of this problem (turns out it indeed wasn't).