### PR TITLE
fix: evergreen content cleanup tool

### DIFF
--- a/lib/screens/util/admin.ex
+++ b/lib/screens/util/admin.ex
@@ -14,22 +14,25 @@ defmodule Screens.Util.Admin do
 
   def cleanup_evergreen_content(screen, _before_date), do: screen
 
-  defp should_cleanup_evergreen_item?(
-         %EvergreenContentItem{schedule: schedule_items},
-         before_date
-       ) do
-    Enum.all?(schedule_items, fn
-      %Schedule{end_dt: nil} ->
-        false
-
-      %Schedule{end_dt: datetime} ->
-        Date.compare(datetime, before_date) == :lt
-
-      %RecurrentSchedule{dates: date_ranges} ->
-        Enum.all?(date_ranges, fn
-          %{end_date: nil} -> false
-          %{end_date: end_date} -> Date.compare(end_date, before_date) == :lt
-        end)
+  defp should_cleanup_evergreen_item?(%EvergreenContentItem{schedule: schedules}, before_date)
+       when is_list(schedules) do
+    Enum.all?(schedules, fn
+      %Schedule{end_dt: nil} -> false
+      %Schedule{end_dt: datetime} -> Date.compare(datetime, before_date) == :lt
     end)
   end
+
+  defp should_cleanup_evergreen_item?(
+         %EvergreenContentItem{schedule: %RecurrentSchedule{dates: date_ranges}},
+         before_date
+       ) do
+    Enum.all?(date_ranges, fn
+      %{end_date: nil} -> false
+      %{end_date: end_date} -> Date.compare(end_date, before_date) == :lt
+    end)
+  end
+
+  # Cleaning up alert-linked content is not supported
+  defp should_cleanup_evergreen_item?(%EvergreenContentItem{schedule: _other}, _before_date),
+    do: false
 end

--- a/test/screens/util/admin_test.exs
+++ b/test/screens/util/admin_test.exs
@@ -2,7 +2,7 @@ defmodule Screens.Util.AdminTest do
   use ExUnit.Case, async: true
 
   alias Screens.Util.Admin
-  alias ScreensConfig.{EvergreenContentItem, RecurrentSchedule, Schedule, Screen}
+  alias ScreensConfig.{AlertSchedule, EvergreenContentItem, RecurrentSchedule, Schedule, Screen}
   alias ScreensConfig.Screen.BusShelter
 
   describe "cleanup_evergreen_content/2" do
@@ -32,25 +32,22 @@ defmodule Screens.Util.AdminTest do
         ])
 
       recurring_all_ended =
-        build_item([
-          %RecurrentSchedule{
-            dates: [
-              %{start_date: ~D[2024-10-01], end_date: ~D[2024-10-03]},
-              %{start_date: ~D[2024-11-01], end_date: ~D[2024-11-03]}
-            ]
-          },
-          %Schedule{start_dt: ~U[2024-12-01T00:00:00Z], end_dt: ~U[2024-12-03T00:00:00Z]}
-        ])
+        build_item(%RecurrentSchedule{
+          dates: [
+            %{start_date: ~D[2024-10-01], end_date: ~D[2024-10-03]},
+            %{start_date: ~D[2024-11-01], end_date: ~D[2024-11-03]}
+          ]
+        })
 
       recurring_some_ended =
-        build_item([
-          %RecurrentSchedule{
-            dates: [
-              %{start_date: ~D[2024-10-01], end_date: ~D[2024-10-03]},
-              %{start_date: ~D[2024-11-01], end_date: nil}
-            ]
-          }
-        ])
+        build_item(%RecurrentSchedule{
+          dates: [
+            %{start_date: ~D[2024-10-01], end_date: ~D[2024-10-03]},
+            %{start_date: ~D[2024-11-01], end_date: nil}
+          ]
+        })
+
+      alert_linked = build_item(%AlertSchedule{alert_ids: ["1"]})
 
       screen =
         build_screen([
@@ -58,13 +55,14 @@ defmodule Screens.Util.AdminTest do
           some_ended,
           indefinite,
           recurring_all_ended,
-          recurring_some_ended
+          recurring_some_ended,
+          alert_linked
         ])
 
       cleaned_screen = Admin.cleanup_evergreen_content(screen, ~D[2025-01-01])
 
       assert cleaned_screen.app_params.evergreen_content ==
-               [some_ended, indefinite, recurring_some_ended]
+               [some_ended, indefinite, recurring_some_ended, alert_linked]
     end
   end
 end


### PR DESCRIPTION
When 03f7f3f3 introduced alert-based content schedules, this tool was never updated to account for them. As such it would crash if any such schedules existed in the config.

Also fix bad test data that concealed a bug, dating back to the introduction of the tool: it would also crash if the config contained any recurring schedules. (the value of the `schedule` field when using a `RecurrentSchedule` is just a single one of these, not a list)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214548587982622