### PR TITLE
chore: increase API cache memory limits

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -503,14 +503,14 @@ config :screens, Screens.DeviceMonitor.Store, backend: Screens.DeviceMonitor.Sto
 # should be tweaked as the V3 API usage patterns and requirements of the app change over time.
 
 config :screens, Screens.V3Api.Cache.Realtime,
-  allocated_memory: 50 * 1024 * 1024,
+  allocated_memory: 100 * 1024 * 1024,
   gc_interval: :timer.seconds(30),
   gc_memory_check_interval: :timer.seconds(5),
   stats: true,
   telemetry_prefix: ~w[screens v3_api cache]a
 
 config :screens, Screens.V3Api.Cache.Static,
-  allocated_memory: 150 * 1024 * 1024,
+  allocated_memory: 250 * 1024 * 1024,
   gc_interval: :timer.hours(1),
   stats: true,
   telemetry_prefix: ~w[screens v3_api cache]a


### PR DESCRIPTION
Prod metrics indicate the static data cache is often far above its memory limit. This is allowed to happen temporarily, since the memory check happens on a 10-second interval, but the cache consistently spending a lot of time above the limit could indicate some degree of thrashing, and means if we have some memory to spare we could trade it off for speed (since cached requests are served much faster).

The previous memory limits were established when instances had 1GB of memory allocated, but they now have 2GB and we are almost never using more than 50% of it, so it should be fine to bump these up.