### PR TITLE
Add rotation index to DUP header in version number

### DIFF
--- a/assets/src/components/dup/normal_header.tsx
+++ b/assets/src/components/dup/normal_header.tsx
@@ -1,6 +1,7 @@
 import DefaultNormalHeader, { Icon } from "Components/normal_header";
 import { DUP_VERSION } from "./version";
 import { usePlayerName } from "Hooks/outfront";
+import { getRotationIndex } from "Util/outfront";
 
 interface NormalHeaderProps {
   text: string;
@@ -16,7 +17,11 @@ const NormalHeader = ({
   accentPattern,
 }: NormalHeaderProps) => {
   const playerName = usePlayerName();
+  const rotationIndex = getRotationIndex();
   let version = DUP_VERSION;
+  if (rotationIndex) {
+    version = `${version}.${rotationIndex}`;
+  }
   if (playerName) {
     version = `${version}-${playerName}`;
   }


### PR DESCRIPTION
Just a little change to include the rotation index with the version displayed in the DUP header that I found helpful when debugging. Figure this could be helpful for potential production debugging as well, since this would allow us to easily see the rotation being shown in any image of a DUP screen.

Note that this doesn't show up when looking at the DUPs on Screens Admin or Screenplay, since those don't technically have a rotation, just a wider viewport to show all three rotations. 

<img width="1096" height="664" alt="image" src="https://github.com/user-attachments/assets/4bf41361-3620-4162-84df-da61c674a13d" />
