### PR TITLE
fix: Filter to only subway platforms when determining closure type

### DIFF
--- a/lib/screens/alerts/alert.ex
+++ b/lib/screens/alerts/alert.ex
@@ -420,16 +420,13 @@ defmodule Screens.Alerts.Alert do
     # Typically, these partial closures affecting child stops will only affect a single station.
     # However, we do want to consider the case in which multiple stations have closures,
     # but not every child stop at those parent stations are closed.
-
-    informed_parent_stations = informed_parent_stations(alert)
-
     platforms_affected_by_alert =
       informed_platforms_from_entities(informed_entities, platforms_at_informed_stations)
 
-    case informed_parent_stations do
+    case informed_parent_stations(alert) do
       [_single_parent_station] ->
         # Compare number of platforms in alert to total number of child platforms at station
-        if length(platforms_affected_by_alert) != length(platforms_at_informed_stations) do
+        if length(platforms_affected_by_alert) < length(platforms_at_informed_stations) do
           :partial_closure
         else
           :full_station_closure

--- a/lib/screens/stops/stop.ex
+++ b/lib/screens/stops/stop.ex
@@ -85,7 +85,12 @@ defmodule Screens.Stops.Stop do
   def fetch_subway_platforms_for_stop(stop_id) do
     {:ok, [%__MODULE__{child_stops: child_stops}]} = fetch(%{ids: [stop_id]}, true)
 
-    Enum.filter(child_stops, fn
+    filter_subway_platforms(child_stops)
+  end
+
+  @spec filter_subway_platforms(list(t())) :: list(t())
+  def filter_subway_platforms(stops) do
+    Enum.filter(stops, fn
       %__MODULE__{location_type: 0, vehicle_type: vt} when vt in ~w[light_rail subway]a -> true
       _ -> false
     end)

--- a/lib/screens/v2/candidate_generator/widgets/reconstructed_alert.ex
+++ b/lib/screens/v2/candidate_generator/widgets/reconstructed_alert.ex
@@ -163,7 +163,8 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlert do
     # Given informed entities representing an alert at a single station,
     # finds the corresponding platform names for those child stops included.
     with [informed_parent_station] <- Alert.informed_parent_stations(alert),
-         [_ | _] = child_platforms <- informed_parent_station.stop.child_stops,
+         [_ | _] = child_platforms <-
+           Stop.filter_subway_platforms(informed_parent_station.stop.child_stops),
          :partial_closure <- Alert.station_closure_type(alert, child_platforms) do
       platform_ids = child_platforms |> Enum.map(& &1.id) |> MapSet.new()
 

--- a/lib/screens/v2/candidate_generator/widgets/reconstructed_alert.ex
+++ b/lib/screens/v2/candidate_generator/widgets/reconstructed_alert.ex
@@ -163,10 +163,10 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlert do
     # Given informed entities representing an alert at a single station,
     # finds the corresponding platform names for those child stops included.
     with [informed_parent_station] <- Alert.informed_parent_stations(alert),
-         [_ | _] = child_platforms <-
-           Stop.filter_subway_platforms(informed_parent_station.stop.child_stops),
+         [_ | _] = child_platforms <- informed_parent_station.stop.child_stops,
          :partial_closure <- Alert.station_closure_type(alert, child_platforms) do
-      platform_ids = child_platforms |> Enum.map(& &1.id) |> MapSet.new()
+      platform_ids =
+        child_platforms |> Stop.filter_subway_platforms() |> Enum.map(& &1.id) |> MapSet.new()
 
       informed_entities
       |> Enum.filter(&(&1.stop.id in platform_ids))

--- a/lib/screens/v2/widget_instance/dup_alert.ex
+++ b/lib/screens/v2/widget_instance/dup_alert.ex
@@ -158,6 +158,7 @@ defmodule Screens.V2.WidgetInstance.DupAlert do
     t
     |> LocalizedAlert.informed_routes_at_home_stop()
     |> Enum.flat_map(&Map.get(t.location_context.child_stops_at_station, &1, []))
+    |> Stop.filter_subway_platforms()
     |> Enum.uniq()
   end
 

--- a/lib/screens/v2/widget_instance/subway_status/serialize.ex
+++ b/lib/screens/v2/widget_instance/subway_status/serialize.ex
@@ -5,6 +5,7 @@ defmodule Screens.V2.WidgetInstance.SubwayStatus.Serialize do
 
   alias Screens.Alerts.Alert
   alias Screens.Routes.Route
+  alias Screens.Stops.Stop
   alias Screens.V2.WidgetInstance.SubwayStatus
   alias Screens.V2.WidgetInstance.SubwayStatus.Serialize.GreenLine
   alias Screens.V2.WidgetInstance.SubwayStatus.Serialize.RedLine
@@ -256,7 +257,7 @@ defmodule Screens.V2.WidgetInstance.SubwayStatus.Serialize do
           child_stops -> child_stops
         end
       )
