### PR TITLE
fix: Remove v2 from dup-app.html

### DIFF
--- a/priv/dup-app.html
+++ b/priv/dup-app.html
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Screens</title>
-    <link rel="stylesheet" href="packaged_dup_v2.css" />
+    <link rel="stylesheet" href="packaged_dup.css" />
   </head>
 
   <body>
@@ -14,6 +14,6 @@
       data-last-refresh="2020-09-25T17:23:00Z"
       data-environment-name="screens-prod"
     ></div>
-    <script type="text/javascript" src="packaged_dup_v2.js"></script>
+    <script type="text/javascript" src="packaged_dup.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Just a small change I needed to make while testing an updated DUP package because of the earlier change to remove v2 from the naming in this app.