### PR TITLE
feat: CR and Subway Shuttle Pill Icons (BE piece)

### DIFF
--- a/lib/screens/lines/line.ex
+++ b/lib/screens/lines/line.ex
@@ -11,4 +11,12 @@ defmodule Screens.Lines.Line do
           short_name: String.t(),
           sort_order: integer()
         }
+
+  def color("line-Red"), do: :red
+  def color("line-Mattapan"), do: :red
+  def color("line-Orange"), do: :orange
+  def color("line-Green" <> _), do: :green
+  def color("line-Blue"), do: :blue
+  def color("line-CR-" <> _), do: :purple
+  def color(_), do: :yellow
 end

--- a/lib/screens/lines/line.ex
+++ b/lib/screens/lines/line.ex
@@ -11,12 +11,4 @@ defmodule Screens.Lines.Line do
           short_name: String.t(),
           sort_order: integer()
         }
-
-  def color("line-Red"), do: :red
-  def color("line-Mattapan"), do: :red
-  def color("line-Orange"), do: :orange
-  def color("line-Green" <> _), do: :green
-  def color("line-Blue"), do: :blue
-  def color("line-CR-" <> _), do: :purple
-  def color(_), do: :yellow
 end

--- a/lib/screens/v2/widget_instance/departures.ex
+++ b/lib/screens/v2/widget_instance/departures.ex
@@ -115,6 +115,11 @@ defmodule Screens.V2.WidgetInstance.Departures do
            optional(:time_in_epoch) => integer()
          }
 
+  @type serialized_headsign :: %{
+          headsign: String.t(),
+          variation: String.t() | nil
+        }
+
   # Limits how many rows per section will be sent to the client.
   @max_rows_per_section 15
   @sl_route_ids ~w[741 742 743 746 749 751]
@@ -303,7 +308,7 @@ defmodule Screens.V2.WidgetInstance.Departures do
         departures,
         screen,
         now,
-        &RoutePill.serialize_for_audio_departure/4
+        &RoutePill.serialize_for_audio_departure/3
       )
     }
   end
@@ -407,7 +412,7 @@ defmodule Screens.V2.WidgetInstance.Departures do
          rows,
          screen,
          now,
