### PR TITLE
test: Add non-platform stop to parent station in reconstructed alert test

### DIFF
--- a/test/screens/v2/candidate_generator/widgets/reconstructed_alert_test.exs
+++ b/test/screens/v2/candidate_generator/widgets/reconstructed_alert_test.exs
@@ -5,6 +5,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlertTest do
 
   alias Screens.Alerts.Alert
   alias Screens.LocationContext
+  alias Screens.Stops.Stop
   alias Screens.V2.WidgetInstance.ReconstructedAlert, as: ReconstructedAlertWidget
   alias ScreensConfig.Screen
   alias ScreensConfig.Screen.{Busway, PreFare}

--- a/test/screens/v2/candidate_generator/widgets/reconstructed_alert_test.exs
+++ b/test/screens/v2/candidate_generator/widgets/reconstructed_alert_test.exs
@@ -5,7 +5,6 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlertTest do
 
   alias Screens.Alerts.Alert
   alias Screens.LocationContext
-  alias Screens.Stops.Stop
   alias Screens.V2.WidgetInstance.ReconstructedAlert, as: ReconstructedAlertWidget
   alias ScreensConfig.Screen
   alias ScreensConfig.Screen.{Busway, PreFare}
@@ -79,11 +78,17 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlertTest do
         vehicle_type: :subway
       }
 
+      malden_center_non_platform = %Stop{
+        id: "node-945-platform",
+        name: "Malden Center - Non-platform Stop",
+        location_type: 3
+      }
+
       malden_center_parent = %Stop{
         id: "place-mlmnl",
         name: "Malden Center",
         location_type: 1,
-        child_stops: [malden_center_nb, malden_center_sb]
+        child_stops: [malden_center_nb, malden_center_sb, malden_center_non_platform]
       }
 
       alerts = [
@@ -173,6 +178,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlertTest do
         happening_now_active_period: happening_now_active_period,
         malden_center_nb: malden_center_nb,
         malden_center_sb: malden_center_sb,
+        malden_center_parent: malden_center_parent,
         oak_grove_nb: oak_grove_nb,
         oak_grove_sb: oak_grove_sb,
         fetch_alerts_fn: fn _ -> {:ok, alerts} end,
@@ -196,7 +202,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlertTest do
         oak_grove_sb: oak_grove_sb,
         oak_grove_nb: oak_grove_nb,
         malden_center_sb: malden_center_sb,
-        malden_center_nb: malden_center_nb
+        malden_center_parent: malden_center_parent
       } = context
 
       alerts = [
@@ -220,14 +226,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlertTest do
           id: "2",
           effect: :station_closure,
           informed_entities: [
-            ie(
-              stop: %Stop{
-                id: "place-mlmnl",
-                name: "Malden Center",
-                location_type: 1,
-                child_stops: [malden_center_sb, malden_center_nb]
-              }
-            ),
+            ie(stop: malden_center_parent),
             ie(stop: malden_center_sb)
           ],
           active_period: happening_now_active_period
@@ -282,14 +281,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlertTest do
               id: "2",
               effect: :station_closure,
               informed_entities: [
-                ie(
-                  stop: %Stop{
-                    id: "place-mlmnl",
-                    name: "Malden Center",
-                    location_type: 1,
-                    child_stops: [malden_center_sb, malden_center_nb]
-                  }
-                ),
+                ie(stop: malden_center_parent),
                 ie(stop: malden_center_sb)
               ],
               active_period: [{~U[2020-12-31T00:00:00Z], ~U[2021-01-02T00:00:00Z]}]
@@ -544,6 +536,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlertTest do
         oak_grove_nb: oak_grove_nb,
         malden_center_sb: malden_center_sb,
         malden_center_nb: malden_center_nb,
+        malden_center_parent: malden_center_parent,
         fetch_location_context_fn: fetch_location_context_fn,
         fetch_alerts_fn: fetch_alerts_fn,
         x_fetch_stop_name_fn: x_fetch_stop_name_fn
@@ -590,14 +583,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlertTest do
               id: "2",
               effect: :station_closure,
               informed_entities: [
-                ie(
-                  stop: %Stop{
-                    id: "place-mlmnl",
-                    name: "Malden Center",
-                    location_type: 1,
-                    child_stops: [malden_center_nb, malden_center_sb]
-                  }
-                ),
+                ie(stop: malden_center_parent),
                 ie(stop: malden_center_nb),
                 ie(stop: malden_center_sb)
               ],
@@ -710,8 +696,8 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlertTest do
         happening_now_active_period: happening_now_active_period,
         fetch_stop_name_fn: fetch_stop_name_fn,
         fetch_location_context_fn: fetch_location_context_fn,
-        malden_center_nb: malden_center_nb,
-        malden_center_sb: malden_center_sb
+        malden_center_sb: malden_center_sb,
+        malden_center_parent: malden_center_parent
       } = context
 
       alerts = [
@@ -725,14 +711,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlertTest do
           id: "2",
           effect: :station_closure,
           informed_entities: [
-            ie(
-              stop: %Stop{
-                id: "place-mlmnl",
-                name: "Malden Center",
-                location_type: 1,
-                child_stops: [malden_center_sb, malden_center_nb]
-              }
-            ),
+            ie(stop: malden_center_parent),
             ie(stop: malden_center_sb)
           ],
           active_period: happening_now_active_period
@@ -757,14 +736,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlertTest do
               id: "2",
               effect: :station_closure,
               informed_entities: [
-                ie(
-                  stop: %Stop{
-                    id: "place-mlmnl",
-                    name: "Malden Center",
-                    location_type: 1,
-                    child_stops: [malden_center_sb, malden_center_nb]
-                  }
-                ),
+                ie(stop: malden_center_parent),
                 ie(stop: malden_center_sb)
               ],
               active_period: [{~U[2020-12-31T00:00:00Z], ~U[2021-01-02T00:00:00Z]}]


### PR DESCRIPTION
Follow up to a fix made in [this PR](https://github.com/mbta/screens/pull/3102). 

Simply adding a non-platform stop to the parent station that's used in these tests would have caused assertion failures before the fix above. This addition to the test validates that the node stop is filtered out properly when building the alert widget and seeing if all the platform stops are closed.