### PR TITLE
fix: raise timeout for DUP RDS variant generator

### DIFF
--- a/lib/screens/v2/candidate_generator/dup_new.ex
+++ b/lib/screens/v2/candidate_generator/dup_new.ex
@@ -20,7 +20,7 @@ defmodule Screens.V2.CandidateGenerator.DupNew do
   @impl CandidateGenerator
   def candidate_instances(config, now \\ DateTime.utc_now()) do
     @instance_generators
-    |> Task.async_stream(& &1.(config, now))
+    |> Task.async_stream(& &1.(config, now), timeout: 20_000)
     |> Enum.flat_map(fn {:ok, instances} -> instances end)
   end
 


### PR DESCRIPTION
This was using the default timeout of 5 seconds, which we sometimes exceed. For now, set this the same as the base variant (20 seconds). We should reevaluate once we have a better sense for how this variant performs.