### PR TITLE
chore: Bump DUP version 

### DIFF
--- a/assets/src/components/dup/version.ts
+++ b/assets/src/components/dup/version.ts
@@ -6,4 +6,4 @@
  * to help determine which version of the client a given DUP data request is
  * coming from.
  */
-export const DUP_VERSION = "26.04.15.1";
+export const DUP_VERSION = "26.04.16.1";

--- a/assets/src/components/dup/version.ts
+++ b/assets/src/components/dup/version.ts
@@ -6,4 +6,4 @@
  * to help determine which version of the client a given DUP data request is
  * coming from.
  */
-export const DUP_VERSION = "26.02.11.1";
+export const DUP_VERSION = "26.04.15.1";


### PR DESCRIPTION
Forgot to bump the DUP version with my previous change to add shuttle pill styling to the DUPs. 

Still waiting on Outfront for a confirmation that this version works on hardware, but will commit the bump when everything is in order. Should be in order since everything is working fine on Chrome 51 in Browserstack