### PR TITLE
fix: Full closure at Symphony showing as partial in reconstructed_alert

### DIFF
--- a/lib/screens/alerts/informed_entity.ex
+++ b/lib/screens/alerts/informed_entity.ex
@@ -76,4 +76,16 @@ defmodule Screens.Alerts.InformedEntity do
     end)
     |> Enum.filter(fn ie -> not is_nil(ie.stop) end)
   end
+
+  @spec boarding_platforms_from_entities([t()]) :: [Stop.t()]
+  def boarding_platforms_from_entities(informed_parent_stations) do
+    informed_parent_stations
+    |> Enum.flat_map(
+      &case &1.stop.child_stops do
+        nil -> []
+        child_stops -> child_stops
+      end
+    )
+    |> Stop.filter_subway_platforms()
+  end
 end

--- a/lib/screens/v2/candidate_generator/widgets/reconstructed_alert.ex
+++ b/lib/screens/v2/candidate_generator/widgets/reconstructed_alert.ex
@@ -163,7 +163,8 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlert do
     # Given informed entities representing an alert at a single station,
     # finds the corresponding platform names for those child stops included.
     with [informed_parent_station] <- Alert.informed_parent_stations(alert),
-         [_ | _] = child_platforms <- informed_parent_station.stop.child_stops,
+         [_ | _] = child_platforms <-
+           informed_parent_station.stop.child_stops |> Stop.filter_subway_platforms(),
          :partial_closure <- Alert.station_closure_type(alert, child_platforms) do
       platform_ids =
         child_platforms |> Stop.filter_subway_platforms() |> Enum.map(& &1.id) |> MapSet.new()

--- a/lib/screens/v2/candidate_generator/widgets/reconstructed_alert.ex
+++ b/lib/screens/v2/candidate_generator/widgets/reconstructed_alert.ex
@@ -164,10 +164,10 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlert do
     # finds the corresponding platform names for those child stops included.
     with [informed_parent_station] <- Alert.informed_parent_stations(alert),
          [_ | _] = child_platforms <-
-           informed_parent_station.stop.child_stops |> Stop.filter_subway_platforms(),
+           InformedEntity.boarding_platforms_from_entities([informed_parent_station]),
          :partial_closure <- Alert.station_closure_type(alert, child_platforms) do
       platform_ids =
-        child_platforms |> Stop.filter_subway_platforms() |> Enum.map(& &1.id) |> MapSet.new()
+        child_platforms |> Enum.map(& &1.id) |> MapSet.new()
 
       informed_entities
       |> Enum.filter(&(&1.stop.id in platform_ids))

--- a/lib/screens/v2/widget_instance/subway_status/serialize.ex
+++ b/lib/screens/v2/widget_instance/subway_status/serialize.ex
@@ -4,8 +4,8 @@ defmodule Screens.V2.WidgetInstance.SubwayStatus.Serialize do
   """
 
   alias Screens.Alerts.Alert
+  alias Screens.Alerts.InformedEntity
   alias Screens.Routes.Route
-  alias Screens.Stops.Stop
   alias Screens.V2.WidgetInstance.SubwayStatus
   alias Screens.V2.WidgetInstance.SubwayStatus.Serialize.GreenLine
   alias Screens.V2.WidgetInstance.SubwayStatus.Serialize.RedLine
@@ -251,13 +251,7 @@ defmodule Screens.V2.WidgetInstance.SubwayStatus.Serialize do
     child_platforms_at_informed_stations =
       alert
       |> Alert.informed_parent_stations()
-      |> Enum.flat_map(
-        &case &1.stop.child_stops do
-          nil -> []
-          child_stops -> child_stops
-        end
-      )
-      |> Stop.filter_subway_platforms()
+      |> InformedEntity.boarding_platforms_from_entities()
 
     case Alert.station_closure_type(alert, child_platforms_at_informed_stations) do
       # Logic for partial_station_closure will remove any alerts that apply to more than


### PR DESCRIPTION
**Asana task**: [Bug: "skipping n platforms" alert message](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1215512201269422?focus=true)

For the reconstructed alert, we're not filtering down to just Subway platforms before checking if it's a partial closure.

<img width="594" height="405" alt="image" src="https://github.com/user-attachments/assets/bd6b4773-46ce-4505-8af5-9be7de09a7f3" />
