### PR TITLE
dev: remove unneeded `concurrently` option

### DIFF
--- a/assets/package.json
+++ b/assets/package.json
@@ -6,7 +6,7 @@
     "deploy:dup": "webpack --mode production --env package=dup",
     "test": "jest",
     "test:watch": "jest --watch",
-    "watch": "concurrently --kill-others --prefix-colors auto npm:watch-*",
+    "watch": "concurrently --kill-others npm:watch-*",
     "watch-build": "webpack --mode development --stats minimal --watch",
     "watch-tsc": "tsc --preserveWatchOutput --watch",
     "lint": "eslint --fix .",


### PR DESCRIPTION
`--prefix-colors auto` is the default in `concurrently` v10 (version bumped in 2ce5678f).