### PR TITLE
chore: enable non-Outfront DUPs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ npm-debug.log
 # this depending on your deployment strategy.
 /priv/static/
 
+# packaged client assets
+/priv/packaged/
+
 # Local config files
 /priv/local.json
 /priv/local_pending.json

--- a/assets/src/components/dup/README.md
+++ b/assets/src/components/dup/README.md
@@ -1,24 +1,21 @@
 # DUP app packaging
 
-- Ensure [Corsica](https://hexdocs.pm/corsica/Corsica.html) is used on the server to allow CORS requests (ideally limited to just the DUP-relevant routes). It should already be configured in [the API controller](/lib/screens_web/controllers/v2/screen_api_controller.ex) -- if it is, you don't need to do anything for this step.
-- Double check that any behavior specific to the DUP screen environment happens inside of an `isDup()` check. This includes:
-  - `useApiPath` in [`use_api_response.ts`][use_api_response.ts] should return a full URL for the API path: the URL base should be "https://screens.mbta.com".
-  - `imagePath` in [`util.ts`][util.ts] should return relative paths (no leading `/`).
-
-- Set the version string in [`version.ts`][version.ts]. Refer to this file's JSDoc for instructions on how to set the version string value.
+- Double check that any behavior specific to the packaged environment happens inside of an `isOutfront()` condition.
 - If you've renamed / removed image assets, you might want to delete the corresponding folder in `/priv/static`. The folder accumulates assets without clearing old ones out, and these will be included in the built bundle!
-- **Only if you are packaging for local testing:** To test against your local screens backend instead of production, then replace the definition of `OUTFRONT_BASE_URI` in [`use_api_response.ts`][use_api_response.ts] with `"http://localhost:4000"`.
-- `cd` to `scripts` and run the following shell script: `sh build_dup_client_package.sh`
-- On completion, the packaged client apps will be saved at `priv/static/dup-app-(0|1|2).zip`.
-- To test the created package locally or in Browserstack, you need to add any query param with key `test` to the `index.html`, such as `index.html?test=`.
+- **Only if you are packaging for local testing:** To test against your local screens backend instead of production, then replace the value of `data-api-origin` in [`priv/dup-app.html`][dup-app.html] with `http://localhost:4000`.
+- Run `scripts/build_dup_client_package.sh`. The packaged client apps will be output at `priv/packaged/dup-app-<rotation>-<version>.zip`.
+- To test a created package locally or in Browserstack, you need to add any query param with key `test` to the `index.html`, such as `index.html?test=`.
   - Setting this query param sets up a fake MRAID object that emulates the real one available to the client when running on Outfront screens.
   - You can also set `playerName` and `station` within the URL params to change which screen is emulated.
   - If you are testing multiple iterations locally and don't want to add the URL params with each rebuild of the package, temporarily modify the if statement and/or defaults within [`outfront.tsx`][outfront.tsx]'s `initFakeMRAID` function. Just make sure to remove before sending client packages to Outfront to test.
 - When testing is complete, commit the version bump on a branch, push it, and create a PR to mark the deploy.
 
+[dup-app.html]: /priv/dup-app.html
+[outfront.tsx]: /assets/src/util/outfront.tsx
+
 ## Working with Outfront
 
-Once you've created the client app packages, you'll need to send them to Outfront to test and deploy. Make sure to remove any changes that you made to [`outfront.tsx`][outfront.tsx] and [`use_api_response.ts`][use_api_response.ts] for local testing before generating packages for Outfront.
+Once you've created the client app packages, you'll need to send them to Outfront to test and deploy. Make sure to revert any local changes you've made before generating the packages.
 
 For detailed instructions on this process, go to [this Notion doc](https://www.notion.so/mbta-downtown-crossing/Deploying-DUP-Package-Updates-120f5d8d11ea805fa219f214c1633293).
 
@@ -69,8 +66,3 @@ console.log = function (...msgs) {
   }
 };
 ```
-
-[outfront.tsx]: /assets/src/util/outfront.tsx
-[version.ts]: /assets/src/components/dup/version.ts
-[use_api_response.ts]: /assets/src/hooks/use_api_response.ts
-[util.ts]: /assets/src/util/utils.ts

--- a/assets/src/components/dup/normal_header.tsx
+++ b/assets/src/components/dup/normal_header.tsx
@@ -1,7 +1,6 @@
 import DefaultNormalHeader, { Icon } from "Components/normal_header";
-import { DUP_VERSION } from "./version";
 import { usePlayerName } from "Hooks/outfront";
-import { getRotationIndex } from "Util/outfront";
+import { getRotationIndex, getVersion, isOutfront } from "Util/outfront";
 
 interface NormalHeaderProps {
   text: string;
@@ -17,13 +16,13 @@ const NormalHeader = ({
   accentPattern,
 }: NormalHeaderProps) => {
   const playerName = usePlayerName();
-  const rotationIndex = getRotationIndex();
-  let version = DUP_VERSION;
-  if (rotationIndex) {
-    version = `${version}.${rotationIndex}`;
-  }
-  if (playerName) {
-    version = `${version}-${playerName}`;
+
+  let version: string | undefined = undefined;
+
+  if (isOutfront()) {
+    version = [playerName, getVersion(), getRotationIndex()]
+      .filter(Boolean)
+      .join("/");
   }
 
   return (

--- a/assets/src/components/dup/rotation_index.tsx
+++ b/assets/src/components/dup/rotation_index.tsx
@@ -1,1 +1,0 @@
-export const ROTATION_INDEX = 2;

--- a/assets/src/components/dup/version.ts
+++ b/assets/src/components/dup/version.ts
@@ -1,9 +1,0 @@
-/**
- * The value here is expected to be of the format:
- * `current_year.current_month.current_day.version_for_current_day`.
- *
- * Technically, this value can be _anything_. However, it does propagate to logs
- * to help determine which version of the client a given DUP data request is
- * coming from.
- */
-export const DUP_VERSION = "26.04.16.1";

--- a/assets/src/components/screen_container.tsx
+++ b/assets/src/components/screen_container.tsx
@@ -10,12 +10,12 @@ import {
 import useApiResponse, {
   ApiResponse,
   SimulationData,
-  useDUPApiResponse,
+  useOutfrontApiResponse,
 } from "Hooks/use_api_response";
 import WidgetTreeErrorBoundary from "Components/widget_tree_error_boundary";
 import Widget, { WidgetData } from "Components/widget";
 import useAudioReadout from "Hooks/use_audio_readout";
-import { isDup } from "Util/outfront";
+import { isOutfront } from "Util/outfront";
 import { classWithModifier, getScreenSide } from "Util/utils";
 
 type ResponseMapper = (apiResponse: ApiResponse) => WidgetData | SimulationData;
@@ -93,7 +93,7 @@ const ScreenLayout: ComponentType<ScreenLayoutProps> = ({
   showBlink,
 }) => {
   const responseMapper = useContext(ResponseMapperContext);
-  const ErrorBoundaryOrFragment = isDup() ? Fragment : WidgetTreeErrorBoundary;
+  const MaybeErrorBoundary = isOutfront() ? Fragment : WidgetTreeErrorBoundary;
 
   // We know this can only be `WidgetData` and not `SimulationData` here because
   // `ScreenPage` is only used in contexts where a "non-simulation" API response
@@ -104,17 +104,17 @@ const ScreenLayout: ComponentType<ScreenLayoutProps> = ({
 
   return (
     <div className={classWithModifier("screen-container", getScreenSide())}>
-      <ErrorBoundaryOrFragment>
+      <MaybeErrorBoundary>
         {apiResponse && <Widget data={widgetData} />}
-      </ErrorBoundaryOrFragment>
+      </MaybeErrorBoundary>
       {showBlink && <div className="screen-container-blink" />}
     </div>
   );
 };
 
 const getApiResponseHook = () => {
-  if (isDup()) {
-    return useDUPApiResponse;
+  if (isOutfront()) {
+    return useOutfrontApiResponse;
   } else {
     return useApiResponse;
   }

--- a/assets/src/hooks/use_api_response.ts
+++ b/assets/src/hooks/use_api_response.ts
@@ -12,15 +12,13 @@ import { WidgetData } from "Components/widget";
 import useDriftlessInterval from "Hooks/use_driftless_interval";
 import { getDatasetValue } from "Util/dataset";
 import { sendToInspector, useReceiveFromInspector } from "Util/inspector";
-import { getRotationIndex, isDup } from "Util/outfront";
+import { getRotationIndex, getVersion } from "Util/outfront";
 import { getScreenSide, isRealScreen } from "Util/utils";
 import { report } from "Util/sentry";
-import { DUP_VERSION } from "Components/dup/version";
 import useRefreshRate from "./use_refresh_rate";
 
 const BASE_PATH = "/v2/api/screen";
 const MINUTE_IN_MS = 60_000;
-const OUTFRONT_BASE_URI = "https://screens.mbta.com";
 
 type SimulationResponse = { full_page: WidgetData; flex_zone: WidgetData[] };
 
@@ -122,7 +120,7 @@ const isSuccess = (
 
 const useApiPath = (screenId: string, appendPath?: string): string => {
   return useMemo(() => {
-    const base = isDup() ? OUTFRONT_BASE_URI : document.baseURI;
+    const base = getDatasetValue("apiOrigin") ?? document.baseURI;
     const path = [
       BASE_PATH,
       getDatasetValue("isPending") === "true" ? "pending" : null,
@@ -141,7 +139,7 @@ const useApiPath = (screenId: string, appendPath?: string): string => {
       rotation_index: getRotationIndex(),
       screen_side: getScreenSide(),
       variant: getDatasetValue("variant"),
-      version: isDup() ? DUP_VERSION : null,
+      version: getVersion(),
     };
 
     for (const [key, value] of Object.entries(params)) {
@@ -294,15 +292,13 @@ const useApiResponse = ({ id }): UseApiResponseReturn =>
 const useSimulationApiResponse = ({ id }): UseApiResponseReturn =>
   useBaseApiResponse({ id, appendPath: "simulation" });
 
-// For OFM apps--DUPs--we need to request a different
-// route that's more permissive of CORS, since these clients are loaded from a local html file
-// (and thus their data requests to our server are cross-origin).
-//
-// The /dup endpoint only has the CORS stuff, and otherwise runs exactly the same backend logic as
-// the normal one used by `useApiResponse`.
-const useDUPApiResponse = ({ id }): UseApiResponseReturn =>
+// When running the packaged client, use a distinct API route that allows
+// cross-origin requests, since these clients are loaded from a local HTML file
+// (and thus their data requests to our server are cross-origin). This route is
+// otherwise identical to the one used by `useApiResponse`.
+const useOutfrontApiResponse = ({ id }): UseApiResponseReturn =>
   useBaseApiResponse({ id, appendPath: "dup" });
 
 export default useApiResponse;
 export type { ApiResponse, SimulationData };
-export { useSimulationApiResponse, useDUPApiResponse };
+export { useOutfrontApiResponse, useSimulationApiResponse };

--- a/assets/src/hooks/use_refresh_rate.ts
+++ b/assets/src/hooks/use_refresh_rate.ts
@@ -1,7 +1,6 @@
 import _ from "lodash";
 import { useMemo } from "react";
 import { fetchDatasetValue, getDatasetValue } from "Util/dataset";
-import { isDup } from "Util/outfront";
 import { useScreenID } from "./use_screen_id";
 
 interface RefreshRateConfig {
@@ -13,9 +12,7 @@ const useRefreshRate = (): RefreshRateConfig => {
   const screenId = useScreenID();
 
   return useMemo(() => {
-    // Live OFM screens ignore any configured refreshRate.
-    // Hardcoding to 0 prevents an interval from being started unnecessarily.
-    const refreshRate = isDup() ? "0" : fetchDatasetValue("refreshRate");
+    const refreshRate = fetchDatasetValue("refreshRate");
     const refreshRateOffset = getDatasetValue("refreshRateOffset") || "0";
     const screenIdsWithOffsetMap = getDatasetValue("screenIdsWithOffsetMap");
 

--- a/assets/src/util/outfront.tsx
+++ b/assets/src/util/outfront.tsx
@@ -1,12 +1,9 @@
-import { ROTATION_INDEX } from "Components/dup/rotation_index";
 import { getDatasetValue } from "Util/dataset";
 
 /**
- * Returns true if this client is running on a DUP screen.
- *
- * Use this for DUP-specific logic.
+ * True if this is the "packaged" client deployed to Outfront hardware.
  */
-export const isDup = () => /.*dup-app.*/.test(location.href);
+export const isOutfront = () => getDatasetValue("isOutfront") === "true";
 
 type RotationIndex = "0" | "1" | "2";
 const isRotationIndex = (value: any): value is RotationIndex => {
@@ -14,12 +11,11 @@ const isRotationIndex = (value: any): value is RotationIndex => {
 };
 
 export const getRotationIndex = (): RotationIndex | null => {
-  const rotationIndex = isDup()
-    ? ROTATION_INDEX.toString()
-    : getDatasetValue("rotationIndex");
-
+  const rotationIndex = getDatasetValue("rotationIndex");
   return isRotationIndex(rotationIndex) ? rotationIndex : null;
 };
+
+export const getVersion = () => getDatasetValue("packagedVersion");
 
 /**
  * Gets Outfront's unique name/ID for the media player we're running on.
@@ -96,7 +92,6 @@ interface OFMTag {
 }
 
 export const getMRAID = (): MRAID | false => {
-  if (!isDup()) return false;
   return (parent?.parent as OFMWindow)?.mraid ?? false;
 };
 

--- a/assets/src/util/sentry.tsx
+++ b/assets/src/util/sentry.tsx
@@ -1,7 +1,7 @@
 import * as Sentry from "@sentry/react";
 import type { SeverityLevel } from "@sentry/react";
 
-import { isDup } from "Util/outfront";
+import { isOutfront } from "Util/outfront";
 import { isRealScreen } from "Util/utils";
 import { getDataset } from "Util/dataset";
 
@@ -26,7 +26,11 @@ const initSentry = (appString: string) => {
       sendDefaultPii: true,
     });
 
-    if (isDup()) {
+    // Outfront devices load the page anew every time our content is displayed,
+    // so they "initialize" very frequently compared to other screen hardware.
+    // Limit these messages to a specific time of day so they don't exceed our
+    // rate limit, but we still collect the browser/device data.
+    if (isOutfront()) {
       const today = new Date();
       const hour = today.getHours();
       const min = today.getMinutes();

--- a/assets/src/util/utils.ts
+++ b/assets/src/util/utils.ts
@@ -3,7 +3,7 @@ import "moment-timezone";
 import cx from "classnames";
 
 import { getDatasetValue } from "Util/dataset";
-import { isDup } from "Util/outfront";
+import { isOutfront } from "Util/outfront";
 
 export const classWithModifier = (baseClass, modifier) => {
   if (!modifier) {
@@ -37,10 +37,9 @@ export const hasOverflow = (elem: Element): boolean =>
   hasOverflowX(elem) || hasOverflowY(elem);
 
 export const imagePath = (fileName: string): string =>
-  isDup() ? `images/${fileName}` : `/images/${fileName}`;
+  isOutfront() ? `images/${fileName}` : `/images/${fileName}`;
 
-export const isRealScreen = () =>
-  isDup() || getDatasetValue("isRealScreen") === "true";
+export const isRealScreen = () => getDatasetValue("isRealScreen") === "true";
 
 type ScreenSide = "left" | "right" | "duo" | "solo";
 const isScreenSide = (value: any): value is ScreenSide => {

--- a/lib/screens/config/cache.ex
+++ b/lib/screens/config/cache.ex
@@ -16,6 +16,7 @@ defmodule Screens.Config.Cache do
 
   def ok?, do: table_exists?()
 
+  @callback last_deploy_timestamp() :: DateTime.t() | nil
   def last_deploy_timestamp do
     with_table do
       [[last_deploy_timestamp]] = :ets.match(@table, {:last_deploy_timestamp, :"$1"})

--- a/lib/screens/v2/screen_data/parameters.ex
+++ b/lib/screens/v2/screen_data/parameters.ex
@@ -33,7 +33,7 @@ defmodule Screens.V2.ScreenData.Parameters do
     },
     dup_v2: %Static{
       candidate_generator: CandidateGenerator.Dup,
-      refresh_rate: 30,
+      refresh_rate: 20,
       variants: %{"new_departures" => CandidateGenerator.DupNew}
     },
     gl_eink_v2: %Static{

--- a/lib/screens_web/controllers/v2/screen_api_controller.ex
+++ b/lib/screens_web/controllers/v2/screen_api_controller.ex
@@ -2,10 +2,12 @@ defmodule ScreensWeb.V2.ScreenApiController do
   use ScreensWeb, :controller
 
   alias Phoenix.View
-  alias Screens.Config.Cache
   alias Screens.V2.{ScreenAudioData, ScreenData}
   alias ScreensConfig.Screen
   alias ScreensWeb.Plug.{ScreenRequest, VariantCanary}
+
+  import Screens.Inject
+  @cache injected(Screens.Config.Cache)
 
   @base_response %{data: nil, disabled: false, force_reload: false}
 
@@ -104,7 +106,7 @@ defmodule ScreensWeb.V2.ScreenApiController do
   defp put_extra_fields(response, %Screen{vendor: :mercury} = screen) do
     response
     |> Map.put(:audio_data, fetch_ssml(screen))
-    |> Map.put(:last_deploy_timestamp, Cache.last_deploy_timestamp())
+    |> Map.put(:last_deploy_timestamp, @cache.last_deploy_timestamp())
   end
 
   defp put_extra_fields(response, _screen), do: response
@@ -135,10 +137,15 @@ defmodule ScreensWeb.V2.ScreenApiController do
 
   defp disabled_response(conn, _), do: conn
 
-  # Never tell a DUP client to reload, since it would just reload its local copy of the client
-  # code, not changing anything, resulting in an infinite loop. TODO: Rework this once we support
-  # non-Outfront-managed DUPs (should not rely on IDs having a specific format).
-  defp outdated_response(%{assigns: %{screen_id: "DUP-" <> _}} = conn, _), do: conn
+  # The packaged client can't reload the page to update itself; this would just reload the local
+  # copy of the code, resulting in an infinite loop. Compatibility and versioning of the packaged
+  # client is handled manually.
+  defp outdated_response(%{params: %{"last_refresh" => "packaged"}} = conn, _), do: conn
+
+  # Value used in previous releases of the packaged client. Treat as an extra sentinel value for
+  # now, and remove once clients are updated to use `packaged`.
+  defp outdated_response(%{params: %{"last_refresh" => "2020-09-25T17:23:00Z"}} = conn, _),
+    do: conn
 
   defp outdated_response(
          %{
@@ -150,7 +157,7 @@ defmodule ScreensWeb.V2.ScreenApiController do
     with param when is_binary(param) <- params["last_refresh"],
          {:ok, last_refresh_at, _offset} <- DateTime.from_iso8601(param) do
       should_refresh_at =
-        [Cache.last_deploy_timestamp(), refresh_if_loaded_before]
+        [@cache.last_deploy_timestamp(), refresh_if_loaded_before]
         |> Enum.reject(&is_nil/1)
         |> Enum.max(DateTime, fn -> nil end)
 

--- a/priv/dup-app.html
+++ b/priv/dup-app.html
@@ -11,8 +11,14 @@
   <body>
     <div
       id="app"
-      data-last-refresh="2020-09-25T17:23:00Z"
+      data-api-origin="https://screens.mbta.com"
       data-environment-name="screens-prod"
+      data-is-outfront="true"
+      data-is-real-screen="true"
+      data-last-refresh="packaged"
+      data-packaged-version="%version%"
+      data-refresh-rate="0"
+      data-rotation-index="%rotation%"
     ></div>
     <script type="text/javascript" src="packaged_dup.js"></script>
   </body>

--- a/priv/dup_template.json
+++ b/priv/dup_template.json
@@ -1,7 +1,7 @@
 {
   "templates": [
     {
-      "displayName": "MBTA - DUP APP 0",
+      "displayName": "MBTA - DUP APP %rotation%",
       "preview": "dup_preview.png",
       "indexTemplate": "dup-app.html",
       "previewOrientation": "landscape"

--- a/scripts/build_dup_client_package.sh
+++ b/scripts/build_dup_client_package.sh
@@ -1,16 +1,37 @@
 #!/bin/sh
 
-# Builds all three rotations of the DUP client package in priv/static
-cd ../priv/static
+# Builds all three rotations of the DUP client package.
 
-ROTATION_INDEX=0
-while [ "${ROTATION_INDEX}" -le 2 ]; do
-  echo "export const ROTATION_INDEX = ${ROTATION_INDEX};" > ../../assets/src/components/dup/rotation_index.tsx && \
-  npm --prefix ../../assets run deploy:dup && \
-  cp js/packaged_dup.js js/packaged_dup.js.map ../dup_preview.png ../dup-app.html . && \
-  cp ../dup_template.json ./template.json && \
-  sed -i "" "s/DUP APP ./DUP APP ${ROTATION_INDEX}/" template.json && \
-  zip -r dup-app-${ROTATION_INDEX}.zip packaged_dup.css packaged_dup.js fonts images dup-app.html template.json dup_preview.png
+set -eu
 
-  ROTATION_INDEX=$((ROTATION_INDEX + 1))
+if [ $# -eq 0 ]; then
+  version=$(git rev-parse --short HEAD)
+  echo "No version string specified, defaulting to current git rev: ${version}"
+else
+  version=$1
+  echo "Using specified version string: ${version}"
+fi
+
+npm --prefix assets run deploy:dup
+
+outdir=priv/packaged
+rm -r $outdir 2> /dev/null || :
+mkdir -p $outdir
+cd $outdir
+
+mv ../static/packaged_dup.css* ../static/js/packaged_dup.js* .
+cp -r ../static/fonts ../static/images ../dup_preview.png .
+
+rotation_index=0
+while [ $rotation_index -le 2 ]; do
+  cp ../dup-app.html .
+  cp ../dup_template.json template.json
+  sed -i "" "s/%rotation%/$rotation_index/" dup-app.html template.json
+  sed -i "" "s/%version%/$version/" dup-app.html
+  zip -qr "dup-app-$rotation_index-$version.zip" fonts images dup-app.html dup_preview.png packaged_dup.css* packaged_dup.js* template.json
+
+  rotation_index=$((rotation_index + 1))
 done
+
+echo
+echo "📦 Packages built in: $outdir"

--- a/test/screens_web/controllers/v2/screen_api_controller_test.exs
+++ b/test/screens_web/controllers/v2/screen_api_controller_test.exs
@@ -14,61 +14,81 @@ defmodule ScreensWeb.V2.ScreenApiControllerTest do
 
   require Stub
 
-  Stub.candidate_generator(MercuryGenerator, fn _ -> [placeholder(:green)] end)
-  Stub.candidate_generator(LgMriGenerator, fn _ -> [placeholder(:red)] end)
+  Stub.candidate_generator(StubGenerator, fn _ -> [placeholder(:blue)] end)
 
   setup do
+    stub(@cache, :last_deploy_timestamp, fn -> ~U[2020-01-01 00:00:00Z] end)
+    stub(@cache, :screen, fn _id -> struct(Screen) end)
+    stub(@parameters, :candidate_generator, fn _screen, _variant -> StubGenerator end)
     stub(@parameters, :refresh_rate, fn _app_id -> 0 end)
-    stub(@parameters, :variants, fn _ -> [nil] end)
+    stub(@parameters, :variants, fn _screen -> [nil] end)
     stub(ScreensByAlert.Mock, :put_data, fn _screen_id, _alert_ids -> :ok end)
     :ok
   end
 
   describe "show/2" do
-    test "only returns flex_zone for Mercury screens", %{conn: conn} do
-      expect(@cache, :screen, fn
-        "EIG-604" ->
-          struct(Screen, app_id: :gl_eink_v2, vendor: :mercury)
+    test "tells client to reload when its code is outdated", %{conn: conn} do
+      expect(@cache, :last_deploy_timestamp, fn -> ~U[2026-01-01 12:00:00Z] end)
+
+      conn = get(conn, "/v2/api/screen/1?last_refresh=2026-01-01T11:00:00Z")
+
+      assert %{"force_reload" => true} = json_response(conn, 200)
+    end
+
+    test "tells client to reload based on refresh_if_loaded_before", %{conn: conn} do
+      expect(@cache, :last_deploy_timestamp, fn -> ~U[2026-01-01 12:00:00Z] end)
+
+      expect(@cache, :screen, fn "1" ->
+        struct(Screen, refresh_if_loaded_before: ~U[2026-01-01 14:00:00Z])
       end)
 
-      stub(
-        @parameters,
-        :candidate_generator,
-        fn %Screen{vendor: :mercury}, nil -> MercuryGenerator end
-      )
+      conn = get(conn, "/v2/api/screen/1?last_refresh=2026-01-01T13:00:00Z")
+
+      assert %{"force_reload" => true} = json_response(conn, 200)
+    end
+
+    test "does not tell packaged client to reload", %{conn: conn} do
+      conn = get(conn, "/v2/api/screen/1?last_refresh=packaged")
+
+      assert %{"force_reload" => false} = json_response(conn, 200)
+    end
+
+    @tag :capture_log
+    test "errors on missing or invalid refresh timestamp", %{conn: conn} do
+      assert conn |> get("/v2/api/screen/1") |> response(400)
+      assert conn |> get("/v2/api/screen/1?last_refresh=foo") |> response(400)
+    end
+
+    test "returns flex_zone for Mercury screens", %{conn: conn} do
+      expect(@cache, :screen, fn
+        "EIG-604" -> struct(Screen, app_id: :gl_eink_v2, vendor: :mercury)
+      end)
 
       conn = get(conn, "/v2/api/screen/EIG-604?last_refresh=2024-12-02T00:00:00Z")
 
       assert %{
                "audio_data" => "",
                "data" => %{
-                 "main" => %{"color" => "green", "type" => "placeholder", "text" => ""},
+                 "main" => %{"color" => "blue", "type" => "placeholder", "text" => ""},
                  "type" => "normal"
                },
                "disabled" => false,
                "flex_zone" => [],
                "force_reload" => false,
-               "last_deploy_timestamp" => nil
+               "last_deploy_timestamp" => "2020-01-01T00:00:00Z"
              } == json_response(conn, 200)
     end
 
     test "omits flex_zone from non-Mercury screens", %{conn: conn} do
       expect(@cache, :screen, fn
-        "1401" ->
-          struct(Screen, app_id: :bus_shelter_v2, vendor: :lg_mri)
+        "1401" -> struct(Screen, app_id: :bus_shelter_v2, vendor: :lg_mri)
       end)
-
-      stub(
-        @parameters,
-        :candidate_generator,
-        fn %Screen{vendor: :lg_mri}, nil -> LgMriGenerator end
-      )
 
       conn = get(conn, "/v2/api/screen/1401?last_refresh=2024-12-02T00:00:00Z")
 
       assert %{
                "data" => %{
-                 "main" => %{"color" => "red", "type" => "placeholder", "text" => ""},
+                 "main" => %{"color" => "blue", "type" => "placeholder", "text" => ""},
                  "type" => "normal"
                },
                "disabled" => false,


### PR DESCRIPTION
This incorporates several improvements to the client packaging process and a general separation of the concept of a "DUP screen" from the concept of a "packaged client" (deployed to Outfront DUPs). The overall goal is to enable using the "DUP app" on non-Outfront devices that have a similar form factor.

Key changes to enable non-Outfront DUPs:

* Reduce refresh rate from 30 to 20 seconds, in line with other "LCD" screen types. In practice this was never used (and continues not to be used) on Outfront DUPs, since they load the page fresh every time the content appears; it would have only applied to e.g. Screenplay.

* Display the package version information in the DUP header only in packaged copies of the client, as it is only relevant there; "live" clients should always be using the currently deployed code version.

* Refactor the mechanism that checks for outdated client code: Instead of bypassing this for screens whose IDs start with `DUP-`, bypass it when the client sends `last_refresh=packaged`, a sentinel value only present in the packaged client template. This allows non-Outfront DUPs to still have IDs starting with `DUP-` if we'd like them to be that way for organization.

Other changes to improve client packaging:

* Rename `isDup` to `isOutfront`, since this condition will be `false` on "DUP screens" if they are not the packaged client for Outfront devices. Make this check more reliable by reading a data value only present in the packaged client's HTML, instead of looking at the URL.

* Remove the need for three separate Webpack builds by moving the definition of the rotation index from the client JS into the template HTML. Packaged DUP builds are consequently 3x faster. 🚀

* Simplify a few additional instances of `isOutfront` conditional logic by using existing or new data attributes in the template HTML instead.

* Make the packaged client's "version" string solely a property of the built packages, instead of a committed value in the repo. Populate it automatically with the current Git commit short hash, since this is likely to be a more useful value for knowing "what version the client is" than the date the package was built. For special cases, the build script accepts an argument to override the version string.

* File some rough edges off the build script. Client packages are now built into a separate (gitignored) `priv/packaged` directory and the `priv/static` directory is kept clean of packaged DUP files; package filenames now include the version; the script clears the output directory on each run to prevent old versions from piling up.

**Asana task**: https://app.asana.com/1/15492006741476/project/1185117109217413/task/1213739174252146?focus=true