### PR TITLE
fix: shuttle bus message overlapping

### DIFF
--- a/assets/css/pre_fare/prefare_single_screen_alert.scss
+++ b/assets/css/pre_fare/prefare_single_screen_alert.scss
@@ -114,7 +114,7 @@
   }
 
   .alert-card__content-block__text-sections {
-    max-height: 772px;
+    max-height: 850px;
   }
 
   .alert-card__fallback__icon {

--- a/assets/src/components/disruption_diagram/disruption_diagram.tsx
+++ b/assets/src/components/disruption_diagram/disruption_diagram.tsx
@@ -1,4 +1,4 @@
-// SPECIFICATION: https://www.notion.so/mbta-downtown-crossing/Disruption-Diagram-Specification-a779027385b545abbff6fb4b4fd0adc1
+// SPECIFICATION: https://www.notion.so/mbta-downtown-crossing/Disruption-Diagram-Specification-17cf5d8d11ea81c48f8bd380003ef62b
 
 import {
   type ComponentType,

--- a/assets/src/components/pre_fare_single_screen_alert.tsx
+++ b/assets/src/components/pre_fare_single_screen_alert.tsx
@@ -150,7 +150,7 @@ const PartialClosureLayout: ComponentType<PartialClosureLayoutProps> = ({
     <div className="alert-card__content-block">
       <div className="alert-card__issue">
         <NoServiceIcon className="alert-card__icon" />
-        <h3 className="alert-card__content-block__text">
+        <h3>
           <AffectedLinePill
             className="alert-card__content-block__route-pill"
             color={affectedLineColor}
@@ -160,7 +160,7 @@ const PartialClosureLayout: ComponentType<PartialClosureLayoutProps> = ({
       </div>
       <div className="alert-card__issue">
         <InfoIcon className="alert-card__icon" />
-        <h3 className="alert-card__content-block__text">
+        <h3>
           {unaffected_routes.map((route) => {
             const UnaffectedLinePill = STRING_TO_SVG[route.svg_name];
             const unaffectedLineColor = getHexColor(
@@ -240,11 +240,7 @@ const StandardIssueSection: ComponentType<StandardIssueSectionProps> = ({
       className={classWithModifiers("alert-card__icon", [contentTextSize])}
     />
     <div>
-      {contentTextSize === "large" ? (
-        <h3 className="alert-card__content-block__text">{issue}</h3>
-      ) : (
-        <h4 className="alert-card__content-block__text">{issue}</h4>
-      )}
+      {contentTextSize === "large" ? <h3>{issue}</h3> : <h4>{issue}</h4>}
       {location && (
         <div className="alert-card__issue__location body-4">{location}</div>
       )}
@@ -261,7 +257,7 @@ const DownstreamIssueSection: ComponentType<DownstreamIssueSectionProps> = ({
 }) => (
   <div className="alert-card__issue">
     <NoServiceIcon className="alert-card__icon" />
-    <h4 className="alert-card__content-block__text">
+    <h4>
       No trains between {endpoints[0]} & {endpoints[1]}
     </h4>
   </div>
@@ -293,11 +289,7 @@ const RemedySection: ComponentType<RemedySectionProps> = ({
           />
         </div>
         <div>
-          {contentTextSize === "large" ? (
-            <h3 className="alert-card__content-block__text">{remedy}</h3>
-          ) : (
-            <h4 className="alert-card__content-block__text">{remedy}</h4>
-          )}
+          {contentTextSize === "large" ? <h3>{remedy}</h3> : <h4>{remedy}</h4>}
           <div className="alert-card__body__accessibility-info--text body-4">
             All shuttle buses are accessible
             <ISAIcon className="alert-card__isa-icon" />


### PR DESCRIPTION
**Asana task**: [Screens bug: shuttle bus message overlapping](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1214364461704789?focus=true)

**Description**

Extend the `max-height` that the text sections on prefare screens may
take. In https://github.com/mbta/screens/commit/de699b640147a9ae73e8e7a2607da636104f3888, we updated the styling for "Use shuttle buses",
amongst other bits of text. In the case of alerts where station name(s)
are long (such as "Braintree & Ashmont"), the height of the section was
exceeding the previous `max-height`. The value of `850px` was arbitrarily
chosen to fit the content associated with the bug.

Remove class name assignments of `.alert-card__content-block__text`. In
https://github.com/mbta/screens/commit/de699b640147a9ae73e8e7a2607da636104f3888, we removed the css class from
`prefare_single_screen_alert.scss`, but did not remove it from the
components consuming it.

Update reference to disruption diagram 

**Screenshots**

Firefox:
<img width="551" height="966" alt="Screenshot 2026-05-06 at 13 47 43" src="https://github.com/user-attachments/assets/a6ae54a2-7421-46bc-9e68-a5cde9439664" />

Chrome:
<img width="551" height="966" alt="Screenshot 2026-05-06 at 13 50 20" src="https://github.com/user-attachments/assets/4084b283-cf12-46a5-8ffb-e01f3868d6e1" />

**Notes**

You'll see that in the screenshots above (included Firefox and Chrome to demonstrate, even though we're target Chrome IRL) that Braintree's last 'E' gets cut off. I believe this to be a pre-existing bug and not strictly related to flexbox - it seems like the `viewbox` on the SVG is setting the minY value incorrectly. However, this might be an artifact of simulating the screen - open to discussion, but my vote is to spin that bug out into a separate task