### PR TITLE
fix: headway row crash for RDS

### DIFF
--- a/lib/screens/schedules/schedule.ex
+++ b/lib/screens/schedules/schedule.ex
@@ -2,6 +2,7 @@ defmodule Screens.Schedules.Schedule do
   @moduledoc false
 
   alias Screens.Trips.Trip
+  alias Screens.Util
   alias Screens.V2.Departure
 
   defstruct id: nil,
@@ -29,15 +30,13 @@ defmodule Screens.Schedules.Schedule do
 
   @includes ~w[route.line stop trip.route_pattern.representative_trip trip.stops]
 
-  @type date_param :: DateTime.t() | Date.t() | String.t() | nil
-
   @type result :: {:ok, [t()]} | :error
-  @type fetch_with_date :: (Departure.params(), date_param() -> result())
+  @type fetch_with_date :: (Departure.params(), Date.t() -> result())
 
   @callback fetch(Departure.params()) :: result()
-  @callback fetch(Departure.params(), date_param()) :: result()
-  def fetch(%{} = params, date \\ nil) do
-    params = if is_nil(date), do: params, else: Map.put(params, :date, date)
+  @callback fetch(Departure.params(), Date.t()) :: result()
+  def fetch(%{} = params, date \\ current_service_date()) do
+    params = Map.put(params, :date, date)
     result = Departure.do_fetch("schedules", Map.put(params, :include, @includes))
 
     case result do
@@ -45,4 +44,6 @@ defmodule Screens.Schedules.Schedule do
       :error -> :error
     end
   end
+
+  defp current_service_date(now \\ DateTime.utc_now()), do: Util.service_date(now)
 end

--- a/lib/screens/v2/rds.ex
+++ b/lib/screens/v2/rds.ex
@@ -63,6 +63,7 @@ defmodule Screens.V2.RDS do
           | :active_period
           | :service_impacted
           | :no_service
+          | :error
 
   # These alert types eliminate service to a destination.
   @relevant_alert_effects [
@@ -286,6 +287,7 @@ defmodule Screens.V2.RDS do
           now
         )
       end)
+      |> Enum.reject(&is_nil(&1.state))
 
     {:ok, section_rds}
   end
@@ -418,6 +420,17 @@ defmodule Screens.V2.RDS do
           direction_id: direction_id,
           range: headway_for_stop
         }
+
+      :error ->
+        Logster.warning([
+          "rds_state_creation_failed",
+          destination_key: destination_key,
+          now: now,
+          first_scheduled_departure: first_scheduled_departure.schedule.id,
+          last_scheduled_departure: last_scheduled_departure.schedule.id
+        ])
+
+        nil
     end
   end
 
@@ -573,8 +586,11 @@ defmodule Screens.V2.RDS do
           Util.service_date(now) == Util.service_date(Departure.time(last_departure)) ->
         :after_scheduled_end
 
-      true ->
+      headway_for_stop != nil ->
         :active_period
+
+      true ->
+        :error
     end
   end
 

--- a/test/screens/v2/rds_test.exs
+++ b/test/screens/v2/rds_test.exs
@@ -1,5 +1,6 @@
 defmodule Screens.V2.RDSTest do
   use ExUnit.Case, async: true
+  import ExUnit.CaptureLog
 
   alias Screens.Alerts.Alert
   alias Screens.Config.Cache
@@ -958,6 +959,120 @@ defmodule Screens.V2.RDSTest do
                   no_service("sC", "l2", "hC")
                 ]}
              ]
