### PR TITLE
feat: GL branch handling for DUP alerts

### DIFF
--- a/assets/css/dup/free_text.scss
+++ b/assets/css/dup/free_text.scss
@@ -52,7 +52,9 @@
 }
 
 .free-text__route-pill,
-.free-text__text-pill {
+.free-text__text-pill,
+.free-text__branch-route-pill__main-line,
+.free-text__branch-route-pill__branch {
   display: inline-block;
   text-align: center;
 
@@ -103,12 +105,42 @@
 }
 
 .free-text__route-pill__text,
-.free-text__text-pill__text {
+.free-text__text-pill__text,
+.free-text__branch-route-pill {
   font-family: Helvetica, sans-serif;
   font-weight: 700;
 
   &--branch {
     font-size: 84px;
+  }
+}
+
+.free-text__branch-route-pill {
+  display: inline-flex;
+  align-items: center;
+  overflow: hidden;
+  font-size: 96px;
+  line-height: 144px;
+
+  &__main-line,
+  &__branch {
+    box-sizing: border-box;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 80px;
+  }
+
+  &__main-line {
+    width: 248px;
+    height: 144px;
+  }
+
+  &__branch {
+    min-width: 158px;
+    height: 158px;
+    margin: 0 0 0 -28px;
+    border: 6px solid colors.$cool-black-15;
   }
 }
 

--- a/assets/src/components/free_text.tsx
+++ b/assets/src/components/free_text.tsx
@@ -133,6 +133,42 @@ const TextRoutePill = ({ route }: { route: string }) => {
   );
 };
 
+const BranchRoutePill = ({
+  branches,
+  color,
+  text,
+}: {
+  branches: string[];
+  color?: string;
+  text?: string;
+}) => {
+  return (
+    <span className="free-text__element">
+      <span className="free-text__branch-route-pill">
+        <span
+          className={classWithModifier(
+            "free-text__branch-route-pill__main-line",
+            color,
+          )}
+        >
+          {text}
+        </span>
+        {branches?.map((branch) => (
+          <span
+            className={classWithModifier(
+              "free-text__branch-route-pill__branch",
+              color,
+            )}
+            key={branch}
+          >
+            {branch.toUpperCase()}
+          </span>
+        ))}
+      </span>
+    </span>
+  );
+};
+
 const IconRoutePill = ({ route }: { route: string }) => {
   return (
     <span className="free-text__element">
@@ -168,6 +204,7 @@ interface FreeTextElementType {
   color?: string;
   special?: string;
   icon?: string;
+  branches?: string[];
 }
 
 const FreeTextElement = ({ elt }: { elt: string | FreeTextElementType }) => {
@@ -175,6 +212,14 @@ const FreeTextElement = ({ elt }: { elt: string | FreeTextElementType }) => {
     return <FormatString text={elt} format={null} />;
   } else if (elt.format !== undefined) {
     return <FormatString text={elt.text} format={elt.format} />;
+  } else if (elt.branches !== undefined) {
+    return (
+      <BranchRoutePill
+        color={elt.color}
+        branches={elt.branches}
+        text={elt.text}
+      />
+    );
   } else if (elt.route !== undefined) {
     return <TextRoutePill route={elt.route} />;
   } else if (elt.color !== undefined) {

--- a/lib/screens/v2/widget_instance/dup_alert.ex
+++ b/lib/screens/v2/widget_instance/dup_alert.ex
@@ -106,7 +106,8 @@ defmodule Screens.V2.WidgetInstance.DupAlert do
     # some is (either we're at a boundary and there's still service in one direction, or we're at
     # a transfer station and the alert only affects one line).
     if LocalizedAlert.location(t) == :inside and not partial_station_closure?(t) and
-         length(get_affected_lines(t)) == length(primary_sections),
+         length(get_affected_lines(t)) == length(primary_sections) and
+         green_line_with_routes_affected?(get_affected_lines(t), t),
        do: :all,
        else: :some
   end
@@ -126,6 +127,28 @@ defmodule Screens.V2.WidgetInstance.DupAlert do
   end
 
   defp eliminated_service_type(_other), do: :none
+
+  defp green_line_with_routes_affected?(lines, t) do
+    if Enum.any?(lines, &String.contains?(&1, "Green")) do
+      all_green_line_routes_affected?(t)
+    else
+      true
+    end
+  end
+
+  @spec all_green_line_routes_affected?(__MODULE__.t()) :: boolean()
+  def all_green_line_routes_affected?(%__MODULE__{location_context: location_context} = t) do
+    affected_routes =
+      t |> LocalizedAlert.informed_routes_at_home_stop() |> MapSet.new()
+
+    all_green_line_routes =
+      location_context
+      |> LocationContext.route_ids()
+      |> Enum.filter(&String.contains?(&1, "Green"))
+      |> MapSet.new()
+
+    MapSet.equal?(affected_routes, all_green_line_routes)
+  end
 
   def get_affected_lines(t) do
     t

--- a/lib/screens/v2/widget_instance/dup_alert/serialize.ex
+++ b/lib/screens/v2/widget_instance/dup_alert/serialize.ex
@@ -81,6 +81,12 @@ defmodule Screens.V2.WidgetInstance.DupAlert.Serialize do
     |> String.to_existing_atom()
   end
 
+  defp green_route_to_pill_atom(route_string) do
+    route_string
+    |> String.downcase()
+    |> String.replace("-", "_")
+  end
+
   defp get_affected_lines_as_strings(t) do
     t
     |> DupAlert.get_affected_lines()
@@ -106,7 +112,7 @@ defmodule Screens.V2.WidgetInstance.DupAlert.Serialize do
         [bold(line), "delays"]
 
       {[line], _, :inside, nil} ->
-        ["No", bold(line), "trains"]
+        get_banner_text_for_single_line(t, line)
 
       {[_line], _, boundary, nil} when boundary in [:boundary_upstream, :boundary_downstream] ->
         headsign = get_headsign(t)
@@ -124,6 +130,31 @@ defmodule Screens.V2.WidgetInstance.DupAlert.Serialize do
         ["No", bold(platform_name)]
     end
   end
+
+  defp get_banner_text_for_single_line(t, "Green" <> _ = line) do
+    if DupAlert.all_green_line_routes_affected?(t) do
+      ["No", bold(line), "trains"]
+    else
+      t
+      |> LocalizedAlert.informed_routes_at_home_stop()
+      |> Enum.map(fn route_id -> get_abbreviated_green_line(route_id) end)
+      |> case do
+        [abbr_route] ->
+          ["No", bold(abbr_route), "trains"]
+
+        [abbr_route_one, abbr_route_two] ->
+          ["No", bold(abbr_route_one), "and", bold(abbr_route_two), "svc"]
+
+        [abbr_route_one, abbr_route_two, abbr_route_three] ->
+          ["No", bold(abbr_route_one <> ","), bold(abbr_route_two <> ","), bold(abbr_route_three)]
+      end
+    end
+  end
+
+  defp get_banner_text_for_single_line(_t, line),
+    do: ["No", bold(line), "trains"]
+
+  defp get_abbreviated_green_line("Green-" <> route), do: "GL·" <> route
 
   defp banner_icon(t) when t.alert.effect == :delay,
     do: if(line_color(t) == :yellow, do: :delay_negative, else: :delay)
@@ -146,7 +177,12 @@ defmodule Screens.V2.WidgetInstance.DupAlert.Serialize do
     case {affected_platform_name, affected_lines} do
       # All platforms for a single line
       {nil, [line_pill]} ->
-        no_trains = [bold("No"), line_pill, bold("trains")]
+        no_trains =
+          get_full_screen_single_line_no_trains_text(
+            line_pill,
+            get_affected_lines_as_strings(t),
+            t
+          )
 
         if LocalizedAlert.location(t) in [:boundary_upstream, :boundary_downstream] do
           headsign = get_headsign(t)
@@ -169,6 +205,30 @@ defmodule Screens.V2.WidgetInstance.DupAlert.Serialize do
       {platform_name, [_line_pill]} ->
         [bold("#{platform_name} platform closed")]
     end
+  end
+
+  defp get_full_screen_single_line_no_trains_text(line_pill, ["Green" <> _], t) do
+    if DupAlert.all_green_line_routes_affected?(t) do
+      [bold("No"), line_pill, bold("trains")]
+    else
+      case LocalizedAlert.informed_routes_at_home_stop(t) do
+        [single_route] ->
+          single_route_pill =
+            single_route
+            |> green_route_to_pill_atom()
+            |> free_text_pill()
+
+          [bold("No"), single_route_pill, bold("trains")]
+
+        [_ | _] = route_ids ->
+          branches = Enum.map(route_ids, fn "Green-" <> route_letter -> route_letter end)
+          [bold("No"), %{text: "GL", color: :green, branches: branches}, bold("trains")]
+      end
+    end
+  end
+
+  defp get_full_screen_single_line_no_trains_text(line_pill, _line, _t) do
+    [bold("No"), line_pill, bold("trains")]
   end
 
   defp cause_description(%Alert{cause: :unknown}), do: []

--- a/test/screens/v2/widget_instance/dup_alert_test.exs
+++ b/test/screens/v2/widget_instance/dup_alert_test.exs
@@ -61,6 +61,20 @@ defmodule Screens.V2.WidgetInstance.DupAlertTest do
     }
   end
 
+  defp build_location_context_with_tagged_stops(home_stop, tagged_stop_sequences) do
+    stop_sequences = LocationContext.untag_stop_sequences(tagged_stop_sequences)
+
+    %LocationContext{
+      home_stop: home_stop,
+      tagged_stop_sequences: tagged_stop_sequences,
+      upstream_stops: LocationContext.upstream_stop_id_set([home_stop], stop_sequences),
+      downstream_stops: LocationContext.downstream_stop_id_set([home_stop], stop_sequences),
+      routes: tagged_stop_sequences |> Map.keys() |> Enum.map(&%{active?: true, route_id: &1}),
+      alert_route_types: LocationContext.route_type_filter(Screen.Dup, [home_stop]),
+      child_stops_at_station: @child_stops
+    }
+  end
+
   defp build_screen(primary_sections_count \\ 1, has_secondary_departures? \\ false) do
     struct(Screen,
       app_id: :dup_v2,
@@ -155,6 +169,68 @@ defmodule Screens.V2.WidgetInstance.DupAlertTest do
       alert =
         build_alert(
           informed_entities: stop_informed_entities("Red", ~w[place-r1 place-r2 place-r3])
+        )
+
+      assert widget_types(screen, context, alert) ==
+               [:partial_alert, :takeover_alert, :partial_alert]
+    end
+
+    test "one branch of Green Line has service eliminated" do
+      screen = build_screen()
+
+      tagged_stop_sequences = %{
+        "Green-B" => [~w[place-g1 place-g2 place-g3 place-x place-g4]],
+        "Green-C" => [~w[place-g1 place-g2 place-g3 place-x place-g4]]
+      }
+
+      context = build_location_context_with_tagged_stops("place-x", tagged_stop_sequences)
+
+      alert =
+        build_alert(
+          informed_entities: stop_informed_entities("Green-B", ~w[place-g1 place-g2 place-g3])
+        )
+
+      assert widget_types(screen, context, alert) ==
+               [:partial_alert, :takeover_alert, :partial_alert]
+    end
+
+    test "all branches of Green Line service eliminated" do
+      screen = build_screen()
+
+      tagged_stop_sequences = %{
+        "Green-B" => [~w[place-g1 place-g2 place-g3 place-x place-g4]],
+        "Green-C" => [~w[place-g1 place-g2 place-g3 place-x place-g4]]
+      }
+
+      context = build_location_context_with_tagged_stops("place-g2", tagged_stop_sequences)
+
+      alert =
+        build_alert(
+          informed_entities:
+            stop_informed_entities("Green-B", ~w[place-g1 place-g2 place-g3]) ++
+              stop_informed_entities("Green-C", ~w[place-g1 place-g2 place-g3])
+        )
+
+      assert widget_types(screen, context, alert) ==
+               [:takeover_alert, :takeover_alert, :takeover_alert]
+    end
+
+    test "all branches of Green Line service eliminated but other service remains" do
+      screen = build_screen()
+
+      tagged_stop_sequences = %{
+        "Green-B" => [~w[place-g1 place-x place-g2 place-g3 place-g4]],
+        "Green-C" => [~w[place-g1 place-x place-g2 place-g3 place-g4]],
+        "Orange" => [~w[place-o1 place-o2 place-x place-o3 place-o4]]
+      }
+
+      context = build_location_context_with_tagged_stops("place-x", tagged_stop_sequences)
+
+      alert =
+        build_alert(
+          informed_entities:
+            stop_informed_entities("Green-B", ~w[place-r1 place-r2 place-r3]) ++
+              stop_informed_entities("Green-C", ~w[place-r1 place-r2 place-r3])
         )
 
       assert widget_types(screen, context, alert) ==


### PR DESCRIPTION
**Asana task**: [Partial Suspensions on GL Trunk DUPs](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1214815711763938?focus=true)

Description
- handle single and multiple branch alerts when displaying the alert banner/full screen alerts for Green Line branches
- this changes it so that we will display the branches that are under the alert instead of a broad Green Line text in cases where we have service for other branches for both the banner text and the full screen text
- also modify the DUP alert logic to check that all green line routes are included in the alert in order to display full screen alerts across all rotations

<img width="965" height="285" alt="Screenshot 2026-05-28 at 9 52 03 AM" src="https://github.com/user-attachments/assets/e492dfdd-268f-439f-9035-e5126e8c8609" />
<img width="964" height="279" alt="Screenshot 2026-05-28 at 11 42 27 AM" src="https://github.com/user-attachments/assets/a5cb42a1-3a19-4c3b-9745-5d066f37a871" />
<img width="969" height="284" alt="Screenshot 2026-05-28 at 12 13 16 PM" src="https://github.com/user-attachments/assets/db7ed48d-dbd6-443c-9775-27fa547a382d" />
<img width="970" height="276" alt="Screenshot 2026-05-28 at 12 14 49 PM" src="https://github.com/user-attachments/assets/02d7198a-098b-47b2-95b4-4c24d659cb86" />
<img width="967" height="277" alt="Screenshot 2026-05-28 at 12 42 22 PM" src="https://github.com/user-attachments/assets/23f2ab94-4507-4c5d-a704-3bd3a9f8ce05" />




- [x] Tests added?
