### PR TITLE
fix: fixed RDS headway grouping and route pills for grouped headways

### DIFF
--- a/lib/screens/v2/candidate_generator/dup_new/departures.ex
+++ b/lib/screens/v2/candidate_generator/dup_new/departures.ex
@@ -3,6 +3,7 @@ defmodule Screens.V2.CandidateGenerator.DupNew.Departures do
 
   import Screens.Inject
 
+  alias Screens.Lines.Line
   alias Screens.Routes.Route
 
   alias Screens.V2.Departure
@@ -12,6 +13,7 @@ defmodule Screens.V2.CandidateGenerator.DupNew.Departures do
   alias Screens.V2.WidgetInstance.Departures, as: DeparturesWidget
 
   alias Screens.V2.WidgetInstance.Departures.{
+    HeadwayRow,
     HeadwaySection,
     NoDataSection,
     NormalSection,
@@ -171,10 +173,10 @@ defmodule Screens.V2.CandidateGenerator.DupNew.Departures do
 
   # Bidirectional -> Use no headsign for the trains message
   defp create_headway_section([
-         %RDS{state: %{route_id: route_id, direction_name: direction_name_one, range: range}}
-         | [%RDS{state: %{route_id: route_id, direction_name: direction_name_two, range: range}}]
+         %RDS{state: %{route_id: route_id, direction_id: direction_id_one, range: range}}
+         | [%RDS{state: %{route_id: route_id, direction_id: direction_id_two, range: range}}]
        ])
-       when direction_name_one != direction_name_two do
+       when direction_id_one != direction_id_two do
     %HeadwaySection{
       route: route_id,
       time_range: range,
@@ -188,35 +190,38 @@ defmodule Screens.V2.CandidateGenerator.DupNew.Departures do
   defp create_headway_section(
          [
            %RDS{
-             headsign: first_headsign,
+             headsign: headsign,
+             line: %Line{id: first_line_id},
              state: %Headways{
-               route_id: first_route_id,
-               direction_name: first_direction_name,
-               range: first_range
+               route_id: route_id,
+               direction_name: direction_name,
+               direction_id: direction_id,
+               range: range
              }
            }
            | _
          ] = destinations
        ) do
     %HeadwaySection{
-      route: first_route_id,
-      time_range: first_range,
+      route: route_id,
+      time_range: range,
       headsign:
         cond do
-          Enum.all?(destinations, fn %RDS{headsign: headsign} ->
-            headsign == first_headsign
+          Enum.all?(destinations, fn %RDS{headsign: other_headsign} ->
+            headsign == other_headsign
           end) ->
-            first_headsign
+            headsign
 
           Enum.all?(
             destinations,
             fn %RDS{
-                 state: %Headways{route_id: other_route_id, direction_name: other_direction_name}
+                 line: %Line{id: other_line_id},
+                 state: %Headways{direction_id: other_direction_id}
                } ->
-              other_direction_name == first_direction_name and other_route_id == first_route_id
+              first_line_id == other_line_id and direction_id == other_direction_id
             end
           ) ->
-            first_direction_name
+            direction_name
 
           true ->
             nil
@@ -314,7 +319,7 @@ defmodule Screens.V2.CandidateGenerator.DupNew.Departures do
     rds = Map.get(grouped_rds, :other, [])
 
     sorted_departures_from_rds(rds) ++
-      headways_from_rds(headway_rds) ++
+      headways_from_rds(rds, headway_rds) ++
       sorted_departures_from_rds(service_ended_rds, true)
   end
 
@@ -351,28 +356,54 @@ defmodule Screens.V2.CandidateGenerator.DupNew.Departures do
     )
   end
 
-  @spec headways_from_rds([RDS.t()]) :: [NormalSection.headway_row()]
-  defp headways_from_rds(headway_rds) do
+  @spec headways_from_rds([RDS.t()], [RDS.t()]) :: [HeadwayRow.t()]
+  defp headways_from_rds(
+         rds,
+         headway_rds
+       ) do
+    # If there are other similar line/direction_id destinations that are in one of the other states,
+    # disregard the headway for that particular destination
+    lines_in_other_states =
+      rds
+      |> Enum.flat_map(&extract_line_direction_pairs/1)
+      |> MapSet.new()
+
     headway_rds
-    |> Enum.group_by(fn %RDS{line: line, state: %Headways{departure: departure}} ->
-      direction_id = Departure.direction_id(departure)
-      route = Departure.route(departure)
-
-      direction_name =
-        route
-        |> Route.normalized_direction_names()
-        |> Enum.at(direction_id, nil)
-
-      {line, direction_name}
+    |> Enum.reject(fn %RDS{
+                        line: %Line{id: line_id},
+                        state: %Headways{direction_id: direction_id}
+                      } ->
+      MapSet.member?(lines_in_other_states, {line_id, direction_id})
     end)
-    |> Enum.flat_map(fn
-      {{_line, _direction_name}, [%RDS{state: %Headways{departure: departure, range: range}}]} ->
-        [{departure, range, nil, :headways}]
+    |> Enum.group_by(fn %RDS{
+                          line: line,
+                          state: %Headways{direction_id: direction_id}
+                        } ->
+      {line, direction_id}
+    end)
+    |> Enum.flat_map(fn {{line, direction_id}, rds_list} ->
+      %RDS{
+        headsign: headsign,
+        state: %Headways{
+          departure_id: departure_id,
+          direction_name: direction_name,
+          range: range
+        }
+      } = hd(rds_list)
 
       # If there are multiple headways with the same line but different headsigns,
       # combine them and use the direction name
-      {{_line, direction_name}, [%RDS{state: %Headways{departure: departure, range: range}} | _]} ->
-        [{departure, range, direction_name, :headways}]
+      displayed_headsign = if length(rds_list) == 1, do: headsign, else: direction_name
+
+      [
+        %HeadwayRow{
+          id: departure_id,
+          line: line,
+          direction_id: direction_id,
+          range: range,
+          headsign: displayed_headsign
+        }
+      ]
     end)
   end
 
@@ -411,6 +442,24 @@ defmodule Screens.V2.CandidateGenerator.DupNew.Departures do
   defp departure_direction_id({last_scheduled_departure, :last_trip}),
     do: Departure.direction_id(last_scheduled_departure)
 
-  defp departure_direction_id({departure, _range, _headsign, :headways}),
-    do: Departure.direction_id(departure)
+  defp departure_direction_id(%HeadwayRow{direction_id: direction_id}), do: direction_id
+
+  defp extract_line_direction_pairs(%RDS{line: %Line{id: line_id}, state: state}) do
+    case state do
+      %NoService{} ->
+        [{line_id, 0}, {line_id, 1}]
+
+      %Countdowns{departures: []} ->
+        [{line_id, 0}, {line_id, 1}]
+
+      %Countdowns{departures: [first_departure | _]} ->
+        [{line_id, Departure.direction_id(first_departure)}]
+
+      %FirstTrip{first_scheduled_departure: departure} ->
+        [{line_id, Departure.direction_id(departure)}]
+
+      %ServiceEnded{last_scheduled_departure: departure} ->
+        [{line_id, Departure.direction_id(departure)}]
+    end
+  end
 end

--- a/lib/screens/v2/rds.ex
+++ b/lib/screens/v2/rds.ex
@@ -22,6 +22,7 @@ defmodule Screens.V2.RDS do
   alias Screens.RouteType
   alias Screens.Schedules.Schedule
   alias Screens.Stops.Stop
+  alias Screens.Trips.Trip
   alias Screens.Util
 
   alias Screens.V2.Departure
@@ -127,12 +128,13 @@ defmodule Screens.V2.RDS do
     Shows an every “X-Y” minutes message. 
     """
     @type t :: %__MODULE__{
-            departure: Departure.t(),
+            departure_id: String.t(),
             route_id: Route.id(),
             direction_name: String.t(),
+            direction_id: Trip.direction(),
             range: Headway.range()
           }
-    defstruct ~w[departure route_id direction_name range]a
+    defstruct ~w[departure_id route_id direction_name direction_id range]a
   end
 
   @alert injected(Alert)
@@ -410,12 +412,10 @@ defmodule Screens.V2.RDS do
         direction_id = Departure.direction_id(first_scheduled_departure)
 
         %Headways{
-          departure: first_scheduled_departure,
+          departure_id: Departure.id(first_scheduled_departure),
           route_id: route.id,
-          direction_name:
-            route
-            |> Route.normalized_direction_names()
-            |> Enum.at(direction_id, nil),
+          direction_name: route |> Route.normalized_direction_names() |> Enum.at(direction_id),
+          direction_id: direction_id,
           range: headway_for_stop
         }
     end

--- a/lib/screens/v2/widget_instance/departures.ex
+++ b/lib/screens/v2/widget_instance/departures.ex
@@ -4,10 +4,12 @@ defmodule Screens.V2.WidgetInstance.Departures do
   """
 
   alias Screens.Headways
+  alias Screens.Lines.Line
   alias Screens.Predictions.Prediction
   alias Screens.Routes.Route
   alias Screens.Schedules.Schedule
   alias Screens.Stops.Stop
+  alias Screens.Trips.Trip
   alias Screens.Util
   alias Screens.Util.Assets
   alias Screens.V2.Departure
@@ -18,17 +20,28 @@ defmodule Screens.V2.WidgetInstance.Departures do
   alias ScreensConfig.{FreeTextLine, Screen}
   alias ScreensConfig.Screen.PreFare
 
+  defmodule HeadwayRow do
+    @moduledoc "A row that shows headway values in a NormalSection, X every Y - Z minutes"
+    @type t :: %__MODULE__{
+            id: String.t(),
+            line: Line.t(),
+            direction_id: Trip.direction(),
+            range: Headways.range(),
+            headsign: String.t()
+          }
+
+    defstruct id: nil, line: nil, direction_id: nil, range: nil, headsign: nil
+  end
+
   defmodule NormalSection do
     @moduledoc "Section which includes a number of independent 'rows' or items."
 
     @type special_trip_type :: :first_trip | :last_trip
 
-    @type headway_row :: {Departure.t(), Headways.range(), String.t() | nil, :headways}
-
     @type row ::
             Departure.t()
             | {Departure.t(), special_trip_type()}
-            | headway_row()
+            | HeadwayRow.t()
             | FreeTextLine.t()
 
     @type t :: %__MODULE__{
@@ -490,33 +503,26 @@ defmodule Screens.V2.WidgetInstance.Departures do
 
   defp serialize_departure_group(
          [
-           {departure, {lo, hi}, headsign, :headways}
+           %HeadwayRow{
+             id: id,
+             line: line,
+             direction_id: direction_id,
+             range: {lo, hi},
+             headsign: headsign
+           }
            | _
          ],
          screen,
          _now,
          route_pill_serializer
        ) do
-    departure_id = Departure.id(departure)
-    departures = [departure]
-
     %{
-      id: hash_and_encode(departure_id),
+      id: hash_and_encode(id),
       type: :departure_row,
-      route: serialize_route(departures, route_pill_serializer, screen),
-      headsign:
-        if headsign do
-          %{headsign: headsign}
-        else
-          serialize_headsign(departures, screen)
-        end,
-      times_with_crowding: [
-        %{
-          id: departure_id,
-          time: %{type: :status, pages: ["every #{lo}-#{hi}m"]}
-        }
-      ],
-      direction_id: serialize_direction_id(departures)
+      route: route_pill_serializer.(line, nil, screen),
+      headsign: %{headsign: headsign},
+      times_with_crowding: [%{id: id, time: %{type: :status, pages: ["every #{lo}-#{hi}m"]}}],
+      direction_id: direction_id
     }
   end
 
@@ -531,8 +537,7 @@ defmodule Screens.V2.WidgetInstance.Departures do
           [Departure.t()],
           (Departure.t(), pos_integer() | nil, Screen.t() -> RoutePill.t()),
           Screen.t()
-        ) ::
-          RoutePill.t()
+        ) :: RoutePill.t()
   def serialize_route([first_departure | _], route_pill_serializer, screen) do
     route = Departure.route(first_departure)
     track_number = Departure.track_number(first_departure)

--- a/lib/screens/v2/widget_instance/serializer/route_pill.ex
+++ b/lib/screens/v2/widget_instance/serializer/route_pill.ex
@@ -81,6 +81,7 @@ defmodule Screens.V2.WidgetInstance.Serializer.RoutePill do
   @maximum_pill_text_length 3
 
   @spec serialize_for_departure(Route.t(), pos_integer() | nil, Screen.t()) :: t()
+  @spec serialize_for_departure(Line.t(), nil, Screen.t()) :: t()
   def serialize_for_departure(
         %Route{id: route_id, type: route_type, line: %Line{id: line_id}} = route,
         track_number,
@@ -107,6 +108,23 @@ defmodule Screens.V2.WidgetInstance.Serializer.RoutePill do
         })
         |> Map.put(:color, Route.color(route_id, route_type))
     end
+  end
+
+  def serialize_for_departure(
+        %Line{id: "line-" <> route_id},
+        _track_number,
+        _screen
+      ) do
+    adjusted_route_id =
+      if route_id in Map.keys(@cr_line_abbreviations) do
+        "CR-" <> route_id
+      else
+        route_id
+      end
+
+    adjusted_route_id
+    |> do_serialize(%{})
+    |> Map.merge(%{color: Route.color(adjusted_route_id)})
   end
 
   @spec serialize_for_audio_departure(Route.t(), pos_integer() | nil, Screen.t()) :: audio_route()

--- a/test/screens/v2/candidate_generator/dup_new/departures_test.exs
+++ b/test/screens/v2/candidate_generator/dup_new/departures_test.exs
@@ -11,6 +11,7 @@ defmodule Screens.V2.CandidateGenerator.DupNew.DeparturesTest do
   alias Screens.V2.Departure
   alias Screens.V2.RDS
   alias Screens.V2.WidgetInstance.Departures, as: DeparturesWidget
+  alias Screens.V2.WidgetInstance.Departures.HeadwayRow
   alias Screens.V2.WidgetInstance.{DeparturesNoData, DeparturesNoService}
   alias Screens.V2.WidgetInstance.OvernightDepartures
   alias ScreensConfig.{Alerts, Departures, Header}
@@ -91,18 +92,16 @@ defmodule Screens.V2.CandidateGenerator.DupNew.DeparturesTest do
     }
   end
 
-  defp headways(stop_id, line_id, headsign, first_scheduled, route_id, direction_name, range) do
+  defp headways(stop_id, line_id, headsign, route_id, direction_name, direction_id, range) do
     %RDS{
       stop: %Stop{id: stop_id},
       line: %Line{id: line_id},
       headsign: headsign,
       state: %RDS.Headways{
-        departure: %Departure{
-          prediction: nil,
-          schedule: first_scheduled
-        },
+        departure_id: "Test ID",
         route_id: route_id,
         direction_name: direction_name,
+        direction_id: direction_id,
         range: range
       }
     }
@@ -982,13 +981,6 @@ defmodule Screens.V2.CandidateGenerator.DupNew.DeparturesTest do
       expected_time_range = {6, 10}
       expected_headsign = "headsign"
 
-      schedule = %Schedule{
-        departure_time: ~U[2024-10-11 13:15:00Z],
-        route: %Route{id: "r3", line: %Line{id: "l3"}, type: :ferry},
-        stop: %Stop{id: "s3"},
-        trip: %Trip{headsign: "other3", pattern_headsign: "h3"}
-      }
-
       expected_primary_sections = [
         %Screens.V2.WidgetInstance.Departures.HeadwaySection{
           headsign: expected_headsign,
@@ -1009,18 +1001,18 @@ defmodule Screens.V2.CandidateGenerator.DupNew.DeparturesTest do
                "s1",
                "l1",
                "headsign",
-               schedule,
                expected_route_id,
                "Northbound",
+               0,
                expected_time_range
              ),
              headways(
                "s1",
                "l1",
                "headsign",
-               schedule,
                expected_route_id,
                "Northbound",
+               0,
                expected_time_range
              )
            ]}
@@ -1047,13 +1039,6 @@ defmodule Screens.V2.CandidateGenerator.DupNew.DeparturesTest do
       expected_time_range = {6, 10}
       expected_direction_name = "Northbound"
 
-      schedule = %Schedule{
-        departure_time: ~U[2024-10-11 13:15:00Z],
-        route: %Route{id: "r3", line: %Line{id: "l3"}, type: :ferry},
-        stop: %Stop{id: "s3"},
-        trip: %Trip{headsign: "other3", pattern_headsign: "h3"}
-      }
-
       expected_primary_sections = [
         %Screens.V2.WidgetInstance.Departures.HeadwaySection{
           headsign: expected_direction_name,
@@ -1074,18 +1059,18 @@ defmodule Screens.V2.CandidateGenerator.DupNew.DeparturesTest do
                "s1",
                "l1",
                "headsign",
-               schedule,
                expected_route_id,
                expected_direction_name,
+               0,
                expected_time_range
              ),
              headways(
                "s1",
                "l1",
                "other_headsign",
-               schedule,
                expected_route_id,
                expected_direction_name,
+               0,
                expected_time_range
              )
            ]}
