### PR TITLE
chore: disable "auto" behaviors in admin forms

### DIFF
--- a/assets/src/components/admin/admin_cells.tsx
+++ b/assets/src/components/admin/admin_cells.tsx
@@ -2,7 +2,7 @@ import { useRef, useMemo, useEffect } from "react";
 import { Link } from "react-router-dom";
 import _ from "lodash";
 
-import { gatherSelectOptions } from "Util/admin";
+import { AUTOLESS_ATTRIBUTES, gatherSelectOptions } from "Util/admin";
 
 const EditableCell = ({
   value: initialValue,
@@ -18,6 +18,7 @@ const EditableCell = ({
 
   return (
     <input
+      {...AUTOLESS_ATTRIBUTES}
       defaultValue={initialValue}
       className={`admin-table__column--${id}`}
       onBlur={onBlur}
@@ -40,6 +41,7 @@ const EditableList = ({
 
   return (
     <input
+      {...AUTOLESS_ATTRIBUTES}
       defaultValue={initialValue}
       className={`admin-table__column--${id}`}
       onBlur={onBlur}
@@ -66,6 +68,7 @@ const EditableNumberInput = ({
 
   return (
     <input
+      {...AUTOLESS_ATTRIBUTES}
       defaultValue={initialValue}
       className={`admin-table__column--${id}`}
       onBlur={onBlur}
@@ -146,6 +149,7 @@ const EditableTextarea = ({
 
   return (
     <textarea
+      {...AUTOLESS_ATTRIBUTES}
       className="admin-table__textarea"
       defaultValue={JSON.stringify(initialValue, null, 2)}
       onBlur={onBlur}

--- a/assets/src/components/admin/admin_form.tsx
+++ b/assets/src/components/admin/admin_form.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from "react";
-import { fetch } from "Util/admin";
+import { AUTOLESS_ATTRIBUTES, fetch } from "Util/admin";
 
 const validateJson = (json) => {
   try {
@@ -95,6 +95,7 @@ const AdminForm = ({
   return (
     <div className="admin-form">
       <textarea
+        {...AUTOLESS_ATTRIBUTES}
         ref={configRef}
         id="config"
         disabled={!editable}

--- a/assets/src/components/admin/admin_form_cells.tsx
+++ b/assets/src/components/admin/admin_form_cells.tsx
@@ -1,3 +1,5 @@
+import { AUTOLESS_ATTRIBUTES } from "Util/admin";
+
 const FormStaticCell = ({ value }) => {
   return <input defaultValue={value} disabled={true} />;
 };
@@ -11,7 +13,9 @@ const FormTextCell = ({ value, header, setFormValues }) => {
     }));
   };
 
-  return <input defaultValue={value} onBlur={onBlur} />;
+  return (
+    <input {...AUTOLESS_ATTRIBUTES} defaultValue={value} onBlur={onBlur} />
+  );
 };
 
 const buildFormSelect = (options, isNumber?) => {
@@ -82,7 +86,11 @@ const FormTextarea = ({ value, header, setFormValues }) => {
   };
 
   return (
-    <textarea onBlur={onBlur} defaultValue={JSON.stringify(value, null, 2)} />
+    <textarea
+      {...AUTOLESS_ATTRIBUTES}
+      onBlur={onBlur}
+      defaultValue={JSON.stringify(value, null, 2)}
+    />
   );
 };
 

--- a/assets/src/util/admin.tsx
+++ b/assets/src/util/admin.tsx
@@ -19,6 +19,17 @@ export type Screen = {
   vendor: string;
 };
 
+/**
+ * Set of attributes for forms and form elements which disable "auto" browser
+ * behaviors like autocomplete and spell check.
+ */
+const AUTOLESS_ATTRIBUTES = {
+  autoCapitalize: "off",
+  autoComplete: "off",
+  autoCorrect: "off",
+  spellCheck: false,
+} as const;
+
 const gatherSelectOptions = (rows, columnId) => {
   const options = rows.map((row) => row.values[columnId]);
   const uniqueOptions = new Set(options);
@@ -80,4 +91,4 @@ const doFetch = async (
   }
 };
 
-export { fetch, gatherSelectOptions };
+export { AUTOLESS_ATTRIBUTES, fetch, gatherSelectOptions };


### PR DESCRIPTION
We don't want things like spell check being applied to JSON editors, where they are more annoying than helpful.