### PR TITLE
fix: fixed DUP cross origin access within Screenplay

### DIFF
--- a/assets/src/util/outfront.tsx
+++ b/assets/src/util/outfront.tsx
@@ -92,7 +92,13 @@ interface OFMTag {
 }
 
 export const getMRAID = (): MRAID | false => {
-  return (parent?.parent as OFMWindow)?.mraid ?? false;
+  // We wrap this in a try catch because Screenplay shows
+  // Screens via an iframe and tries to get this value for DUPs
+  try {
+    return (parent?.parent as OFMWindow)?.mraid ?? false;
+  } catch {
+    return false;
+  }
 };
 
 /**


### PR DESCRIPTION
**Asana task**: [Screenplay bug: DUP previews don't display](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1215329063361089?focus=true)

Description
- trying to access `parent?.parent?.mraid` was causing cross origin access problems within Screenplay
- this just wraps the access in a try catch, resulting in MRAID being false and forgoes some of the metadata, header titles and extras that we normally add to the Screens page (which I think might be fine for screenplay)
