### PR TITLE
feat: add serial numbers to Mercury device monitor

### DIFF
--- a/lib/screens/device_monitor/mercury.ex
+++ b/lib/screens/device_monitor/mercury.ex
@@ -79,6 +79,7 @@ defmodule Screens.DeviceMonitor.Mercury do
                "State" => state
              }
            ],
+           "serial_number" => serial_number,
            "stop" => %{"stop_id" => stop_id}
          },
          button_press_count
@@ -92,6 +93,7 @@ defmodule Screens.DeviceMonitor.Mercury do
       connectivity_used: connectivity_used,
       last_heartbeat: last_heartbeat,
       name: name,
+      serial_number: serial_number,
       signal_strength: signal_strength,
       state: state,
       stop_id: stop_id,
@@ -99,8 +101,15 @@ defmodule Screens.DeviceMonitor.Mercury do
     }
   end
 
-  defp device_info(%{"device_id" => device_id, "stop" => %{"stop_id" => stop_id}}, _count) do
-    %{device_id: device_id, state: "error", stop_id: stop_id}
+  defp device_info(
+         %{
+           "device_id" => device_id,
+           "serial_number" => serial_number,
+           "stop" => %{"stop_id" => stop_id}
+         },
+         _count
+       ) do
+    %{device_id: device_id, serial_number: serial_number, state: "error", stop_id: stop_id}
   end
 
   defp get_api_key, do: System.fetch_env!("MERCURY_API_KEY")


### PR DESCRIPTION
This information is useful for identifying the hardware associated with an E-ink device entry. Per Mercury, `device_id` is a "server-side serial number" and may not appear on the physical device.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214901633382565