### PR TITLE
feat: RDS Last Trip tracking

### DIFF
--- a/lib/screens/application.ex
+++ b/lib/screens/application.ex
@@ -14,6 +14,7 @@ defmodule Screens.Application do
         {Finch, name: Screens.V3Api.Finch, pools: %{:default => [start_pool_metrics?: true]}},
         Screens.V3Api.Cache.Realtime,
         Screens.V3Api.Cache.Static,
+        Screens.LastTrip.Cache,
         # Task supervisor for ScreensByAlert async updates
         {Task.Supervisor, name: Screens.ScreensByAlert.Memcache.TaskSupervisor},
         # ScreensByAlert server process

--- a/lib/screens/last_trip/cache.ex
+++ b/lib/screens/last_trip/cache.ex
@@ -1,0 +1,13 @@
+defmodule Screens.LastTrip.Cache do
+  @moduledoc """
+  Cache of departures times for predictions where `last_trip` is true
+  """
+  use Nebulex.Cache,
+    otp_app: :screens,
+    adapter: Nebulex.Adapters.Local
+
+  alias Screens.V2.RDS
+
+  @type key :: destination :: RDS.destination_key()
+  @type value :: departure_times :: [DateTime.t()]
+end

--- a/lib/screens/last_trip/last_trip.ex
+++ b/lib/screens/last_trip/last_trip.ex
@@ -1,0 +1,50 @@
+defmodule Screens.LastTrip.LastTrip do
+  @moduledoc """
+  Last Trip of the Day cache interface
+  """
+  alias Screens.LastTrip.Cache
+  alias Screens.Predictions.Prediction
+  alias Screens.V2.Departure
+  alias Screens.V2.RDS
+
+  @callback update_last_trip_cache([Departure.t()], DateTime.t()) :: :ok
+  def update_last_trip_cache(departures, now) do
+    departures
+    |> Enum.filter(&Departure.last_trip?(&1))
+    |> Enum.group_by(
+      &{Departure.stop(&1).id, Departure.route(&1).line.id,
+       Departure.representative_headsign(&1)},
+      fn %Departure{prediction: %Prediction{departure_time: departure_time}} -> departure_time end
+    )
+    |> Enum.each(fn {destination_key, new_departure_times} ->
+      if Cache.get(destination_key, nil) != new_departure_times do
+        Cache.put(destination_key, new_departure_times, ttl: time_to_service_end(now))
+      end
+    end)
+
+    :ok
+  end
+
+  @callback last_trip_departure_times(RDS.destination_key()) :: DateTime.t() | nil
+  def last_trip_departure_times(destination_key) do
+    case Cache.get(destination_key) do
+      {:ok, nil} -> nil
+      {:ok, departure_times} -> departure_times
+    end
+  end
+
+  defp time_to_service_end(%DateTime{time_zone: time_zone} = now) do
+    service_end_time =
+      now
+      |> DateTime.to_date()
+      |> DateTime.new!(~T[04:00:00], time_zone)
+
+    if DateTime.compare(now, service_end_time) == :gt do
+      service_end_time
+      |> DateTime.add(1, :day)
+      |> DateTime.diff(now, :millisecond)
+    else
+      DateTime.diff(service_end_time, now, :millisecond)
+    end
+  end
+end

--- a/lib/screens/last_trip/last_trip.ex
+++ b/lib/screens/last_trip/last_trip.ex
@@ -1,0 +1,70 @@
+defmodule Screens.LastTrip.LastTrip do
+  @moduledoc """
+  Last Trip of the Day cache interface
+  """
+  alias Screens.LastTrip.Cache
+  alias Screens.Predictions.Prediction
+  alias Screens.V2.Departure
+  alias Screens.V2.RDS
+
+  @callback update_last_trip_cache([Departure.t()], DateTime.t()) :: :ok
+  def update_last_trip_cache(departures, now) do
+    departures
+    |> Enum.filter(&Departure.last_trip?(&1))
+    |> Enum.group_by(
+      &{Departure.stop(&1).id, Departure.route(&1).line.id,
+       Departure.representative_headsign(&1)},
+      fn %Departure{prediction: %Prediction{departure_time: departure_time}} = departure ->
+        {Departure.trip_id(departure), departure_time}
+      end
+    )
+    |> Enum.each(fn {destination_key, last_trip_departure_times} ->
+      last_trip_departure_map = Map.new(last_trip_departure_times)
+
+      Cache.transaction(
+        fn ->
+          Cache.get_and_update(
+            destination_key,
+            fn current_value ->
+              updated_value =
+                if is_nil(current_value) do
+                  last_trip_departure_map
+                else
+                  Map.merge(current_value, last_trip_departure_map)
+                end
+
+              {current_value, updated_value}
+            end,
+            ttl: time_to_service_end(now)
+          )
+        end,
+        keys: [destination_key]
+      )
+    end)
+
+    :ok
+  end
+
+  @callback last_trip_departure_times(RDS.destination_key()) :: [DateTime.t()]
+  def last_trip_departure_times(destination_key) do
+    case Cache.get(destination_key) do
+      {:ok, nil} -> []
+      {:ok, departure_times_by_trip_id} -> Map.values(departure_times_by_trip_id)
+    end
+  end
+
+  defp time_to_service_end(%DateTime{time_zone: time_zone} = now) do
+    service_end_time =
+      now
+      |> DateTime.to_date()
+      |> DateTime.new!(~T[04:00:00], time_zone)
+
+    if DateTime.compare(now, service_end_time) == :gt do
+      service_end_time
+      |> DateTime.add(1, :day)
+    else
+      service_end_time
+    end
+    |> DateTime.diff(now, :millisecond)
+  end
+end

--- a/lib/screens/predictions/parser.ex
+++ b/lib/screens/predictions/parser.ex
@@ -10,6 +10,7 @@ defmodule Screens.Predictions.Parser do
           "attributes" => %{
             "arrival_time" => arrival_time_string,
             "departure_time" => departure_time_string,
+            "last_trip" => last_trip,
             "schedule_relationship" => schedule_relationship,
             "status" => status
           },
