### PR TITLE
feat: FE for CR Shuttle Pill on LCDs and DUPs

### DIFF
--- a/assets/css/common/route_pill_mixins.scss
+++ b/assets/css/common/route_pill_mixins.scss
@@ -1,0 +1,55 @@
+@use "CSS/colors";
+
+@mixin pill-background-colors {
+  &--blue {
+    background-color: colors.$line-blue;
+  }
+
+  &--green {
+    background-color: colors.$line-green;
+  }
+
+  &--ocean_blue {
+    background-color: colors.$line-capeflyer;
+  }
+
+  &--orange {
+    background-color: colors.$line-orange;
+  }
+
+  &--purple {
+    background-color: colors.$line-cr;
+  }
+
+  &--red {
+    background-color: colors.$line-red;
+  }
+
+  &--silver {
+    background-color: colors.$line-silver;
+  }
+
+  &--teal {
+    background-color: colors.$line-ferry;
+  }
+
+  &--yellow {
+    background-color: colors.$line-bus;
+  }
+}
+
+@mixin pill-text-colors {
+  &--yellow {
+    color: black;
+  }
+
+  &--blue,
+  &--green,
+  &--orange,
+  &--purple,
+  &--red,
+  &--silver,
+  &--teal {
+    color: white;
+  }
+}

--- a/assets/css/dup/departures/destination.scss
+++ b/assets/css/dup/departures/destination.scss
@@ -10,7 +10,7 @@
 
   // The width of the destination is reduced if either/both of the
   // route pill and time columns need to take up more space.
-   .departure-row--extended-route_pill & {
+  .departure-row--extended-route_pill & {
     width: 970px;
   }
 

--- a/assets/css/dup/departures/destination.scss
+++ b/assets/css/dup/departures/destination.scss
@@ -8,8 +8,18 @@
   color: colors.$cool-black-15;
   white-space: nowrap;
 
-  .departures-section--shortened-headsigns & {
+  // The width of the destination is reduced if either/both of the
+  // route pill and time columns need to take up more space.
+   .departure-row--extended-route_pill & {
+    width: 970px;
+  }
+
+  .departures-section--extended-times & {
     width: 843px;
+  }
+
+  .departure-row--extended-route_pill.departures-section--extended-times & {
+    width: 743px;
   }
 }
 

--- a/assets/css/dup/departures/destination.scss
+++ b/assets/css/dup/departures/destination.scss
@@ -11,7 +11,7 @@
   // The width of the destination is reduced if either/both of the
   // route pill and time columns need to take up more space.
   .departure-row--extended-route_pill & {
-    width: 970px;
+    width: 967px;
   }
 
   .departures-section--extended-times & {
@@ -19,7 +19,7 @@
   }
 
   .departure-row--extended-route_pill.departures-section--extended-times & {
-    width: 743px;
+    width: 740px;
   }
 }
 

--- a/assets/css/dup/departures/route_pill.scss
+++ b/assets/css/dup/departures/route_pill.scss
@@ -5,8 +5,8 @@
   position: relative;
   width: 100%;
   height: 100%;
-  border-radius: 100px;
   font-family: Helvetica, sans-serif;
+  border-radius: 100px;
 
   @include mixins.pill-background-colors;
 
