### PR TITLE
fix: fixed crash mixing no service and headways states

### DIFF
--- a/lib/screens/v2/candidate_generator/dup_new/departures.ex
+++ b/lib/screens/v2/candidate_generator/dup_new/departures.ex
@@ -166,7 +166,7 @@ defmodule Screens.V2.CandidateGenerator.DupNew.Departures do
   end
 
   defp headways?(rds_list) do
-    Enum.all?(rds_list, &(is_struct(&1.state, Headways) || is_struct(&1.state, NoService)))
+    Enum.all?(rds_list, &is_struct(&1.state, Headways))
   end
 
   @spec create_headway_section([RDS.t()]) :: HeadwaySection.t()
@@ -319,7 +319,7 @@ defmodule Screens.V2.CandidateGenerator.DupNew.Departures do
     rds = Map.get(grouped_rds, :other, [])
 
     sorted_departures_from_rds(rds) ++
-      headways_from_rds(rds, headway_rds) ++
+      headways_from_rds(rds ++ service_ended_rds, headway_rds) ++
       sorted_departures_from_rds(service_ended_rds, true)
   end
 
@@ -446,14 +446,17 @@ defmodule Screens.V2.CandidateGenerator.DupNew.Departures do
 
   defp extract_line_direction_pairs(%RDS{line: %Line{id: line_id}, state: state}) do
     case state do
-      %NoService{} ->
+      %NoService{direction_id: nil} ->
         []
 
-      %Countdowns{departures: []} ->
-        [{line_id, 0}, {line_id, 1}]
+      %NoService{direction_id: direction_id} ->
+        [{line_id, direction_id}]
 
       %Countdowns{departures: [first_departure | _]} ->
         [{line_id, Departure.direction_id(first_departure)}]
+
+      %Countdowns{departures: [], direction_id: direction_id} ->
+        [{line_id, direction_id}]
 
       %FirstTrip{first_scheduled_departure: departure} ->
         [{line_id, Departure.direction_id(departure)}]

--- a/lib/screens/v2/rds.ex
+++ b/lib/screens/v2/rds.ex
@@ -89,8 +89,8 @@ defmodule Screens.V2.RDS do
     has no relevant live data (alerts or predictions)
     and no scheduled departures for the day.
     """
-    @type t :: %__MODULE__{routes: [Route.t()]}
-    defstruct ~w[routes]a
+    @type t :: %__MODULE__{routes: [Route.t()], direction_id: Trip.direction() | nil}
+    defstruct ~w[routes direction_id]a
   end
 
   defmodule Countdowns do
@@ -98,8 +98,8 @@ defmodule Screens.V2.RDS do
     State when there is upcoming service to a destination
     and/or alerts which affect service to the destination.
     """
-    @type t :: %__MODULE__{departures: [Departure.t()]}
-    defstruct ~w[departures]a
+    @type t :: %__MODULE__{departures: [Departure.t()], direction_id: Trip.direction() | nil}
+    defstruct ~w[departures direction_id]a
   end
 
   defmodule FirstTrip do
@@ -404,7 +404,10 @@ defmodule Screens.V2.RDS do
         %ServiceEnded{last_scheduled_departure: last_scheduled_departure}
 
       :service_impacted ->
-        %Countdowns{departures: departures_for_headsign}
+        %Countdowns{
+          departures: departures_for_headsign,
+          direction_id: Departure.direction_id(first_scheduled_departure)
+        }
 
       :no_service ->
         %NoService{routes: routes_for_section}
@@ -417,7 +420,7 @@ defmodule Screens.V2.RDS do
           departure_id: Departure.id(first_scheduled_departure),
           route_id: route.id,
           direction_name: route |> Route.normalized_direction_names() |> Enum.at(direction_id),
-          direction_id: direction_id,
+          direction_id: Departure.direction_id(first_scheduled_departure),
           range: headway_for_stop
         }
 

--- a/test/screens/v2/candidate_generator/dup_new/departures_test.exs
+++ b/test/screens/v2/candidate_generator/dup_new/departures_test.exs
@@ -60,7 +60,7 @@ defmodule Screens.V2.CandidateGenerator.DupNew.DeparturesTest do
       stop: %Stop{id: stop_id},
       line: %Line{id: line_id},
       headsign: headsign,
