### PR TITLE
deps(dev): bump eslint-plugin-react-hooks

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -42,7 +42,7 @@
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-jest": "^29.15.1",
         "eslint-plugin-react": "^7.37.5",
-        "eslint-plugin-react-hooks": "^7.0.1",
+        "eslint-plugin-react-hooks": "^7.1.1",
         "exit_on_eof": "^1.0.4",
         "fishery": "^2.4.0",
         "globals": "^17.4.0",
@@ -7806,9 +7806,9 @@
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.0.1.tgz",
-      "integrity": "sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
+      "integrity": "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7822,7 +7822,7 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
       }
     },
     "node_modules/eslint-plugin-react-hooks/node_modules/zod-validation-error": {

--- a/assets/package.json
+++ b/assets/package.json
@@ -55,7 +55,7 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-jest": "^29.15.1",
     "eslint-plugin-react": "^7.37.5",
-    "eslint-plugin-react-hooks": "^7.0.1",
+    "eslint-plugin-react-hooks": "^7.1.1",
     "exit_on_eof": "^1.0.4",
     "fishery": "^2.4.0",
     "globals": "^17.4.0",

--- a/assets/src/components/admin/admin_image_manager.tsx
+++ b/assets/src/components/admin/admin_image_manager.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState, type JSX } from "react";
+import { useCallback, useState, type JSX } from "react";
 import { useDropzone } from "react-dropzone";
 import _ from "lodash";
 
@@ -122,6 +122,7 @@ const ImageUpload = ({ onUploaded, selectedPrefix }): JSX.Element => {
 };
 
 const ImageManager = (): JSX.Element => {
+  const [didInit, setDidInit] = useState(false);
   const [images, setImages] = useState<ImageEntry[]>([]);
   const [selectedKey, setSelectedKey] = useState<string | undefined>(undefined);
   const [isDeleting, setIsDeleting] = useState(false);
@@ -134,10 +135,10 @@ const ImageManager = (): JSX.Element => {
     setSelectedKey(selectKey);
   };
 
-  useEffect(() => {
+  if (!didInit) {
     loadImages();
-    return;
-  }, []);
+    setDidInit(true);
+  }
 
   const imageUrls = Object.fromEntries(
     images.map(({ key, url }) => [key, url]),

--- a/assets/src/components/disruption_diagram/disruption_diagram.tsx
+++ b/assets/src/components/disruption_diagram/disruption_diagram.tsx
@@ -2,9 +2,9 @@
 
 import {
   type ComponentType,
+  type RefCallback,
   useCallback,
   useEffect,
-  useRef,
   useState,
 } from "react";
 import { classWithModifier, classWithModifiers } from "Util/utils";
@@ -610,10 +610,10 @@ Client is responsible for:
 - sizing, spacing, positioning of edges/end arrows/shuttle dashes/the diagram as a whole within its container
 */
 
-/* eslint-disable react-hooks/exhaustive-deps --
+/* eslint-disable react-hooks/exhaustive-deps,react-hooks/set-state-in-effect --
  * TODO: There are many places where this component breaks the Rules of Hooks.
  * We know it (mostly) works in its current form and have no pressing need to
- * change it, so this lint warning is disabled for now. Trying to change this
+ * change it, so these warnings are disabled for now. Trying to change this
  * logic without fully understanding and extensively testing everything going
  * on here is likely to break something.
  */
@@ -630,19 +630,15 @@ const DisruptionDiagram: ComponentType<DisruptionDiagramData> = (props) => {
   const [diagramContainerHeight, setDiagramContainerHeight] = useState(0);
   const [simulationTransform, setSimulationTransform] = useState(1);
 
-  const ref = useRef<HTMLDivElement>(null);
-  useEffect(() => {
-    if (!ref.current) return;
-    const resizeObserver = new ResizeObserver(() => {
-      if (ref?.current) {
-        setDiagramContainerHeight(
-          ref.current.clientHeight * simulationTransform,
-        );
-      }
-    });
-    resizeObserver.observe(ref.current);
-    return () => resizeObserver.disconnect();
-  }, [ref?.current]);
+  const ref: RefCallback<HTMLDivElement> = useCallback((elem) => {
+    if (elem) {
+      const resizeObserver = new ResizeObserver(() => {
+        setDiagramContainerHeight(elem.clientHeight * simulationTransform);
+      });
+      resizeObserver.observe(elem);
+      return () => resizeObserver.disconnect();
+    }
+  }, []);
 
   // Measures line-map svg when the scaleFactor changes, updates state
   const measureLineMapNode = useCallback(
@@ -686,6 +682,7 @@ const DisruptionDiagram: ComponentType<DisruptionDiagramData> = (props) => {
   const middleSlots = middle.map((s, i) => {
     // Add 1 to the index to counteract the offset caused by removing `beginning` from the original `slots` array.
     const slotIndex = i + 1;
+    /* eslint-disable react-hooks/immutability */
     x = (spaceBetween + SLOT_WIDTH) * slotIndex;
     const slot = s as MiddleSlot;
     const key = slot.label === "…" ? i : slot.label.full;

--- a/assets/src/components/dup/departures/destination.tsx
+++ b/assets/src/components/dup/departures/destination.tsx
@@ -72,6 +72,11 @@ const Destination: ComponentType<DupDestination> = ({
     parts = parts.map((p) => ABBREVIATIONS[p] || p);
   }
 
+  /* eslint-disable react-hooks/set-state-in-effect --
+   * Similar to `useAutoSize`, setting state in an effect here is intentional
+   * and a required part of the iterative approach to auto-sizing.
+   */
+
   /* eslint-disable-next-line react-hooks/exhaustive-deps --
    * TODO: Replace this with `useAutoSize`. For now, we know this logic cannot
    * cause infinite update loops, so we don't need to be warned that it might.
@@ -135,6 +140,8 @@ const Destination: ComponentType<DupDestination> = ({
       }
     }
   });
+
+  /* eslint-enable react-hooks/set-state-in-effect */
 
   // Render paged version when done determining breaks
   if (phase === PHASES.DONE) {


### PR DESCRIPTION
This is holding up #3026 due to failures with the new version of `eslint-plugin-react-hooks`.

* Improvements to `set-state-in-effect` catch more occurrences. Fix or ignore these as appropriate.

* Improvements to `immutability` catch an unconventional use of variable reassignment in `DisruptionDiagram`. Ignore this for now to avoid a disruptive refactoring of the component that might affect behavior.