-      |> Enum.filter(&(&1.location_type == 0))
+      |> Stop.filter_subway_platforms()
 
     case Alert.station_closure_type(alert, child_platforms_at_informed_stations) do
       # Logic for partial_station_closure will remove any alerts that apply to more than

--- a/test/screens/v2/candidate_generator/widgets/reconstructed_alert_test.exs
+++ b/test/screens/v2/candidate_generator/widgets/reconstructed_alert_test.exs
@@ -44,20 +44,22 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlertTest do
         id: "70036",
         name: "Oak Grove - Southbound",
         platform_name: "Southbound",
-        location_type: "0"
+        location_type: 0,
+        vehicle_type: :subway
       }
 
       oak_grove_nb = %Stop{
         id: "70035",
         name: "Oak Grove - Northbound",
         platform_name: "Northbound",
-        location_type: "0"
+        location_type: 0,
+        vehicle_type: :subway
       }
 
       oak_grove_parent = %Stop{
         id: "place-ogmnl",
         name: "Oak Grove",
-        location_type: "1",
+        location_type: 1,
         child_stops: [oak_grove_nb, oak_grove_sb]
       }
 
@@ -65,20 +67,22 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlertTest do
         id: "70034",
         name: "Malden Center - Southbound",
         platform_name: "Southbound",
-        location_type: "0"
+        location_type: 0,
+        vehicle_type: :subway
       }
 
       malden_center_nb = %Stop{
         id: "70033",
         name: "Malden Center - Northbound",
         platform_name: "Northbound",
-        location_type: "0"
+        location_type: 0,
+        vehicle_type: :subway
       }
 
       malden_center_parent = %Stop{
         id: "place-mlmnl",
         name: "Malden Center",
-        location_type: "1",
+        location_type: 1,
         child_stops: [malden_center_nb, malden_center_sb]
       }
 
@@ -204,7 +208,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlertTest do
               stop: %Stop{
                 id: "place-ogmnl",
                 name: "Oak Grove",
-                location_type: "1",
+                location_type: 1,
                 child_stops: [oak_grove_sb, oak_grove_nb]
               }
             ),
@@ -220,7 +224,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlertTest do
               stop: %Stop{
                 id: "place-mlmnl",
                 name: "Malden Center",
-                location_type: "1",
+                location_type: 1,
                 child_stops: [malden_center_sb, malden_center_nb]
               }
             ),
@@ -258,7 +262,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlertTest do
                   stop: %Stop{
                     id: "place-ogmnl",
                     name: "Oak Grove",
-                    location_type: "1",
+                    location_type: 1,
                     child_stops: [oak_grove_sb, oak_grove_nb]
                   }
                 ),
@@ -282,7 +286,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlertTest do
                   stop: %Stop{
                     id: "place-mlmnl",
                     name: "Malden Center",
-                    location_type: "1",
+                    location_type: 1,
                     child_stops: [malden_center_sb, malden_center_nb]
                   }
                 ),
@@ -564,7 +568,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlertTest do
                   stop: %Stop{
                     id: "place-ogmnl",
                     name: "Oak Grove",
-                    location_type: "1",
+                    location_type: 1,
                     child_stops: [oak_grove_nb, oak_grove_sb]
                   },
                   route: "Orange",
@@ -590,7 +594,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlertTest do
                   stop: %Stop{
                     id: "place-mlmnl",
                     name: "Malden Center",
-                    location_type: "1",
+                    location_type: 1,
                     child_stops: [malden_center_nb, malden_center_sb]
                   }
                 ),
@@ -615,7 +619,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlertTest do
                   stop: %Stop{
                     id: "place-ogmnl",
                     name: "Oak Grove",
-                    location_type: "1",
+                    location_type: 1,
                     child_stops: [oak_grove_nb, oak_grove_sb]
                   }
                 )
@@ -725,7 +729,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlertTest do
               stop: %Stop{
                 id: "place-mlmnl",
                 name: "Malden Center",
-                location_type: "1",
+                location_type: 1,
                 child_stops: [malden_center_sb, malden_center_nb]
               }
             ),
@@ -757,7 +761,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlertTest do
                   stop: %Stop{
                     id: "place-mlmnl",
                     name: "Malden Center",
-                    location_type: "1",
+                    location_type: 1,
                     child_stops: [malden_center_sb, malden_center_nb]
                   }
                 ),

--- a/test/screens/v2/widget_instance/dup_alert_test.exs
+++ b/test/screens/v2/widget_instance/dup_alert_test.exs
@@ -35,12 +35,14 @@ defmodule Screens.V2.WidgetInstance.DupAlertTest do
       %Screens.Stops.Stop{
         id: "child_plat_b0",
         platform_name: "Northbound",
-        location_type: 0
+        location_type: 0,
+        vehicle_type: :subway
       },
       %Screens.Stops.Stop{
         id: "child_plat_b1",
         platform_name: "Southbound",
-        location_type: 0
+        location_type: 0,
+        vehicle_type: :subway
       }
     ]
   }
