### PR TITLE
feat: remove am/pm from timestamps

### DIFF
--- a/assets/css/dup/departures/time.scss
+++ b/assets/css/dup/departures/time.scss
@@ -50,23 +50,10 @@
 }
 
 .departure-time__timestamp {
-  display: inline-block;
-  text-decoration: inherit;
-  direction: rtl;
-}
-
-.departure-time__time {
   font-size: 138px;
   font-weight: 800;
   line-height: 128px;
-}
-
-.departure-time__ampm {
-  margin-left: 20px;
-  font-size: 96px;
-  font-weight: 400;
-  line-height: 108px;
-  letter-spacing: 2px;
+  text-decoration: inherit;
 }
 
 .departure-time__live-icon {

--- a/assets/src/components/departures/departure_time.tsx
+++ b/assets/src/components/departures/departure_time.tsx
@@ -8,7 +8,7 @@ import { classWithModifier, classWithModifiers } from "Util/utils";
 type DepartureTime =
   | { type: "text"; text: string }
   | { type: "minutes"; minutes: number }
-  | { type: "timestamp"; hour: number; minute: number; am_pm: string | null }
+  | { type: "timestamp"; hour: number; minute: number }
   | { type: "status"; pages: string[] }
   | { type: "overnight" };
 
@@ -37,14 +37,7 @@ const DepartureTimePart: ComponentType<DepartureTimePartProps> = ({
       const paddedMinute = time.minute < 10 ? "0" + time.minute : time.minute;
       const timestamp = `${time.hour}:${paddedMinute}`;
 
-      return (
-        <div className="departure-time__timestamp">
-          <span className="departure-time__time">{timestamp}</span>
-          {time.am_pm && (
-            <span className="departure-time__ampm">{time.am_pm}</span>
-          )}
-        </div>
-      );
+      return <span className="departure-time__timestamp">{timestamp}</span>;
     }
 
     case "status": {

--- a/assets/src/components/dup/departures/departure_row.tsx
+++ b/assets/src/components/dup/departures/departure_row.tsx
@@ -16,7 +16,7 @@ const DepartureRow: ComponentType<DepartureRowBase> = ({
     route.type === "dual" ? "extended-route_pill" : "";
 
   const classModifier = timesWithCrowding.some(
-    (time) => time.time?.type === "timestamp" && time?.time.am_pm,
+    (time) => time.time?.type === "timestamp",
   )
     ? "shortened-headsign"
     : "";

--- a/lib/screens/v2/widget_instance/departures.ex
+++ b/lib/screens/v2/widget_instance/departures.ex
@@ -92,8 +92,7 @@ defmodule Screens.V2.WidgetInstance.Departures do
   @type serialized_timestamp :: %{
           type: :timestamp,
           hour: pos_integer(),
-          minute: non_neg_integer(),
-          am_pm: :am | :pm | nil
+          minute: non_neg_integer()
         }
   @type serialized_status :: %{type: :status, pages: [String.t()]}
   @type serialized_overnight :: %{type: :overnight}
@@ -635,7 +634,7 @@ defmodule Screens.V2.WidgetInstance.Departures do
               scheduled_time: serialized_timestamp() | nil,
               is_live: boolean()
             }
-  defp serialize_time(departure, %Screen{app_id: app_id} = screen, now)
+  defp serialize_time(departure, %Screen{app_id: app_id}, now)
        when app_id in [:bus_eink_v2, :gl_eink_v2] do
     departure_time = Departure.time(departure)
     second_diff = DateTime.diff(departure_time, now)
@@ -645,7 +644,7 @@ defmodule Screens.V2.WidgetInstance.Departures do
       cond do
         second_diff < 60 -> %{type: :text, text: "Now"}
         minute_diff < 60 -> %{type: :minutes, minutes: minute_diff}
-        true -> serialize_timestamp(departure_time, screen, now)
+        true -> serialize_timestamp(departure_time)
       end
 
     # See `docs/mercury_api.md`
@@ -670,12 +669,12 @@ defmodule Screens.V2.WidgetInstance.Departures do
       cond do
         Departure.cancelled?(departure) -> nil
         predicted? and not include_scheduled_time? -> serialize_realtime(departure, screen, now)
-        true -> departure |> Departure.time() |> serialize_timestamp(screen, now)
+        true -> departure |> Departure.time() |> serialize_timestamp()
       end
 
     serialized_scheduled_time =
       if include_scheduled_time? and not is_nil(scheduled_time) do
-        serialized_scheduled_time = serialize_timestamp(scheduled_time, screen, now)
+        serialized_scheduled_time = serialize_timestamp(scheduled_time)
 
         case serialized_time do
           %{type: :text} -> nil
@@ -705,22 +704,17 @@ defmodule Screens.V2.WidgetInstance.Departures do
       subway? and boarding?(departure, second_diff) -> %{type: :text, text: "BRD"}
       second_diff <= 30 -> %{type: :text, text: if(subway?, do: "ARR", else: "Now")}
       minute_diff < 60 -> %{type: :minutes, minutes: minute_diff}
-      true -> serialize_timestamp(departure_time, screen, now)
+      true -> serialize_timestamp(departure_time)
     end
   end
 
-  @spec serialize_timestamp(DateTime.t(), Screen.t(), DateTime.t()) ::
-          serialized_timestamp()
-  defp serialize_timestamp(datetime, %Screen{app_id: app_id}, now) do
+  @spec serialize_timestamp(DateTime.t()) :: serialized_timestamp()
+  defp serialize_timestamp(datetime) do
     local_time = Util.to_eastern(datetime)
     hour = 1 + Integer.mod(local_time.hour - 1, 12)
     minute = local_time.minute
-    am_pm = if local_time.hour >= 12, do: :pm, else: :am
-    service_date_tomorrow = now |> Util.service_date() |> Date.add(1)
-    # Screen types other than DUPs currently have no implemented design for the AM/PM indicator.
-    show_am_pm = app_id == :dup_v2 and local_time.day == service_date_tomorrow.day
 
-    %{type: :timestamp, hour: hour, minute: minute, am_pm: if(show_am_pm, do: am_pm, else: nil)}
+    %{type: :timestamp, hour: hour, minute: minute}
   end
 
   defp boarding?(

--- a/lib/screens_web/views/v2/audio/departures_view.ex
+++ b/lib/screens_web/views/v2/audio/departures_view.ex
@@ -148,9 +148,9 @@ defmodule ScreensWeb.V2.Audio.DeparturesView do
     ~E|<%= minute_diff %> <%= pluralize_minutes(minute_diff) %>|
   end
 
-  defp render_time(%{type: :timestamp, hour: hour, minute: minute, am_pm: am_pm}) do
+  defp render_time(%{type: :timestamp, hour: hour, minute: minute}) do
     minute_string = if minute < 10, do: "0#{minute}", else: "#{minute}"
-    ~E|<%= hour %>:<%= minute_string %><%= am_pm %>|
+    ~E|<%= hour %>:<%= minute_string %>|
   end
 
   defp pluralize_minutes(1), do: "minute"

--- a/test/screens/v2/widget_instance/departures_test.exs
+++ b/test/screens/v2/widget_instance/departures_test.exs
@@ -1015,7 +1015,7 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
         }
       }
 
-      assert [%{time: %{type: :timestamp, am_pm: nil, hour: 7, minute: 0}}] =
+      assert [%{time: %{type: :timestamp, hour: 7, minute: 0}}] =
                Departures.serialize_times_with_crowding([departure], screen, now)
     end
 
@@ -1055,13 +1055,7 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
         }
       }
 
-      assert [
-               %{
-                 id: nil,
-                 crowding: nil,
-                 time: %{type: :timestamp, am_pm: nil, hour: 12, minute: 20}
-               }
-             ] =
+      assert [%{id: nil, crowding: nil, time: %{type: :timestamp, hour: 12, minute: 20}}] =
                Departures.serialize_times_with_crowding([departure], screen, now)
     end
 
@@ -1087,8 +1081,8 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
                %{
                  id: nil,
                  crowding: nil,
-                 time: %{am_pm: nil, hour: 9, minute: 20, type: :timestamp},
-                 scheduled_time: %{am_pm: nil, hour: 9, minute: 15, type: :timestamp}
+                 time: %{hour: 9, minute: 20, type: :timestamp},
+                 scheduled_time: %{hour: 9, minute: 15, type: :timestamp}
                }
              ] =
                Departures.serialize_times_with_crowding([departure], screen, now)
