### PR TITLE
dev: auto-tag releases in DUP client build script

### DIFF
--- a/assets/src/components/dup/README.md
+++ b/assets/src/components/dup/README.md
@@ -3,19 +3,19 @@
 - Double check that any behavior specific to the packaged environment happens inside of an `isOutfront()` condition.
 - If you've renamed / removed image assets, you might want to delete the corresponding folder in `/priv/static`. The folder accumulates assets without clearing old ones out, and these will be included in the built bundle!
 - **Only if you are packaging for local testing:** To test against your local screens backend instead of production, then replace the value of `data-api-origin` in [`priv/dup-app.html`][dup-app.html] with `http://localhost:4000`.
-- Run `scripts/build_dup_client_package.sh`. The packaged client apps will be output at `priv/packaged/dup-app-<rotation>-<version>.zip`.
+- Run `scripts/build_dup_client_package.sh`. The packaged client apps will be output at `priv/packaged`.
+  - Run with `-h` to see available options; in particular, it can automatically create a tag to record deploying the package with Outfront.
 - To test a created package locally or in Browserstack, you need to add any query param with key `test` to the `index.html`, such as `index.html?test=`.
   - Setting this query param sets up a fake MRAID object that emulates the real one available to the client when running on Outfront screens.
   - You can also set `playerName` and `station` within the URL params to change which screen is emulated.
   - If you are testing multiple iterations locally and don't want to add the URL params with each rebuild of the package, temporarily modify the if statement and/or defaults within [`outfront.tsx`][outfront.tsx]'s `initFakeMRAID` function. Just make sure to remove before sending client packages to Outfront to test.
-- When testing is complete, commit the version bump on a branch, push it, and create a PR to mark the deploy.
 
 [dup-app.html]: /priv/dup-app.html
 [outfront.tsx]: /assets/src/util/outfront.tsx
 
 ## Working with Outfront
 
-Once you've created the client app packages, you'll need to send them to Outfront to test and deploy. Make sure to revert any local changes you've made before generating the packages.
+Once you've created the client app packages, you'll need to send them to Outfront to test and deploy.
 
 For detailed instructions on this process, go to [this Notion doc](https://www.notion.so/mbta-downtown-crossing/Deploying-DUP-Package-Updates-120f5d8d11ea805fa219f214c1633293).
 

--- a/scripts/build_dup_client_package.sh
+++ b/scripts/build_dup_client_package.sh
@@ -1,15 +1,69 @@
 #!/bin/sh
 
-# Builds all three rotations of the DUP client package.
+# Builds DUP client packages. Optionally creates a git tag to record deployment
+# of the package to Outfront.
 
 set -eu
 
-if [ $# -eq 0 ]; then
-  version=$(git rev-parse --short HEAD)
-  echo "No version string specified, defaulting to current git rev: ${version}"
+is_force=false
+is_tagged=false
+release_num=0
+
+bold() {
+  bold=$(tput bold)
+  reset=$(tput sgr0)
+  echo "${bold}${1}${reset}"
+}
+
+while getopts "fhn:t" opt; do
+  case $opt in
+  h)
+    echo "Options:"
+    echo "-h        Show this help"
+    echo "-n <num>  Specify a release number for this date (default 0)"
+    echo "-t        Create/push a git tag to record deployment of this version"
+    echo "-f        Force-push/overwrite the git tag"
+    exit
+    ;;
+  f) is_force=true;;
+  n) release_num=$OPTARG;;
+  t) is_tagged=true;;
+  *)
+    >&2 echo "ℹ️ Run with $(bold "-h") for valid options"
+    exit 1
+    ;;
+  esac
+done
+
+client_path=assets
+if $is_tagged && ! git diff-index --quiet HEAD $client_path; then
+  >&2 echo "❌ Refusing to tag a release with uncommitted changes"
+  >&2 echo "ℹ️ Commit or stash changes in $(bold $client_path) or run without $(bold "-t")"
+  exit 1
+fi
+
+version=$(date +%Y.%m.%d).$release_num
+tag=dup-$version
+prev_tagged_sha=""
+head_sha=$(git rev-parse --short HEAD)
+
+if ! $is_tagged; then
+  echo "ℹ️ Not creating a release tag (request with $(bold "-t"))"
+elif ! [ "$(git tag -l $tag)" ]; then
+  echo "ℹ️ Release tag $(bold $tag) will be created"
 else
-  version=$1
-  echo "Using specified version string: ${version}"
+  prev_tagged_sha=$(git rev-parse --short $tag)
+
+  if [ $head_sha = $prev_tagged_sha ]; then
+    echo "ℹ️ Release tag $(bold $tag) already exists and points to HEAD"
+    is_tagged=false
+  elif $is_force; then
+    echo "⚠️ Release tag $(bold $tag) already exists and will be overwritten"
+  else
+    >&2 echo "❌ Release tag $(bold $tag) already exists"
+    >&2 echo "ℹ️ Overwrite with $(bold "-f") or choose a different release number with $(bold "-n <num>")"
+    exit 1
+  fi
 fi
 
 npm --prefix assets run deploy:dup
@@ -28,10 +82,27 @@ while [ $rotation_index -le 2 ]; do
   cp ../dup_template.json template.json
   sed -i "" "s/%rotation%/$rotation_index/" dup-app.html template.json
   sed -i "" "s/%version%/$version/" dup-app.html
-  zip -qr "dup-app-$rotation_index-$version.zip" fonts images dup-app.html dup_preview.png packaged_dup.css* packaged_dup.js* template.json
+  zip -qr "dup-app-$rotation_index-v$version.zip" fonts images dup-app.html dup_preview.png packaged_dup.css* packaged_dup.js* template.json
 
   rotation_index=$((rotation_index + 1))
 done
 
 echo
-echo "📦 Packages built in: $outdir"
+echo "📦 Packages built in: $(bold $outdir)"
+
+if $is_tagged; then
+  opts=""
+  if $is_force; then opts="-f"; fi
+
+  git tag $opts $tag > /dev/null
+
+  if [ -n "$prev_tagged_sha" ]; then
+    echo "⚠️ Updated tag $(bold $tag) to $(bold $head_sha) (was $(bold $prev_tagged_sha))"
+  else
+    echo "🏷️ Tag $(bold $tag) created at $(bold $head_sha)"
+  fi
+
+  git push --quiet $opts origin $tag
+
+  echo "📤 Tag pushed to origin"
+fi


### PR DESCRIPTION
Update the build script to, by default, automatically generate and push a release tag as per the below task. The generated version number is also used (once again) as the version string embedded in the package instead of the Git short hash, since with the addition of the tagging, this should point back to a specific commit.

...I might have had a little fun with the formatting and emojis. ❌ ⚠️ ℹ️ ✨ 

**Asana task**: https://app.asana.com/1/15492006741476/project/1185117109217413/task/1214901633382581?focus=true