@@ -33,6 +34,7 @@ defmodule Screens.Predictions.Parser do
       arrival_time: parse_time(arrival_time_string),
       departure_time: parse_time(departure_time_string),
       track_number: stop.platform_code,
+      last_trip: last_trip,
       schedule_relationship: ScheduleRelationship.parse(schedule_relationship),
       status: status
     }

--- a/lib/screens/predictions/parser.ex
+++ b/lib/screens/predictions/parser.ex
@@ -10,6 +10,7 @@ defmodule Screens.Predictions.Parser do
           "attributes" => %{
             "arrival_time" => arrival_time_string,
             "departure_time" => departure_time_string,
+            "last_trip" => last_trip,
             "schedule_relationship" => schedule_relationship,
             "status" => status,
             "trip_headsign" => trip_headsign
@@ -34,6 +35,7 @@ defmodule Screens.Predictions.Parser do
       arrival_time: parse_time(arrival_time_string),
       departure_time: parse_time(departure_time_string),
       track_number: stop.platform_code,
+      last_trip: last_trip,
       schedule_relationship: ScheduleRelationship.parse(schedule_relationship),
       status: status,
       trip_headsign: trip_headsign

--- a/lib/screens/predictions/prediction.ex
+++ b/lib/screens/predictions/prediction.ex
@@ -15,7 +15,8 @@ defmodule Screens.Predictions.Prediction do
             stop_headsign: nil,
             track_number: nil,
             schedule_relationship: :scheduled,
-            status: nil
+            status: nil,
+            last_trip: false
 
   @type t :: %__MODULE__{
           id: String.t(),
@@ -28,7 +29,8 @@ defmodule Screens.Predictions.Prediction do
           stop_headsign: String.t() | nil,
           track_number: String.t() | nil,
           schedule_relationship: ScheduleRelationship.t(),
-          status: String.t() | nil
+          status: String.t() | nil,
+          last_trip: boolean()
         }
 
   @includes ~w[route.line stop trip.route_pattern.representative_trip trip.stops vehicle]

--- a/lib/screens/predictions/prediction.ex
+++ b/lib/screens/predictions/prediction.ex
@@ -15,7 +15,8 @@ defmodule Screens.Predictions.Prediction do
             track_number: nil,
             schedule_relationship: :scheduled,
             status: nil,
-            trip_headsign: nil
+            trip_headsign: nil,
+            last_trip: false
 
   @type t :: %__MODULE__{
           id: String.t(),
@@ -28,7 +29,8 @@ defmodule Screens.Predictions.Prediction do
           track_number: String.t() | nil,
           schedule_relationship: ScheduleRelationship.t(),
           status: String.t() | nil,
-          trip_headsign: String.t() | nil
+          trip_headsign: String.t() | nil,
+          last_trip: boolean()
         }
 
   @includes ~w[route.line stop trip.route_pattern.representative_trip trip.stops vehicle]

--- a/lib/screens/v2/departure.ex
+++ b/lib/screens/v2/departure.ex
@@ -12,6 +12,9 @@ defmodule Screens.V2.Departure do
   alias Screens.V3Api
   alias Screens.Vehicles.Vehicle
 
+  import Screens.Inject
+  @last_trip injected(Screens.LastTrip.LastTrip)
+
   @type t :: %__MODULE__{
           prediction: Screens.Predictions.Prediction.t() | nil,
           schedule: Screens.Schedules.Schedule.t() | nil
@@ -46,7 +49,9 @@ defmodule Screens.V2.Departure do
 
     with {:ok, predictions} <- fetch_predictions_fn.(params),
          {:ok, schedules} <- fetch_schedules(params, opts) do
-      {:ok, Builder.build(predictions, schedules, now, opts)}
+      departures = Builder.build(predictions, schedules, now, opts)
+      @last_trip.update_last_trip_cache(departures, now)
+      {:ok, departures}
     else
       _ -> :error
     end
@@ -161,6 +166,9 @@ defmodule Screens.V2.Departure do
 
   def id(%__MODULE__{prediction: %Prediction{id: prediction_id}}), do: prediction_id
   def id(%__MODULE__{schedule: %Schedule{id: schedule_id}}), do: schedule_id
+
+  def last_trip?(%__MODULE__{prediction: %Prediction{last_trip: last_trip}}), do: last_trip
+  def last_trip?(_), do: false
 
   @spec representative_headsign(t()) :: String.t() | nil
   def representative_headsign(%__MODULE__{prediction: %Prediction{trip: trip}}),

--- a/lib/screens/v2/departure.ex
+++ b/lib/screens/v2/departure.ex
@@ -12,6 +12,9 @@ defmodule Screens.V2.Departure do
   alias Screens.V3Api
   alias Screens.Vehicles.Vehicle
 
+  import Screens.Inject
+  @last_trip injected(Screens.LastTrip.LastTrip)
+
   @type t :: %__MODULE__{
           prediction: Screens.Predictions.Prediction.t() | nil,
           schedule: Screens.Schedules.Schedule.t() | nil
@@ -46,7 +49,9 @@ defmodule Screens.V2.Departure do
 
     with {:ok, predictions} <- fetch_predictions_fn.(params),
          {:ok, schedules} <- fetch_schedules(params, opts) do
-      {:ok, Builder.build(predictions, schedules, now, opts)}
+      departures = Builder.build(predictions, schedules, now, opts)
+      @last_trip.update_last_trip_cache(departures, now)
+      {:ok, departures}
     else
       _ -> :error
     end
@@ -156,6 +161,9 @@ defmodule Screens.V2.Departure do
 
   def id(%__MODULE__{prediction: %Prediction{id: prediction_id}}), do: prediction_id
   def id(%__MODULE__{schedule: %Schedule{id: schedule_id}}), do: schedule_id
+
+  def last_trip?(%__MODULE__{prediction: %Prediction{last_trip: last_trip}}), do: last_trip
+  def last_trip?(_), do: false
 
   @spec representative_headsign(t()) :: String.t() | nil
   def representative_headsign(%__MODULE__{prediction: %Prediction{trip: trip}}),

--- a/lib/screens/v2/rds.ex
+++ b/lib/screens/v2/rds.ex
@@ -15,6 +15,7 @@ defmodule Screens.V2.RDS do
   alias Screens.Alerts.InformedEntity
   alias Screens.Config.Cache
   alias Screens.Headways, as: Headway
+  alias Screens.LastTrip.LastTrip
   alias Screens.Lines.Line
   alias Screens.RoutePatterns.RoutePattern
   alias Screens.Routes.Route
@@ -66,6 +67,11 @@ defmodule Screens.V2.RDS do
     :stop_move,
     :suspension
   ]
+
+  @red_trunk [70_061..70_061, 70_063..70_084]
+             |> Enum.flat_map(& &1)
+             |> Enum.map(&Integer.to_string(&1))
+  @last_trip_buffer_seconds 3
 
   defmodule NoService do
     @moduledoc """
@@ -128,6 +134,7 @@ defmodule Screens.V2.RDS do
   @schedule injected(Schedule)
   @stop injected(Stop)
   @config_cache injected(Cache)
+  @last_trip injected(LastTrip)
 
   @max_departure_minutes 120
 
@@ -250,7 +257,7 @@ defmodule Screens.V2.RDS do
   end
 
   defp create_destination_rds(
-         {%Stop{id: stop_id} = stop, line, headsign} = destination,
+         {%Stop{id: stop_id} = stop, %Line{id: line_id} = line, headsign} = destination,
          departures_by_destination,
          scheduled_departures_by_destination,
          routes_for_section,
@@ -258,16 +265,17 @@ defmodule Screens.V2.RDS do
          now
        ) do
     headway_for_stop = @headways.get(stop_id, now)
+    destination_key = {stop_id, line_id, headsign}
 
     departures =
-      Map.get(departures_by_destination, {stop.id, line.id, headsign}, [])
+      Map.get(departures_by_destination, destination_key, [])
       |> Enum.filter(fn
         %{prediction: nil} -> headway_for_stop == nil
         _ -> true
       end)
 
     scheduled_departures =
-      scheduled_departures_by_destination |> Map.get({stop.id, line.id, headsign}, [])
+      scheduled_departures_by_destination |> Map.get(destination_key, [])
 
     impacted_by_alert = destination in impacted_destinations
 
@@ -279,7 +287,7 @@ defmodule Screens.V2.RDS do
         state(
           departures,
           scheduled_departures,
-          stop_id,
+          destination_key,
           routes_for_section,
           headway_for_stop,
           impacted_by_alert,
@@ -313,7 +321,7 @@ defmodule Screens.V2.RDS do
   @spec state(
           [Departure.t()],
           [Departure.t()],
-          Stop.id(),
+          destination_key(),
           [Route.t()],
           Headway.range() | nil,
           boolean(),
@@ -322,7 +330,7 @@ defmodule Screens.V2.RDS do
   defp state(
          [] = _departures_for_headsign,
          [] = _scheduled_departures_for_headsign,
-         _stop_id,
+         _destination_key,
          routes_for_section,
          _headway_for_stop,
          false = _impacted_by_alert,
@@ -334,7 +342,7 @@ defmodule Screens.V2.RDS do
   defp state(
          [] = departures_for_headsign,
          [_ | _] = scheduled_departures_for_headsign,
-         _stop_id,
+         destination_key,
          routes_for_section,
          headway_for_stop,
          impacted_by_alert,
@@ -350,6 +358,7 @@ defmodule Screens.V2.RDS do
            last_scheduled_departure,
            headway_for_stop,
            impacted_by_alert,
+           after_last_trip?(destination_key, now),
            now
          ) do
       :before_scheduled_start ->
@@ -383,13 +392,38 @@ defmodule Screens.V2.RDS do
   defp state(
          departures_for_headsign,
          _scheduled_departures_by_headsign,
-         _stop_id,
+         _destination_key,
          _routes_for_section,
          _headway_for_stop,
          _impacted_by_alert,
          _now
        ) do
     %Countdowns{departures: departures_for_headsign}
+  end
+
+  @spec after_last_trip?(destination_key(), DateTime.t()) :: boolean()
+  # Red Trunk stops need two last trip departures in order to classify as Service Ended
+  defp after_last_trip?({stop_id, _line_id, "Alewife"} = destination_key, now)
+       when stop_id in @red_trunk do
+    case @last_trip.last_trip_departure_times(destination_key) do
+      [_departure_time_one, _departure_time_two] = departure_times ->
+        departure_times
+        |> Enum.max()
+        |> after_last_trip_with_buffer?(now)
+
+      _ ->
+        false
+    end
+  end
+
+  defp after_last_trip?(destination_key, now) do
+    case @last_trip.last_trip_departure_times(destination_key) do
+      [departure_time] ->
+        after_last_trip_with_buffer?(departure_time, now)
+
+      _ ->
+        false
+    end
   end
 
   @spec group_by_destination([Departure.t()]) :: %{destination_key() => [Departure.t()]}
@@ -453,16 +487,48 @@ defmodule Screens.V2.RDS do
           Departure.t(),
           Headway.range() | nil,
           boolean(),
+          boolean(),
           DateTime.t()
         ) :: service_state()
-  defp classify_service_state(_first_departure, _last_departure, _headway_for_stop, true, _now),
-    do: :service_impacted
+  defp classify_service_state(
+         _first_departure,
+         _last_departure,
+         _headway_for_stop,
+         true,
+         _after_last_trip,
+         _now
+       ),
+       do: :service_impacted
 
-  defp classify_service_state(first_departure, last_departure, _headway_for_stop, _in_alert, _now)
+  defp classify_service_state(
+         _first_departure,
+         _last_departure,
+         _headway_for_stop,
+         _in_alert,
+         true,
+         _now
+       ),
+       do: :after_scheduled_end
+
+  defp classify_service_state(
+         first_departure,
+         last_departure,
+         _headway_for_stop,
+         _in_alert,
+         _after_last_trip,
+         _now
+       )
        when first_departure == nil and last_departure == nil,
        do: :no_service
 
-  defp classify_service_state(first_departure, last_departure, headway_for_stop, _in_alert, now) do
+  defp classify_service_state(
+         first_departure,
+         last_departure,
+         headway_for_stop,
+         _in_alert,
+         _after_last_trip,
+         now
+       ) do
     first_departure_time =
       case headway_for_stop do
         nil ->
@@ -535,36 +601,47 @@ defmodule Screens.V2.RDS do
 
   @spec ie_affects_destination?(InformedEntity.t(), RoutePattern.t(), Stop.t()) :: boolean()
   # Alert effects the entire route
-  def ie_affects_destination?(
-        %InformedEntity{route: route_id, direction_id: nil, stop: nil},
-        %RoutePattern{route: %Route{id: route_id}},
-        _home_stop
-      ),
-      do: true
+  defp ie_affects_destination?(
+         %InformedEntity{route: route_id, direction_id: nil, stop: nil},
+         %RoutePattern{route: %Route{id: route_id}},
+         _home_stop
+       ),
+       do: true
 
   # Alert effects the entire route in the direction of the destination
-  def ie_affects_destination?(
-        %InformedEntity{route: route_id, direction_id: direction_id, stop: nil},
-        %RoutePattern{route: %Route{id: route_id}, direction_id: direction_id},
-        _home_stop
-      ),
-      do: true
+  defp ie_affects_destination?(
+         %InformedEntity{route: route_id, direction_id: direction_id, stop: nil},
+         %RoutePattern{route: %Route{id: route_id}, direction_id: direction_id},
+         _home_stop
+       ),
+       do: true
 
   # Alert effects the entire route in both directions
-  def ie_affects_destination?(
-        %InformedEntity{route_type: informed_route_type, stop: nil},
-        %RoutePattern{route: %Route{type: route_type}},
-        _home_stop
-      ),
-      do: RouteType.to_id(route_type) == informed_route_type
+  defp ie_affects_destination?(
+         %InformedEntity{route_type: informed_route_type, stop: nil},
+         %RoutePattern{route: %Route{type: route_type}},
+         _home_stop
+       ),
+       do: RouteType.to_id(route_type) == informed_route_type
 
   # Alert does not affect the route or a specific stop
-  def ie_affects_destination?(%InformedEntity{stop: nil}, _pattern, _home_stop),
+  defp ie_affects_destination?(%InformedEntity{stop: nil}, _pattern, _home_stop),
     do: false
 
   # Alert effects the child stop
-  def ie_affects_destination?(%InformedEntity{stop: %Stop{id: id}}, _pattern, %Stop{id: id}),
+  defp ie_affects_destination?(%InformedEntity{stop: %Stop{id: id}}, _pattern, %Stop{id: id}),
     do: true
 
-  def ie_affects_destination?(_, _, _), do: false
+  defp ie_affects_destination?(_, _, _), do: false
+
+  defp after_last_trip_with_buffer?(last_trip_departure_time, now) do
+    departure_time_with_buffer =
+      DateTime.add(
+        last_trip_departure_time,
+        @last_trip_buffer_seconds,
+        :second
+      )
+
+    DateTime.after?(now, departure_time_with_buffer)
+  end
 end

--- a/lib/screens/v2/rds.ex
+++ b/lib/screens/v2/rds.ex
@@ -15,6 +15,7 @@ defmodule Screens.V2.RDS do
   alias Screens.Alerts.InformedEntity
   alias Screens.Config.Cache
   alias Screens.Headways, as: Headway
+  alias Screens.LastTrip.LastTrip
   alias Screens.Lines.Line
   alias Screens.RoutePatterns.RoutePattern
   alias Screens.Routes.Route
@@ -66,6 +67,11 @@ defmodule Screens.V2.RDS do
     :stop_move,
     :suspension
   ]
+
+  @red_trunk [70_061..70_061, 70_063..70_084]
+             |> Enum.flat_map(& &1)
+             |> Enum.map(&Integer.to_string(&1))
+  @last_trip_buffer_seconds 3
 
   defmodule NoService do
     @moduledoc """
@@ -128,6 +134,7 @@ defmodule Screens.V2.RDS do
   @schedule injected(Schedule)
   @stop injected(Stop)
   @config_cache injected(Cache)
+  @last_trip injected(LastTrip)
 
   @max_departure_minutes 120
 
@@ -250,7 +257,7 @@ defmodule Screens.V2.RDS do
   end
 
   defp create_destination_rds(
-         {%Stop{id: stop_id} = stop, line, headsign} = destination,
+         {%Stop{id: stop_id} = stop, %Line{id: line_id} = line, headsign} = destination,
          departures_by_destination,
          scheduled_departures_by_destination,
          routes_for_section,
@@ -258,16 +265,17 @@ defmodule Screens.V2.RDS do
          now
        ) do
     headway_for_stop = @headways.get(stop_id, now)
+    destination_key = {stop_id, line_id, headsign}
 
     departures =
-      Map.get(departures_by_destination, {stop.id, line.id, headsign}, [])
+      Map.get(departures_by_destination, destination_key, [])
       |> Enum.filter(fn
         %{prediction: nil} -> headway_for_stop == nil
         _ -> true
       end)
 
     scheduled_departures =
-      scheduled_departures_by_destination |> Map.get({stop.id, line.id, headsign}, [])
+      scheduled_departures_by_destination |> Map.get(destination_key, [])
 
     impacted_by_alert = destination in impacted_destinations
 
@@ -279,7 +287,7 @@ defmodule Screens.V2.RDS do
         state(
           departures,
           scheduled_departures,
-          stop_id,
+          destination_key,
           routes_for_section,
           headway_for_stop,
           impacted_by_alert,
@@ -313,7 +321,7 @@ defmodule Screens.V2.RDS do
   @spec state(
           [Departure.t()],
           [Departure.t()],
-          Stop.id(),
+          destination_key(),
           [Route.t()],
           Headway.range() | nil,
           boolean(),
@@ -322,7 +330,7 @@ defmodule Screens.V2.RDS do
   defp state(
          [] = _departures_for_headsign,
          [] = _scheduled_departures_for_headsign,
-         _stop_id,
+         _destination_key,
          routes_for_section,
          _headway_for_stop,
          false = _impacted_by_alert,
@@ -334,7 +342,7 @@ defmodule Screens.V2.RDS do
   defp state(
          [] = departures_for_headsign,
          [_ | _] = scheduled_departures_for_headsign,
-         _stop_id,
+         destination_key,
          routes_for_section,
          headway_for_stop,
          impacted_by_alert,
@@ -350,6 +358,7 @@ defmodule Screens.V2.RDS do
            last_scheduled_departure,
            headway_for_stop,
            impacted_by_alert,
+           after_last_trip?(destination_key, now),
            now
          ) do
       :before_scheduled_start ->
@@ -383,13 +392,30 @@ defmodule Screens.V2.RDS do
   defp state(
          departures_for_headsign,
          _scheduled_departures_by_headsign,
-         _stop_id,
+         _destination_key,
          _routes_for_section,
          _headway_for_stop,
          _impacted_by_alert,
          _now
        ) do
     %Countdowns{departures: departures_for_headsign}
+  end
+
+  @spec after_last_trip?(destination_key(), DateTime.t()) :: boolean()
+  defp after_last_trip?({stop_id, _line_id, headsign} = destination_key, now) do
+    departure_times = @last_trip.last_trip_departure_times(destination_key)
+
+    case {red_trunk_to_alewife?(stop_id, headsign), departure_times} do
+      {true, [_last_departure_time_one, _last_departure_time_two] = departure_times} ->
+        Enum.max(departure_times, DateTime)
+
+      {false, [last_departure_time]} ->
+        last_departure_time
+
+      _ ->
+        nil
+    end
+    |> after_last_trip_with_buffer?(now)
   end
 
   @spec group_by_destination([Departure.t()]) :: %{destination_key() => [Departure.t()]}
@@ -453,16 +479,48 @@ defmodule Screens.V2.RDS do
           Departure.t(),
           Headway.range() | nil,
           boolean(),
+          boolean(),
           DateTime.t()
         ) :: service_state()
-  defp classify_service_state(_first_departure, _last_departure, _headway_for_stop, true, _now),
-    do: :service_impacted
+  defp classify_service_state(
+         _first_departure,
+         _last_departure,
+         _headway_for_stop,
+         true,
+         _after_last_trip,
+         _now
+       ),
+       do: :service_impacted
 
-  defp classify_service_state(first_departure, last_departure, _headway_for_stop, _in_alert, _now)
+  defp classify_service_state(
+         _first_departure,
+         _last_departure,
+         _headway_for_stop,
+         _in_alert,
+         true,
+         _now
+       ),
+       do: :after_scheduled_end
+
+  defp classify_service_state(
+         first_departure,
+         last_departure,
+         _headway_for_stop,
+         _in_alert,
+         _after_last_trip,
+         _now
+       )
        when first_departure == nil and last_departure == nil,
        do: :no_service
 
-  defp classify_service_state(first_departure, last_departure, headway_for_stop, _in_alert, now) do
+  defp classify_service_state(
+         first_departure,
+         last_departure,
+         headway_for_stop,
+         _in_alert,
+         _after_last_trip,
+         now
+       ) do
     first_departure_time =
       case headway_for_stop do
         nil ->
@@ -535,36 +593,53 @@ defmodule Screens.V2.RDS do
 
   @spec ie_affects_destination?(InformedEntity.t(), RoutePattern.t(), Stop.t()) :: boolean()
   # Alert effects the entire route
-  def ie_affects_destination?(
-        %InformedEntity{route: route_id, direction_id: nil, stop: nil},
-        %RoutePattern{route: %Route{id: route_id}},
-        _home_stop
-      ),
-      do: true
+  defp ie_affects_destination?(
+         %InformedEntity{route: route_id, direction_id: nil, stop: nil},
+         %RoutePattern{route: %Route{id: route_id}},
+         _home_stop
+       ),
+       do: true
 
   # Alert effects the entire route in the direction of the destination
-  def ie_affects_destination?(
-        %InformedEntity{route: route_id, direction_id: direction_id, stop: nil},
-        %RoutePattern{route: %Route{id: route_id}, direction_id: direction_id},
-        _home_stop
-      ),
-      do: true
+  defp ie_affects_destination?(
+         %InformedEntity{route: route_id, direction_id: direction_id, stop: nil},
+         %RoutePattern{route: %Route{id: route_id}, direction_id: direction_id},
+         _home_stop
+       ),
+       do: true
 
   # Alert effects the entire route in both directions
-  def ie_affects_destination?(
-        %InformedEntity{route_type: informed_route_type, stop: nil},
-        %RoutePattern{route: %Route{type: route_type}},
-        _home_stop
-      ),
-      do: RouteType.to_id(route_type) == informed_route_type
+  defp ie_affects_destination?(
+         %InformedEntity{route_type: informed_route_type, stop: nil},
+         %RoutePattern{route: %Route{type: route_type}},
+         _home_stop
+       ),
+       do: RouteType.to_id(route_type) == informed_route_type
 
   # Alert does not affect the route or a specific stop
-  def ie_affects_destination?(%InformedEntity{stop: nil}, _pattern, _home_stop),
+  defp ie_affects_destination?(%InformedEntity{stop: nil}, _pattern, _home_stop),
     do: false
 
   # Alert effects the child stop
-  def ie_affects_destination?(%InformedEntity{stop: %Stop{id: id}}, _pattern, %Stop{id: id}),
+  defp ie_affects_destination?(%InformedEntity{stop: %Stop{id: id}}, _pattern, %Stop{id: id}),
     do: true
 
-  def ie_affects_destination?(_, _, _), do: false
+  defp ie_affects_destination?(_, _, _), do: false
+
+  defp red_trunk_to_alewife?(stop_id, "Alewife") when stop_id in @red_trunk, do: true
+
+  defp red_trunk_to_alewife?(_stop_id, _headsign), do: false
+
+  defp after_last_trip_with_buffer?(nil, _now), do: false
+
+  defp after_last_trip_with_buffer?(last_trip_departure_time, now) do
+    departure_time_with_buffer =
+      DateTime.add(
+        last_trip_departure_time,
+        @last_trip_buffer_seconds,
+        :second
+      )
+
+    DateTime.after?(now, departure_time_with_buffer)
+  end
 end

--- a/test/screens/last_trip/last_trip_test.exs
+++ b/test/screens/last_trip/last_trip_test.exs
@@ -1,0 +1,91 @@
+defmodule Screens.LastTrip.LastTripTest do
+  use ExUnit.Case, async: true
+
+  alias Screens.LastTrip.LastTrip
+  alias Screens.Lines.Line
+  alias Screens.Predictions.Prediction
+  alias Screens.Routes.Route
+  alias Screens.Schedules.Schedule
+  alias Screens.Stops.Stop
+  alias Screens.Trips.Trip
+
+  alias Screens.V2.Departure
+
+  setup do
+    departures = [
+      %Departure{
+        prediction: %Prediction{
+          departure_time: ~U[2024-10-11 12:30:00Z],
+          route: %Route{id: "r1", line: %Line{id: "l1"}, type: :subway},
+          stop: %Stop{id: "s1"},
+          trip: %Trip{headsign: "other1", pattern_headsign: "h1"},
+          last_trip: true
+        },
+        schedule: nil
+      },
+      %Departure{
+        prediction: %Prediction{
+          departure_time: ~U[2024-10-11 12:20:00Z],
+          route: %Route{id: "r1", line: %Line{id: "l1"}, type: :subway},
+          stop: %Stop{id: "s1"},
+          trip: %Trip{headsign: "other1", pattern_headsign: "h1"},
+          last_trip: true
+        },
+        schedule: nil
+      },
+      %Departure{
+        prediction: %Prediction{
+          departure_time: ~U[2024-10-11 12:40:00Z],
+          route: %Route{id: "r1", line: %Line{id: "l1"}, type: :subway},
+          stop: %Stop{id: "s1"},
+          trip: %Trip{headsign: "other1", pattern_headsign: "h1"},
+          last_trip: false
+        },
+        schedule: nil
+      },
+      %Departure{
+        prediction: %Prediction{
+          departure_time: ~U[2024-10-11 12:20:00Z],
+          route: %Route{id: "r2", line: %Line{id: "l2"}, type: :subway},
+          stop: %Stop{id: "s2"},
+          trip: %Trip{headsign: "other2", pattern_headsign: "h2"},
+          last_trip: true
+        },
+        schedule: nil
+      },
+      %Departure{
+        prediction: %Prediction{
+          departure_time: ~U[2024-10-11 12:40:00Z],
+          route: %Route{id: "r2", line: %Line{id: "l2"}, type: :subway},
+          stop: %Stop{id: "s2"},
+          trip: %Trip{headsign: "other2", pattern_headsign: "h2"},
+          last_trip: false
+        },
+        schedule: nil
+      },
+      %Departure{
+        prediction: nil,
+        schedule: %Schedule{
+          departure_time: ~U[2024-10-11 13:15:00Z],
+          route: %Route{id: "r3", line: %Line{id: "l3"}},
+          stop: %Stop{id: "s3"},
+          trip: %Trip{headsign: "other3", pattern_headsign: "h3"}
+        }
+      }
+    ]
+
+    {:ok, departures: departures}
+  end
+
+  test "last_trip_departure_times/1", %{departures: departures} do
+    LastTrip.update_last_trip_cache(departures, DateTime.utc_now())
+
+    assert LastTrip.last_trip_departure_times({"s1", "l1", "h1"}) == [
+             ~U[2024-10-11 12:30:00Z],
+             ~U[2024-10-11 12:20:00Z]
+           ]
+
+    assert LastTrip.last_trip_departure_times({"s2", "l2", "h2"}) == [~U[2024-10-11 12:20:00Z]]
+    assert LastTrip.last_trip_departure_times({"s3", "l3", "h3"}) == nil
+  end
+end

--- a/test/screens/last_trip/last_trip_test.exs
+++ b/test/screens/last_trip/last_trip_test.exs
@@ -1,0 +1,116 @@
+defmodule Screens.LastTrip.LastTripTest do
+  use ExUnit.Case, async: true
+
+  alias Screens.LastTrip.LastTrip
+  alias Screens.Lines.Line
+  alias Screens.Predictions.Prediction
+  alias Screens.Routes.Route
+  alias Screens.Schedules.Schedule
+  alias Screens.Stops.Stop
+  alias Screens.Trips.Trip
+
+  alias Screens.V2.Departure
+
+  setup do
+    departures = [
+      %Departure{
+        prediction: %Prediction{
+          departure_time: ~U[2024-10-11 12:30:00Z],
+          route: %Route{id: "r1", line: %Line{id: "l1"}, type: :subway},
+          stop: %Stop{id: "s1"},
+          trip: %Trip{id: "t1-1", headsign: "other1", pattern_headsign: "h1"},
+          last_trip: true
+        },
+        schedule: nil
+      },
+      %Departure{
+        prediction: %Prediction{
+          departure_time: ~U[2024-10-11 12:25:00Z],
+          route: %Route{id: "r1", line: %Line{id: "l1"}, type: :subway},
+          stop: %Stop{id: "s1"},
+          trip: %Trip{id: "t1-2", headsign: "other1", pattern_headsign: "h1"},
+          last_trip: true
+        },
+        schedule: nil
+      },
+      %Departure{
+        prediction: %Prediction{
+          departure_time: ~U[2024-10-11 12:40:00Z],
+          route: %Route{id: "r1", line: %Line{id: "l1"}, type: :subway},
+          stop: %Stop{id: "s1"},
+          trip: %Trip{id: "t1-3", headsign: "other1", pattern_headsign: "h1"},
+          last_trip: false
+        },
+        schedule: nil
+      },
+      %Departure{
+        prediction: %Prediction{
+          departure_time: ~U[2024-10-11 12:20:00Z],
+          route: %Route{id: "r2", line: %Line{id: "l2"}, type: :subway},
+          stop: %Stop{id: "s2"},
+          trip: %Trip{id: "t2-1", headsign: "other2", pattern_headsign: "h2"},
+          last_trip: true
+        },
+        schedule: nil
+      },
+      %Departure{
+        prediction: %Prediction{
+          departure_time: ~U[2024-10-11 12:40:00Z],
+          route: %Route{id: "r2", line: %Line{id: "l2"}, type: :subway},
+          stop: %Stop{id: "s2"},
+          trip: %Trip{id: "t2-2", headsign: "other2", pattern_headsign: "h2"},
+          last_trip: false
+        },
+        schedule: nil
+      },
+      %Departure{
+        prediction: nil,
+        schedule: %Schedule{
+          departure_time: ~U[2024-10-11 13:15:00Z],
+          route: %Route{id: "r3", line: %Line{id: "l3"}},
+          stop: %Stop{id: "s3"},
+          trip: %Trip{id: "t3", headsign: "other3", pattern_headsign: "h3"}
+        }
+      }
+    ]
+
+    {:ok, departures: departures}
+  end
+
+  test "last_trip_departure_times/1", %{departures: departures} do
+    LastTrip.update_last_trip_cache(departures, DateTime.utc_now())
+
+    updated_departures = [
+      %Departure{
+        prediction: %Prediction{
+          departure_time: ~U[2024-10-11 12:25:00Z],
+          route: %Route{id: "r1", line: %Line{id: "l1"}, type: :subway},
+          stop: %Stop{id: "s1"},
+          trip: %Trip{id: "t1-2", headsign: "other1", pattern_headsign: "h1"},
+          last_trip: true
+        },
+        schedule: nil
+      },
+      %Departure{
+        prediction: %Prediction{
+          departure_time: ~U[2024-10-11 12:40:00Z],
+          route: %Route{id: "r1", line: %Line{id: "l1"}, type: :subway},
+          stop: %Stop{id: "s1"},
+          trip: %Trip{id: "t1-1", headsign: "other1", pattern_headsign: "h1"},
+          last_trip: true
+        },
+        schedule: nil
+      }
+    ]
+
+    LastTrip.update_last_trip_cache(updated_departures, DateTime.utc_now())
+
+    assert LastTrip.last_trip_departure_times({"s1", "l1", "h1"}) == [
+             ~U[2024-10-11 12:40:00Z],
+             ~U[2024-10-11 12:25:00Z]
+           ]
+
+    assert LastTrip.last_trip_departure_times({"s2", "l2", "h2"}) == [~U[2024-10-11 12:20:00Z]]
+    assert LastTrip.last_trip_departure_times({"s3", "l3", "h3"}) == []
+  end
+end

--- a/test/screens/v2/departure_test.exs
+++ b/test/screens/v2/departure_test.exs
@@ -8,6 +8,15 @@ defmodule Screens.V2.DepartureTest do
   alias Screens.V2.Departure
   alias Screens.Vehicles.Vehicle
 
+  import Screens.Inject
+  import Mox
+  @last_trip injected(Screens.LastTrip.LastTrip)
+
+  setup do
+    stub(@last_trip, :update_last_trip_cache, fn _, _ -> [] end)
+    :ok
+  end
+
   describe "crowding_level/1" do
     test "returns relevant crowding levels" do
       trip = %Trip{id: "trip-1", stops: ["1", "2", "3"]}

--- a/test/screens/v2/rds_test.exs
+++ b/test/screens/v2/rds_test.exs
@@ -4,6 +4,7 @@ defmodule Screens.V2.RDSTest do
   alias Screens.Alerts.Alert
   alias Screens.Config.Cache
   alias Screens.Headways
+  alias Screens.LastTrip.LastTrip
   alias Screens.Lines.Line
   alias Screens.Predictions.Prediction
   alias Screens.RoutePatterns.RoutePattern
@@ -28,6 +29,7 @@ defmodule Screens.V2.RDSTest do
   @schedule injected(Schedule)
   @stop injected(Stop)
   @config_cache injected(Cache)
+  @last_trip injected(LastTrip)
 
   setup do
     stub(@alert, :fetch, fn _ -> {:ok, []} end)
@@ -37,6 +39,7 @@ defmodule Screens.V2.RDSTest do
     stub(@schedule, :fetch, fn _, _ -> {:ok, []} end)
     stub(@stop, :fetch, fn %{ids: ids}, true -> {:ok, Enum.map(ids, &stop/1)} end)
     stub(@config_cache, :disabled_modes, fn -> [] end)
+    stub(@last_trip, :last_trip_departure_times, fn _ -> [] end)
     :ok
   end
 
@@ -478,6 +481,142 @@ defmodule Screens.V2.RDSTest do
              ]
     end
 
+    test "creates service ended state before last scheduled departure with last trip flagged" do
+      now = ~U[2024-10-11 10:44:53Z]
+      stop_ids = ~w[s0 s1]
+
+      first_schedule =
+        %Schedule{
+          departure_time: ~U[2024-10-11 10:45:00Z],
+          route: %Route{
+            id: "r1",
+            line: %Line{id: "l1"},
+            type: :bus,
+            direction_names: ["Northbound", "Southbound"]
+          },
+          stop: %Stop{id: "sA"},
+          trip: %Trip{headsign: "h1", pattern_headsign: "hA", direction_id: 0}
+        }
+
+      second_schedule = %Schedule{
+        departure_time: ~U[2024-10-11 10:45:00Z],
+        route: %Route{
+          id: "r2",
+          line: %Line{id: "l2"},
+          type: :bus,
+          direction_names: ["Northbound", "Southbound"]
+        },
+        stop: %Stop{id: "sB"},
+        trip: %Trip{headsign: "h2", pattern_headsign: "hB", direction_id: 0}
+      }
+
+      third_schedule =
+        %Schedule{
+          departure_time: ~U[2024-10-11 10:45:00Z],
+          route: %Route{
+            id: "r2",
+            line: %Line{id: "l2"},
+            type: :bus,
+            direction_names: ["Northbound", "Southbound"]
+          },
+          stop: %Stop{id: "sC"},
+          trip: %Trip{headsign: "hC", pattern_headsign: "hC", direction_id: 0}
+        }
+
+      all_schedules = [first_schedule, second_schedule, third_schedule]
+
+      departures = %Departures{
+        sections: [
+          %Section{query: %Query{params: %Query.Params{route_type: :bus, stop_ids: stop_ids}}}
+        ]
+      }
+
+      stub(@headways, :get, fn _, _ -> {5, 10} end)
+
+      expect(@departure, :fetch, fn
+        %{direction_id: :both, route_type: :bus, stop_ids: ^stop_ids}, [now: ^now] ->
+          {:ok, []}
+      end)
+
+      expect(@schedule, :fetch, fn %{stop_ids: ^stop_ids}, _now -> {:ok, all_schedules} end)
+      expect_standard_stations(stop_ids)
+      expect_standard_route_patterns(stop_ids)
+
+      expect(@last_trip, :last_trip_departure_times, fn {"sA", "l1", "hA"} ->
+        [~U[2024-10-11 10:43:50Z]]
+      end)
+
+      expect(@last_trip, :last_trip_departure_times, fn {"sB", "l2", "hB"} ->
+        [~U[2024-10-11 10:43:50Z]]
+      end)
+
+      expect(@last_trip, :last_trip_departure_times, fn {"sC", "l2", "hC"} ->
+        [~U[2024-10-11 10:43:50Z]]
+      end)
+
+      assert RDS.get(departures, now) == [
+               {:ok,
+                [
+                  service_ended("sA", "l1", "hA", first_schedule),
+                  service_ended("sB", "l2", "hB", second_schedule),
+                  service_ended("sC", "l2", "hC", third_schedule)
+                ]}
+             ]
+    end
+
+    test "creates service ended state before last scheduled departure with last trip flagged for Red Trunk" do
+      now = ~U[2024-10-11 10:44:53Z]
+      stop_ids = ~w[70061 70063]
+
+      first_schedule =
+        %Schedule{
+          departure_time: ~U[2024-10-11 10:45:00Z],
+          route: %Route{id: "r1", line: %Line{id: "l1"}, type: :bus},
+          stop: %Stop{id: "70061"},
+          trip: %Trip{headsign: "Alewife", pattern_headsign: "Alewife", direction_id: 0}
+        }
+
+      all_schedules = [first_schedule]
+
+      departures = %Departures{
+        sections: [
+          %Section{query: %Query{params: %Query.Params{route_type: :bus, stop_ids: stop_ids}}}
+        ]
+      }
+
+      expect(@departure, :fetch, fn
+        %{direction_id: :both, route_type: :bus, stop_ids: ^stop_ids}, [now: ^now] ->
+          {:ok, []}
+      end)
+
+      expect(@schedule, :fetch, fn %{stop_ids: ^stop_ids}, _now -> {:ok, all_schedules} end)
+
+      expect(@stop, :fetch, fn %{ids: ^stop_ids}, true ->
+        {:ok, [station("70061", ~w[70061])]}
+      end)
+
+      patterns = [
+        %RoutePattern{
+          id: "A",
+          headsign: "Alewife",
+          route: %Route{id: "r1", line: %Line{id: "l1"}, type: :subway},
+          stops: [%Stop{id: "70061"}, %Stop{id: "last_stop"}]
+        }
+      ]
+
+      expect(@route_pattern, :fetch, fn %{route_type: :bus, stop_ids: ^stop_ids, typicality: 1} ->
+        {:ok, patterns}
+      end)
+
+      expect(@last_trip, :last_trip_departure_times, fn {"70061", "l1", "Alewife"} ->
+        [~U[2024-10-11 10:43:50Z], ~U[2024-10-11 10:42:50Z]]
+      end)
+
+      assert RDS.get(departures, now) == [
+               {:ok, [service_ended("70061", "l1", "Alewife", first_schedule)]}
+             ]
+    end
+
     test "does not create NoService destinations for those affected by an alert that affects the home stop" do
       stop_ids = ~w[s0 s1]
       now = ~U[2024-10-11 10:44:00Z]
@@ -832,7 +971,9 @@ defmodule Screens.V2.RDSTest do
       now = ~U[2024-10-11 12:00:00Z]
       stop_ids = ~w[s0]
 
-      expect(@departure, :fetch, fn %{stop_ids: ^stop_ids}, [now: ^now] -> :error end)
+      expect(@departure, :fetch, fn %{stop_ids: ^stop_ids}, [now: ^now] ->
+        :error
+      end)
 
       departures = %Departures{
         sections: [

--- a/test/support/mocks.ex
+++ b/test/support/mocks.ex
@@ -4,6 +4,7 @@ injected_modules = [
   Screens.Elevator,
   Screens.Facilities.Facility,
   Screens.Headways,
+  Screens.LastTrip.LastTrip,
   Screens.PendingConfig.Fetch,
   Screens.RoutePatterns.RoutePattern,
   Screens.Routes.Route,


### PR DESCRIPTION
**Asana task**: [RDS Core: Last Trip tracking](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1212463750135887?focus=true)

Description
- Added Nebulex to cache last trip departure times when building Departures
- Last Trips have a `TTL` till the end of the service day
- RDS consumes the last trip departure time and if the current time is 3 seconds greater than the departure time, we consider the branch to be service ended regardless of the last scheduled departure time
- Red Trunk stops to Alewife require two last trips in order to declare service ended

- [x] Tests added?
