### PR TITLE
ci: remove `scripts` from ignored paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,6 @@ on:
   pull_request:
     paths-ignore:
       - docs/**
-      - scripts/**
       - "*.md"
       - LICENSE
 


### PR DESCRIPTION
In 981c96f we updated the Elixir formatter config to also format files in `scripts`, but did not update the CI workflow (which enforces the formatting) to stop ignoring this path.