### PR TITLE
fix: V3 API connection pool telemetry

### DIFF
--- a/lib/screens/telemetry.ex
+++ b/lib/screens/telemetry.ex
@@ -60,7 +60,7 @@ defmodule Screens.Telemetry do
 
   def pool_stats do
     with {:ok, status} <- Finch.get_pool_status(Screens.V3Api.Finch, :default) do
-      for {{_scheme, host, _port}, pools} <- status, metrics <- pools do
+      for {%Finch.Pool{host: host}, pools} <- status, metrics <- pools do
         :telemetry.execute(~w[screens v3_api pool stats]a, metrics, %{host: host})
       end
     end


### PR DESCRIPTION
In eceb27b Dependabot quietly upgraded our Finch version from 0.21.0 to 0.22.0, which semantically ought to be considered a "major"/breaking change but was lumped in with a PR of "minor" updates. This version changed the values returned from `Finch.get_pool_status/2`[^1], which broke our telemetry.

[^1]: https://finch.hexdocs.pm/0.22.0/changelog.html#v0-22-0-2026-05-12

**Asana task**: https://app.asana.com/1/15492006741476/project/1185117109217413/task/1215076233813257?focus=true