### PR TITLE
fix: Fixed Bus Route Pill spacing on DUPS

### DIFF
--- a/assets/css/dup/departures/route_pill.scss
+++ b/assets/css/dup/departures/route_pill.scss
@@ -13,9 +13,7 @@
   &--yellow {
     width: 280px;
     height: 168px;
-    margin-top: 20px;
-    margin-bottom: 20px;
-    margin-left: 0;
+    margin: 20px 32px 20px 0;
     color: black;
     letter-spacing: -2px;
     background-color: colors.$line-bus;

--- a/assets/css/dup/departures/row.scss
+++ b/assets/css/dup/departures/row.scss
@@ -17,13 +17,16 @@
 
 .departure-row__route {
   display: inline-block;
-  width: 248px;
-  height: 144px;
-  margin: 32px;
   vertical-align: middle;
 
   .departure-row--extended-route_pill & {
     width: 351px;
+  }
+
+  &:not(.departure-row__route--yellow) {
+    width: 248px;
+    height: 144px;
+    margin: 32px;
   }
 }
 

--- a/assets/src/components/dup/departures/departure_row.tsx
+++ b/assets/src/components/dup/departures/departure_row.tsx
@@ -17,7 +17,7 @@ const DepartureRow: ComponentType<DepartureRowBase> = ({
 
   return (
     <div className={classWithModifier("departure-row", parentClassModifier)}>
-      <div className="departure-row__route">
+      <div className={classWithModifier("departure-row__route", route.color)}>
         <RoutePill pill={route} />
       </div>
       <div className="departure-row__destination">


### PR DESCRIPTION
Description
Removed some spacing/width requirements for specifically yellow (bus) route pills within the row CSS but added some margin on the right for the pill itself.

<img width="975" height="548" alt="Screenshot 2026-04-16 at 10 08 25 AM" src="https://github.com/user-attachments/assets/73fd86da-7d45-481c-b063-493d0272e220" />
<img width="987" height="557" alt="Screenshot 2026-04-16 at 10 19 46 AM" src="https://github.com/user-attachments/assets/741331af-46a1-4ae2-af98-a51149aad863" />


