### PR TITLE
fix: headway text style/alignment and headways for no service

### DIFF
--- a/assets/css/dup/departures/time.scss
+++ b/assets/css/dup/departures/time.scss
@@ -1,4 +1,5 @@
 @use "CSS/colors";
+@use "../font";
 
 .departure-time {
   font-size: 138px;
@@ -44,7 +45,7 @@
 
 .departure-time__minutes-label {
   display: inline-block;
-  font-size: 0.729em;
+  font-size: font.$font-size-small-label;
   font-weight: 400;
   line-height: 1em;
 }

--- a/assets/css/dup/font.scss
+++ b/assets/css/dup/font.scss
@@ -1,0 +1,2 @@
+// Currently used for minutes/right side label on DUPs
+$font-size-small-label: 0.729em;

--- a/assets/css/dup/free_text.scss
+++ b/assets/css/dup/free_text.scss
@@ -1,4 +1,5 @@
 @use "CSS/colors";
+@use "font";
 
 // General styles for free text / route pills
 .free-text {
@@ -135,7 +136,8 @@
 
 // Partial alert and one-line headway have similar styles
 .partial-alert,
-.headway-section--row {
+.headway-section--row,
+.headway-section--row_with_headsign {
   .free-text__line {
     width: 1608px;
     white-space: nowrap;
@@ -150,6 +152,33 @@
     height: 128px;
     padding-top: 40px;
     padding-bottom: 40px;
+  }
+}
+
+.headway-section--row_with_headsign {
+  .free-text__line {
+    display: flex;
+    align-items: center;
+  }
+
+  .free-text__line-container {
+    display: flex;
+  }
+
+  .free-text__line {
+    display: flex;
+    justify-content: space-between;
+    margin-right: 32px;
+  }
+
+  .free-text__string--bold {
+    font-size: 138px;
+    font-weight: 600;
+  }
+
+  .free-text__string--small {
+    font-size: font.$font-size-small-label;
+    font-weight: 400;
   }
 }
 

--- a/lib/screens/v2/candidate_generator/dup_new/departures.ex
+++ b/lib/screens/v2/candidate_generator/dup_new/departures.ex
@@ -120,9 +120,6 @@ defmodule Screens.V2.CandidateGenerator.DupNew.Departures do
     num_departures_per_section = div(@max_departures_per_rotation, section_count)
 
     cond do
-      headways?(rds_list) ->
-        create_headway_section(rds_list)
-
       no_service?(rds_list) ->
         %NoServiceSection{
           routes:
@@ -145,6 +142,9 @@ defmodule Screens.V2.CandidateGenerator.DupNew.Departures do
             |> Enum.uniq()
         }
 
+      headways?(rds_list) ->
+        create_headway_section(rds_list)
+
       true ->
         %NormalSection{
           rows:
@@ -166,7 +166,7 @@ defmodule Screens.V2.CandidateGenerator.DupNew.Departures do
   end
 
   defp headways?(rds_list) do
-    Enum.all?(rds_list, &is_struct(&1.state, Headways))
+    Enum.all?(rds_list, &(is_struct(&1.state, Headways) || is_struct(&1.state, NoService)))
   end
 
   @spec create_headway_section([RDS.t()]) :: HeadwaySection.t()
@@ -447,7 +447,7 @@ defmodule Screens.V2.CandidateGenerator.DupNew.Departures do
   defp extract_line_direction_pairs(%RDS{line: %Line{id: line_id}, state: state}) do
     case state do
       %NoService{} ->
-        [{line_id, 0}, {line_id, 1}]
+        []
 
       %Countdowns{departures: []} ->
         [{line_id, 0}, {line_id, 1}]

--- a/lib/screens/v2/widget_instance/departures.ex
+++ b/lib/screens/v2/widget_instance/departures.ex
@@ -209,7 +209,13 @@ defmodule Screens.V2.WidgetInstance.Departures do
         is_only_section
       ) do
     pill_color = Route.color(route)
-    layout = if is_only_section, do: :full_screen, else: :row
+
+    layout =
+      cond do
+        is_only_section -> :full_screen
+        headsign == nil -> :row
+        true -> :row_with_headsign
+      end
 
     text = get_headway_text(headsign, time_range, pill_color, route, is_only_section)
 

--- a/test/screens/v2/widget_instance/departures_test.exs
+++ b/test/screens/v2/widget_instance/departures_test.exs
@@ -217,7 +217,7 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
         text: [%{format: :bold, text: "Alewife"}, %{format: :small, text: "every 12-15m"}]
       }
 
-      assert %{type: :headway_section, text: expected_text, layout: :row} ==
+      assert %{type: :headway_section, text: expected_text, layout: :row_with_headsign} ==
                Departures.serialize_section(section, dup_screen, now, false)
     end
 


### PR DESCRIPTION
Description
- added a new FreeTextLine layout that provides spacing in between spans which allows for the Headsign to the on the left and the headway values to be on the right. Currently, this is only used for Partial Headway Sections with a headway defined in order to match the new Headway Rows. Full Headway Sections and Headway Sections with no headsign will continue to be the same
- also fixed an issue where No Service destinations were causing Headways not to show up.

<img width="974" height="557" alt="Screenshot 2026-05-13 at 12 43 22 PM" src="https://github.com/user-attachments/assets/1d847dda-2523-4338-b49c-4723d17346e6" />

- [x] Tests modified?