@@ -1107,18 +1092,6 @@ defmodule Screens.V2.CandidateGenerator.DupNew.DeparturesTest do
       expected_time_range = {6, 10}
       expected_direction_name = "Northbound"
 
-      schedule = %Schedule{
-        departure_time: ~U[2024-10-11 13:15:00Z],
-        route: %Route{
-          id: "r3",
-          line: %Line{id: "l3"},
-          type: :ferry,
-          direction_names: ["Northbound", "Southbound"]
-        },
-        stop: %Stop{id: "s3"},
-        trip: %Trip{headsign: "other3", pattern_headsign: "h3", direction_id: 0}
-      }
-
       primary_departures = [
         %Section{query: %Query{params: %Query.Params{stop_ids: ["s1"]}}},
         %Section{query: %Query{params: %Query.Params{stop_ids: ["s2"]}}}
@@ -1131,7 +1104,7 @@ defmodule Screens.V2.CandidateGenerator.DupNew.DeparturesTest do
             departure_time: ~U[2024-10-11 12:30:00Z],
             route: %Route{id: "r1", line: %Line{id: "l1"}, type: :bus},
             stop: %Stop{id: "s1"},
-            trip: %Trip{headsign: "other1", pattern_headsign: "h1"}
+            trip: %Trip{headsign: "other1", pattern_headsign: "h1", direction_id: 1}
           },
           schedule: nil
         }
