### PR TITLE
chore: remove Sentry reporting of diagram errors

### DIFF
--- a/lib/screens/v2/widget_instance/reconstructed_alert.ex
+++ b/lib/screens/v2/widget_instance/reconstructed_alert.ex
@@ -4,7 +4,6 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
   alias Screens.Alerts.Alert
   alias Screens.Alerts.InformedEntity
   alias Screens.LocationContext
-  alias Screens.Report
   alias Screens.Routes.Route
   alias Screens.Stops.{Stop, Subway}
   alias Screens.Util
@@ -1327,11 +1326,12 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
   defp serialize_flex_zone(t, location), do: flex_zone_fields(t, location)
 
   defp report_diagram_error(%__MODULE__{} = t, reason) do
-    Report.warning("disruption_diagram_error",
+    Logster.warning([
+      "disruption_diagram_error",
       alert_id: t.alert.id,
       home_stop: t.location_context.home_stop,
       reason: reason
-    )
+    ])
 
     t
   end


### PR DESCRIPTION
When a relevant alert is active, this warning is reported every time an impacted screen refreshes its data. This quickly uses up all available Sentry quota, making it harder to see more-impactful errors. Since this warning doesn't necessarily mean that anything is "wrong" (just that we are using the fallback layout for an alert), it is reasonable for it to only report to Splunk.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214548661698523