+    end
+  end
+
+  describe "get/1 error for state" do
+    test "logs and returns nil for fallback creating state" do
+      now = ~U[2024-10-11 11:44:00Z]
+      stop_ids = ~w[s0 s1]
+
+      first_schedule_one =
+        %Schedule{
+          id: "Test ID 11",
+          departure_time: ~U[2024-10-11 10:45:00Z],
+          route: %Route{
+            id: "r1",
+            line: %Line{id: "l1"},
+            type: :bus,
+            direction_names: ["Northbound", "Southbound"]
+          },
+          stop: %Stop{id: "sA"},
+          trip: %Trip{headsign: "h1", pattern_headsign: "hA", direction_id: 0}
+        }
+
+      last_schedule_one =
+        %Schedule{
+          id: "Test ID 12",
+          departure_time: ~U[2024-10-12 01:45:00Z],
+          route: %Route{
+            id: "r1",
+            line: %Line{id: "l1"},
+            type: :bus,
+            direction_names: ["Northbound", "Southbound"]
+          },
+          stop: %Stop{id: "sA"},
+          trip: %Trip{headsign: "h1", pattern_headsign: "hA", direction_id: 0}
+        }
+
+      first_schedule_two = %Schedule{
+        id: "Test ID 21",
+        departure_time: ~U[2024-10-11 10:45:00Z],
+        route: %Route{
+          id: "r2",
+          line: %Line{id: "l2"},
+          type: :bus,
+          direction_names: ["Eastbound", "Westbound"]
+        },
+        stop: %Stop{id: "sB"},
+        trip: %Trip{headsign: "h2", pattern_headsign: "hB", direction_id: 1}
+      }
+
+      last_schedule_two =
+        %Schedule{
+          id: "Test ID 22",
+          departure_time: ~U[2024-10-12 01:45:00Z],
+          route: %Route{
+            id: "r2",
+            line: %Line{id: "l2"},
+            type: :bus,
+            direction_names: ["Eastbound", "Westbound"]
+          },
+          stop: %Stop{id: "sB"},
+          trip: %Trip{headsign: "h2", pattern_headsign: "hB", direction_id: 1}
+        }
+
+      first_schedule_three =
+        %Schedule{
+          id: "Test ID 31",
+          departure_time: ~U[2024-10-11 10:45:00Z],
+          route: %Route{
+            id: "r2",
+            line: %Line{id: "l2"},
+            type: :bus,
+            direction_names: ["Eastbound", "Westbound"]
+          },
+          stop: %Stop{id: "sC"},
+          trip: %Trip{headsign: "h3", pattern_headsign: "hC", direction_id: 0}
+        }
+
+      last_schedule_three =
+        %Schedule{
+          id: "Test ID 32",
+          departure_time: ~U[2024-10-12 01:45:00Z],
+          route: %Route{
+            id: "r2",
+            line: %Line{id: "l2"},
+            type: :bus,
+            direction_names: ["Eastbound", "Westbound"]
+          },
+          stop: %Stop{id: "sC"},
+          trip: %Trip{headsign: "h3", pattern_headsign: "hC", direction_id: 0}
+        }
+
+      all_schedules = [
+        first_schedule_one,
+        last_schedule_one,
+        first_schedule_two,
+        last_schedule_two,
+        first_schedule_three,
+        last_schedule_three
+      ]
+
+      departures = %Departures{
+        sections: [
+          %Section{query: %Query{params: %Query.Params{route_type: :bus, stop_ids: stop_ids}}}
+        ]
+      }
+
+      stub(@headways, :get, fn _, _ -> nil end)
+      expect(@schedule, :fetch, fn %{stop_ids: ^stop_ids}, _now -> {:ok, all_schedules} end)
+      expect_standard_stations(stop_ids)
+      expect_standard_route_patterns(stop_ids)
+      {result, log} = with_log(fn -> RDS.get(departures, now) end)
+
+      assert result == [{:ok, []}]
+      assert log =~ "rds_state_creation_failed"
     end
   end
 


### PR DESCRIPTION
**Asana task**: [Bug: RDS DUP Headways Crash](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1215197336744751?focus=true)

Description
- it seems like we were somehow getting into a situation where we were getting schedules for a destination, but had zero departures (with a nil headway range) forcing the state into a Headway state. This should be impossible in cases where have no headsign, due to how we filter out departures for only scheduled ones. This was causing a crash down the line when we tried to serialize it because of the nil headway
- this modifies how `Schedule.fetch` works so we're always passing in the service date when we fetch instead of relying on the backend to choose what service day we're in. This will keep the Departures schedules and the RDS schedules in sync so there should never be a case where we have scheduled departures, but no departures for departures without headways

Note: This makes it so that #3073 can be fully reverted

- [ ] Tests added?
