### PR TITLE
fix: Kenmore special case handling for inside alerts

### DIFF
--- a/lib/screens/v2/candidate_generator/dup/alerts.ex
+++ b/lib/screens/v2/candidate_generator/dup/alerts.ex
@@ -55,7 +55,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Alerts do
            {:ok, alerts} <- fetch_alerts_fn.(route_ids: route_ids) do
         alerts
         |> relevant_alerts(config, location_context, now)
-        |> alert_special_cases(config)
+        |> alert_special_cases(config, location_context)
         |> create_alert_widgets(config, location_context, stop_name)
       else
         :error -> []
@@ -157,25 +157,49 @@ defmodule Screens.V2.CandidateGenerator.Dup.Alerts do
 
   # If this is a special case, this function returns the widgets that should be used for it.
   # Otherwise, returns the alerts unchanged.
-  @spec alert_special_cases(list(Alert.t()), ScreensConfig.Screen.t()) ::
+  #
+  # In the case where we are inside of any of the alerts, we assume that it will create
+  # the full screen alert rather than use the special case. In this case, we bypass
+  # the special case altogether.
+  @spec alert_special_cases(list(Alert.t()), ScreensConfig.Screen.t(), LocationContext.t()) ::
           {:normal, list(Alert.t())} | {:special, list(Screens.V2.WidgetInstance.t())}
-  defp alert_special_cases([], _), do: {:normal, []}
+  defp alert_special_cases([], _, _), do: {:normal, []}
 
   defp alert_special_cases(
          alerts,
-         %Screen{app_params: %Dup{alerts: %AlertsConfig{stop_id: stop_id}}}
+         %Screen{app_params: %Dup{alerts: %AlertsConfig{stop_id: stop_id}}},
+         location_context
        ) do
     case stop_id do
-      "place-kencl" -> kenmore_special_case(alerts)
-      "place-wtcst" -> wtc_special_case(alerts)
-      _ -> {:normal, alerts}
+      "place-kencl" ->
+        inside_alert = Enum.any?(alerts, &inside_alert?(&1, location_context))
+        kenmore_special_case(alerts, inside_alert)
+
+      "place-wtcst" ->
+        wtc_special_case(alerts)
+
+      _ ->
+        {:normal, alerts}
     end
+  end
+
+  @spec inside_alert?(Alert.t(), LocationContext.t()) :: boolean()
+  defp inside_alert?(alert, location_context) do
+    LocalizedAlert.location(%{alert: alert, location_context: location_context}) == :inside
   end
 
   # In the case where Kenmore has 2 or more boundary shuttles / suspensions to the west,
   # don't only select 1 alert; instead look at all alerts and make custom text
-  @spec kenmore_special_case(list(Alert.t())) :: {:special, list(Screens.V2.WidgetInstance.t())}
-  defp kenmore_special_case(alerts) do
+  #
+  # In cases where we are inside any of the alerts, assume that we will just use the
+  # full screen presentation of the alert and bypass this special case altogether
+  @spec kenmore_special_case(list(Alert.t()), boolean()) ::
+          {:normal, list(Alert.t())}
+          | {:special, list(Screens.V2.WidgetInstance.t())}
+
+  defp kenmore_special_case(alerts, true), do: {:normal, alerts}
+
+  defp kenmore_special_case(alerts, _inside_location) do
     branches =
       alerts
       |> Enum.filter(fn a -> a.effect === :shuttle end)

--- a/test/screens/v2/widget_instance/dup_special_case_alert_test.exs
+++ b/test/screens/v2/widget_instance/dup_special_case_alert_test.exs
@@ -3,6 +3,7 @@ defmodule Screens.V2.WidgetInstance.DupSpecialCaseAlertTest do
 
   alias Screens.LocationContext
   alias Screens.V2.CandidateGenerator.Dup.Alerts, as: DupAlerts
+  alias Screens.V2.WidgetInstance.DupAlert
   alias Screens.V2.WidgetInstance.DupSpecialCaseAlert
   alias ScreensConfig.{Alerts, Departures, FreeTextLine, Screen}
   alias ScreensConfig.Screen.Dup
@@ -297,6 +298,65 @@ defmodule Screens.V2.WidgetInstance.DupSpecialCaseAlertTest do
         }
       ]
 