@@ -104,7 +104,6 @@
 
 .route-pill__dual-text {
   position: absolute;
-  font-family: Helvetica, sans-serif;
   width: 248px;
   height: 128px;
   font-size: 96px;

--- a/assets/css/dup/departures/route_pill.scss
+++ b/assets/css/dup/departures/route_pill.scss
@@ -1,43 +1,13 @@
 @use "CSS/colors";
+@use "CSS/common/route_pill_mixins" as mixins;
 
 .route-pill {
   position: relative;
-  width: 248px;
-  height: 144px;
-  margin: 32px;
+  width: 100%;
+  height: 100%;
   border-radius: 100px;
 
-  &--blue {
-    background-color: colors.$line-blue;
-  }
-
-  &--green {
-    background-color: colors.$line-green;
-  }
-
-  &--ocean_blue {
-    background-color: colors.$line-capeflyer;
-  }
-
-  &--orange {
-    background-color: colors.$line-orange;
-  }
-
-  &--purple {
-    background-color: colors.$line-cr;
-  }
-
-  &--red {
-    background-color: colors.$line-red;
-  }
-
-  &--silver {
-    background-color: colors.$line-silver;
-  }
-
-  &--teal {
-    background-color: colors.$line-ferry;
-  }
+  @include mixins.pill-background-colors;
 
   &--yellow {
     width: 280px;
@@ -125,4 +95,48 @@
     font-size: 28px;
     line-height: 64px;
   }
+}
+
+.route-pill__dual-container {
+  width: 100%;
+  height: 100%;
+  padding-top: 8px;
+}
+
+.route-pill__dual-text {
+  position: absolute;
+  width: 248px;
+  height: 128px;
+  font-size: 96px;
+  font-weight: 700;
+  line-height: 128px;
+  text-align: center;
+  clip-path: path(
+    "M235.745 10.6577C225.611 3.92349 213.448 0 200.368 0H64C28.6538 0 0 28.6538 0 64C0 99.3462 28.6537 128 63.9999 128H200.368C213.448 128 225.611 124.076 235.745 117.342C221.792 103.846 213.118 84.9349 213.118 63.9999C213.118 43.065 221.791 24.1539 235.745 10.6577Z"
+  );
+
+  @include mixins.pill-text-colors;
+  @include mixins.pill-background-colors;
+
+  &--small {
+    font-size: 84px;
+  }
+}
+
+.route-pill__dual-secondary {
+  position: absolute;
+  right: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 128px;
+  height: 128px;
+  border-radius: 50%;
+  box-shadow: 2px 4px 2px 0 rgb(0 0 0 / 25%);
+
+  @include mixins.pill-background-colors;
+}
+
+.route-pill__dual-secondary-image {
+  height: 104px;
 }

--- a/assets/css/dup/departures/route_pill.scss
+++ b/assets/css/dup/departures/route_pill.scss
@@ -6,6 +6,7 @@
   width: 100%;
   height: 100%;
   border-radius: 100px;
+  font-family: Helvetica, sans-serif;
 
   @include mixins.pill-background-colors;
 
@@ -26,18 +27,17 @@
 .route-pill__text {
   position: absolute;
   width: 100%;
-  font-family: Helvetica, sans-serif;
   font-size: 96px;
   font-weight: 700;
   line-height: 144px;
-  color: white;
   text-align: center;
   letter-spacing: 0.0277em;
+
+  @include mixins.pill-text-colors;
 
   &--yellow {
     font-size: 128px;
     line-height: 168px;
-    color: black;
   }
 
   &--green,
@@ -60,7 +60,6 @@
 .route-pill__slashed-text {
   position: absolute;
   width: 100%;
-  font-family: Helvetica, sans-serif;
   font-size: 32px;
   font-weight: 700;
   line-height: 74px;
@@ -105,6 +104,7 @@
 
 .route-pill__dual-text {
   position: absolute;
+  font-family: Helvetica, sans-serif;
   width: 248px;
   height: 128px;
   font-size: 96px;

--- a/assets/css/dup/departures/row.scss
+++ b/assets/css/dup/departures/row.scss
@@ -23,7 +23,7 @@
   vertical-align: middle;
 
   .departure-row--extended-route_pill & {
-    width: 348px;
+    width: 351px;
   }
 }
 

--- a/assets/css/dup/departures/row.scss
+++ b/assets/css/dup/departures/row.scss
@@ -17,7 +17,14 @@
 
 .departure-row__route {
   display: inline-block;
+  width: 248px;
+  height: 144px;
+  margin: 32px;
   vertical-align: middle;
+
+  .departure-row--extended-route_pill & {
+    width: 348px;
+  }
 }
 
 .departure-row__destination {
@@ -34,7 +41,7 @@
   color: colors.$cool-black-15;
   text-align: right;
 
-  .departures-section--shortened-headsigns & {
+  .departures-section--extended-times & {
     width: 733px;
   }
 }

--- a/assets/css/lcd/departures/destination.scss
+++ b/assets/css/lcd/departures/destination.scss
@@ -1,9 +1,5 @@
 @use "CSS/colors";
 
-.departure-destination {
-  width: 520px;
-}
-
 .departure-destination__headsign {
   padding-bottom: 6px;
   overflow: hidden;

--- a/assets/css/lcd/departures/row.scss
+++ b/assets/css/lcd/departures/row.scss
@@ -9,23 +9,28 @@
   margin-left: 32px;
 }
 
+.departure-row {
+  display: grid;
+  grid-template-columns: 144px 520px 302px;
+  column-gap: 24px;
+  padding-right: 32px;
+  padding-left: 32px;
+
+  &--wide-pill {
+    grid-template-columns: 198px 466px 302px;
+  }
+}
+
 .departure-row__route {
-  display: inline-block;
+  height: 74px;
   margin-top: 27px;
-  margin-left: 32px;
-  vertical-align: top;
 }
 
 .departure-row__destination {
-  display: inline-block;
   margin-top: 32px;
-  margin-left: 24px;
-  vertical-align: top;
 }
 
 .departure-row__time {
-  display: inline-block;
+  justify-self: end;
   margin-top: 32px;
-  margin-right: 32px;
-  vertical-align: top;
 }

--- a/assets/css/lcd/departures/section.scss
+++ b/assets/css/lcd/departures/section.scss
@@ -14,7 +14,7 @@
     border-radius: 2px;
   }
 
-  & > .departure-row.direction-split::after {
+  & > .departure-row--direction-split::after {
     left: 0;
     width: 100%;
     background-color: colors.$true-grey-70;

--- a/assets/css/lcd/route_pill.scss
+++ b/assets/css/lcd/route_pill.scss
@@ -1,45 +1,15 @@
 @use "CSS/colors";
+@use "CSS/common/route_pill_mixins" as mixins;
 
 .route-pill {
   position: relative;
-  width: 144px;
-  height: 74px;
+  width: 100%;
+  height: 100%;
   border-radius: 100px;
 
-  &--blue {
-    background-color: colors.$line-blue;
-  }
-
-  &--green {
-    background-color: colors.$line-green;
-  }
-
-  &--ocean_blue {
-    background-color: colors.$line-capeflyer;
-  }
-
-  &--orange {
-    background-color: colors.$line-orange;
-  }
-
-  &--purple {
-    background-color: colors.$line-cr;
-  }
-
-  &--red {
-    background-color: colors.$line-red;
-  }
-
-  &--silver {
-    background-color: colors.$line-silver;
-  }
-
-  &--teal {
-    background-color: colors.$line-ferry;
-  }
+  @include mixins.pill-background-colors;
 
   &--yellow {
-    background-color: colors.$line-bus;
     box-shadow: 2px 4px 2px 0 rgb(0 0 0 / 25%);
   }
 
@@ -62,19 +32,7 @@
   line-height: 74px;
   text-align: center;
 
-  &--yellow {
-    color: black;
-  }
-
-  &--blue,
-  &--green,
-  &--orange,
-  &--purple,
-  &--red,
-  &--silver,
-  &--teal {
-    color: white;
-  }
+  @include mixins.pill-text-colors;
 
   &--outline {
     color: colors.$cool-black-30;
@@ -107,6 +65,52 @@
 
 .route-pill__slashed-part-2 {
   display: inline-block;
+}
+
+.route-pill__dual-container {
+  width: 100%;
+  height: 100%;
+}
+
+.route-pill__dual-text {
+  position: absolute;
+  width: 144px;
+  font-size: 48px;
+  font-weight: 700;
+  line-height: 74px;
+  text-align: center;
+  clip-path: path(
+    "M 0 37 C 0 16.565 16.565 0 37 0 L 112 0 C 119.386 0 126.189 2.195 131.857 5.961 C 124.053 13.51 119.201 24.087 119.201 35.797 C 119.201 47.506 124.053 58.083 131.857 65.632 C 126.189 69.399 119.386 71.593 112 71.593 L 37 71.593 C 16.565 71.593 0 55.028 0 34.593 Z"
+  );
+
+  @include mixins.pill-text-colors;
+  @include mixins.pill-background-colors;
+
+  &--small {
+    font-size: 42px;
+  }
+
+  &--large {
+    font-size: 48px;
+  }
+}
+
+.route-pill__dual-secondary {
+  position: absolute;
+  right: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 72px;
+  height: 72px;
+  border-radius: 50%;
+  box-shadow: 2px 4px 2px 0 rgb(0 0 0 / 25%);
+
+  @include mixins.pill-background-colors;
+}
+
+.route-pill__dual-secondary-image {
+  height: 52px;
 }
 
 .alert-widget__content__route-pills--small {

--- a/assets/src/components/departures/departure_row.tsx
+++ b/assets/src/components/departures/departure_row.tsx
@@ -3,6 +3,7 @@ import type { ComponentType } from "react";
 import RoutePill, { Pill } from "./route_pill";
 import Destination from "./destination";
 import DepartureTimes, { TimeWithCrowding } from "./departure_times";
+import { classWithModifiers } from "Util/utils";
 
 type DepartureRow = {
   id: string;
@@ -21,11 +22,7 @@ const DepartureRow: ComponentType<DepartureRow> = ({
   times_with_crowding: timesWithCrowding,
 }) => {
   return (
-    <div
-      className={
-        "departure-row" + (isBeforeDirectionSplit ? " direction-split" : "")
-      }
-    >
+    <div className={departureRowClassName(route, isBeforeDirectionSplit)}>
       <div className="departure-row__route">
         <RoutePill pill={route} />
       </div>
@@ -37,6 +34,20 @@ const DepartureRow: ComponentType<DepartureRow> = ({
       </div>
     </div>
   );
+};
+
+const departureRowClassName = (
+  route: Pill,
+  isBeforeDirectionSplit: boolean,
+) => {
+  let modifiers: String[] = [];
+  if (route.type === "dual") {
+    modifiers.push("wide-pill");
+  }
+  if (isBeforeDirectionSplit) {
+    modifiers.push("direction-split");
+  }
+  return classWithModifiers("departure-row", modifiers);
 };
 
 export default DepartureRow;

--- a/assets/src/components/departures/departure_row.tsx
+++ b/assets/src/components/departures/departure_row.tsx
@@ -40,7 +40,7 @@ const departureRowClassName = (
   route: Pill,
   isBeforeDirectionSplit: boolean,
 ) => {
-  let modifiers: String[] = [];
+  const modifiers: string[] = [];
   if (route.type === "dual") {
     modifiers.push("wide-pill");
   }

--- a/assets/src/components/departures/route_pill.tsx
+++ b/assets/src/components/departures/route_pill.tsx
@@ -101,14 +101,15 @@ const DualRouteIconPill: ComponentType<DualPill> = ({
   secondary_color: secondaryColor,
 }) => {
   const iconSrc = imagePath(pathForIcon[icon]);
-  const textModifiers: string[] = [color];
+
   const routeNum = Number(text);
+  const textModifiers: string[] = [color];
   if (isNaN(routeNum)) {
     textModifiers.push(text.length > 3 ? "small" : "large");
   } else {
     textModifiers.push("large");
   }
-  classWithModifiers("route-pill__dual-primary-pill", textModifiers);
+
   return (
     <div className="route-pill__dual-container">
       <div

--- a/assets/src/components/departures/route_pill.tsx
+++ b/assets/src/components/departures/route_pill.tsx
@@ -108,7 +108,7 @@ const DualRouteIconPill: ComponentType<DualPill> = ({
   } else {
     textModifiers.push("large");
   }
-  classWithModifiers("route-pill__dual-text-pill", textModifiers);
+  classWithModifiers("route-pill__dual-primary-pill", textModifiers);
   return (
     <div className="route-pill__dual-container">
       <div
@@ -143,22 +143,11 @@ type Props = {
 };
 
 const RoutePill: ComponentType<Props> = ({ pill, outline, useRouteAbbrev }) => {
-  // TODO: Remove debug log
-  console.log(
-    "Rendering RoutePill with pill:",
-    pill,
-    "outline:",
-    outline,
-    "useRouteAbbrev:",
-    useRouteAbbrev,
-  );
-
   const modifiers: string[] = pill.type == "dual" ? ["dual"] : [pill.color];
   if (outline) modifiers.push("outline");
 
   let innerContent: JSX.Element | null = null;
   let branches: JSX.Element[] | null = null;
-  let secondaryIcon: JSX.Element | null = null;
 
   if (useRouteAbbrev && pill.route_abbrev) {
     innerContent = (

--- a/assets/src/components/departures/route_pill.tsx
+++ b/assets/src/components/departures/route_pill.tsx
@@ -5,7 +5,8 @@ import { imagePath, classWithModifiers } from "Util/utils";
 type Pill =
   | (TextPill & { type: "text" })
   | (IconPill & { type: "icon" })
-  | (SlashedPill & { type: "slashed" });
+  | (SlashedPill & { type: "slashed" })
+  | (DualPill & { type: "dual" });
 
 interface BasePill {
   color: Color;
@@ -20,6 +21,12 @@ interface TextPill extends BasePill {
 
 interface IconPill extends BasePill {
   icon: PillIcon;
+}
+
+interface DualPill extends BasePill {
+  text: string;
+  icon: PillIcon;
+  secondary_color: Color;
 }
 
 interface SlashedPill extends BasePill {
@@ -87,6 +94,39 @@ const IconRoutePill: ComponentType<IconPill> = ({ icon }) => {
   );
 };
 
+const DualRouteIconPill: ComponentType<DualPill> = ({
+  text,
+  icon,
+  color,
+  secondary_color: secondaryColor,
+}) => {
+  const iconSrc = imagePath(pathForIcon[icon]);
+  const textModifiers: string[] = [color];
+  const routeNum = Number(text);
+  if (isNaN(routeNum)) {
+    textModifiers.push(text.length > 3 ? "small" : "large");
+  } else {
+    textModifiers.push("large");
+  }
+  classWithModifiers("route-pill__dual-text-pill", textModifiers);
+  return (
+    <div className="route-pill__dual-container">
+      <div
+        className={classWithModifiers("route-pill__dual-text", textModifiers)}
+      >
+        {text}
+      </div>
+      <div
+        className={classWithModifiers("route-pill__dual-secondary", [
+          secondaryColor,
+        ])}
+      >
+        <img className="route-pill__dual-secondary-image" src={iconSrc} />
+      </div>
+    </div>
+  );
+};
+
 const SlashedRoutePill: ComponentType<SlashedPill> = ({ part1, part2 }) => {
   return (
     <div className="route-pill__slashed-text">
@@ -103,11 +143,22 @@ type Props = {
 };
 
 const RoutePill: ComponentType<Props> = ({ pill, outline, useRouteAbbrev }) => {
-  const modifiers: string[] = [pill.color];
+  // TODO: Remove debug log
+  console.log(
+    "Rendering RoutePill with pill:",
+    pill,
+    "outline:",
+    outline,
+    "useRouteAbbrev:",
+    useRouteAbbrev,
+  );
+
+  const modifiers: string[] = pill.type == "dual" ? ["dual"] : [pill.color];
   if (outline) modifiers.push("outline");
 
   let innerContent: JSX.Element | null = null;
   let branches: JSX.Element[] | null = null;
+  let secondaryIcon: JSX.Element | null = null;
 
   if (useRouteAbbrev && pill.route_abbrev) {
     innerContent = (
@@ -125,6 +176,10 @@ const RoutePill: ComponentType<Props> = ({ pill, outline, useRouteAbbrev }) => {
 
       case "icon":
         innerContent = <IconRoutePill {...pill} />;
+        break;
+
+      case "dual":
+        innerContent = <DualRouteIconPill {...pill} />;
         break;
 
       case "slashed":
@@ -167,6 +222,8 @@ const routePillKey = (pill: Pill): string => {
       return pill.text;
     case "icon":
       return pill.icon;
+    case "dual":
+      return `${pill.text}-${pill.icon}`;
     case "slashed":
       return `${pill.part1}-${pill.part2}`;
   }

--- a/assets/src/components/departures/route_pill.tsx
+++ b/assets/src/components/departures/route_pill.tsx
@@ -143,7 +143,7 @@ type Props = {
 };
 
 const RoutePill: ComponentType<Props> = ({ pill, outline, useRouteAbbrev }) => {
-  const modifiers: string[] = pill.type == "dual" ? ["dual"] : [pill.color];
+  const modifiers: string[] = pill.type === "dual" ? ["dual"] : [pill.color];
   if (outline) modifiers.push("outline");
 
   let innerContent: JSX.Element | null = null;

--- a/assets/src/components/dup/departures/departure_row.tsx
+++ b/assets/src/components/dup/departures/departure_row.tsx
@@ -2,8 +2,9 @@ import type { ComponentType } from "react";
 
 import type DepartureRowBase from "Components/departures/departure_row";
 import DepartureTimes from "Components/departures/departure_times";
-import RoutePill from "Components/departures/route_pill";
+import RoutePill, { Pill } from "Components/departures/route_pill";
 import Destination from "./destination";
+import { classWithModifiers } from "Util/utils";
 
 const DepartureRow: ComponentType<DepartureRowBase> = ({
   headsign,
@@ -11,8 +12,13 @@ const DepartureRow: ComponentType<DepartureRowBase> = ({
   times_with_crowding: timesWithCrowding,
   is_first_trip: isFirstTrip,
 }) => {
+  let classModifiers: String[] = [];
+  if (wideRoutePill(route)) {
+    classModifiers.push("extended-route_pill");
+  }
+
   return (
-    <div className="departure-row">
+    <div className={classWithModifiers("departure-row", classModifiers)}>
       <div className="departure-row__route">
         <RoutePill pill={route} />
       </div>
@@ -26,5 +32,7 @@ const DepartureRow: ComponentType<DepartureRowBase> = ({
     </div>
   );
 };
+
+const wideRoutePill = (route_pill: Pill) => route_pill.type === "dual";
 
 export default DepartureRow;

--- a/assets/src/components/dup/departures/departure_row.tsx
+++ b/assets/src/components/dup/departures/departure_row.tsx
@@ -2,9 +2,9 @@ import type { ComponentType } from "react";
 
 import type DepartureRowBase from "Components/departures/departure_row";
 import DepartureTimes from "Components/departures/departure_times";
-import RoutePill, { Pill } from "Components/departures/route_pill";
+import RoutePill from "Components/departures/route_pill";
 import Destination from "./destination";
-import { classWithModifiers } from "Util/utils";
+import { classWithModifier } from "Util/utils";
 
 const DepartureRow: ComponentType<DepartureRowBase> = ({
   headsign,
@@ -12,13 +12,11 @@ const DepartureRow: ComponentType<DepartureRowBase> = ({
   times_with_crowding: timesWithCrowding,
   is_first_trip: isFirstTrip,
 }) => {
-  let classModifiers: String[] = [];
-  if (wideRoutePill(route)) {
-    classModifiers.push("extended-route_pill");
-  }
+  const parentClassModifier =
+    route.type === "dual" ? "extended-route_pill" : "";
 
   return (
-    <div className={classWithModifiers("departure-row", classModifiers)}>
+    <div className={classWithModifier("departure-row", parentClassModifier)}>
       <div className="departure-row__route">
         <RoutePill pill={route} />
       </div>
@@ -32,7 +30,5 @@ const DepartureRow: ComponentType<DepartureRowBase> = ({
     </div>
   );
 };
-
-const wideRoutePill = (route_pill: Pill) => route_pill.type === "dual";
 
 export default DepartureRow;

--- a/assets/src/components/dup/departures/normal_section.tsx
+++ b/assets/src/components/dup/departures/normal_section.tsx
@@ -11,17 +11,20 @@ import { classWithModifier } from "Util/utils";
 const NormalSection: ComponentType<Props> = ({ rows }) => {
   if (rows.length === 0) return null;
 
-  const classModifier = shortenHeadsignsForSection(rows)
-    ? "shortened-headsigns"
-    : "";
+  const classModifiers: String[] = [];
+  if (shortenHeadsignsForSection(rows)) {
+    classModifiers.push("extended-times");
+  }
 
   return (
-    <div className={classWithModifier("departures-section", classModifier)}>
+    <div className={classWithModifier("departures-section", classModifiers)}>
       {rows.map((row, index) => {
         if (row.type === "departure_row") {
           // When the available width for headsigns changes, re-render the
           // departures so headsign abbreviation will be redone.
-          return <DepartureRow {...row} key={row.id + classModifier} />;
+          return (
+            <DepartureRow {...row} key={row.id + classModifiers.join("-")} />
+          );
         } else {
           return <NoticeRow row={row} key={"notice" + index} />;
         }
@@ -40,5 +43,4 @@ const shortenHeadsignsForSection = (rows: Row[]) => {
         row.is_first_trip),
   );
 };
-
 export default NormalSection;

--- a/assets/src/components/dup/departures/normal_section.tsx
+++ b/assets/src/components/dup/departures/normal_section.tsx
@@ -11,20 +11,15 @@ import { classWithModifier } from "Util/utils";
 const NormalSection: ComponentType<Props> = ({ rows }) => {
   if (rows.length === 0) return null;
 
-  const classModifiers: String[] = [];
-  if (shortenHeadsignsForSection(rows)) {
-    classModifiers.push("extended-times");
-  }
+  const classModifier = sectionHasWideTimeCol(rows) ? "extended-times" : "";
 
   return (
-    <div className={classWithModifier("departures-section", classModifiers)}>
+    <div className={classWithModifier("departures-section", classModifier)}>
       {rows.map((row, index) => {
         if (row.type === "departure_row") {
           // When the available width for headsigns changes, re-render the
           // departures so headsign abbreviation will be redone.
-          return (
-            <DepartureRow {...row} key={row.id + classModifiers.join("-")} />
-          );
+          return <DepartureRow {...row} key={row.id + classModifier} />;
         } else {
           return <NoticeRow row={row} key={"notice" + index} />;
         }
@@ -33,8 +28,8 @@ const NormalSection: ComponentType<Props> = ({ rows }) => {
   );
 };
 
-const shortenHeadsignsForSection = (rows: Row[]) => {
-  // Stop away messages and First Trip text take up a larger block of space,
+const sectionHasWideTimeCol = (rows: Row[]) => {
+  // Stop away messages, headway information, and First Trip text take up a larger block of space,
   // so we need to shorten the space designated for headsigns.
   return rows.some(
     (row) =>
@@ -43,4 +38,5 @@ const shortenHeadsignsForSection = (rows: Row[]) => {
         row.is_first_trip),
   );
 };
+
 export default NormalSection;


### PR DESCRIPTION
**Asana task**: [Departures: CR Shuttle Pill Icon](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1209370311249958?focus=true)

### Summary
Adds logic to our Frontend to add the split CR Shuttle pill to our LCD and DUP screens. Though we have done similar types of pills as SVGs for our e-ink screens, I made this a reusable React component that uses the `clip-path` from the associated Figma files to create the proper route pill shape.
The CSS for this is handled differently on DUPs and our other LCD screens. This frontend change will need to be deployed to DUPs before we make the relevant BE change.

### Breakdown of Changes
- Added `@mixin` for route_pill background and text colors, since these are re-used multiple places
- Adds a new type of `dual` route pill (open to naming changes here). This is currently set up to just take text for the primary pill and an icon for the secondary circle pill, but this would be easily modifiable in the future.
- LCD specific Changes
  - Modifies the CSS within `departures/row.scss` to use a grid layout. Shortens the departures row when there is a dual route pill
- DUP Specific Changes
  -  Since grid layouts aren't supported until Chrome 57 and DUPs are stuck on 51, we could not use the same approach with these. We also already have a way to shorten headsigns for an entire section when there is an extended time column. However, in this case, we only want to shorten headsigns for a specific row rather than the entire section. 

### Examples
Note for the examples below, I had the BE `Enum.random`ly return some route pills as dual pills with the color of their actual route, which is why their colors differ. 

#### Sectional
<img width="598" height="772" alt="WASHINGTON ST @ ESSEX ST" src="https://github.com/user-attachments/assets/6a5dbc8e-fa5b-4c91-b69f-8af6577a9742" />

#### DUP
<img width="1062" height="596" alt="image" src="https://github.com/user-attachments/assets/39cb03f2-8273-4e52-96b1-2498175c4070" />
