### PR TITLE
chore: adjust DUP and RDS generation timeouts

### DIFF
--- a/lib/screens/v2/candidate_generator/dup.ex
+++ b/lib/screens/v2/candidate_generator/dup.ex
@@ -78,7 +78,7 @@ defmodule Screens.V2.CandidateGenerator.Dup do
 
   @impl CandidateGenerator
   def candidate_instances(config, now \\ DateTime.utc_now()) do
-    CandidateGenerator.async_stream(@instance_generators, & &1.(config, now), timeout: 20_000)
+    CandidateGenerator.async_stream(@instance_generators, & &1.(config, now), timeout: 15_000)
   end
 
   @impl CandidateGenerator

--- a/lib/screens/v2/rds.ex
+++ b/lib/screens/v2/rds.ex
@@ -207,7 +207,7 @@ defmodule Screens.V2.RDS do
     ]
 
     data_fetch_fns
-    |> Task.async_stream(fn {key, func} -> {key, func.(params, now)} end, timeout: 30_000)
+    |> Task.async_stream(fn {key, func} -> {key, func.(params, now)} end, timeout: 15_000)
     |> Enum.reduce_while(%{}, fn
       {:ok, {key, {:ok, data}}}, results -> {:cont, Map.put(results, key, data)}
       {:ok, {_key, _error}}, _results -> {:halt, :error}


### PR DESCRIPTION
* Since 7fe8b3a DUPs technically have a refresh rate of 20 seconds instead of 30 (would only apply to hypothetical non-Outfront DUPs), so their candidate generator timeout should be lowered from 20s.

* RDS async data fetching should have, at most, the same timeout as the overall generation timeout for the screen types that use it.