@@ -1153,7 +1126,13 @@ defmodule Screens.V2.CandidateGenerator.DupNew.DeparturesTest do
           grouping_type: :time,
           rows: [
             expected_primary_departure,
-            {%Departure{prediction: nil, schedule: schedule}, {6, 10}, nil, :headways}
+            %HeadwayRow{
+              id: "Test ID",
+              line: %Line{id: "l1"},
+              direction_id: 0,
+              range: {6, 10},
+              headsign: "other_headsign"
+            }
           ]
         }
       ]
@@ -1171,9 +1150,84 @@ defmodule Screens.V2.CandidateGenerator.DupNew.DeparturesTest do
                "s1",
                "l1",
                "other_headsign",
-               schedule,
                expected_route_id,
                expected_direction_name,
+               0,
+               expected_time_range
+             )
+           ]}
+        ]
+      end)
+
+      expect(@rds, :get, fn _secondary_departures, @now -> [{:ok, []}] end)
+
+      expected_instances =
+        expected_departures_widget(config, expected_primary_sections, expected_primary_sections)
+
+      actual_instances = DupNew.Departures.instances(config, @now)
+
+      assert actual_instances == expected_instances
+    end
+
+    test "creates NormalSections but removes headways when similar line/direction_id destinations are not in headway mode" do
+      expected_route_id = "r1"
+      expected_time_range = {6, 10}
+      expected_direction_name = "Northbound"
+
+      primary_departures = [
+        %Section{query: %Query{params: %Query.Params{stop_ids: ["s1"]}}},
+        %Section{query: %Query{params: %Query.Params{stop_ids: ["s2"]}}}
+      ]
+
+      expected_primary_departure =
+        %Departure{
+          prediction: %Prediction{
+            arrival_time: ~U[2024-10-11 12:27:00Z],
+            departure_time: ~U[2024-10-11 12:30:00Z],
+            route: %Route{id: "r1", line: %Line{id: "l1"}, type: :subway},
+            stop: %Stop{id: "s1"},
+            trip: %Trip{headsign: "other1", pattern_headsign: "h1", direction_id: 0}
+          },
+          schedule: nil
+        }
+
+      expected_primary_sections = [
+        %Screens.V2.WidgetInstance.Departures.NormalSection{
+          header: %ScreensConfig.Departures.Header{
+            arrow: nil,
+            read_as: nil,
+            subtitle: nil,
+            title: nil
+          },
+          layout: %ScreensConfig.Departures.Layout{
+            base: nil,
+            include_later: false,
+            max: nil,
+            min: 1
+          },
+          grouping_type: :time,
+          rows: [
+            expected_primary_departure
+          ]
+        }
+      ]
+
+      config =
+        @config
+        |> put_primary_departures(primary_departures)
+
+      expect(@rds, :get, fn _primary_departures, @now ->
+        [
+          {:ok,
+           [
+             rds_countdown("s1", "l1", "other1", [expected_primary_departure]),
+             headways(
+               "s1",
+               "l1",
+               "other_headsign",
+               expected_route_id,
+               expected_direction_name,
+               0,
                expected_time_range
              )
            ]}

--- a/test/screens/v2/rds_test.exs
+++ b/test/screens/v2/rds_test.exs
@@ -114,15 +114,24 @@ defmodule Screens.V2.RDSTest do
     }
   end
 
-  defp headways(stop_id, line_id, headsign, first_scheduled_departure, route_id, direction_name) do
+  defp headways(
+         stop_id,
+         line_id,
+         headsign,
+         route_id,
+         direction_name,
+         direction_id,
+         departure_id
+       ) do
     %RDS{
       stop: %Stop{id: stop_id},
       line: %Line{id: line_id},
       headsign: headsign,
       state: %RDS.Headways{
-        departure: %Departure{prediction: nil, schedule: first_scheduled_departure},
+        departure_id: departure_id,
         route_id: route_id,
         direction_name: direction_name,
+        direction_id: direction_id,
         range: {5, 10}
       }
     }
@@ -631,6 +640,7 @@ defmodule Screens.V2.RDSTest do
 
       first_schedule_one =
         %Schedule{
+          id: "Test ID 11",
           departure_time: ~U[2024-10-11 10:45:00Z],
           route: %Route{
             id: "r1",
@@ -644,6 +654,7 @@ defmodule Screens.V2.RDSTest do
 
       last_schedule_one =
         %Schedule{
+          id: "Test ID 12",
           departure_time: ~U[2024-10-12 01:45:00Z],
           route: %Route{
             id: "r1",
@@ -656,6 +667,7 @@ defmodule Screens.V2.RDSTest do
         }
 
       first_schedule_two = %Schedule{
+        id: "Test ID 21",
         departure_time: ~U[2024-10-11 10:45:00Z],
         route: %Route{
           id: "r2",
@@ -669,6 +681,7 @@ defmodule Screens.V2.RDSTest do
 
       last_schedule_two =
         %Schedule{
+          id: "Test ID 22",
           departure_time: ~U[2024-10-12 01:45:00Z],
           route: %Route{
             id: "r2",
@@ -682,6 +695,7 @@ defmodule Screens.V2.RDSTest do
 
       first_schedule_three =
         %Schedule{
+          id: "Test ID 31",
           departure_time: ~U[2024-10-11 10:45:00Z],
           route: %Route{
             id: "r2",
@@ -695,6 +709,7 @@ defmodule Screens.V2.RDSTest do
 
       last_schedule_three =
         %Schedule{
+          id: "Test ID 32",
           departure_time: ~U[2024-10-12 01:45:00Z],
           route: %Route{
             id: "r2",
@@ -729,9 +744,9 @@ defmodule Screens.V2.RDSTest do
       assert RDS.get(departures, now) == [
                {:ok,
                 [
-                  headways("sA", "l1", "hA", first_schedule_one, "r1", "Northbound"),
-                  headways("sB", "l2", "hB", first_schedule_two, "r2", "Westbound"),
-                  headways("sC", "l2", "hC", first_schedule_three, "r2", "Eastbound")
+                  headways("sA", "l1", "hA", "r1", "Northbound", 0, "Test ID 11"),
+                  headways("sB", "l2", "hB", "r2", "Westbound", 1, "Test ID 21"),
+                  headways("sC", "l2", "hC", "r2", "Eastbound", 0, "Test ID 31")
                 ]}
              ]
     end

--- a/test/screens/v2/widget_instance/departures_test.exs
+++ b/test/screens/v2/widget_instance/departures_test.exs
@@ -2,6 +2,7 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
   use ExUnit.Case, async: true
 
   alias Screens.Departures.Departure
+  alias Screens.Lines.Line
   alias Screens.Predictions.Prediction
   alias Screens.Routes.Route
   alias Screens.Schedules.Schedule
@@ -9,7 +10,14 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
   alias Screens.Trips.Trip
   alias Screens.V2.{Departure, WidgetInstance}
   alias Screens.V2.WidgetInstance.Departures
-  alias Screens.V2.WidgetInstance.Departures.{HeadwaySection, NoDataSection, NormalSection}
+
+  alias Screens.V2.WidgetInstance.Departures.{
+    HeadwayRow,
+    HeadwaySection,
+    NoDataSection,
+    NormalSection
+  }
+
   alias Screens.V2.WidgetInstance.Serializer.RoutePill
   alias Screens.Vehicles.Vehicle
   alias ScreensConfig.Departures.Header
@@ -354,6 +362,136 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
                ]
              } =
                Departures.serialize_section(section, bus_shelter_screen, now, false)
+    end
+
+    test "serializes normal section with countdown and headway rows", %{
+      dup_screen: dup_screen,
+      now: now
+    } do
+      rows = [
+        %Departure{
+          prediction: %Prediction{
+            id: "one",
+            departure_time: ~U[2020-01-01T00:01:10Z],
+            route: route(id: "Green-E", type: :subway),
+            trip: %Trip{headsign: "Medford/Tufts", direction_id: 1},
+            stop: %Stop{}
+          }
+        },
+        %HeadwayRow{
+          id: "Test ID",
+          line: %Line{id: "line-Green"},
+          direction_id: 0,
+          range: {20, 30},
+          headsign: %{headsign: "Westbound"}
+        }
+      ]
+
+      section = %NormalSection{
+        rows: rows,
+        layout: %Layout{},
+        header: %Header{title: "Section Header"},
+        grouping_type: :time
+      }
+
+      assert %{
+               type: :normal_section,
+               rows: [
+                 %{headsign: %{headsign: "Medford/Tufts"}},
+                 %{
+                   headsign: %{headsign: %{headsign: "Westbound"}},
+                   direction_id: 0,
+                   route: %{type: :text, text: "GL", color: :green},
+                   times_with_crowding: [
+                     %{id: "Test ID", time: %{type: :status, pages: ["every 20-30m"]}}
+                   ]
+                 }
+               ]
+             } =
+               Departures.serialize_section(section, dup_screen, now, false)
+    end
+
+    test "serializes normal section with first trip row", %{
+      dup_screen: dup_screen,
+      now: now
+    } do
+      rows = [
+        {%Departure{
+           schedule: %Schedule{
+             id: "one",
+             departure_time: ~U[2020-01-01T00:01:10Z],
+             route: route(id: "Green-E", type: :subway),
+             trip: %Trip{headsign: "Medford/Tufts", direction_id: 1},
+             stop: %Stop{}
+           }
+         }, :first_trip}
+      ]
+
+      section = %NormalSection{
+        rows: rows,
+        layout: %Layout{},
+        header: %Header{title: "Section Header"},
+        grouping_type: :time
+      }
+
+      assert %{
+               rows: [
+                 %{
+                   headsign: %{headsign: "Medford/Tufts"},
+                   is_first_trip: true,
+                   route: %{type: :text, text: "GL·E", color: :green},
+                   times_with_crowding: [
+                     %{
+                       id: "one",
+                       time: %{type: :timestamp, minute: 1, hour: 7}
+                     }
+                   ],
+                   type: :departure_row
+                 }
+               ]
+             } =
+               Departures.serialize_section(section, dup_screen, now, false)
+    end
+
+    test "serializes normal section with last trip row", %{
+      dup_screen: dup_screen,
+      now: now
+    } do
+      rows = [
+        {%Departure{
+           schedule: %Schedule{
+             id: "one",
+             departure_time: ~U[2020-01-01T00:01:10Z],
+             route: route(id: "Green-E", type: :subway),
+             trip: %Trip{headsign: "Medford/Tufts", direction_id: 1},
+             stop: %Stop{}
+           }
+         }, :last_trip}
+      ]
+
+      section = %NormalSection{
+        rows: rows,
+        layout: %Layout{},
+        header: %Header{title: "Section Header"},
+        grouping_type: :time
+      }
+
+      assert %{
+               rows: [
+                 %{
+                   headsign: %{headsign: "Medford/Tufts"},
+                   route: %{type: :text, text: "GL·E", color: :green},
+                   times_with_crowding: [
+                     %{
+                       id: "one",
+                       time: %{type: :overnight}
+                     }
+                   ],
+                   type: :departure_row
+                 }
+               ]
+             } =
+               Departures.serialize_section(section, dup_screen, now, false)
     end
   end
 

--- a/test/screens/v2/widget_instance/serializer/route_pill_test.exs
+++ b/test/screens/v2/widget_instance/serializer/route_pill_test.exs
@@ -1,13 +1,14 @@
 defmodule Screens.V2.WidgetInstance.Serializer.RoutePillTest do
   use ExUnit.Case, async: true
 
+  alias Screens.Lines.Line
   alias ScreensConfig.Screen
 
   import ExUnit.CaptureLog
   import Screens.TestSupport.RouteBuilder
   import Screens.V2.WidgetInstance.Serializer.RoutePill
 
-  describe "serialize_for_departure/3" do
+  describe "serialize_for_departure/3 with route" do
     setup do
       pre_fare_screen = struct(Screen, %{app_id: :pre_fare_v2})
       gl_eink_screen = struct(Screen, %{app_id: :gl_eink_v2})
@@ -283,6 +284,36 @@ defmodule Screens.V2.WidgetInstance.Serializer.RoutePillTest do
     test "Includes branch list and text for Green Line" do
       assert %{type: :text, text: "GL", color: :green, branches: ["B"]} ==
                serialize_route_for_reconstructed_alert({"Green", ["Green-B"]})
+    end
+  end
+
+  describe "serialize_for_departure/3 with line" do
+    setup do
+      dup_screen = struct(Screen, %{app_id: :dup_v2})
+
+      %{
+        dup_screen: dup_screen
+      }
+    end
+
+    test "returns GL for line-Green", %{dup_screen: dup_screen} do
+      assert %{type: :text, text: "GL", color: :green} ==
+               serialize_for_departure(%Line{id: "line-Green"}, nil, dup_screen)
+    end
+
+    test "returns RL for line-Red", %{dup_screen: dup_screen} do
+      assert %{type: :text, text: "RL", color: :red} ==
+               serialize_for_departure(%Line{id: "line-Red"}, nil, dup_screen)
+    end
+
+    test "returns CR pill for commuter rail lines", %{dup_screen: dup_screen} do
+      assert %{type: :icon, icon: :rail, route_abbrev: "FOX", color: :purple} ==
+               serialize_for_departure(%Line{id: "line-Foxboro"}, nil, dup_screen)
+    end
+
+    test "returns Bus pill for numbered lines", %{dup_screen: dup_screen} do
+      assert %{type: :text, text: "90", color: :yellow} ==
+               serialize_for_departure(%Line{id: "line-90"}, nil, dup_screen)
     end
   end
 end


### PR DESCRIPTION
**Asana task**: [[Bug] GL-Branch pill showing for Eastbound headways](https://app.asana.com/1/15492006741476/project/1212581278818608/task/1214550997506231?focus=true)

Description
- Fixed showing headways when there were still other states for similar line/direction_id destinations. We now omit headways when we find other destinations in other states other than headway
- Fixed pill grouping when we have headways, added a `serialize_line` within `RoutePill` and we now use the line to create the Route Pill rather than using individual departures
- Cleaned up some parameters being passed through in order to simplify serialization
- Added test for the headway omission case and also `serialize_line` within RoutePills, and a missing First Trip/Service Ended serialization

- [x] Tests added?
