### PR TITLE
chore: increase V3 API HTTP pool size

### DIFF
--- a/lib/screens/application.ex
+++ b/lib/screens/application.ex
@@ -11,7 +11,8 @@ defmodule Screens.Application do
       [
         {Screens.Cache.Owner, engine_module: Screens.Config.Cache.Engine},
         {Screens.Cache.Owner, engine_module: Screens.SignsUiConfig.Cache.Engine},
-        {Finch, name: Screens.V3Api.Finch, pools: %{:default => [start_pool_metrics?: true]}},
+        {Finch,
+         name: Screens.V3Api.Finch, pools: %{default: [size: 100, start_pool_metrics?: true]}},
         Screens.V3Api.Cache.Realtime,
         Screens.V3Api.Cache.Static,
         Screens.LastTrip.Cache,


### PR DESCRIPTION
The number of used connections reported in production is frequently at the limit of the default pool size (50), and we are seeing occasional checkout timeouts, which means even successful requests may be delaying screen refreshes by several seconds. At the same time, we are using only ~35% of our 2GB memory allocation on average.

Assuming each open connection requires ~5MB of memory (seen in previous performance measurements, though this was with Hackney instead of Mint), doubling the pool size to 100 should take us to ~50% memory usage, which seems like a good trade for better screen performance (if indeed we see a reasonable improvement there).

<img width="1970" height="784" alt="" src="https://github.com/user-attachments/assets/ac8fd4d7-5cb5-4688-a409-120522576a30" />
<img width="976" height="786" alt="" src="https://github.com/user-attachments/assets/c2f3faeb-9792-4c6e-a77d-b2e0592e001a" />