-      state: %RDS.NoService{routes: routes}
+      state: %RDS.NoService{routes: routes, direction_id: 0}
     }
   end
 
@@ -1169,7 +1169,7 @@ defmodule Screens.V2.CandidateGenerator.DupNew.DeparturesTest do
       assert actual_instances == expected_instances
     end
 
-    test "creates NormalSections but removes headways when similar line/direction_id destinations are not in headway mode" do
+    test "creates NormalSections but removes headways when similar line/direction_id destinations in Countdown state" do
       expected_route_id = "r1"
       expected_time_range = {6, 10}
       expected_direction_name = "Northbound"
@@ -1224,6 +1224,97 @@ defmodule Screens.V2.CandidateGenerator.DupNew.DeparturesTest do
              headways(
                "s1",
                "l1",
+               "other_headsign",
+               expected_route_id,
+               expected_direction_name,
+               0,
+               expected_time_range
+             )
+           ]}
+        ]
+      end)
+
+      expect(@rds, :get, fn _secondary_departures, @now -> [{:ok, []}] end)
+
+      expected_instances =
+        expected_departures_widget(config, expected_primary_sections, expected_primary_sections)
+
+      actual_instances = DupNew.Departures.instances(config, @now)
+
+      assert actual_instances == expected_instances
+    end
+
+    test "creates NormalSections but removes headways when similar line/direction_id destinations are in No Service state" do
+      expected_route_id = "r1"
+      expected_time_range = {6, 10}
+      expected_direction_name = "Northbound"
+
+      primary_departures = [
+        %Section{query: %Query{params: %Query.Params{stop_ids: ["s1"]}}},
+        %Section{query: %Query{params: %Query.Params{stop_ids: ["s2"]}}}
+      ]
+
+      expected_primary_departure =
+        %Departure{
+          prediction: %Prediction{
+            arrival_time: ~U[2024-10-11 12:27:00Z],
+            departure_time: ~U[2024-10-11 12:30:00Z],
+            route: %Route{id: "r1", line: %Line{id: "l1"}, type: :subway},
+            stop: %Stop{id: "s1"},
+            trip: %Trip{headsign: "other1", pattern_headsign: "h1", direction_id: 0}
+          },
+          schedule: nil
+        }
+
+      expected_primary_sections = [
+        %Screens.V2.WidgetInstance.Departures.NormalSection{
+          header: %ScreensConfig.Departures.Header{
+            arrow: nil,
+            read_as: nil,
+            subtitle: nil,
+            title: nil
+          },
+          layout: %ScreensConfig.Departures.Layout{
+            base: nil,
+            include_later: false,
+            max: nil,
+            min: 1
+          },
+          grouping_type: :time,
+          rows: [
+            expected_primary_departure
+          ]
+        }
+      ]
+
+      config =
+        @config
+        |> put_primary_departures(primary_departures)
+
+      expect(@rds, :get, fn _primary_departures, @now ->
+        [
+          {:ok,
+           [
+             rds_countdown("s1", "l1", "other1", [expected_primary_departure]),
+             no_service("s1", "l2", "some_headsign", [
+               %Screens.Routes.Route{
+                 id: "r1",
+                 short_name: nil,
+                 long_name: nil,
+                 direction_names: nil,
+                 direction_destinations: nil,
+                 type: :bus,
+                 line: %Screens.Lines.Line{
+                   id: "l2",
+                   long_name: nil,
+                   short_name: nil,
+                   sort_order: nil
+                 }
+               }
+             ]),
+             headways(
+               "s1",
+               "l2",
                "other_headsign",
                expected_route_id,
                expected_direction_name,


### PR DESCRIPTION
Description
- originally, the code was added in aea810d8593fe37ff5bc570a8fb64dace210a248 so that we would show headways for all destinations even when a single one of them was in the NoService state, but this is [causing crashes](https://mbtace.sentry.io/issues/7518132467/?environment=screens-prod&project=6061747&query=is%3Aunresolved&referrer=issue-stream) because of how we parameter match for creating headway sections
- this backs out the extra `||` check so that we only create headway sections when every state is exactly Headway mode. In cases where we have mixed states now, we'll default to showing headway rows with individual headsigns rather than grouped (which makes more sense in representing the data properly)

