### PR TITLE
chore: remove ttl from dev/test configuration

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -30,8 +30,7 @@ config :ueberauth, Ueberauth,
       {Ueberauth.Strategy.FakeOidcc,
        [
          client_id: "dev-client",
-         roles: ["screens-admin"],
-         ttl: System.system_time(:second) + 60 * 60
+         roles: ["screens-admin"]
        ]}
   ]
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -149,8 +149,7 @@ config :ueberauth, Ueberauth,
          client_id: "test-client",
          roles: [
            "screens-admin"
-         ],
-         ttl: System.system_time(:second) + 60 * 60
+         ]
        ]}
   ]
 


### PR DESCRIPTION


**Asana task**: N/A

Description

Remove the `ttl` field from both the dev and test configuration files. This configuration, added in 5b068d3b95369a11a60e8f92a762844af89edf4d, was wrong for two reasons:
1. It's evaluated at compile time, and wouldn't be re-evaluated until the server was restarted
2. The value provided was a timestamp was incorrect, which lead to the `Ueberauth.Strategy.FakeOidcc` library to create a TTL _way_ too far in the future

With the omission of this property, we use the default value provided by `Ueberauth.Strategy.FakeOidcc`

- [ ] Tests added?
