### PR TITLE
Changed mbta.com/status to mbta.com/alerts for Subway Status widget

### DIFF
--- a/assets/src/components/v2/subway_status/eink_subway_status.tsx
+++ b/assets/src/components/v2/subway_status/eink_subway_status.tsx
@@ -97,7 +97,7 @@ interface AlertRowProps extends Alert {
   showInlineBranches: boolean;
 }
 
-const STATUS_URL = "mbta.com/status";
+const ALERTS_URL = "mbta.com/alerts";
 const ALERT_FITTING_STEPS = [
   FittingStep.FullSize,
   FittingStep.Abbrev,
@@ -117,7 +117,7 @@ const AlertRow: ComponentType<AlertRowProps> = ({
 
   let locationText: string | null;
   if (replaceLocationWithUrl) {
-    locationText = STATUS_URL;
+    locationText = ALERTS_URL;
   } else if (isAlertLocationMap(location)) {
     locationText = abbrev ? location.abbrev : location.full;
   } else {

--- a/assets/src/components/v2/subway_status/lcd_subway_status.tsx
+++ b/assets/src/components/v2/subway_status/lcd_subway_status.tsx
@@ -107,7 +107,7 @@ const CONTRACTED_ALERT_FITTING_STEPS = [
 ];
 const EXTENDED_ALERT_FITTING_STEPS = [FittingStep.FullSize, FittingStep.Abbrev];
 
-const STATUS_URL = "mbta.com/status";
+const ALERTS_URL = "mbta.com/alerts";
 
 const ContractedAlert: ComponentType<AlertWithID> = ({
   route_pill: routePill,
@@ -121,7 +121,7 @@ const ContractedAlert: ComponentType<AlertWithID> = ({
 
   let locationText: string | null;
   if (replaceLocationWithUrl) {
-    locationText = STATUS_URL;
+    locationText = ALERTS_URL;
   } else if (isAlertLocationMap(location)) {
     locationText = abbrev ? location.abbrev : location.full;
   } else {

--- a/lib/screens/v2/widget_instance/subway_status.ex
+++ b/lib/screens/v2/widget_instance/subway_status.ex
@@ -85,7 +85,7 @@ defmodule Screens.V2.WidgetInstance.SubwayStatus do
 
   @green_line_branches ["Green-B", "Green-C", "Green-D", "Green-E"]
 
-  @mbta_status_url "mbta.com/status"
+  @mbta_alerts_url "mbta.com/alerts"
 
   defimpl Screens.V2.WidgetInstance do
     alias ScreensConfig.Audio
@@ -408,7 +408,7 @@ defmodule Screens.V2.WidgetInstance.SubwayStatus do
                                 other {# stops}}",
             num_informed_platforms: length(informed_platforms)
           ),
-        location: %{full: @mbta_status_url, abbrev: @mbta_status_url}
+        location: %{full: @mbta_alerts_url, abbrev: @mbta_alerts_url}
       }
     else
       # Get closed station names from informed entities
@@ -660,7 +660,7 @@ defmodule Screens.V2.WidgetInstance.SubwayStatus do
     %{
       route_pill: route_pill,
       status: "#{alert_count} current alerts",
-      location: @mbta_status_url
+      location: @mbta_alerts_url
     }
   end
 
@@ -783,7 +783,7 @@ defmodule Screens.V2.WidgetInstance.SubwayStatus do
 
       stop_names ->
         {"Bypassing #{length(stop_names)} stops",
-         %{full: @mbta_status_url, abbrev: @mbta_status_url}}
+         %{full: @mbta_alerts_url, abbrev: @mbta_alerts_url}}
     end
   end
 

--- a/test/screens/v2/widget_instance/subway_status_test.exs
+++ b/test/screens/v2/widget_instance/subway_status_test.exs
@@ -61,7 +61,7 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
             alert: %{
               route_pill: @bl_pill,
               status: "Bypassing 4 stops",
-              location: %{abbrev: "mbta.com/status", full: "mbta.com/status"},
+              location: %{abbrev: "mbta.com/alerts", full: "mbta.com/alerts"},
               station_count: 4
             }
           }
@@ -267,13 +267,13 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
         | blue: %{
             type: :contracted,
             alerts: [
-              %{route_pill: @bl_pill, status: "2 current alerts", location: "mbta.com/status"}
+              %{route_pill: @bl_pill, status: "2 current alerts", location: "mbta.com/alerts"}
             ]
           },
           orange: %{
             type: :contracted,
             alerts: [
-              %{route_pill: @ol_pill, status: "2 current alerts", location: "mbta.com/status"}
+              %{route_pill: @ol_pill, status: "2 current alerts", location: "mbta.com/alerts"}
             ]
           }
       }
@@ -435,7 +435,7 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
               %{
                 route_pill: gl_pill([:b, :c]),
                 status: "2 current alerts",
-                location: "mbta.com/status"
+                location: "mbta.com/alerts"
               }
             ]
           }
@@ -560,7 +560,7 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
               %{
                 route_pill: gl_pill([:b, :c, :e]),
                 status: "3 current alerts",
-                location: "mbta.com/status"
+                location: "mbta.com/alerts"
               }
             ]
           }
@@ -656,7 +656,7 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
         | green: %{
             type: :contracted,
             alerts: [
-              %{route_pill: @gl_pill, status: "3 current alerts", location: "mbta.com/status"}
+              %{route_pill: @gl_pill, status: "3 current alerts", location: "mbta.com/alerts"}
             ]
           }
       }
@@ -706,7 +706,7 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
               %{
                 route_pill: @ol_pill,
                 status: "2 current alerts",
-                location: "mbta.com/status"
+                location: "mbta.com/alerts"
               }
             ]
           },
@@ -891,7 +891,7 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
             type: :extended,
             alert: %{
               status: "Bypassing 1 stop",
-              location: %{full: "mbta.com/status", abbrev: "mbta.com/status"},
+              location: %{full: "mbta.com/alerts", abbrev: "mbta.com/alerts"},
               route_pill: @rl_pill
             }
           }
@@ -1032,7 +1032,7 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
             type: :extended,
             alert: %{
               status: "Bypassing 2 stops",
-              location: %{full: "mbta.com/status", abbrev: "mbta.com/status"},
+              location: %{full: "mbta.com/alerts", abbrev: "mbta.com/alerts"},
               route_pill: @rl_pill
             }
           }


### PR DESCRIPTION
**Asana task**: [Subway Status: Revert URL to /alerts ](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1211373312003187?focus=true)

Description
Changed mbta.com/status to mbta.com/alerts for Subway Status widget

Effectively a revert of https://github.com/mbta/screens/pull/2569 but kept some of the extra refactoring cleanup that was done 

- [x] Tests modified?
