### PR TITLE
fix: fixed extra divider with using subtitles only for departure headers

### DIFF
--- a/assets/css/lcd/departures/header.scss
+++ b/assets/css/lcd/departures/header.scss
@@ -32,6 +32,10 @@
   display: none;
 }
 
+.departures-header__separator:last-child {
+  display: none;
+}
+
 .departures-header__image {
   vertical-align: middle;
 }


### PR DESCRIPTION
**Asana task**: [Screens: double divider on header-only section with subtitle](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1214109901253938?focus=true)

Description
- in cases where we have just a subtitle for the header, the current CSS shows a divider due to there being an in between div for the header and the divider
- added an extra scss removing the divider if it's the last child (to allow for the next header to provide the divider)

