### PR TITLE
fix: Dependabot not updating composite actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,9 @@
 version: 2
 updates:
   - package-ecosystem: github-actions
-    directory: "/"
+    directories:
+      - "/.github/actions/*"
+      - "/.github/workflows"
     schedule:
       interval: weekly
       time: "10:00"


### PR DESCRIPTION
Using `/` as the directory of a `github-actions` ecosystem is actually an "alias" for `.github/workflows`, and so ignores our composite actions which live in subdirectories of `.github/actions`.

By switching to the `directories` field, we can specify multiple directories and they can include wildcards. Use this to include `actions/*` and also make the `workflows` "alias" explicit.