@@ -330,7 +332,12 @@ defmodule Screens.V2.WidgetInstance.DupAlertTest do
                 ie(route: "Blue", stop: %Stop{id: "place-x"}, route_type: 1),
                 ie(
                   route: "Blue",
-                  stop: %Stop{id: "child_plat_b0", platform_name: "Northbound"},
+                  stop: %Stop{
+                    id: "child_plat_b0",
+                    platform_name: "Northbound",
+                    location_type: 0,
+                    vehicle_type: :subway
+                  },
                   route_type: 1
                 )
               ]

--- a/test/screens/v2/widget_instance/subway_status_test.exs
+++ b/test/screens/v2/widget_instance/subway_status_test.exs
@@ -1233,8 +1233,18 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
                   stop: %Stop{
                     id: "place-portr",
                     child_stops: [
-                      %Stop{id: "70065", platform_name: "Ashmont/Braintree", location_type: 0},
-                      %Stop{id: "70066", platform_name: "Alewife", location_type: 0}
+                      %Stop{
+                        id: "70065",
+                        platform_name: "Ashmont/Braintree",
+                        location_type: 0,
+                        vehicle_type: :subway
+                      },
+                      %Stop{
+                        id: "70066",
+                        platform_name: "Alewife",
+                        location_type: 0,
+                        vehicle_type: :subway
+                      }
                     ]
                   },
                   route_type: 1
@@ -1280,15 +1290,30 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
                   stop: %Stop{
                     id: "place-eliot",
                     child_stops: [
-                      %Stop{id: "70166", platform_name: "Park Street & North", location_type: 0},
-                      %Stop{id: "70167", platform_name: "Riverside", location_type: 0}
+                      %Stop{
+                        id: "70166",
+                        platform_name: "Park Street & North",
+                        location_type: 0,
+                        vehicle_type: :subway
+                      },
+                      %Stop{
+                        id: "70167",
+                        platform_name: "Riverside",
+                        location_type: 0,
+                        vehicle_type: :subway
+                      }
                     ]
                   },
                   route_type: 1
                 ),
                 ie(
                   route: "Green-D",
-                  stop: %Stop{id: "70166", platform_name: "Park Street & North", location_type: 0},
+                  stop: %Stop{
+                    id: "70166",
+                    platform_name: "Park Street & North",
+                    location_type: 0,
+                    vehicle_type: :subway
+                  },
                   route_type: 1
                 )
               ]
@@ -1319,11 +1344,17 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
       closed_child_stop = %Stop{
         id: "70201",
         platform_name: "North Station & North",
-        location_type: 0
+        location_type: 0,
+        vehicle_type: :subway
       }
 
       child_stops = [
-        %Stop{id: "70201", platform_name: "North Station & North", location_type: 0},
+        %Stop{
+          id: "70201",
+          platform_name: "North Station & North",
+          location_type: 0,
+          vehicle_type: :subway
+        },
         closed_child_stop
       ]
 
@@ -1369,18 +1400,30 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
       porter_to_ashmont_stop = %Stop{
         id: "70065",
         platform_name: "Ashmont/Braintree",
-        location_type: 0
+        location_type: 0,
+        vehicle_type: :subway
       }
 
-      porter_to_alewife_stop = %Stop{id: "70066", platform_name: "Alewife", location_type: 0}
+      porter_to_alewife_stop = %Stop{
+        id: "70066",
+        platform_name: "Alewife",
+        location_type: 0,
+        vehicle_type: :subway
+      }
 
       davis_to_ashmont_stop = %Stop{
         id: "70063",
         platform_name: "Ashmont/Braintree",
-        location_type: 0
+        location_type: 0,
+        vehicle_type: :subway
       }
 
-      davis_to_alewife_stop = %Stop{id: "70064", platform_name: "Alewife", location_type: 0}
+      davis_to_alewife_stop = %Stop{
+        id: "70064",
+        platform_name: "Alewife",
+        location_type: 0,
+        vehicle_type: :subway
+      }
 
       instance = %SubwayStatus{
         subway_alerts: [
@@ -1546,13 +1589,15 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
                       %Stop{
                         id: "70086",
                         platform_name: "Alewife (from Ashmont)",
-                        location_type: 0
+                        location_type: 0,
+                        vehicle_type: :subway
                       },
                       %Stop{id: "70095", platform_name: "Braintree", location_type: 0},
                       %Stop{
                         id: "70096",
                         platform_name: "Alewife (from Braintree)",
-                        location_type: 0
+                        location_type: 0,
+                        vehicle_type: :subway
                       }
                     ],
                     location_type: 1


### PR DESCRIPTION
**Asana task**: [[title](regression: "N platforms closed" when entire station is closed)](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1214148649236060?focus=true)

With the change to use platform_names from the `InformedEntity`'s within an `Alert`, we did not filter them to only include stops with `vehicle_types` for `:subway` and `:light_rail`. This adds a function within the Stop module that does this filtering so that its done consistently everywhere these alerts are handled

<img width="598" height="410" alt="GREEN LINE" src="https://github.com/user-attachments/assets/a188c540-5e85-4b10-bd58-24add309725c" />
