### PR TITLE
feat: randomize some DUP requests to RDS variant

### DIFF
--- a/lib/screens_web/controllers/v2/screen_api_controller.ex
+++ b/lib/screens_web/controllers/v2/screen_api_controller.ex
@@ -5,7 +5,7 @@ defmodule ScreensWeb.V2.ScreenApiController do
   alias Screens.Config.Cache
   alias Screens.V2.{ScreenAudioData, ScreenData}
   alias ScreensConfig.Screen
-  alias ScreensWeb.Plug.{LegacyLogging, ScreenRequest}
+  alias ScreensWeb.Plug.{LegacyLogging, ScreenRequest, VariantCanary}
 
   @base_response %{data: nil, disabled: false, force_reload: false}
 
@@ -16,6 +16,7 @@ defmodule ScreensWeb.V2.ScreenApiController do
   plug ScreenRequest, [type: :data] when action in @non_pending_show_actions
   plug ScreenRequest, [type: :data, pending?: true] when action in @pending_show_actions
   plug LegacyLogging, :data when action in [:show, :show_dup]
+  plug VariantCanary when action in @non_pending_show_actions
   plug :disabled_response when action in @non_pending_show_actions
   plug :outdated_response when action in @non_pending_show_actions
 

--- a/lib/screens_web/plug/variant_canary.ex
+++ b/lib/screens_web/plug/variant_canary.ex
@@ -1,0 +1,32 @@
+defmodule ScreensWeb.Plug.VariantCanary do
+  @moduledoc """
+  Randomizes a percentage of "real screen" data requests that do not specify a variant to instead
+  use a specific variant under testing. Expects to be run after `ScreenRequest` in the pipeline.
+  """
+
+  alias Plug.Conn
+  alias ScreensConfig.Screen
+
+  @app_id :dup_v2
+  @is_enabled Mix.env() != :test
+  @percentage 1
+  @variant "new_departures"
+
+  def init(options), do: options
+
+  def call(
+        %Conn{assigns: %{is_real_screen: true, screen: %Screen{app_id: @app_id}, variant: nil}} =
+          conn,
+        _options
+      ) do
+    if @is_enabled and :rand.uniform() * 100 < @percentage do
+      # Update metadata previously set in `ScreenRequest` so request logging remains accurate
+      Logger.metadata(variant: @variant)
+      Conn.assign(conn, :variant, @variant)
+    else
+      conn
+    end
+  end
+
+  def call(conn, _options), do: conn
+end


### PR DESCRIPTION
Add a temporary plug that randomizes 1% of all "real" DUP data requests to use the RDS variant. This should help expose any lurking crashes (while minimizing their impact, if any exist) and give us some indication of the real-world performance of the new system.