### PR TITLE
feat: handle June 13th late night service

### DIFF
--- a/lib/screens/util.ex
+++ b/lib/screens/util.ex
@@ -156,7 +156,12 @@ defmodule Screens.Util do
   @spec service_date(DateTime.t()) :: Date.t()
   def service_date(datetime) do
     dt = to_eastern(datetime)
-    if dt.hour >= 4, do: DateTime.to_date(dt), else: Date.add(dt, -1)
+    # Late Night work-around for June 13th for the World Cup
+    if DateTime.to_date(datetime) == ~D[2026-06-14] do
+      if dt.hour >= 5, do: DateTime.to_date(dt), else: Date.add(dt, -1)
+    else
+      if dt.hour >= 4, do: DateTime.to_date(dt), else: Date.add(dt, -1)
+    end
   end
 
   @doc """

--- a/lib/screens/v2/candidate_generator/gl_eink/headways.ex
+++ b/lib/screens/v2/candidate_generator/gl_eink/headways.ex
@@ -106,41 +106,45 @@ defmodule Screens.V2.CandidateGenerator.GlEink.Headways do
       Enum.find(
         @dayparts,
         {:overnight, nil, nil},
-        &match(&1, local_time, {stop_id, direction_id})
+        &match(&1, local_time, {stop_id, direction_id}, datetime)
       )
 
     daypart
   end
 
-  defp match({daypart, :open, t_end}, local_time, {stop_id, direction_id}) do
-    t_start = service_start(stop_id, direction_id)
+  defp match({daypart, :open, t_end}, local_time, {stop_id, direction_id}, now) do
+    t_start = service_start(stop_id, direction_id, now)
 
     case t_start do
-      %Time{} -> match({daypart, t_start, t_end}, local_time, nil)
+      %Time{} -> match({daypart, t_start, t_end}, local_time, nil, now)
       nil -> false
     end
   end
 
-  defp match({daypart, t_start, :close}, local_time, {stop_id, direction_id}) do
-    t_end = service_end(stop_id, direction_id)
+  defp match({daypart, t_start, :close}, local_time, {stop_id, direction_id}, now) do
+    t_end = service_end(stop_id, direction_id, now)
 
     case t_end do
-      %Time{} -> match({daypart, t_start, t_end}, local_time, nil)
+      %Time{} -> match({daypart, t_start, t_end}, local_time, nil, now)
       nil -> false
     end
   end
 
-  defp match({_daypart, t_start, :midnight}, local_time, _) do
+  defp match({_daypart, t_start, :midnight}, local_time, _, _) do
     Time.compare(t_start, local_time) == :lt
   end
 
-  defp match({_daypart, t_start, t_end}, local_time, _) do
+  defp match({_daypart, t_start, t_end}, local_time, _, _) do
     Enum.member?([:lt, :eq], Time.compare(t_start, local_time)) and
       Time.compare(local_time, t_end) == :lt
   end
 
-  defp service_start_or_end(stop_id, direction_id, min_or_max_fn) do
-    with {:ok, schedules} <- Schedule.fetch(%{stop_ids: [stop_id], direction_id: direction_id}),
+  defp service_start_or_end(stop_id, direction_id, min_or_max_fn, now) do
+    with {:ok, schedules} <-
+           Schedule.fetch(
+             %{stop_ids: [stop_id], direction_id: direction_id},
+             Util.service_date(now)
+           ),
          [_ | _] = arrival_times <- get_arrival_times(schedules) do
       arrival_times |> min_or_max_fn.() |> Util.to_eastern() |> DateTime.to_time()
     else
@@ -155,12 +159,12 @@ defmodule Screens.V2.CandidateGenerator.GlEink.Headways do
   end
 
   # Time to stop showing Good Night screen if there are no predictions
-  defp service_start(stop_id, direction_id) do
-    service_start_or_end(stop_id, direction_id, &Enum.min/1)
+  defp service_start(stop_id, direction_id, now) do
+    service_start_or_end(stop_id, direction_id, &Enum.min/1, now)
   end
 
   # Time to begin showing Good Night screen if there are no predictions
-  defp service_end(stop_id, direction_id) do
-    service_start_or_end(stop_id, direction_id, &Enum.max/1)
+  defp service_end(stop_id, direction_id, now) do
+    service_start_or_end(stop_id, direction_id, &Enum.max/1, now)
   end
 end


### PR DESCRIPTION
**Asana task**: [Support Very Late Service in Screens](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1214365239209201?focus=true)

Description
- added hard-coded logic in `service_date/1` to specifically handle the service date for the extended late night
- reworked GL E-Ink to use `service_date/1` in order to use the late night logic instead of using the default service date cutoff times

Using the [late night schedule knowledge](https://www.notion.so/mbta-downtown-crossing/Overnight-service-June-13th-14th-352f5d8d11ea80f9a3fec8bc8ed8e0d0) this will have a two effects:
1. For GL E-Ink, according to the written Green-D final schedule it will just have one minute of potential overlap with the new schedule. In this case, it will be in the Overnight mode for just a minute more. 
2. All other lines will be scheduled to begin after 5 o clock, so it should match our current logic