+      # WB B / C / D shuttle alert with Kenmore inside
+      kenmore_inside_alert =
+        %Screens.Alerts.Alert{
+          active_period: [{~U[2023-04-14 10:53:53Z], ~U[2023-04-14 21:53:59Z]}],
+          cause: :unknown,
+          created_at: ~U[2023-04-14 10:53:54Z],
+          description:
+            "Affected stops:\r\nHynes\r\nKenmore\r\nBlandford Street\r\nSaint Mary's Street\r\nFenway",
+          effect: :shuttle,
+          header: "Shuttle buses replacing Green Line service",
+          id: "137273",
+          informed_entities: [
+            ie(stop_id: "70187", route: "Green-E", route_type: 0),
+            ie(stop_id: "70149", route: "Green-D", route_type: 0),
+            ie(stop_id: "71151", route: "Green-B", route_type: 0),
+            ie(stop_id: "70148", route: "Green-D", route_type: 0),
+            ie(stop_id: "70149", route: "Green-C", route_type: 0),
+            ie(stop_id: "71150", route: "Green-C", route_type: 0),
+            ie(stop_id: "place-smary", route: "Green-D", route_type: 0),
+            ie(stop_id: "place-fenwy", route: "Green-E", route_type: 0),
+            ie(stop_id: "place-bland", route: "Green-B", route_type: 0),
+            ie(stop_id: "place-kencl", route: "Green-C", route_type: 0),
+            ie(stop_id: "70187", route: "Green-B", route_type: 0),
+            ie(stop_id: "place-smary", route: "Green-C", route_type: 0),
+            ie(stop_id: "place-bland", route: "Green-E", route_type: 0),
+            ie(stop_id: "70151", route: "Green-E", route_type: 0),
+            ie(stop_id: "70148", route: "Green-E", route_type: 0),
+            ie(stop_id: "70186", route: "Green-D", route_type: 0),
+            ie(stop_id: "70150", route: "Green-B", route_type: 0),
+            ie(stop_id: "71151", route: "Green-C", route_type: 0),
+            ie(stop_id: "71150", route: "Green-B", route_type: 0),
+            ie(stop_id: "place-bland", route: "Green-C", route_type: 0),
+            ie(stop_id: "70148", route: "Green-B", route_type: 0),
+            ie(stop_id: "place-smary", route: "Green-B", route_type: 0),
+            ie(stop_id: "place-fenwy", route: "Green-C", route_type: 0),
+            ie(stop_id: "70151", route: "Green-B", route_type: 0),
+            ie(stop_id: "71151", route: "Green-D", route_type: 0),
+            ie(stop_id: "70212", route: "Green-D", route_type: 0),
+            ie(stop_id: "70151", route: "Green-C", route_type: 0),
+            ie(stop_id: "70212", route: "Green-C", route_type: 0),
+            ie(stop_id: "70211", route: "Green-D", route_type: 0),
+            ie(stop_id: "71151", route: "Green-E", route_type: 0),
+            ie(stop_id: "place-kencl", route: "Green-D", route_type: 0),
+            ie(stop_id: "70149", route: "Green-B", route_type: 0),
+            ie(stop_id: "71150", route: "Green-D", route_type: 0),
+            ie(stop_id: "70212", route: "Green-E", route_type: 0),
+            ie(stop_id: "70211", route: "Green-E", route_type: 0),
+            ie(stop_id: "place-smary", route: "Green-E", route_type: 0),
+            ie(stop_id: "place-hymnl", route: "Green-B", route_type: 0),
+            ie(stop_id: "place-hymnl", route: "Green-C", route_type: 0),
+            ie(stop_id: "place-hymnl", route: "Green-D", route_type: 0)
+          ],
+          lifecycle: "NEW",
+          severity: 7,
+          timeframe: nil,
+          updated_at: ~U[2023-04-14 19:53:54Z],
+          url: nil
+        }
+
       wtc_alerts = [
         %Screens.Alerts.Alert{
           active_period: [{~U[2023-04-14 10:48:05Z], ~U[2023-04-14 16:53:05Z]}],
@@ -347,6 +407,7 @@ defmodule Screens.V2.WidgetInstance.DupSpecialCaseAlertTest do
         now: now,
         fetch_stop_name_fn: fn _ -> "Test" end,
         kenmore_alerts: kenmore_alerts,
+        kenmore_inside_alert: kenmore_inside_alert,
         wtc_alerts: wtc_alerts,
         fetch_location_context_fn: fn
           _, stop_id, _ ->
@@ -608,6 +669,23 @@ defmodule Screens.V2.WidgetInstance.DupSpecialCaseAlertTest do
 
       assert Enum.at(expected_serialized_json, 2) ==
                DupSpecialCaseAlert.serialize(Enum.at(actual_widgets, 2))
+    end
+
+    test "serialize DupAlert for alerts inside Kenmore, bypasses special case", context do
+      alerts = [context.kenmore_inside_alert]
+
+      fetch_alerts_fn = fn route_ids: ["Green-B", "Green-C", "Green-D"] -> {:ok, alerts} end
+
+      actual_widgets =
+        DupAlerts.alert_instances(
+          context.config_kenmore,
+          context.now,
+          context.fetch_stop_name_fn,
+          fetch_alerts_fn,
+          context.fetch_location_context_fn
+        )
+
+      assert Enum.all?(actual_widgets, &match?(%DupAlert{}, &1))
     end
 
     test "serializes WTC special case: WTC is detoured", context do


### PR DESCRIPTION
**Asana task**: [DUP behavior when Kenmore is in middle of diversion](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1213877855438317?focus=true)

Description
- When we are now inside an alert at Kenmore, we will disregard the special case and allow the full screen presentation for handling the alert
- This assumes that we are not overlapping alerts, which I think we agreed we wouldn't do in Slack. If we unfortunately do overlap alerts, it will show one of the alerts associated.

- [x] Tests added?
