### PR TITLE
fix: Pre-Fare blank screen inside station closure

### DIFF
--- a/assets/src/components/v2/pre_fare_single_screen_alert.tsx
+++ b/assets/src/components/v2/pre_fare_single_screen_alert.tsx
@@ -21,7 +21,7 @@ interface PreFareSingleScreenAlertProps {
   remedy: string;
   remedy_bold?: string;
   routes: EnrichedRoute[];
-  unaffected_routes: EnrichedRoute[];
+  unaffected_routes?: EnrichedRoute[];
   endpoints: [string, string];
   effect:
     | "suspension"
@@ -325,6 +325,7 @@ const isPartialClosure = ({
 }: PreFareSingleScreenAlertProps): boolean =>
   effect === "station_closure" &&
   region === "here" &&
+  unaffected_routes !== undefined &&
   unaffected_routes.length > 0;
 
 const PreFareSingleScreenAlert: ComponentType<PreFareSingleScreenAlertProps> = (
@@ -369,10 +370,12 @@ const PreFareSingleScreenAlert: ComponentType<PreFareSingleScreenAlertProps> = (
       );
       break;
     case isPartialClosure(alert):
+      // By definition if `isPartialClosure` is true then `unaffected_routes` is
+      // present, so it's okay to use a non-null assertion here.
       layout = (
         <PartialClosureLayout
           routes={routes}
-          unaffected_routes={unaffected_routes}
+          unaffected_routes={unaffected_routes!}
           disruptionDiagram={disruption_diagram}
         />
       );


### PR DESCRIPTION
This was caused by a mismatch between the server and client types for single-screen reconstructed alerts: the server had `unaffected_routes` as an optional field, while the client thought it would always be present. When the screen was inside a station closure the client would crash on an undefined property access. (When the screen was inside some other kind of alert, the client code would safely return before trying to access this property.)

**Asana task**: https://app.asana.com/1/15492006741476/project/1185117109217413/task/1211333265042010