### PR TITLE
fix: include cand. gen. timeouts in HTTP logs

### DIFF
--- a/lib/screens/v2/candidate_generator.ex
+++ b/lib/screens/v2/candidate_generator.ex
@@ -4,6 +4,10 @@ defmodule Screens.V2.CandidateGenerator do
   alias Screens.V2.WidgetInstance
   alias ScreensConfig.Screen
 
+  defmodule Timeout do
+    defexception message: "Candidate generation timed out", plug_status: 503
+  end
+
   @doc """
   Returns the template for this screen.
   """
@@ -22,4 +26,20 @@ defmodule Screens.V2.CandidateGenerator do
   """
   @callback audio_only_instances(widgets :: [WidgetInstance.t()], config :: Screen.t()) ::
               [WidgetInstance.t()]
+
+  @doc """
+  Convenience wrapper around `Task.async_stream/3` for running several candidate generation
+  functions in parallel, raising `Screens.Timeout` if any exceed a timeout.
+  """
+  @spec async_stream(Enumerable.t(), (term() -> term())) :: Enumerable.t()
+  @spec async_stream(Enumerable.t(), (term() -> term()), [Task.async_stream_option()]) ::
+          Enumerable.t()
+  def async_stream(enum, func, options \\ []) do
+    enum
+    |> Task.async_stream(func, Keyword.merge(options, on_timeout: :kill_task))
+    |> Enum.flat_map(fn
+      {:ok, instances} -> instances
+      {:exit, :timeout} -> raise Timeout
+    end)
+  end
 end

--- a/lib/screens/v2/candidate_generator/bus_eink.ex
+++ b/lib/screens/v2/candidate_generator/bus_eink.ex
@@ -55,17 +55,19 @@ defmodule Screens.V2.CandidateGenerator.BusEink do
         evergreen_content_instances_fn \\ &Widgets.Evergreen.evergreen_content_instances/2,
         subway_status_instances_fn \\ &Widgets.SubwayStatus.subway_status_instances/2
       ) do
-    [
-      fn -> header_instances_fn.(config, now) end,
-      fn -> departures_instances_fn.(config, now) end,
-      fn -> alert_instances_fn.(config, now) end,
-      fn -> footer_instances(config) end,
-      fn -> evergreen_content_instances_fn.(config, now) end,
-      fn -> bottom_screen_filler_instances(config) end,
-      fn -> subway_status_instances_fn.(config, now) end
-    ]
-    |> Task.async_stream(& &1.(), timeout: 20_000)
-    |> Enum.flat_map(fn {:ok, instances} -> instances end)
+    CandidateGenerator.async_stream(
+      [
+        fn -> header_instances_fn.(config, now) end,
+        fn -> departures_instances_fn.(config, now) end,
+        fn -> alert_instances_fn.(config, now) end,
+        fn -> footer_instances(config) end,
+        fn -> evergreen_content_instances_fn.(config, now) end,
+        fn -> bottom_screen_filler_instances(config) end,
+        fn -> subway_status_instances_fn.(config, now) end
+      ],
+      & &1.(),
+      timeout: 20_000
+    )
   end
 
   @impl CandidateGenerator

--- a/lib/screens/v2/candidate_generator/bus_shelter.ex
+++ b/lib/screens/v2/candidate_generator/bus_shelter.ex
@@ -53,17 +53,19 @@ defmodule Screens.V2.CandidateGenerator.BusShelter do
         evergreen_content_instances_fn \\ &Widgets.Evergreen.evergreen_content_instances/2,
         subway_status_instances_fn \\ &Widgets.SubwayStatus.subway_status_instances/2
       ) do
-    [
-      fn -> header_instances_fn.(config, now) end,
-      fn -> departures_instances_fn.(config, now) end,
-      fn -> alert_instances_fn.(config, now) end,
-      fn -> footer_instances(config) end,
-      fn -> subway_status_instances_fn.(config, now) end,
-      fn -> evergreen_content_instances_fn.(config, now) end,
-      fn -> survey_instances(config) end
-    ]
-    |> Task.async_stream(& &1.(), timeout: 15_000)
-    |> Enum.flat_map(fn {:ok, instances} -> instances end)
+    CandidateGenerator.async_stream(
+      [
+        fn -> header_instances_fn.(config, now) end,
+        fn -> departures_instances_fn.(config, now) end,
+        fn -> alert_instances_fn.(config, now) end,
+        fn -> footer_instances(config) end,
+        fn -> subway_status_instances_fn.(config, now) end,
+        fn -> evergreen_content_instances_fn.(config, now) end,
+        fn -> survey_instances(config) end
+      ],
+      & &1.(),
+      timeout: 15_000
+    )
   end
 
   @impl CandidateGenerator

--- a/lib/screens/v2/candidate_generator/busway.ex
+++ b/lib/screens/v2/candidate_generator/busway.ex
@@ -27,14 +27,8 @@ defmodule Screens.V2.CandidateGenerator.Busway do
   end
 
   @impl CandidateGenerator
-  def candidate_instances(
-        config,
-        now \\ DateTime.utc_now(),
-        instance_fns \\ @instance_fns
-      ) do
-    instance_fns
-    |> Task.async_stream(& &1.(config, now), timeout: 10_000)
-    |> Enum.flat_map(fn {:ok, instances} -> instances end)
+  def candidate_instances(config, now \\ DateTime.utc_now(), instance_fns \\ @instance_fns) do
+    CandidateGenerator.async_stream(instance_fns, & &1.(config, now), timeout: 10_000)
   end
 
   @impl CandidateGenerator

--- a/lib/screens/v2/candidate_generator/dup.ex
+++ b/lib/screens/v2/candidate_generator/dup.ex
@@ -78,15 +78,17 @@ defmodule Screens.V2.CandidateGenerator.Dup do
         alerts_instances_fn \\ &AlertsInstances.alert_instances/2,
         emergency_takeover_instances_fn \\ &Widgets.EmergencyTakeover.emergency_takeover_instances/2
       ) do
-    [
-      fn -> header_instances_fn.(config, now) end,
-      fn -> alerts_instances_fn.(config, now) end,
-      fn -> departures_instances_fn.(config, now) end,
-      fn -> evergreen_content_instances_fn.(config, now) end,
-      fn -> emergency_takeover_instances_fn.(config, now) end
-    ]
-    |> Task.async_stream(& &1.(), timeout: 20_000)
-    |> Enum.flat_map(fn {:ok, instances} -> instances end)
+    CandidateGenerator.async_stream(
+      [
+        fn -> header_instances_fn.(config, now) end,
+        fn -> alerts_instances_fn.(config, now) end,
+        fn -> departures_instances_fn.(config, now) end,
+        fn -> evergreen_content_instances_fn.(config, now) end,
+        fn -> emergency_takeover_instances_fn.(config, now) end
+      ],
+      & &1.(),
+      timeout: 20_000
+    )
   end
 
   @impl CandidateGenerator

--- a/lib/screens/v2/candidate_generator/dup_new.ex
+++ b/lib/screens/v2/candidate_generator/dup_new.ex
@@ -19,9 +19,7 @@ defmodule Screens.V2.CandidateGenerator.DupNew do
 
   @impl CandidateGenerator
   def candidate_instances(config, now \\ DateTime.utc_now()) do
-    @instance_generators
-    |> Task.async_stream(& &1.(config, now), timeout: 20_000)
-    |> Enum.flat_map(fn {:ok, instances} -> instances end)
+    CandidateGenerator.async_stream(@instance_generators, & &1.(config, now), timeout: 20_000)
   end
 
   @impl CandidateGenerator

--- a/lib/screens/v2/candidate_generator/gl_eink.ex
+++ b/lib/screens/v2/candidate_generator/gl_eink.ex
@@ -76,20 +76,22 @@ defmodule Screens.V2.CandidateGenerator.GlEink do
         evergreen_content_instances_fn \\ &Widgets.Evergreen.evergreen_content_instances/1,
         subway_status_instances_fn \\ &Widgets.SubwayStatus.subway_status_instances/2
       ) do
-    [
-      fn -> header_instances(config, now, fetch_destination_fn) end,
-      fn ->
-        departures_instances_fn.(config, now, post_process_fn: &departures_post_processing/2)
-      end,
-      fn -> alert_instances_fn.(config) end,
-      fn -> footer_instances(config) end,
-      fn -> line_map_instances_fn.(config, now) end,
-      fn -> evergreen_content_instances_fn.(config) end,
-      fn -> bottom_screen_filler_instances(config) end,
-      fn -> subway_status_instances_fn.(config, now) end
-    ]
-    |> Task.async_stream(& &1.(), timeout: 20_000)
-    |> Enum.flat_map(fn {:ok, instances} -> instances end)
+    CandidateGenerator.async_stream(
+      [
+        fn -> header_instances(config, now, fetch_destination_fn) end,
+        fn ->
+          departures_instances_fn.(config, now, post_process_fn: &departures_post_processing/2)
+        end,
+        fn -> alert_instances_fn.(config) end,
+        fn -> footer_instances(config) end,
+        fn -> line_map_instances_fn.(config, now) end,
+        fn -> evergreen_content_instances_fn.(config) end,
+        fn -> bottom_screen_filler_instances(config) end,
+        fn -> subway_status_instances_fn.(config, now) end
+      ],
+      & &1.(),
+      timeout: 20_000
+    )
   end
 
   @impl CandidateGenerator

--- a/lib/screens/v2/candidate_generator/pre_fare.ex
+++ b/lib/screens/v2/candidate_generator/pre_fare.ex
@@ -75,9 +75,7 @@ defmodule Screens.V2.CandidateGenerator.PreFare do
 
   @impl CandidateGenerator
   def candidate_instances(config, now \\ DateTime.utc_now(), instance_fns \\ @instance_fns) do
-    instance_fns
-    |> Task.async_stream(& &1.(config, now), timeout: 15_000)
-    |> Enum.flat_map(fn {:ok, instances} -> instances end)
+    CandidateGenerator.async_stream(instance_fns, & &1.(config, now), timeout: 15_000)
   end
 
   @impl CandidateGenerator


### PR DESCRIPTION
Candidate generators use `Task.async_stream/3` to run their widget generation functions in parallel, with a timeout to ensure this doesn't take forever. The default behavior is to exit the calling process when a task times out. Unfortunately the `phoenix.endpoint.stop` telemetry event, which Logster uses for its HTTP request logs, "is not guaranteed to be emitted in all error cases"[^1], so when this happens we don't see a log for the resulting 500 response and its duration, etc.

* Update candidate generators to use `on_timeout: :kill_task` and raise this as an exception instead of exiting.

* Use a custom exception type with a `plug_status` field, which is picked up by `Plug.Exception`[^2]. 503 Service Unavailable seems most appropriate here.

* Extract this behavior into a shared function so it doesn't have to be duplicated in every candidate generator.

[^1]: https://hexdocs.pm/plug/1.18.1/Plug.Telemetry.html
[^2]: https://hexdocs.pm/plug/1.19.1/Plug.Exception.html