### PR TITLE
fix: Live Icon spacing issue when displaying am/pm times

### DIFF
--- a/assets/css/dup/departures/destination.scss
+++ b/assets/css/dup/departures/destination.scss
@@ -23,6 +23,10 @@
   }
 }
 
+.departure-destination--shortened-headsign {
+  width: 913px;
+}
+
 .departure-destination__headsign {
   overflow: hidden;
   text-overflow: ellipsis;

--- a/assets/css/dup/departures/row.scss
+++ b/assets/css/dup/departures/row.scss
@@ -49,6 +49,10 @@
   }
 }
 
+.departure-row__time--shortened-headsign {
+  width: 663px;
+}
+
 .departure-times-with-crowding {
   display: inline-block;
 }

--- a/assets/src/components/dup/departures/departure_row.tsx
+++ b/assets/src/components/dup/departures/departure_row.tsx
@@ -15,15 +15,21 @@ const DepartureRow: ComponentType<DepartureRowBase> = ({
   const parentClassModifier =
     route.type === "dual" ? "extended-route_pill" : "";
 
+  const classModifier = timesWithCrowding.some(
+    (time) => time.time?.type === "timestamp" && time?.time.am_pm,
+  )
+    ? "shortened-headsign"
+    : "";
+
   return (
     <div className={classWithModifier("departure-row", parentClassModifier)}>
       <div className={classWithModifier("departure-row__route", route.color)}>
         <RoutePill pill={route} />
       </div>
       <div className="departure-row__destination">
-        <Destination {...headsign} />
+        <Destination {...headsign} classModifier={classModifier} />
       </div>
-      <div className="departure-row__time">
+      <div className={classWithModifier("departure-row__time", classModifier)}>
         {isFirstTrip && <div className="departure-row__first">First</div>}
         <DepartureTimes timesWithCrowding={timesWithCrowding} />
       </div>

--- a/assets/src/components/dup/departures/destination.tsx
+++ b/assets/src/components/dup/departures/destination.tsx
@@ -2,7 +2,9 @@ import { type ComponentType, useLayoutEffect, useRef, useState } from "react";
 
 import type DestinationBase from "Components/departures/destination";
 import { useCurrentPage } from "Context/dup_page";
-import { hasOverflowX } from "Util/utils";
+import { classWithModifier, hasOverflowX } from "Util/utils";
+
+type DupDestination = DestinationBase & { classModifier: string };
 
 // Global abbreviations
 const ABBREVIATIONS = {
@@ -30,7 +32,7 @@ enum PHASES {
   DONE,
 }
 
-const RenderedDestination = ({ parts, index1, index2 }) => {
+const RenderedDestination = ({ parts, index1, index2, classModifier }) => {
   const currentPage = useCurrentPage();
 
   let pageContent: string;
@@ -46,13 +48,16 @@ const RenderedDestination = ({ parts, index1, index2 }) => {
   }
 
   return (
-    <div className="departure-destination">
+    <div className={classWithModifier("departure-destination", classModifier)}>
       <div className="departure-destination__headsign">{pageContent}</div>
     </div>
   );
 };
 
-const Destination: ComponentType<DestinationBase> = ({ headsign }) => {
+const Destination: ComponentType<DupDestination> = ({
+  headsign,
+  classModifier,
+}) => {
   const firstLineRef = useRef<HTMLDivElement>(null);
   const secondLineRef = useRef<HTMLDivElement>(null);
 
@@ -134,7 +139,12 @@ const Destination: ComponentType<DestinationBase> = ({ headsign }) => {
   // Render paged version when done determining breaks
   if (phase === PHASES.DONE) {
     return (
-      <RenderedDestination index1={index1} index2={index2} parts={parts} />
+      <RenderedDestination
+        index1={index1}
+        index2={index2}
+        parts={parts}
+        classModifier={classModifier}
+      />
     );
   }
 
@@ -150,7 +160,7 @@ const Destination: ComponentType<DestinationBase> = ({ headsign }) => {
   }
 
   return (
-    <div className="departure-destination">
+    <div className={classWithModifier("departure-destination", classModifier)}>
       <div className="departure-destination__headsign" ref={firstLineRef}>
         {firstLine}
       </div>


### PR DESCRIPTION
Description
Some late night testing uncovered some spacing issues dealing with specifically the AM/PM timestamps. This adds in some shotened headsign spacing to allow for the full timestamp to appear. 

Opted to make this one a class modifier instead of making the spacing default since it feels that showing am/pm happens less often than other cases (Let me know if this is a false assumption, I can just make it the default spacing in that case). 

<img width="966" height="427" alt="Screenshot 2026-04-17 at 12 24 48 PM" src="https://github.com/user-attachments/assets/22155fe4-0095-43cb-a3b7-ea3239d4e235" />
<img width="965" height="418" alt="Screenshot 2026-04-17 at 12 23 49 PM" src="https://github.com/user-attachments/assets/d9d029f3-ac08-4698-9c27-7ac53777565b" />