@@ -1252,7 +1246,7 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
         }
       }
 
-      assert [%{time: %{type: :timestamp, am_pm: nil, hour: 7, minute: 0}, is_live: false}] =
+      assert [%{time: %{type: :timestamp, hour: 7, minute: 0}, is_live: false}] =
                Departures.serialize_times_with_crowding([departure], screen, now)
     end
 

--- a/test/screens_web/views/v2/audio/departures_view_test.exs
+++ b/test/screens_web/views/v2/audio/departures_view_test.exs
@@ -137,7 +137,7 @@ defmodule ScreensWeb.V2.Audio.DeparturesViewTest do
                 times_with_crowding: [
                   %{
                     id: "test3",
-                    time: %{type: :timestamp, minute: 31, hour: 12, am_pm: nil},
+                    time: %{type: :timestamp, minute: 31, hour: 12},
                     crowding: nil
                   }
                 ],


### PR DESCRIPTION
**Asana task**: [[Bug] First Trip states are on two lines instead of one](https://app.asana.com/1/15492006741476/project/1212581278818608/task/1214442254145703?focus=true)

Description
- currently AM/PM seems to be only used on DUPs and with RDS we want to remove AM/PM completely
- this removes instances and usages of am/pm within timestamps, serialization and on the frontend
- fixes an RDS issue for the First Trip state + am/pm timestamps causing the times to split onto two lines

- [x] Tests modified?
