### PR TITLE
chore: restore permissions to deploy-ecs

### DIFF
--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -37,8 +37,8 @@ jobs:
       app-name: screens
       environment: ${{ github.event.inputs.environment || 'dev' }}
     permissions: {
-      contents: read,
-      id-token: write
+      contents: read, # Needed to check out the repository
+      id-token: write # Needed to authenticate against AWS
     }
     secrets:
       aws-role-arn: ${{ secrets.AWS_ROLE_ARN }}

--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -36,6 +36,10 @@ jobs:
     with:
       app-name: screens
       environment: ${{ github.event.inputs.environment || 'dev' }}
+    permissions: {
+      contents: read,
+      id-token: write
+    }
     secrets:
       aws-role-arn: ${{ secrets.AWS_ROLE_ARN }}
       docker-repo: ${{ secrets.DOCKER_REPO }}


### PR DESCRIPTION




**Asana task**: None

Description


In 9502e1b we removed the permissions for deploy-ecs in order to appease zizmor. This resulted in the following error:
```
The workflow is not valid. .github/workflows/deploy-ecs.yml (Line: 34,
Col: 3): Error calling workflow.  The nested job 'deploy' is requesting
'contents: read, id-token: write', but is only allowed 'contents: none,
id-token: none'.
```
This commit restores the necessary permissions

- [ ] Tests added?
