### PR TITLE
fix: multiple GL alerts causing the pill branch to repeat

### DIFF
--- a/lib/screens/v2/widget_instance/subway_status/serialize/route_pill.ex
+++ b/lib/screens/v2/widget_instance/subway_status/serialize/route_pill.ex
@@ -25,6 +25,7 @@ defmodule Screens.V2.WidgetInstance.SubwayStatus.Serialize.RoutePill do
       |> Enum.map(fn "Green-" <> branch ->
         branch |> String.downcase() |> String.to_existing_atom()
       end)
+      |> Enum.uniq()
 
     %{type: :text, color: :green, text: "GL", branches: branches}
   end

--- a/test/screens/v2/widget_instance/subway_status_test.exs
+++ b/test/screens/v2/widget_instance/subway_status_test.exs
@@ -573,6 +573,51 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
       assert expected == WidgetInstance.serialize(instance)
     end
 
+    test "handles 3+ alerts of the same GL branch" do
+      instance = %SubwayStatus{
+        subway_alerts:
+          subway_alerts([
+            %Alert{
+              effect: :delay,
+              severity: 9,
+              informed_entities: [
+                ie(route: "Green-C", stop_id: "first_stop")
+              ]
+            },
+            %Alert{
+              effect: :delay,
+              severity: 5,
+              informed_entities: [
+                ie(route: "Green-C", stop_id: "second_stop")
+              ]
+            },
+            %Alert{
+              effect: :station_closure,
+              informed_entities: [
+                ie(route: "Green-C", stop_id: "third_stop"),
+                ie(route: "Green-C", stop_id: "fourth_stop")
+              ]
+            }
+          ])
+      }
+
+      expected = %{
+        @normal_service
+        | green: %{
+            type: :contracted,
+            alerts: [
+              %{
+                route_pill: gl_pill([:c]),
+                status: "3 current alerts",
+                location: "mbta.com/alerts"
+              }
+            ]
+          }
+      }
+
+      assert expected == WidgetInstance.serialize(instance)
+    end
+
     test "handles 2 alerts on GL branches and 1 alert on non-GL route" do
       instance = %SubwayStatus{
         subway_alerts:


### PR DESCRIPTION
Asana Task: [Screens: duplicate branch letters in Subway Status](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1214901633382571?focus=true)

In `serialize_gl_pill_with_branches` it looks like there's a possibility where we can have multiple repeating `route_ids` cause repeating branches when we serialize to the Subway Status route pill (caused by multiple relevant alerts targeting the same route). 

This just adds a unique check for the branches that we create when we use those `route_ids` in `serialize_gl_pill_with_branches`. 

- [x] Tests added?
