### PR TITLE
fix: subway status pills overlapping with status text

### DIFF
--- a/assets/css/lcd/subway_status.scss
+++ b/assets/css/lcd/subway_status.scss
@@ -61,10 +61,6 @@
   white-space: nowrap;
 }
 
-.subway-status__pill-container {
-  min-width: 136px;
-}
-
 .subway-status__text-container {
   display: flex;
   gap: 16px;

--- a/assets/src/components/subway_status/subway_status_common.tsx
+++ b/assets/src/components/subway_status/subway_status_common.tsx
@@ -163,30 +163,18 @@ export const useSubwayStatusTextResizer = (alert: Alert, type: SectionType) => {
       : [FittingStep.FullSize, FittingStep.Abbrev];
   const { ref, step: fittingStep } = useAutoSize(steps, id);
 
-  const isStopsSkipped = /Stops? Skipped/.test(alert.status);
-  const isSuspension = firstWord(alert.status) === "Suspension";
   const isDelays = firstWord(alert.status) === "Delays";
 
-  const location = (() => {
-    if (
-      fittingStep === FittingStep.PerAlertEffect &&
-      (isStopsSkipped || isSuspension)
-    ) {
-      return "mbta.com/alerts";
-    } else if (isAlertLocationMap(alert.location)) {
-      return fittingStep === FittingStep.Abbrev ||
-        fittingStep === FittingStep.PerAlertEffect
-        ? alert.location.abbrev
-        : alert.location.full;
-    } else {
-      return alert.location;
-    }
-  })();
+  let location = getAlertLocationString(alert.location, fittingStep);
+  let status = alert.status;
 
-  const status =
-    fittingStep === FittingStep.PerAlertEffect && isDelays
-      ? "Delays"
-      : alert.status;
+  if (fittingStep === FittingStep.PerAlertEffect) {
+    if (isDelays) {
+      status = "Delays";
+    } else {
+      location = "mbta.com/alerts";
+    }
+  }
 
   return { ref, location, status };
 };
@@ -200,4 +188,17 @@ export const isAllNormalService = (data: SubwayStatusData): boolean => {
       route_section.type === "contracted" &&
       route_section.alerts.every((alert) => alert.status === NORMAL_STATUS),
   );
+};
+
+const getAlertLocationString = (
+  location: AlertLocation,
+  fittingStep: FittingStep,
+) => {
+  if (isAlertLocationMap(location)) {
+    return fittingStep === FittingStep.FullSize
+      ? location.full
+      : location.abbrev;
+  } else {
+    return location;
+  }
 };


### PR DESCRIPTION
**Asana task**: [Screens bug: overlapping elements in Subway Status](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1214355771717040?focus=true)

Description
<img width="543" height="316" alt="Screenshot 2026-05-12 at 3 14 04 PM" src="https://github.com/user-attachments/assets/963991e3-5aca-4708-9e83-7440b89c7b11" />

- seems like having min-width was causing it so that the divs weren't respecting the full size of the pills
- alongside that, we needed to add Shuttle as a specific alert type to show the alert link
- removes min-width from the container for the RoutePill and also pulled out statuses into a boolean check for showing the alert URL
