### PR TITLE
fix: last deploy time fetching

### DIFF
--- a/lib/screens/util/last_deploy/s3_fetch.ex
+++ b/lib/screens/util/last_deploy/s3_fetch.ex
@@ -1,31 +1,24 @@
 defmodule Screens.Util.LastDeploy.S3Fetch do
   @moduledoc false
 
+  alias Screens.Report
+
   @bucket "mbta-screens"
+  @object "LAST_DEPLOY"
+
+  @rfc2822 "{WDshort}, {D} {Mshort} {YYYY} {h24}:{m}:{s} {Zname}"
 
   def get_last_deploy_time do
     env = Application.get_env(:screens, :environment_name, "screens-prod")
-    path = "/#{env}/LAST_DEPLOY"
+    operation = ExAws.S3.get_object(@bucket, "#{env}/#{@object}")
 
-    get_operation = ExAws.S3.get_object(@bucket, path)
-
-    case ExAws.request(get_operation) do
-      {:ok, %{headers: headers}} ->
-        # Example format: Thu, 12 Jan 2023 17:38:08 GMT
-        last_modified_string =
-          headers
-          |> Enum.into(%{})
-          |> Map.get("Last-Modified")
-
-        case Timex.parse(
-               last_modified_string,
-               "{WDshort}, {D} {Mshort} {YYYY} {h24}:{m}:{s} {Zname}"
-             ) do
-          {:ok, last_modified_dt} -> Timex.to_datetime(last_modified_dt)
-          _ -> nil
-        end
-
-      {:error, _} ->
+    with {:request, {:ok, %{headers: headers}}} <- {:request, ExAws.request(operation)},
+         {:header, {:ok, value}} <- {:header, headers |> Map.new() |> Map.fetch("last-modified")},
+         {:parse, {:ok, %DateTime{} = datetime}} <- {:parse, Timex.parse(value, @rfc2822)} do
+      datetime
+    else
+      {stage, error} ->
+        Report.error("last_deploy_fetch_failed", stage: stage, error: inspect(error))
         nil
     end
   end


### PR DESCRIPTION
This had been broken since c577ff79, when we switched ExAws from using HTTPoison as its HTTP client to Req. The former leaves header names as-is from the server, while the latter downcases them for consistency. So fetching the header `Last-Modified` could succeed with HTTPoison (if the server happened to send it with that capitalization, which S3 did), but would always fail with Req. This code also failed quietly, so we were never alerted to the `force_reload` signal not being sent to clients, until we eventually made a backwards-incompatible change.

* Fix the header name.
* Add error reporting to alert us if any stage of this process fails, including fetching the value from headers.

**Asana task**: https://app.asana.com/1/15492006741476/project/1185117109217413/task/1215144952667240?focus=true