### PR TITLE
fix: header sizing and alignment

### DIFF
--- a/assets/css/v2/dup/normal_header.scss
+++ b/assets/css/v2/dup/normal_header.scss
@@ -39,21 +39,18 @@
   }
 }
 
-.normal-header-icon {
-  display: inline-block;
-  vertical-align: middle;
-}
-
-.normal-header-icon__image {
-  width: 184px;
-  height: 184px;
-  margin-right: 64px;
-}
-
 .normal-header-title {
   position: absolute;
   top: 32px;
   left: 64px;
+}
+
+.normal-header-title__icon {
+  display: inline-block;
+  width: 184px;
+  height: 184px;
+  margin-right: 64px;
+  vertical-align: middle;
 }
 
 .normal-header-title__text {

--- a/assets/css/v2/eink/normal_header.scss
+++ b/assets/css/v2/eink/normal_header.scss
@@ -5,14 +5,6 @@
   background: #000;
 }
 
-.normal-header-icon {
-  display: inline-block;
-  width: 128px;
-  height: 128px;
-  margin: 120px 28px 40px 40px;
-  vertical-align: middle;
-}
-
 .normal-header-title {
   position: relative;
   width: 964px;
@@ -27,6 +19,14 @@
     font-size: 72px;
     line-height: 72px;
   }
+}
+
+.normal-header-title__icon {
+  display: inline-block;
+  width: 128px;
+  height: 128px;
+  margin: 110px 28px 40px 40px;
+  vertical-align: middle;
 }
 
 .normal-header-title__text {

--- a/assets/css/v2/lcd_common/normal_header.scss
+++ b/assets/css/v2/lcd_common/normal_header.scss
@@ -5,12 +5,6 @@
   background: rgb(23 31 38);
 }
 
-.normal-header-icon__image {
-  width: 128px;
-  height: 128px;
-  margin-right: 28px;
-}
-
 .normal-header-title {
   position: absolute;
   left: 40px;
@@ -18,6 +12,7 @@
   align-content: end;
   align-items: center;
   width: 824px;
+  height: 100%;
   font-weight: 700;
   line-height: 1;
   color: #fff;
@@ -32,19 +27,18 @@
   }
 
   &--large {
-    bottom: 40px;
     font-size: 104px;
-    white-space: nowrap;
   }
 
   &--small {
-    bottom: 24px;
     font-size: 72px;
   }
+}
 
-  &--with-icon {
-    bottom: 15px;
-  }
+.normal-header-title__icon {
+  width: 128px;
+  height: 128px;
+  margin-right: 28px;
 }
 
 .normal-header-time {

--- a/assets/src/components/v2/normal_header.tsx
+++ b/assets/src/components/v2/normal_header.tsx
@@ -23,21 +23,6 @@ const ICON_TO_SRC: Record<Icon, string> = {
   logo_negative: "logo-black.svg",
 };
 
-interface NormalHeaderIconProps {
-  icon: Icon;
-}
-
-const NormalHeaderIcon: ComponentType<NormalHeaderIconProps> = ({ icon }) => {
-  return (
-    <div className="normal-header-icon">
-      <img
-        className="normal-header-icon__image"
-        src={imagePath(ICON_TO_SRC[icon])}
-      />
-    </div>
-  );
-};
-
 interface NormalHeaderTitleProps {
   icon?: Icon;
   text: string;
@@ -64,7 +49,12 @@ const NormalHeaderTitle: ComponentType<NormalHeaderTitleProps> = ({
         ])}
         ref={ref}
       >
-        {icon && <NormalHeaderIcon icon={icon} />}
+        {icon && (
+          <img
+            className="normal-header-title__icon"
+            src={imagePath(ICON_TO_SRC[icon])}
+          />
+        )}
         <div className="normal-header-title__text">
           {showTo && <div className="normal-header-to__text">TO</div>}
           {text}


### PR DESCRIPTION
Using the correct fonts for headers exposed an issue with the recent auto-sizing refactor where `lcd_common` screens always had a "small" header even when there was room for a "large" one.

The problem was a combination of the text using `line-height: 1`, which cuts off some of the space intended for descenders, plus the container not having any specified size and conforming to the size of the text. When this is the case, the container "has overflow" because if it had `overflow: hidden` the shortened line-height would cause the descenders to be cut off.

The solution is to allow this container to be 100% of the height of the header slot, which has no downsides and also allows a simplification of how header elements (icon and text) are vertically aligned.