### PR TITLE
fix: Add takeover styles for Sectional solos

### DIFF
--- a/assets/css/busway.scss
+++ b/assets/css/busway.scss
@@ -16,6 +16,7 @@
 @use "lcd/route_pill";
 @use "lcd/screen/duo_normal" as *;
 @use "lcd/screen/duo_takeover";
+@use "lcd/screen/split_takeover";
 @use "lcd/screen_container";
 @use "lcd/simulation" as *;
 @use "lcd/subway_status";


### PR DESCRIPTION
These styles are needed on Sectional solos for full screen takeovers to be the correct width and height, otherwise, the width and height is set to that of two panels.