### PR TITLE
fix: fixed route pill for Green Line headways on multiple branches

### DIFF
--- a/lib/screens/v2/candidate_generator/dup_new/departures.ex
+++ b/lib/screens/v2/candidate_generator/dup_new/departures.ex
@@ -367,12 +367,15 @@ defmodule Screens.V2.CandidateGenerator.DupNew.Departures do
     end)
     |> Enum.flat_map(fn
       {{_line, _direction_name}, [%RDS{state: %Headways{departure: departure, range: range}}]} ->
-        [{departure, range, nil, :headways}]
+        [{[departure], range, nil, :headways}]
 
       # If there are multiple headways with the same line but different headsigns,
       # combine them and use the direction name
-      {{_line, direction_name}, [%RDS{state: %Headways{departure: departure, range: range}} | _]} ->
-        [{departure, range, direction_name, :headways}]
+      {{_line, direction_name}, [%RDS{state: %Headways{range: range}} | _] = headways} ->
+        [
+          {Enum.map(headways, fn %RDS{state: %Headways{departure: departure}} -> departure end),
+           range, direction_name, :headways}
+        ]
     end)
   end
 

--- a/lib/screens/v2/widget_instance/departures.ex
+++ b/lib/screens/v2/widget_instance/departures.ex
@@ -491,20 +491,32 @@ defmodule Screens.V2.WidgetInstance.Departures do
 
   defp serialize_departure_group(
          [
-           {departure, {lo, hi}, headsign, :headways}
+           {[first_departure | _] = departures, {lo, hi}, headsign, :headways}
            | _
          ],
          screen,
          _now,
          route_pill_serializer
        ) do
-    departure_id = Departure.id(departure)
-    departures = [departure]
+    departure_id = Departure.id(first_departure)
+    # Green line has a special case where we might have multiple routes have headways
+    # In these cases, combine them into a single pill for GL
+    multiple_gl_route_ids =
+      departures
+      |> Enum.map(&Departure.route(&1).id)
+      |> Enum.uniq()
+      |> Enum.filter(&String.contains?(&1, "Green"))
+      |> length() > 1
 
     %{
       id: hash_and_encode(departure_id),
       type: :departure_row,
-      route: serialize_route(departures, route_pill_serializer, screen),
+      route:
+        if multiple_gl_route_ids do
+          RoutePill.serialize_icon(:green)
+        else
+          serialize_route(departures, route_pill_serializer, screen)
+        end,
       headsign:
         if headsign do
           %{headsign: headsign}
@@ -532,8 +544,7 @@ defmodule Screens.V2.WidgetInstance.Departures do
           [Departure.t()],
           (Departure.t(), pos_integer() | nil, Screen.t() -> RoutePill.t()),
           Screen.t()
-        ) ::
-          RoutePill.t()
+        ) :: RoutePill.t()
   def serialize_route([first_departure | _], route_pill_serializer, screen) do
     route = Departure.route(first_departure)
     track_number = Departure.track_number(first_departure)

--- a/test/screens/v2/candidate_generator/dup_new/departures_test.exs
+++ b/test/screens/v2/candidate_generator/dup_new/departures_test.exs
@@ -1153,7 +1153,7 @@ defmodule Screens.V2.CandidateGenerator.DupNew.DeparturesTest do
           grouping_type: :time,
           rows: [
             expected_primary_departure,
-            {%Departure{prediction: nil, schedule: schedule}, {6, 10}, nil, :headways}
+            {[%Departure{prediction: nil, schedule: schedule}], {6, 10}, nil, :headways}
           ]
         }
       ]

--- a/test/screens/v2/widget_instance/departures_test.exs
+++ b/test/screens/v2/widget_instance/departures_test.exs
@@ -355,6 +355,187 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
              } =
                Departures.serialize_section(section, bus_shelter_screen, now, false)
     end
