### PR TITLE
dev: fix over-broad Dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,8 +37,10 @@ updates:
           - "@eslint*"
       react:
         patterns:
-          - "react*"
-          - "@types/react*"
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
       testing-tools:
         patterns:
           - "ts-jest"


### PR DESCRIPTION
"React" only consists of a few specific packages, not necessarily everything that begins with `react` or `@types/react`. Many third-party packages also have this pattern.