### PR TITLE
fix: add Alerts/Emergency Takeover Candidate Generator to DupNew

### DIFF
--- a/lib/screens/v2/candidate_generator/dup/alerts.ex
+++ b/lib/screens/v2/candidate_generator/dup/alerts.ex
@@ -16,17 +16,16 @@ defmodule Screens.V2.CandidateGenerator.Dup.Alerts do
 
   require Logger
 
+  import Screens.Inject
+  @alert injected(Alert)
+  @stop injected(Stop)
+  @location_context injected(LocationContext)
+
   @doc """
   Fetches alerts + related data from the API and transforms them to candidate
   widgets for a DUP screen.
   """
-  def alert_instances(
-        config,
-        now \\ DateTime.utc_now(),
-        fetch_stop_name_fn \\ &Stop.fetch_stop_name/1,
-        fetch_alerts_fn \\ &Alert.fetch/1,
-        fetch_location_context_fn \\ &LocationContext.fetch/3
-      ) do
+  def alert_instances(config, now \\ DateTime.utc_now()) do
     # In this function:
     # - Fetch relevant alerts for all SUBWAY/LIGHT RAIL routes serving this stop
     # - Check for special cases. If there is one, just use that. Otherwise:
@@ -41,7 +40,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Alerts do
       stop_name =
         case header_config do
           %{stop_id: stop_id} ->
-            case fetch_stop_name_fn.(stop_id) do
+            case @stop.fetch_stop_name(stop_id) do
               nil -> []
               stop_name -> stop_name
             end
@@ -50,9 +49,9 @@ defmodule Screens.V2.CandidateGenerator.Dup.Alerts do
             stop_name
         end
 
-      with {:ok, location_context} <- fetch_location_context_fn.(Dup, stop_id, now),
+      with {:ok, location_context} <- @location_context.fetch(Dup, stop_id, now),
            route_ids <- LocationContext.route_ids(location_context),
-           {:ok, alerts} <- fetch_alerts_fn.(route_ids: route_ids) do
+           {:ok, alerts} <- @alert.fetch(route_ids: route_ids) do
         alerts
         |> relevant_alerts(config, location_context, now)
         |> alert_special_cases(config, location_context)

--- a/lib/screens/v2/candidate_generator/dup_new.ex
+++ b/lib/screens/v2/candidate_generator/dup_new.ex
@@ -2,6 +2,7 @@ defmodule Screens.V2.CandidateGenerator.DupNew do
   @moduledoc false
 
   alias Screens.V2.CandidateGenerator
+  alias Screens.V2.CandidateGenerator.Dup.Alerts, as: AlertsGenerator
   alias Screens.V2.CandidateGenerator.Widgets
 
   alias __MODULE__.Departures
@@ -11,7 +12,9 @@ defmodule Screens.V2.CandidateGenerator.DupNew do
   @instance_generators [
     &Widgets.Header.instances/2,
     &Departures.instances/2,
-    &Widgets.Evergreen.evergreen_content_instances/2
+    &Widgets.Evergreen.evergreen_content_instances/2,
+    &AlertsGenerator.alert_instances/2,
+    &Widgets.EmergencyTakeover.emergency_takeover_instances/2
   ]
 
   @impl CandidateGenerator

