### PR TITLE
fix: bad header alignment with logo enabled

### DIFF
--- a/assets/css/v2/lcd_common/normal_header.scss
+++ b/assets/css/v2/lcd_common/normal_header.scss
@@ -34,10 +34,6 @@
     width: 800px;
   }
 
-  &--with-icon {
-    bottom: 15px;
-  }
-
   &--large {
     bottom: 40px;
     font-size: 104px;
@@ -47,6 +43,10 @@
   &--small {
     bottom: 24px;
     font-size: 72px;
+  }
+
+  &--with-icon {
+    bottom: 15px;
   }
 }
 


### PR DESCRIPTION
When the logo was enabled on a Sectional screen, the header was not aligned correctly. This is a recent regression introduced when these styles were refactored for cross-screen-type consistency.

| Bug | Fixed |
| :--: | :--: |
| <img width="1080" height="200" alt="Screen Shot 2025-09-15 at 11 32 36" src="https://github.com/user-attachments/assets/521d71c8-e5fc-48f1-be5c-a89fb7d9b53c" /> | <img width="1080" height="200" alt="Screen Shot 2025-09-22 at 13 40 04" src="https://github.com/user-attachments/assets/01fb77f4-7ada-4b8b-a8e7-520612238ab2" /> |