### PR TITLE
fix: empty route pattern and WTC Silver Line headway fix

### DIFF
--- a/lib/screens/headways.ex
+++ b/lib/screens/headways.ex
@@ -35,7 +35,7 @@ defmodule Screens.Headways do
     red_braintree: [70095..70105],
     red_trunk: [70061..70061, 70063..70084],
     silver_seaport: [247..247, 17_091..17_095, 27_092..27_092, 30_249..30_251, 31_255..31_259],
-    silver_chelsea: [7096..7097, 74_630..74_637]
+    silver_chelsea: [7096..7097, 74_611..74_617, 74_630..74_637]
   }
 
   # Mapping of parent station IDs and route IDs to headway keys. For brevity, omits the "place-"

--- a/lib/screens/route_patterns/route_pattern.ex
+++ b/lib/screens/route_patterns/route_pattern.ex
@@ -66,9 +66,11 @@ defmodule Screens.RoutePatterns.RoutePattern do
     do: Enum.filter(patterns, &(&1.typicality == typicality))
 
   defp encode_param({:ids, ids}), do: [{"filter[id]", Enum.join(ids, ",")}]
+  defp encode_param({:route_ids, []}), do: []
   defp encode_param({:route_ids, ids}), do: [{"filter[route]", Enum.join(ids, ",")}]
   defp encode_param({:direction_id, :both}), do: []
   defp encode_param({:direction_id, id}), do: [{"filter[direction_id]", to_string(id)}]
+  defp encode_param({:stop_ids, []}), do: []
   defp encode_param({:stop_ids, ids}), do: [{"filter[stop]", Enum.join(ids, ",")}]
   defp encode_param({:canonical?, canonical?}), do: [{"filter[canonical]", to_string(canonical?)}]
   defp encode_param({:date, date}), do: [{"filter[date]", Date.to_iso8601(date)}]


### PR DESCRIPTION
**Asana task**: [[Bug] WTC DUP not showing headways for Outbound](https://app.asana.com/1/15492006741476/project/1212581278818608/task/1214452554688001?focus=true)

Description
- added South Station, Courthouse and WTC Stop IDs to headway mapping
- fixed route pattern using blank routes for API filtering causing empty data to come back

I have not 100% verified it yet, but the fix hopefully will encompass [this bug](https://app.asana.com/1/15492006741476/project/1212581278818608/task/1214452554688005?focus=true) as well.