--- a/lib/screens/v2/location_context.ex
+++ b/lib/screens/v2/location_context.ex
@@ -43,7 +43,7 @@ defmodule Screens.LocationContext do
   where we know it will not cause major issues, and has intentionally minimal support on those
   screen types (e.g. "does this alert affect the home stop" conditions will always be false).
   """
-  @spec fetch(screen_type(), Stop.id() | [Stop.id()], DateTime.t()) :: {:ok, t()} | :error
+  @callback fetch(screen_type(), Stop.id() | [Stop.id()], DateTime.t()) :: {:ok, t()} | :error
   def fetch(app, stop_id, now) when is_binary(stop_id), do: do_fetch(app, [stop_id], now)
   def fetch(app, [_] = stop_ids, now), do: do_fetch(app, stop_ids, now)
   def fetch(BusEink = app, [_ | _] = stop_ids, now), do: do_fetch(app, stop_ids, now)

--- a/test/screens/v2/candidate_generator/dup/alert_test.exs
+++ b/test/screens/v2/candidate_generator/dup/alert_test.exs
@@ -11,6 +11,13 @@ defmodule Screens.V2.CandidateGenerator.Dup.AlertTest do
   alias ScreensConfig.Screen
   alias ScreensConfig.Screen.Dup
 
+  import Mox
+  setup :verify_on_exit!
+
+  import Screens.Inject
+  @alert injected(Screens.Alerts.Alert)
+  @location_context injected(Screens.LocationContext)
+
   @stop_id "place-bbsta"
   @base_alert %Alert{
     active_period: [{~U[2025-09-18 02:30:00Z], nil}],
@@ -52,15 +59,11 @@ defmodule Screens.V2.CandidateGenerator.Dup.AlertTest do
 
   @now ~U[2025-09-18 02:30:00Z]
 
-  defp fetch_stop_name_fn(_) do
-    "Back Bay"
+  defp expect_alerts(options \\ %{}) do
+    expect(@alert, :fetch, fn _ -> {:ok, [Map.merge(@base_alert, options)]} end)
   end
 
-  defp fetch_alerts_fn(options \\ %{}) do
-    {:ok, [Map.merge(@base_alert, options)]}
-  end
-
-  defp fetch_location_context_fn(stop_id \\ "place-bbsta") do
+  defp expect_location_context(stop_id \\ "place-bbsta") do
     tagged_stop_sequences = %{
       "Orange" => [["place-tumnl", "place-bbsta", "place-masta"]]
     }
@@ -78,27 +81,26 @@ defmodule Screens.V2.CandidateGenerator.Dup.AlertTest do
       }
     ]
 
-    {:ok,
-     %LocationContext{
-       home_stop: stop_id,
-       tagged_stop_sequences: tagged_stop_sequences,
-       upstream_stops: LocationContext.upstream_stop_id_set([stop_id], stop_sequences),
-       downstream_stops: LocationContext.downstream_stop_id_set([stop_id], stop_sequences),
-       routes: routes_at_stop,
-       alert_route_types: LocationContext.route_type_filter(Dup, [stop_id])
-     }}
+    location_context =
+      {:ok,
+       %LocationContext{
+         home_stop: stop_id,
+         tagged_stop_sequences: tagged_stop_sequences,
+         upstream_stops: LocationContext.upstream_stop_id_set([stop_id], stop_sequences),
+         downstream_stops: LocationContext.downstream_stop_id_set([stop_id], stop_sequences),
+         routes: routes_at_stop,
+         alert_route_types: LocationContext.route_type_filter(Dup, [stop_id])
+       }}
+
+    expect(@location_context, :fetch, fn _, _, _ -> location_context end)
   end
 
   describe "alert_instances/5" do
     test "returns alert instances" do
-      actual_widgets =
-        Alerts.alert_instances(
-          @config,
-          @now,
-          &fetch_stop_name_fn/1,
-          fn _ -> fetch_alerts_fn() end,
-          fn _, _, _ -> fetch_location_context_fn() end
-        )
+      expect_alerts()
+      expect_location_context()
+
+      actual_widgets = Alerts.alert_instances(@config, @now)
 
       assert [
                %{
@@ -190,62 +192,37 @@ defmodule Screens.V2.CandidateGenerator.Dup.AlertTest do
   end
 
   test "does not return alert for informational single tracking" do
-    actual_widgets =
-      Alerts.alert_instances(
-        @config,
-        @now,
-        &fetch_stop_name_fn/1,
-        fn _ ->
-          fetch_alerts_fn(%{
-            severity: 1,
-            cause: :single_tracking
-          })
-        end,
-        fn _, _, _ -> fetch_location_context_fn() end
-      )
+    expect_alerts(%{severity: 1, cause: :single_tracking})
+    expect_location_context()
+
+    actual_widgets = Alerts.alert_instances(@config, @now)
 
     assert [] == actual_widgets
   end
 
   test "does not return DUP alert for alerts that are not happening now" do
-    actual_widgets =
-      Alerts.alert_instances(
-        @config,
-        ~U[2025-09-16 02:30:00Z],
-        &fetch_stop_name_fn/1,
-        fn _ -> fetch_alerts_fn() end,
-        fn _, _, _ -> fetch_location_context_fn() end
-      )
+    expect_alerts()
+    expect_location_context()
+
+    actual_widgets = Alerts.alert_instances(@config, ~U[2025-09-16 02:30:00Z])
 
     assert [] == actual_widgets
   end
 
   test "does not return DUP alert for alerts not happening here" do
-    actual_widgets =
-      Alerts.alert_instances(
-        @config,
-        @now,
-        &fetch_stop_name_fn/1,
-        fn _ -> fetch_alerts_fn() end,
-        fn _, _, _ -> fetch_location_context_fn("place-masta") end
-      )
+    expect_alerts()
+    expect_location_context("place-masta")
+
+    actual_widgets = Alerts.alert_instances(@config, @now)
 
     assert [] == actual_widgets
   end
 
   test "does not return alert for alerts that are not severe enough" do
-    actual_widgets =
-      Alerts.alert_instances(
-        @config,
-        @now,
-        &fetch_stop_name_fn/1,
-        fn _ ->
-          fetch_alerts_fn(%{
-            severity: 4
-          })
-        end,
-        fn _, _, _ -> fetch_location_context_fn() end
-      )
+    expect_alerts(%{severity: 4})
+    expect_location_context()
+
+    actual_widgets = Alerts.alert_instances(@config, @now)
 
     assert [] == actual_widgets
   end

--- a/test/screens/v2/candidate_generator/dup_new_test.exs
+++ b/test/screens/v2/candidate_generator/dup_new_test.exs
@@ -1,6 +1,7 @@
 defmodule Screens.V2.CandidateGenerator.DupNewTest do
   use ExUnit.Case, async: true
 
+  alias Screens.LocationContext
   alias Screens.Util.Assets
   alias Screens.V2.CandidateGenerator.DupNew
   alias Screens.V2.RDS
@@ -14,10 +15,18 @@ defmodule Screens.V2.CandidateGenerator.DupNewTest do
 
   import Screens.Inject
   @alert injected(Screens.Alerts.Alert)
+  @stop injected(Screens.Stops.Stop)
+  @location_context injected(LocationContext)
   @rds injected(RDS)
 
   setup do
     stub(@alert, :fetch, fn _ -> {:ok, []} end)
+    stub(@stop, :fetch_stop_name, fn _ -> "" end)
+
+    stub(@location_context, :fetch, fn _, _, _ ->
+      {:ok, %LocationContext{home_stop: "Test", routes: []}}
+    end)
+
     stub(@rds, :get, fn _, _ -> [{:ok, []}] end)
     :ok
   end

--- a/test/screens/v2/widget_instance/dup_special_case_alert_test.exs
+++ b/test/screens/v2/widget_instance/dup_special_case_alert_test.exs
@@ -1,6 +1,7 @@
 defmodule Screens.V2.WidgetInstance.DupSpecialCaseAlertTest do
   use ExUnit.Case, async: true
 
+  alias Screens.Alerts.Alert
   alias Screens.LocationContext
   alias Screens.V2.CandidateGenerator.Dup.Alerts, as: DupAlerts
   alias Screens.V2.WidgetInstance.DupAlert
@@ -9,6 +10,14 @@ defmodule Screens.V2.WidgetInstance.DupSpecialCaseAlertTest do
   alias ScreensConfig.Screen.Dup
 
   import Screens.TestSupport.InformedEntityBuilder
+
+  import Screens.Inject
+  @alert injected(Alert)
+  @stop injected(Screens.Stops.Stop)
+  @location_context injected(Screens.LocationContext)
+
+  import Mox
+  setup :verify_on_exit!
 
   defp routes("place-kencl") do
     [
@@ -136,8 +145,37 @@ defmodule Screens.V2.WidgetInstance.DupSpecialCaseAlertTest do
     }
   end
 
+  defp expect_alerts(_route_ids, alerts) do
+    expect(@alert, :fetch, fn _route_ids -> {:ok, alerts} end)
+  end
+
+  defp expect_stop_name do
+    expect(@stop, :fetch_stop_name, fn _ -> "Test" end)
+  end
+
+  defp expect_location_context do
+    expect(@location_context, :fetch, fn _, stop_id, _ ->
+      tagged_stop_sequences = tagged_stop_sequences(stop_id)
+      stop_sequences = LocationContext.untag_stop_sequences(tagged_stop_sequences)
+
+      {:ok,
+       %LocationContext{
+         home_stop: stop_id,
+         tagged_stop_sequences: tagged_stop_sequences,
+         upstream_stops: LocationContext.upstream_stop_id_set([stop_id], stop_sequences),
+         downstream_stops: LocationContext.downstream_stop_id_set([stop_id], stop_sequences),
+         routes: routes(stop_id),
+         alert_route_types: LocationContext.route_type_filter(Dup, [stop_id])
+       }}
+    end)
+  end
+
   describe "dup alert_instances/6 > serialize/1" do
     setup do
+      stub(@alert, :fetch, fn _ -> [] end)
+      expect_stop_name()
+      expect_location_context()
+
       config_kenmore =
         struct(Screen, %{
           app_params: %Dup{
@@ -408,39 +446,16 @@ defmodule Screens.V2.WidgetInstance.DupSpecialCaseAlertTest do
         fetch_stop_name_fn: fn _ -> "Test" end,
         kenmore_alerts: kenmore_alerts,
         kenmore_inside_alert: kenmore_inside_alert,
-        wtc_alerts: wtc_alerts,
-        fetch_location_context_fn: fn
-          _, stop_id, _ ->
-            tagged_stop_sequences = tagged_stop_sequences(stop_id)
-            stop_sequences = LocationContext.untag_stop_sequences(tagged_stop_sequences)
-
-            {:ok,
-             %LocationContext{
-               home_stop: stop_id,
-               tagged_stop_sequences: tagged_stop_sequences,
-               upstream_stops: LocationContext.upstream_stop_id_set([stop_id], stop_sequences),
-               downstream_stops:
-                 LocationContext.downstream_stop_id_set([stop_id], stop_sequences),
-               routes: routes(stop_id),
-               alert_route_types: LocationContext.route_type_filter(Dup, [stop_id])
-             }}
-        end
+        wtc_alerts: wtc_alerts
       }
     end
 
     test "serializes Kenmore special case: B / C, multiple alerts", context do
       alerts = Enum.drop(context.kenmore_alerts, -2)
 
-      fetch_alerts_fn = fn route_ids: ["Green-B", "Green-C", "Green-D"] -> {:ok, alerts} end
+      expect_alerts(["Green-B", "Green-C", "Green-D"], alerts)
 
-      actual_widgets =
-        DupAlerts.alert_instances(
-          context.config_kenmore,
-          context.now,
-          context.fetch_stop_name_fn,
-          fetch_alerts_fn,
-          context.fetch_location_context_fn
-        )
+      actual_widgets = DupAlerts.alert_instances(context.config_kenmore, context.now)
 
       expected_serialized_json = [
         %{
@@ -494,16 +509,9 @@ defmodule Screens.V2.WidgetInstance.DupSpecialCaseAlertTest do
         |> Enum.drop(1)
         |> Enum.drop(-1)
 
-      fetch_alerts_fn = fn route_ids: ["Green-B", "Green-C", "Green-D"] -> {:ok, alerts} end
+      expect_alerts(["Green-B", "Green-C", "Green-D"], alerts)
 
-      actual_widgets =
-        DupAlerts.alert_instances(
-          context.config_kenmore,
-          context.now,
-          context.fetch_stop_name_fn,
-          fetch_alerts_fn,
-          context.fetch_location_context_fn
-        )
+      actual_widgets = DupAlerts.alert_instances(context.config_kenmore, context.now)
 
       expected_serialized_json = [
         %{
@@ -554,16 +562,9 @@ defmodule Screens.V2.WidgetInstance.DupSpecialCaseAlertTest do
     test "serializes Kenmore special case: B / D, single alert ", context do
       alerts = [Enum.at(context.kenmore_alerts, 0)] ++ [Enum.at(context.kenmore_alerts, 2)]
 
-      fetch_alerts_fn = fn route_ids: ["Green-B", "Green-C", "Green-D"] -> {:ok, alerts} end
+      expect_alerts(["Green-B", "Green-C", "Green-D"], alerts)
 
-      actual_widgets =
-        DupAlerts.alert_instances(
-          context.config_kenmore,
-          context.now,
-          context.fetch_stop_name_fn,
-          fetch_alerts_fn,
-          context.fetch_location_context_fn
-        )
+      actual_widgets = DupAlerts.alert_instances(context.config_kenmore, context.now)
 
       expected_serialized_json = [
         %{
@@ -614,16 +615,9 @@ defmodule Screens.V2.WidgetInstance.DupSpecialCaseAlertTest do
     test "serializes Kenmore special case: B / C / D, single alert", context do
       alerts = [Enum.at(context.kenmore_alerts, 3)]
 
-      fetch_alerts_fn = fn route_ids: ["Green-B", "Green-C", "Green-D"] -> {:ok, alerts} end
+      expect_alerts(["Green-B", "Green-C", "Green-D"], alerts)
 
-      actual_widgets =
-        DupAlerts.alert_instances(
-          context.config_kenmore,
-          context.now,
-          context.fetch_stop_name_fn,
-          fetch_alerts_fn,
-          context.fetch_location_context_fn
-        )
+      actual_widgets = DupAlerts.alert_instances(context.config_kenmore, context.now)
 
       expected_serialized_json = [
         %{
@@ -674,16 +668,9 @@ defmodule Screens.V2.WidgetInstance.DupSpecialCaseAlertTest do
     test "serialize DupAlert for alerts inside Kenmore, bypasses special case", context do
       alerts = [context.kenmore_inside_alert]
 
-      fetch_alerts_fn = fn route_ids: ["Green-B", "Green-C", "Green-D"] -> {:ok, alerts} end
+      expect_alerts(["Green-B", "Green-C", "Green-D"], alerts)
 
-      actual_widgets =
-        DupAlerts.alert_instances(
-          context.config_kenmore,
-          context.now,
-          context.fetch_stop_name_fn,
-          fetch_alerts_fn,
-          context.fetch_location_context_fn
-        )
+      actual_widgets = DupAlerts.alert_instances(context.config_kenmore, context.now)
 
       assert Enum.all?(actual_widgets, &match?(%DupAlert{}, &1))
     end
@@ -691,16 +678,9 @@ defmodule Screens.V2.WidgetInstance.DupSpecialCaseAlertTest do
     test "serializes WTC special case: WTC is detoured", context do
       alerts = context.wtc_alerts
 
-      fetch_alerts_fn = fn route_ids: ["741", "742", "743"] -> {:ok, alerts} end
+      expect_alerts(["741", "742", "743"], alerts)
 
-      actual_widgets =
-        DupAlerts.alert_instances(
-          context.config_wtc,
-          context.now,
-          context.fetch_stop_name_fn,
-          fetch_alerts_fn,
-          context.fetch_location_context_fn
-        )
+      actual_widgets = DupAlerts.alert_instances(context.config_wtc, context.now)
 
       expected_serialized_json = %{
         text: %FreeTextLine{icon: :warning, text: ["Building closed"]},

--- a/test/support/mocks.ex
+++ b/test/support/mocks.ex
@@ -5,6 +5,7 @@ injected_modules = [
   Screens.Facilities.Facility,
   Screens.Headways,
   Screens.LastTrip.LastTrip,
+  Screens.LocationContext,
   Screens.PendingConfig.Fetch,
   Screens.RoutePatterns.RoutePattern,
   Screens.Routes.Route,


### PR DESCRIPTION
Description
- Also had to refactor for injecting Stop/LocationContext so we could probably stub them out in the `DupNewTest` without having to add params to the candidate generators. 

- [x] Tests modified?