-         route_pill_serializer \\ &RoutePill.serialize_for_departure/4
+         route_pill_serializer \\ &RoutePill.serialize_for_departure/3
        )
 
   defp serialize_departure_group(
@@ -426,7 +431,7 @@ defmodule Screens.V2.WidgetInstance.Departures do
     %{
       id: row_id,
       type: :departure_row,
-      route: serialize_route(departures, route_pill_serializer),
+      route: serialize_route(departures, route_pill_serializer, screen),
       headsign: serialize_headsign(departures, screen),
       times_with_crowding: serialize_times_with_crowding(departures, screen, now),
       direction_id: serialize_direction_id(departures)
@@ -449,7 +454,7 @@ defmodule Screens.V2.WidgetInstance.Departures do
     %{
       id: row_id,
       type: :departure_row,
-      route: serialize_route(departures, route_pill_serializer),
+      route: serialize_route(departures, route_pill_serializer, screen),
       headsign: serialize_headsign(departures, screen),
       times_with_crowding: serialize_times_with_crowding(departures, screen, now),
       direction_id: serialize_direction_id(departures),
@@ -472,7 +477,7 @@ defmodule Screens.V2.WidgetInstance.Departures do
     %{
       id: hash_and_encode(departure_id),
       type: :departure_row,
-      route: serialize_route(departures, route_pill_serializer),
+      route: serialize_route(departures, route_pill_serializer, screen),
       headsign: serialize_headsign(departures, screen),
       times_with_crowding: [
         %{
@@ -499,7 +504,7 @@ defmodule Screens.V2.WidgetInstance.Departures do
     %{
       id: hash_and_encode(departure_id),
       type: :departure_row,
-      route: serialize_route(departures, route_pill_serializer),
+      route: serialize_route(departures, route_pill_serializer, screen),
       headsign:
         if headsign do
           %{headsign: headsign}
@@ -523,24 +528,67 @@ defmodule Screens.V2.WidgetInstance.Departures do
     }
   end
 
-  def serialize_route([first_departure | _], route_pill_serializer) do
+  @spec serialize_route(
+          [Departure.t()],
+          (Departure.t(), pos_integer() | nil, Screen.t() -> RoutePill.t()),
+          Screen.t()
+        ) ::
+          RoutePill.t()
+  def serialize_route([first_departure | _], route_pill_serializer, screen) do
     route = Departure.route(first_departure)
-    %Route{id: route_id, type: route_type} = route
     track_number = Departure.track_number(first_departure)
 
-    route_pill_serializer.(route_id, Route.name(route), route_type, track_number)
+    route_pill_serializer.(route, track_number, screen)
   end
 
-  def serialize_headsign([first_departure | _], %Screen{app_id: :dup_v2}) do
-    headsign = Departure.headsign(first_departure)
+  @spec serialize_headsign([Departure.t()], Screen.t()) :: serialized_headsign()
+  def serialize_headsign([first_departure | _], %Screen{app_id: :dup_v2} = screen) do
+    headsign =
+      first_departure
+      |> Departure.headsign()
+      |> simplify_shuttle_headsign(first_departure, screen)
+
     headsign_replacements = Application.get_env(:screens, :dup_headsign_replacements)
 
     %{headsign: Map.get(headsign_replacements, headsign, headsign)}
   end
 
-  def serialize_headsign([first_departure | _], _) do
-    headsign = Departure.headsign(first_departure)
+  def serialize_headsign([first_departure | _], screen) do
+    first_departure
+    |> Departure.headsign()
+    |> simplify_shuttle_headsign(first_departure, screen)
+    |> headsign_with_variation()
+  end
 
+  @doc """
+  Removes "Shuttle" from parenthetical suffixes for routes showing a special shuttle pill.
+  If the parentheses contain only "Shuttle", removes the entire parenthetical.
+  If the parentheses contain a descriptor like "Express Shuttle" or "Local Shuttle",
+  keeps the descriptor but removes "Shuttle".
+  """
+  @spec simplify_shuttle_headsign(String.t(), Departure.t(), Screen.t()) :: String.t()
+  def simplify_shuttle_headsign(headsign, departure, screen) do
+    if RoutePill.shuttle_route?(Departure.route(departure), screen) do
+      case Regex.run(~r/^(.*?)\s*\(([^)]*?)\s*shuttle\s*\)\s*$/i, headsign) do
+        [_, base, prefix] ->
+          trimmed_prefix = String.trim(prefix)
+
+          if trimmed_prefix == "" do
+            String.trim(base)
+          else
+            String.trim(base) <> " (" <> trimmed_prefix <> ")"
+          end
+
+        nil ->
+          headsign
+      end
+    else
+      headsign
+    end
+  end
+
+  @spec headsign_with_variation(String.t()) :: serialized_headsign()
+  def headsign_with_variation(headsign) do
     via_pattern = ~r/(.+) (via .+)/
     paren_pattern = ~r/(.+) (\(.+)/
 

--- a/lib/screens/v2/widget_instance/serializer/route_pill.ex
+++ b/lib/screens/v2/widget_instance/serializer/route_pill.ex
@@ -315,6 +315,4 @@ defmodule Screens.V2.WidgetInstance.Serializer.RoutePill do
   defp serialize_shuttle_line("line-Red", _), do: %{text: "RL", color: :red}
   defp serialize_shuttle_line("line-CR-" <> _line, _), do: %{text: "CR", color: :purple}
   defp serialize_shuttle_line(_, _), do: %{text: "CR", color: :purple}
-
-  def shuttle_pill_enabled_screens, do: @shuttle_pill_enabled_screens
 end

--- a/lib/screens/v2/widget_instance/serializer/route_pill.ex
+++ b/lib/screens/v2/widget_instance/serializer/route_pill.ex
@@ -1,9 +1,11 @@
 defmodule Screens.V2.WidgetInstance.Serializer.RoutePill do
   @moduledoc false
 
+  alias Screens.Lines.Line
   alias Screens.Report
   alias Screens.Routes.Route
   alias Screens.RouteType
+  alias ScreensConfig.Screen
 
   @type t :: text_pill() | icon_pill() | slashed_route_pill()
 
@@ -27,6 +29,14 @@ defmodule Screens.V2.WidgetInstance.Serializer.RoutePill do
           part1: String.t(),
           part2: String.t(),
           color: Route.color()
+        }
+
+  @type dual_route_pill :: %{
+          type: :dual,
+          text: String.t(),
+          icon: icon(),
+          color: Route.color(),
+          secondary_color: Route.color()
         }
 
   @type audio_route :: %{
@@ -65,29 +75,48 @@ defmodule Screens.V2.WidgetInstance.Serializer.RoutePill do
     "708" => "CT3"
   }
 
+  @shuttle_pill_enabled_screens [:bus_shelter_v2, :busway_v2, :dup_v2, :pre_fare_v2]
+
   # Any text longer than this max is not designed to appear correctly in our Pill Components
   @maximum_pill_text_length 3
 
-  @spec serialize_for_departure(Route.id(), String.t(), RouteType.t(), pos_integer() | nil) :: t()
-  def serialize_for_departure(route_id, route_name, route_type, track_number) do
-    route =
-      if route_type == :bus and String.contains?(route_name, "/") do
+  @spec serialize_for_departure(Route.t(), pos_integer() | nil, Screen.t()) :: t()
+  def serialize_for_departure(
+        %Route{id: route_id, type: route_type, line: %Line{id: line_id}} = route,
+        track_number,
+        screen
+      ) do
+    route_name = Route.name(route)
+
+    cond do
+      # Dual pills for shuttles replacing regular service routes
+      shuttle_route?(route, screen) ->
+        do_serialize_shuttle_pill(line_id)
+
+      # Slashed bus routes
+      route_type == :bus and String.contains?(route_name, "/") ->
         [part1, part2] = String.split(route_name, "/")
-        %{type: :slashed, part1: part1, part2: part2}
-      else
-        do_serialize(route_id, %{
+        %{type: :slashed, part1: part1, part2: part2, color: Route.color(route_id, route_type)}
+
+      true ->
+        route_id
+        |> do_serialize(%{
           route_name: route_name,
           track_number: track_number,
           gl_branch: true
         })
-      end
-
-    Map.put(route, :color, Route.color(route_id, route_type))
+        |> Map.put(:color, Route.color(route_id, route_type))
+    end
   end
 
-  @spec serialize_for_audio_departure(Route.id(), String.t(), RouteType.t(), pos_integer() | nil) ::
-          audio_route()
-  def serialize_for_audio_departure(route_id, route_name, route_type, track_number) do
+  @spec serialize_for_audio_departure(Route.t(), pos_integer() | nil, Screen.t()) :: audio_route()
+  def serialize_for_audio_departure(
+        %Route{id: route_id, type: route_type} = route,
+        track_number,
+        _screen
+      ) do
+    route_name = Route.name(route)
+
     vehicle_type =
       case route_type do
         :light_rail -> :train
@@ -254,4 +283,38 @@ defmodule Screens.V2.WidgetInstance.Serializer.RoutePill do
   defp valid_text_for_pill?(text) do
     text != "" and String.length(text) <= @maximum_pill_text_length
   end
+
+  @spec shuttle_route?(Route.t() | nil, Screen.t()) :: boolean()
+  def shuttle_route?(%Route{id: route_id, line: %Line{id: line_id}}, %Screen{app_id: app_id}) do
+    # Shuttle routes have special pills on specific screens
+    # We only show special pills for shuttles replacing subway or CR lines
+    route_id |> String.downcase() |> String.contains?("shuttle") and
+      rail_line?(line_id) and
+      app_id in @shuttle_pill_enabled_screens
+  end
+
+  def shuttle_route?(_, _), do: false
+
+  defp rail_line?("line-Blue"), do: true
+  defp rail_line?("line-Orange"), do: true
+  defp rail_line?("line-Red"), do: true
+  defp rail_line?("line-CR-" <> _line), do: true
+  defp rail_line?(_), do: false
+
+  @spec do_serialize_shuttle_pill(Line.id()) :: dual_route_pill()
+  defp do_serialize_shuttle_pill(line_id) do
+    serialize_shuttle_line(line_id, nil)
+    |> Map.put(:type, :dual)
+    |> Map.put(:icon, :bus)
+    |> Map.put(:secondary_color, :yellow)
+  end
+
+  @spec serialize_shuttle_line(Line.id(), any()) :: map()
+  defp serialize_shuttle_line("line-Blue", _), do: %{text: "BL", color: :blue}
+  defp serialize_shuttle_line("line-Orange", _), do: %{text: "OL", color: :orange}
+  defp serialize_shuttle_line("line-Red", _), do: %{text: "RL", color: :red}
+  defp serialize_shuttle_line("line-CR-" <> _line, _), do: %{text: "CR", color: :purple}
+  defp serialize_shuttle_line(_, _), do: %{text: "CR", color: :purple}
+
+  def shuttle_pill_enabled_screens, do: @shuttle_pill_enabled_screens
 end

--- a/test/screens/v2/widget_instance/departures_test.exs
+++ b/test/screens/v2/widget_instance/departures_test.exs
@@ -17,6 +17,8 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
   alias ScreensConfig.{FreeTextLine, Screen}
   alias ScreensConfig.Screen.{BusShelter, PreFare}
 
+  import Screens.TestSupport.RouteBuilder
+
   describe "priority/1" do
     test "returns 2" do
       instance = %Departures{sections: []}
@@ -114,11 +116,7 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
               struct(Schedule,
                 arrival_time: nil,
                 departure_time: nil,
-                route: %Screens.Routes.Route{
-                  id: "Orange",
-                  type: :subway,
-                  long_name: "Orange Line"
-                },
+                route: route(id: "Orange", type: :subway, name: "Orange Line"),
                 stop: %Stop{id: "70015", name: "Back Bay"},
                 stop_headsign: "Oak Grove"
               )
@@ -293,7 +291,7 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
         %Departure{
           prediction: %Prediction{
             departure_time: ~U[2020-01-01T00:01:10Z],
-            route: %Route{id: "Green-E", type: :subway},
+            route: route(id: "Green-E", type: :subway),
             trip: %Trip{headsign: "Medford/Tufts", direction_id: 1},
             stop: %Stop{}
           }
@@ -301,7 +299,7 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
         %Departure{
           prediction: %Prediction{
             departure_time: ~U[2020-01-01T00:01:10Z],
-            route: %Route{id: "Green-D"},
+            route: route(id: "Green-D", type: :subway),
             trip: %Trip{headsign: "Government Center", direction_id: 1},
             stop: %Stop{}
           }
@@ -309,7 +307,7 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
         %Departure{
           prediction: %Prediction{
             departure_time: ~U[2020-01-01T00:01:10Z],
-            route: %Route{id: "Green-C", type: :subway},
+            route: route(id: "Green-C", type: :subway),
             trip: %Trip{headsign: "Cleveland Circle", direction_id: 0},
             stop: %Stop{}
           }
@@ -317,7 +315,7 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
         %Departure{
           prediction: %Prediction{
             departure_time: ~U[2020-01-01T00:01:10Z],
-            route: %Route{id: "Green-C", type: :subway},
+            route: route(id: "Green-C", type: :subway),
             trip: %Trip{headsign: "Cleveland Circle", direction_id: 0},
             stop: %Stop{}
           }
@@ -325,7 +323,7 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
         %Departure{
           prediction: %Prediction{
             departure_time: ~U[2020-01-01T00:01:10Z],
-            route: %Route{id: "Green-D", type: :subway},
+            route: route(id: "Green-D", type: :subway),
             trip: %Trip{headsign: "Riverside", direction_id: 0},
             stop: %Stop{}
           }
@@ -464,79 +462,82 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
     end
   end
 
-  describe "serialize_route/1" do
+  describe "serialize_route/3" do
     setup do
-      %{serializer: &RoutePill.serialize_for_departure/4}
+      %{
+        serializer: &RoutePill.serialize_for_departure/3,
+        pre_fare_screen: struct(Screen, %{app_id: :pre_fare_v2})
+      }
     end
 
-    test "handles default", %{serializer: serializer} do
+    test "handles default", %{serializer: serializer, pre_fare_screen: screen} do
       departure = %Departure{
         prediction: %Prediction{
-          route: %Route{id: "Blue", short_name: "", long_name: "Blue Line", type: :subway}
+          route: route(id: "Blue", name: "Blue Line", type: :subway)
         }
       }
 
       assert %{type: :text, text: "BL", color: :blue} ==
-               Departures.serialize_route([departure], serializer)
+               Departures.serialize_route([departure], serializer, screen)
 
       departure = %Departure{
         prediction: %Prediction{
-          route: %Route{id: "Green-B", short_name: "", long_name: "Green Line B", type: :subway}
+          route: route(id: "Green-B", name: "Green Line B", type: :subway)
         }
       }
 
       assert %{type: :text, text: "GL·B", color: :green} ==
-               Departures.serialize_route([departure], serializer)
+               Departures.serialize_route([departure], serializer, screen)
 
       departure = %Departure{
-        prediction: %Prediction{route: %Route{id: "741", short_name: "SL1", type: :bus}}
+        prediction: %Prediction{route: route(id: "741", name: "SL1", type: :bus)}
       }
 
       assert %{type: :text, text: "SL1", color: :silver} ==
-               Departures.serialize_route([departure], serializer)
+               Departures.serialize_route([departure], serializer, screen)
 
       departure = %Departure{
-        prediction: %Prediction{route: %Route{id: "1", short_name: "1", type: :bus}}
+        prediction: %Prediction{route: route(id: "1", name: "1", type: :bus)}
       }
 
       assert %{type: :text, text: "1", color: :yellow} ==
-               Departures.serialize_route([departure], serializer)
+               Departures.serialize_route([departure], serializer, screen)
     end
 
-    test "handles slashed routes", %{serializer: serializer} do
+    test "handles slashed routes", %{serializer: serializer, pre_fare_screen: screen} do
       departure = %Departure{
-        prediction: %Prediction{route: %Route{id: "214216", short_name: "214/216", type: :bus}}
+        prediction: %Prediction{route: route(id: "214216", name: "214/216", type: :bus)}
       }
 
       assert %{type: :slashed, part1: "214", part2: "216", color: :yellow} ==
-               Departures.serialize_route([departure], serializer)
+               Departures.serialize_route([departure], serializer, screen)
     end
 
-    test "handles rail", %{serializer: serializer} do
+    test "handles rail", %{serializer: serializer, pre_fare_screen: screen} do
       departure = %Departure{
-        prediction: %Prediction{route: %Route{id: "CR-Providence", type: :rail}}
+        prediction: %Prediction{route: route(id: "CR-Providence", type: :rail)}
       }
 
       assert %{type: :icon, icon: :rail, color: :purple, route_abbrev: "PVD"} ==
-               Departures.serialize_route([departure], serializer)
+               Departures.serialize_route([departure], serializer, screen)
     end
 
-    test "handles ferry", %{serializer: serializer} do
+    test "handles ferry", %{serializer: serializer, pre_fare_screen: screen} do
       departure = %Departure{
-        prediction: %Prediction{route: %Route{id: "Boat-F1", type: :ferry}}
+        prediction: %Prediction{route: route(id: "Boat-F1", type: :ferry)}
       }
 
       assert %{type: :icon, icon: :boat, color: :teal} ==
-               Departures.serialize_route([departure], serializer)
+               Departures.serialize_route([departure], serializer, screen)
     end
 
-    test "handles track numbers", %{serializer: serializer} do
+    test "handles track numbers", %{serializer: serializer, pre_fare_screen: screen} do
       departure = %Departure{
-        prediction: %Prediction{route: %Route{id: "CR-Providence", type: :rail}, track_number: 7}
+        prediction: %Prediction{route: route(id: "CR-Providence", type: :rail), track_number: 7}
       }
 
       assert %{type: :text, text: "TR7", color: :purple, route_abbrev: "PVD"} ==
-               Departures.serialize_route([departure], serializer)
+               Departures.serialize_route([departure], serializer, screen)
     end
   end
 
@@ -613,6 +614,13 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
           device_id: "TEST",
           name: "TEST",
           app_params: nil
+        },
+        gl_eink_screen: %Screen{
+          app_id: :gl_eink_v2,
+          vendor: :gds,
+          device_id: "TEST",
+          name: "TEST",
+          app_params: nil
         }
       }
     end
@@ -654,6 +662,67 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
 
       assert %{headsign: "Test 2"} ==
                Departures.serialize_headsign([departure], dup_screen)
+    end
+
+    test "shortens shuttle headsigns", %{
+      bus_shelter_screen: bus_shelter_screen,
+      dup_screen: dup_screen
+    } do
+      departure = %Departure{
+        prediction: %Prediction{
+          trip: %Trip{
+            headsign: "Alewife (Shuttle)"
+          },
+          route: route(id: "AlewifeShuttle", line_id: "line-Red")
+        }
+      }
+
+      assert %{headsign: "Alewife", variation: nil} ==
+               Departures.serialize_headsign([departure], bus_shelter_screen)
+
+      assert %{headsign: "Alewife"} ==
+               Departures.serialize_headsign([departure], dup_screen)
+
+      departure = %Departure{
+        prediction: %Prediction{
+          trip: %Trip{
+            headsign: "Alewife (Express Shuttle)"
+          },
+          route: route(id: "AlewifeExpressShuttle", line_id: "line-Red")
+        }
+      }
+
+      assert %{headsign: "Alewife", variation: "(Express)"} ==
+               Departures.serialize_headsign([departure], bus_shelter_screen)
+
+      assert %{headsign: "Alewife (Express)"} ==
+               Departures.serialize_headsign([departure], dup_screen)
+    end
+
+    test "does not shorten shuttle headsigns on einks", %{gl_eink_screen: gl_eink_screen} do
+      departure = %Departure{
+        prediction: %Prediction{
+          trip: %Trip{
+            headsign: "Alewife (Shuttle)"
+          },
+          route: route(id: "AlewifeShuttle", line_id: "line-Red")
+        }
+      }
+
+      assert %{headsign: "Alewife", variation: "(Shuttle)"} ==
+               Departures.serialize_headsign([departure], gl_eink_screen)
+
+      departure = %Departure{
+        prediction: %Prediction{
+          trip: %Trip{
+            headsign: "Alewife (Express Shuttle)"
+          },
+          route: route(id: "AlewifeExpressShuttle", line_id: "line-Red")
+        }
+      }
+
+      assert %{headsign: "Alewife", variation: "(Express Shuttle)"} ==
+               Departures.serialize_headsign([departure], gl_eink_screen)
     end
   end
 
@@ -1307,8 +1376,8 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
         rows: [
           %Departure{prediction: @prediction},
           %Departure{prediction: @prediction},
-          %Departure{prediction: %{@prediction | route: %Route{id: "1", type: :bus}}},
-          %Departure{prediction: %{@prediction | route: %Route{id: "2", type: :bus}}}
+          %Departure{prediction: %{@prediction | route: route(id: "1", type: :bus)}},
+          %Departure{prediction: %{@prediction | route: route(id: "2", type: :bus)}}
         ],
         header: %Header{},
         layout: %Layout{max: 3}
@@ -1336,28 +1405,28 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
             prediction: %{
               @prediction
               | arrival_time: ~U[2020-01-01T09:00:00Z],
-                route: %Route{id: "1", type: :bus}
+                route: route(id: "1", type: :bus)
             }
           },
           %Departure{
             prediction: %{
               @prediction
               | arrival_time: ~U[2020-01-01T09:10:00Z],
-                route: %Route{id: "1", type: :bus}
+                route: route(id: "1", type: :bus)
             }
           },
           %Departure{
             prediction: %{
               @prediction
               | arrival_time: ~U[2020-01-01T09:00:00Z],
-                route: %Route{id: "2", type: :bus}
+                route: route(id: "2", type: :bus)
             }
           },
           %Departure{
             prediction: %{
               @prediction
               | arrival_time: ~U[2020-01-01T09:15:00Z],
-                route: %Route{id: "2", type: :bus}
+                route: route(id: "2", type: :bus)
             }
           }
         ],
@@ -1382,7 +1451,7 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
           %Departure{
             prediction: %Prediction{
               arrival_time: ~U[2020-01-01T00:05:00Z],
-              route: %Route{type: :subway},
+              route: route(id: "1", type: :subway),
               trip: %Trip{headsign: "Test"},
               stop: %Stop{id: "place-test"}
             }
@@ -1390,7 +1459,7 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
           %Departure{
             prediction: %Prediction{
               arrival_time: ~U[2020-01-01T02:01:00Z],
-              route: %Route{type: :subway},
+              route: route(id: "1", type: :subway),
               trip: %Trip{headsign: "Test"},
               stop: %Stop{id: "place-test"}
             }
@@ -1424,7 +1493,7 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
           %Departure{
             prediction: %Prediction{
               arrival_time: ~U[2020-01-01T00:01:00Z],
-              route: %Route{type: :subway},
+              route: route(id: "2", type: :subway),
               trip: %Trip{headsign: "Test"},
               stop: %Stop{id: "place-test"}
             }
@@ -1432,7 +1501,7 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
           %Departure{
             prediction: %Prediction{
               arrival_time: ~U[2020-01-01T00:02:00Z],
-              route: %Route{type: :subway},
+              route: route(id: "2", type: :subway),
               trip: %Trip{headsign: "Test"},
               stop: %Stop{id: "place-test"}
             }
@@ -1467,7 +1536,7 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
           %Departure{
             prediction: %Prediction{
               arrival_time: ~U[2020-01-01T00:05:00Z],
-              route: %Route{type: :subway},
+              route: route(id: "1", type: :subway),
               trip: %Trip{headsign: "Test"},
               stop: %Stop{id: "place-test"}
             }
@@ -1475,7 +1544,7 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
           %Departure{
             prediction: %Prediction{
               arrival_time: ~U[2020-01-01T00:06:00Z],
-              route: %Route{type: :subway},
+              route: route(id: "1", type: :subway),
               trip: %Trip{headsign: "Test"},
               stop: %Stop{id: "place-test"}
             }
@@ -1483,7 +1552,7 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
           %Departure{
             prediction: %Prediction{
               arrival_time: ~U[2020-01-01T00:07:00Z],
-              route: %Route{type: :subway},
+              route: route(id: "1", type: :subway),
               trip: %Trip{headsign: "Test"},
               stop: %Stop{id: "place-test"}
             }

--- a/test/screens/v2/widget_instance/serializer/route_pill_test.exs
+++ b/test/screens/v2/widget_instance/serializer/route_pill_test.exs
@@ -1,93 +1,232 @@
 defmodule Screens.V2.WidgetInstance.Serializer.RoutePillTest do
   use ExUnit.Case, async: true
 
+  alias ScreensConfig.Screen
+
   import ExUnit.CaptureLog
+  import Screens.TestSupport.RouteBuilder
   import Screens.V2.WidgetInstance.Serializer.RoutePill
 
-  describe "serialize_for_departure/4" do
-    test "Returns rail icon with a route abbreviation for Commuter Rail" do
+  describe "serialize_for_departure/3" do
+    setup do
+      pre_fare_screen = struct(Screen, %{app_id: :pre_fare_v2})
+      gl_eink_screen = struct(Screen, %{app_id: :gl_eink_v2})
+
+      %{
+        gl_eink_screen: gl_eink_screen,
+        pre_fare_screen: pre_fare_screen
+      }
+    end
+
+    test "Returns rail icon with a route abbreviation for Commuter Rail", %{
+      pre_fare_screen: screen
+    } do
       assert %{type: :icon, icon: :rail, color: :purple, route_abbrev: "FMT"} ==
-               serialize_for_departure("CR-Fairmount", "", :rail, nil)
+               serialize_for_departure(route(id: "CR-Fairmount", type: :rail), nil, screen)
     end
 
-    test "Returns track number with route abbreviation for CR when not nil" do
+    test "Returns track number with route abbreviation for CR when not nil", %{
+      pre_fare_screen: screen
+    } do
       assert %{type: :text, text: "TR3", color: :purple, route_abbrev: "FMT"} ==
-               serialize_for_departure("CR-Fairmount", "", :rail, 3)
+               serialize_for_departure(route(id: "CR-Fairmount", type: :rail), 3, screen)
     end
 
-    test "Returns no abbreviation and logs a warning for an unknown CR route" do
+    test "Returns no abbreviation and logs a warning for an unknown CR route", %{
+      pre_fare_screen: screen
+    } do
       logs =
         capture_log([level: :warning], fn ->
           assert %{type: :icon, icon: :rail, color: :purple, route_abbrev: nil} ==
-                   serialize_for_departure("CR-Foobar", "", :rail, nil)
+                   serialize_for_departure(route(id: "CR-Foobar", type: :rail), nil, screen)
         end)
 
       assert logs =~ ~s(missing_route_pill_abbreviation line=Foobar)
     end
 
-    test "Returns boat icon if route type is :ferry" do
+    test "Returns boat icon if route type is :ferry", %{pre_fare_screen: screen} do
       assert %{type: :icon, icon: :boat, color: :teal} ==
-               serialize_for_departure("Boat-F1", "", :ferry, nil)
+               serialize_for_departure(route(id: "Boat-F1", type: :ferry), nil, screen)
     end
 
-    test "Returns ocean blue rail icon for CapeFlyer" do
+    test "Returns ocean blue rail icon for CapeFlyer", %{pre_fare_screen: screen} do
       assert %{type: :icon, icon: :rail, color: :ocean_blue} ==
-               serialize_for_departure("CapeFlyer", "", :rail, nil)
+               serialize_for_departure(route(id: "CapeFlyer", type: :rail), nil, screen)
     end
 
-    test "Returns slashed route pill if route name contains `/`" do
+    test "Returns slashed route pill if route name contains `/`", %{pre_fare_screen: screen} do
       assert %{type: :slashed, part1: "34", part2: "35", color: :yellow} ==
-               serialize_for_departure("3435", "34/35", :bus, nil)
+               serialize_for_departure(route(id: "3435", type: :bus, name: "34/35"), nil, screen)
     end
 
-    test "Returns RL for Red Line" do
+    test "Returns RL for Red Line", %{pre_fare_screen: screen} do
       assert %{type: :text, text: "RL", color: :red} ==
-               serialize_for_departure("Red", "", :subway, nil)
+               serialize_for_departure(route(id: "Red", type: :subway), nil, screen)
     end
 
-    test "Does not include branch name for Green Line" do
+    test "Does not include branch name for Green Line", %{pre_fare_screen: screen} do
       assert %{type: :text, text: "GL", color: :green} ==
-               serialize_for_departure("Green", "", :light_rail, nil)
+               serialize_for_departure(route(id: "Green", type: :light_rail), nil, screen)
     end
 
-    test "Includes branch name for Green Line" do
+    test "Includes branch name for Green Line", %{
+      pre_fare_screen: screen
+    } do
       assert %{type: :text, text: "GL·B", color: :green} ==
-               serialize_for_departure("Green-B", "", :light_rail, nil)
+               serialize_for_departure(route(id: "Green-B", type: :light_rail), nil, screen)
     end
 
-    test "Handles Silver Line routes" do
+    test "Handles Silver Line routes", %{pre_fare_screen: screen} do
       assert %{type: :text, text: "SL1", color: :silver} ==
-               serialize_for_departure("741", "", :bus, nil)
+               serialize_for_departure(route(id: "741", type: :bus), nil, screen)
     end
 
-    test "Handles cross-town routes" do
+    test "Handles cross-town routes", %{pre_fare_screen: screen} do
       assert %{type: :text, text: "CT2", color: :yellow} ==
-               serialize_for_departure("747", "", :bus, nil)
-    end
-
-    test "Uses route ID for normal bus routes" do
-      assert %{type: :text, text: "44", color: :yellow} ==
-               serialize_for_departure("44", "", :bus, nil)
-    end
-
-    test "Uses route ID for non-special case routes if route name is too long" do
-      assert %{type: :text, text: "999", color: :yellow} ==
-               serialize_for_departure("999", "NewRoute999", :bus, nil)
-    end
-
-    test "Uses route name for non-special case routes if route ID is too long" do
-      assert %{type: :text, text: "SHU", color: :yellow} ==
                serialize_for_departure(
-                 "Example Temporary Shuttle ID",
-                 "SHU",
-                 :bus,
-                 nil
+                 route(
+                   id: "747",
+                   type: :bus,
+                   name: "",
+                   line_id: "line-747"
+                 ),
+                 nil,
+                 screen
                )
     end
 
-    test "Returns icon if both route ID and name are too long" do
+    test "Uses route ID for normal bus routes", %{pre_fare_screen: screen} do
+      assert %{type: :text, text: "44", color: :yellow} ==
+               serialize_for_departure(
+                 route(
+                   id: "44",
+                   type: :bus,
+                   name: "",
+                   line_id: "line-44"
+                 ),
+                 nil,
+                 screen
+               )
+    end
+
+    test "Uses route ID for non-special case routes if route name is too long", %{
+      pre_fare_screen: screen
+    } do
+      assert %{type: :text, text: "999", color: :yellow} ==
+               serialize_for_departure(
+                 route(
+                   id: "999",
+                   type: :bus,
+                   name: "NewRoute999",
+                   line_id: "line-999"
+                 ),
+                 nil,
+                 screen
+               )
+    end
+
+    test "Uses route name for non-special case routes if route ID is too long", %{
+      pre_fare_screen: screen
+    } do
+      assert %{type: :text, text: "SHU", color: :yellow} ==
+               serialize_for_departure(
+                 route(id: "Example Long ID", type: :bus, name: "SHU"),
+                 nil,
+                 screen
+               )
+    end
+
+    test "Returns icon if both route ID and name are too long", %{pre_fare_screen: screen} do
       assert %{type: :icon, icon: :bus, color: :yellow} ==
-               serialize_for_departure("Haverhill Shuttle", "North Station (Shuttle)", :bus, nil)
+               serialize_for_departure(
+                 route(id: "Example Long ID", type: :bus, name: "Example Long Name"),
+                 nil,
+                 screen
+               )
+    end
+
+    test "Returns dual pill for Red Line shuttle", %{pre_fare_screen: screen} do
+      route =
+        route(
+          id: "Shuttle-BoylstonKenmore (shuttle)",
+          type: :bus,
+          line_id: "line-Red"
+        )
+
+      assert %{type: :dual, text: "RL", icon: :bus, color: :red, secondary_color: :yellow} ==
+               serialize_for_departure(route, nil, screen)
+    end
+
+    test "Returns dual pill for Blue Line shuttle", %{pre_fare_screen: screen} do
+      route =
+        route(
+          id: "Blue Line Shuttle (shuttle)",
+          type: :bus,
+          line_id: "line-Blue"
+        )
+
+      assert %{type: :dual, text: "BL", icon: :bus, color: :blue, secondary_color: :yellow} ==
+               serialize_for_departure(route, nil, screen)
+    end
+
+    test "Returns dual pill for Orange Line shuttle", %{pre_fare_screen: screen} do
+      route =
+        route(
+          id: "Orange Line Shuttle (shuttle)",
+          type: :bus,
+          line_id: "line-Orange"
+        )
+
+      assert %{type: :dual, text: "OL", icon: :bus, color: :orange, secondary_color: :yellow} ==
+               serialize_for_departure(route, nil, screen)
+    end
+
+    test "Returns dual pill for Commuter Rail shuttle", %{pre_fare_screen: screen} do
+      route =
+        route(
+          id: "CR-Lowell Shuttle (shuttle)",
+          type: :bus,
+          line_id: "line-CR-Lowell"
+        )
+
+      assert %{type: :dual, text: "CR", icon: :bus, color: :purple, secondary_color: :yellow} ==
+               serialize_for_departure(route, nil, screen)
+    end
+
+    test "Does not return dual pill for Green Line shuttle", %{pre_fare_screen: screen} do
+      route =
+        route(
+          id: "GL Shuttle (shuttle)",
+          type: :bus,
+          line_id: "line-Green"
+        )
+
+      assert %{type: :icon, icon: :bus, color: :yellow} ==
+               serialize_for_departure(route, nil, screen)
+    end
+
+    test "Does not return dual pill for Mattapan Line shuttle", %{pre_fare_screen: screen} do
+      route =
+        route(
+          id: "Mattapan Shuttle (shuttle)",
+          type: :bus,
+          line_id: "line-Mattapan"
+        )
+
+      assert %{type: :icon, icon: :bus, color: :yellow} ==
+               serialize_for_departure(route, nil, screen)
+    end
+
+    test "Does not return dual pill on eink screen", %{gl_eink_screen: screen} do
+      route =
+        route(
+          id: "Blue Line Shuttle (shuttle)",
+          type: :bus,
+          line_id: "line-Blue"
+        )
+
+      assert %{type: :icon, icon: :bus, color: :yellow} ==
+               serialize_for_departure(route, nil, screen)
     end
   end
 

--- a/test/support/route_builder.ex
+++ b/test/support/route_builder.ex
@@ -1,0 +1,19 @@
+defmodule Screens.TestSupport.RouteBuilder do
+  @moduledoc """
+  Provides a function that generates Route structs
+  with less boilerplate for testing purposes.
+  """
+  alias Screens.Lines.Line
+  alias Screens.Routes.Route
+
+  def route(opts) do
+    %Route{
+      id: opts[:id],
+      short_name: opts[:name] || "",
+      long_name: opts[:name],
+      type: opts[:type],
+      line:
+        if(opts[:line_id], do: %Line{id: opts[:line_id]}, else: %Line{id: "line-#{opts[:id]}"})
+    }
+  end
+end


### PR DESCRIPTION
**Asana task**: [Departures: CR Shuttle Pill Icon](https://app.asana.com/1/15492006741476/project/1208877354406742/task/1209370311249958?focus=true)

Note that the FE piece has already been deployed to DUP hardware, so this is good to deploy .

- We identify a shuttle route based on its ID containing the phrase shuttle - I checked and is the case for every shuttle pattern at this point in time
- Adds a list of `shuttle_pill_enabled_screens` that determine if a headsign and route pill is modified when it is a `shuttle_route?`
- Replaces the shuttle pill and shortens the headsign for all subway (BL, OL, RL) and CR lines