### PR TITLE
feat: Use new Predictions trip_headsign field for headsign displays

### DIFF
--- a/lib/screens/predictions/parser.ex
+++ b/lib/screens/predictions/parser.ex
@@ -11,7 +11,8 @@ defmodule Screens.Predictions.Parser do
             "arrival_time" => arrival_time_string,
             "departure_time" => departure_time_string,
             "schedule_relationship" => schedule_relationship,
-            "status" => status
+            "status" => status,
+            "trip_headsign" => trip_headsign
           },
           "relationships" => %{
             "route" => route,
@@ -34,7 +35,8 @@ defmodule Screens.Predictions.Parser do
       departure_time: parse_time(departure_time_string),
       track_number: stop.platform_code,
       schedule_relationship: ScheduleRelationship.parse(schedule_relationship),
-      status: status
+      status: status,
+      trip_headsign: trip_headsign
     }
   end
 

--- a/lib/screens/predictions/prediction.ex
+++ b/lib/screens/predictions/prediction.ex
@@ -12,10 +12,10 @@ defmodule Screens.Predictions.Prediction do
             vehicle: nil,
             arrival_time: nil,
             departure_time: nil,
-            stop_headsign: nil,
             track_number: nil,
             schedule_relationship: :scheduled,
-            status: nil
+            status: nil,
+            trip_headsign: nil
 
   @type t :: %__MODULE__{
           id: String.t(),
@@ -25,10 +25,10 @@ defmodule Screens.Predictions.Prediction do
           vehicle: Screens.Vehicles.Vehicle.t() | nil,
           arrival_time: DateTime.t() | nil,
           departure_time: DateTime.t() | nil,
-          stop_headsign: String.t() | nil,
           track_number: String.t() | nil,
           schedule_relationship: ScheduleRelationship.t(),
-          status: String.t() | nil
+          status: String.t() | nil,
+          trip_headsign: String.t() | nil
         }
 
   @includes ~w[route.line stop trip.route_pattern.representative_trip trip.stops vehicle]

--- a/lib/screens/v2/departure.ex
+++ b/lib/screens/v2/departure.ex
@@ -137,27 +137,22 @@ defmodule Screens.V2.Departure do
     end
   end
 
-  def headsign(%__MODULE__{prediction: p, schedule: s}) when not is_nil(p) do
-    %Prediction{trip: %Trip{headsign: headsign}} = p
+  # The headsign to display in order of preference.
+  # May be updated in the schedule/prediction data w/ the trip's or stop's final destination.
+  @spec headsign(t()) :: String.t()
+  def headsign(%__MODULE__{prediction: %Prediction{trip_headsign: trip_headsign}})
+      when not is_nil(trip_headsign),
+      do: trip_headsign
 
-    case s do
-      %Schedule{stop_headsign: stop_headsign} when not is_nil(stop_headsign) ->
-        stop_headsign
+  def headsign(%__MODULE__{schedule: %Schedule{stop_headsign: stop_headsign}})
+      when not is_nil(stop_headsign),
+      do: stop_headsign
 
-      _ ->
-        headsign
-    end
-  end
+  def headsign(%__MODULE__{prediction: %Prediction{trip: %Trip{headsign: headsign}}}),
+    do: headsign
 
-  def headsign(%__MODULE__{prediction: nil, schedule: s}) do
-    case s do
-      %Schedule{stop_headsign: stop_headsign} when not is_nil(stop_headsign) ->
-        stop_headsign
-
-      %Schedule{trip: %Trip{headsign: headsign}} ->
-        headsign
-    end
-  end
+  def headsign(%__MODULE__{schedule: %Schedule{trip: %Trip{headsign: headsign}}}),
+    do: headsign
 
   def id(%__MODULE__{prediction: %Prediction{id: prediction_id}}), do: prediction_id
   def id(%__MODULE__{schedule: %Schedule{id: schedule_id}}), do: schedule_id

--- a/test/screens/v2/departure_test.exs
+++ b/test/screens/v2/departure_test.exs
@@ -127,6 +127,14 @@ defmodule Screens.V2.DepartureTest do
       assert "Heath St" == Departure.headsign(departure)
     end
 
+    test "overrides stop_headsign from schedule with trip_headsign from prediction" do
+      prediction = %Prediction{trip: %Trip{headsign: "Jackson"}, trip_headsign: "Kenmore"}
+      schedule = %Schedule{trip: %Trip{headsign: "Ruggles"}, stop_headsign: "Heath St"}
+      departure = %Departure{prediction: prediction, schedule: schedule}
+
+      assert "Kenmore" == Departure.headsign(departure)
+    end
+
     test "returns schedule headsign when no prediction is present" do
       schedule = %Schedule{trip: %Trip{headsign: "Ruggles"}}
       departure = %Departure{prediction: nil, schedule: schedule}


### PR DESCRIPTION
**Asana task**: [Screens: Use new `trip_headsign` field for departure headsigns](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1214064512691055?focus=true)


- Adds new `trip_headsign` field to be used as the highest priority option in `Departure.headsign`
- Removes the `stop_headsign` field from the `Prediction` struct, since this field can only exist on a `Schedule` at this time