+
+    test "serializes normal section with countdown and headway rows", %{
+      dup_screen: dup_screen,
+      now: now
+    } do
+      rows = [
+        %Departure{
+          prediction: %Prediction{
+            id: "one",
+            departure_time: ~U[2020-01-01T00:01:10Z],
+            route: route(id: "Green-E", type: :subway),
+            trip: %Trip{headsign: "Medford/Tufts", direction_id: 1},
+            stop: %Stop{}
+          }
+        },
+        {
+          [
+            %Departure{
+              prediction: %Prediction{
+                id: "two",
+                departure_time: ~U[2020-01-01T00:01:10Z],
+                route: route(id: "Green-D", type: :subway),
+                trip: %Trip{headsign: "Union Square", direction_id: 1},
+                stop: %Stop{}
+              }
+            }
+          ],
+          {10, 15},
+          "Union Square",
+          :headways
+        },
+        {
+          [
+            %Departure{
+              prediction: %Prediction{
+                id: "three",
+                departure_time: ~U[2020-01-01T00:01:10Z],
+                route: route(id: "Green-C", type: :subway),
+                trip: %Trip{headsign: "Cleveland Circle", direction_id: 0},
+                stop: %Stop{}
+              }
+            },
+            %Departure{
+              prediction: %Prediction{
+                id: "four",
+                departure_time: ~U[2020-01-01T00:01:10Z],
+                route: route(id: "Green-C", type: :subway),
+                trip: %Trip{headsign: "Cleveland Circle", direction_id: 0},
+                stop: %Stop{}
+              }
+            },
+            %Departure{
+              prediction: %Prediction{
+                id: "five",
+                departure_time: ~U[2020-01-01T00:01:10Z],
+                route: route(id: "Green-D", type: :subway),
+                trip: %Trip{headsign: "Riverside", direction_id: 0},
+                stop: %Stop{}
+              }
+            }
+          ],
+          {20, 30},
+          %{headsign: "Westbound"},
+          :headways
+        }
+      ]
+
+      section = %NormalSection{
+        rows: rows,
+        layout: %Layout{},
+        header: %Header{title: "Section Header"},
+        grouping_type: :time
+      }
+
+      assert %{
+               type: :normal_section,
+               rows: [
+                 %{headsign: %{headsign: "Medford/Tufts"}},
+                 %{
+                   headsign: %{headsign: "Union Square"},
+                   direction_id: 1,
+                   route: %{type: :text, text: "GL·D", color: :green},
+                   times_with_crowding: [
+                     %{id: "two", time: %{type: :status, pages: ["every 10-15m"]}}
+                   ]
+                 },
+                 %{
+                   headsign: %{headsign: %{headsign: "Westbound"}},
+                   direction_id: 0,
+                   route: %{type: :text, text: "GL", color: :green},
+                   times_with_crowding: [
+                     %{id: "three", time: %{type: :status, pages: ["every 20-30m"]}}
+                   ]
+                 }
+               ]
+             } =
+               Departures.serialize_section(section, dup_screen, now, false)
+    end
+
+    test "serializes normal section with first trip row", %{
+      dup_screen: dup_screen,
+      now: now
+    } do
+      rows = [
+        {%Departure{
+           schedule: %Schedule{
+             id: "one",
+             departure_time: ~U[2020-01-01T00:01:10Z],
+             route: route(id: "Green-E", type: :subway),
+             trip: %Trip{headsign: "Medford/Tufts", direction_id: 1},
+             stop: %Stop{}
+           }
+         }, :first_trip}
+      ]
+
+      section = %NormalSection{
+        rows: rows,
+        layout: %Layout{},
+        header: %Header{title: "Section Header"},
+        grouping_type: :time
+      }
+
+      assert %{
+               rows: [
+                 %{
+                   headsign: %{headsign: "Medford/Tufts"},
+                   is_first_trip: true,
+                   route: %{type: :text, text: "GL·E", color: :green},
+                   times_with_crowding: [
+                     %{
+                       id: "one",
+                       time: %{type: :timestamp, minute: 1, hour: 7, am_pm: nil}
+                     }
+                   ],
+                   type: :departure_row
+                 }
+               ]
+             } =
+               Departures.serialize_section(section, dup_screen, now, false)
+    end
+
+    test "serializes normal section with last trip row", %{
+      dup_screen: dup_screen,
+      now: now
+    } do
+      rows = [
+        {%Departure{
+           schedule: %Schedule{
+             id: "one",
+             departure_time: ~U[2020-01-01T00:01:10Z],
+             route: route(id: "Green-E", type: :subway),
+             trip: %Trip{headsign: "Medford/Tufts", direction_id: 1},
+             stop: %Stop{}
+           }
+         }, :last_trip}
+      ]
+
+      section = %NormalSection{
+        rows: rows,
+        layout: %Layout{},
+        header: %Header{title: "Section Header"},
+        grouping_type: :time
+      }
+
+      assert %{
+               rows: [
+                 %{
+                   headsign: %{headsign: "Medford/Tufts"},
+                   route: %{type: :text, text: "GL·E", color: :green},
+                   times_with_crowding: [
+                     %{
+                       id: "one",
+                       time: %{type: :overnight}
+                     }
+                   ],
+                   type: :departure_row
+                 }
+               ]
+             } =
+               Departures.serialize_section(section, dup_screen, now, false)
+    end
   end
 
   describe "group_consecutive_departures/2" do


### PR DESCRIPTION
**Asana task**: [[Bug] GL-Branch pill showing for Eastbound headways](https://app.asana.com/1/15492006741476/project/1212581278818608/task/1214550997506231?focus=true)

Description
- in the previous code, we were only taking the first departure into account when we were generating route pills
- we now calculate to see if there are multiple route_ids from destinations that have headways. If we do, we will manually create a GL pill rather than going through the regular route pill creation
- also added tests to widget_instance/departures_test.exs for serializing first trip, last trip and headways

<img width="979" height="549" alt="Screenshot 2026-05-05 at 3 50 29 PM" src="https://github.com/user-attachments/assets/69dd2e90-8352-4407-9cf7-18c19ac0d2e3" />

- [x] Tests added?
