### PR TITLE
fix: RDS showing cancelled subway departures

### DIFF
--- a/lib/screens/v2/rds.ex
+++ b/lib/screens/v2/rds.ex
@@ -325,9 +325,7 @@ defmodule Screens.V2.RDS do
       |> then(&{List.first(&1), List.last(&1)})
 
     presented_departures =
-      if not is_nil(headways) or impacted_by_alert?,
-        do: Enum.reject(departures, &is_nil(&1.prediction)),
-        else: departures
+      Enum.filter(departures, &presented_departure?(&1, not is_nil(headways), impacted_by_alert?))
 
     service_state =
       scheduled_service_state(first_schedule, last_schedule, headways, last_trip_departed?, now)
@@ -340,6 +338,14 @@ defmodule Screens.V2.RDS do
       service_state == :after -> %ServiceEnded{last_schedule: last_schedule}
       not is_nil(headways) -> headways_state(headways, first_schedule)
       true -> nil
+    end
+  end
+
+  defp presented_departure?(%Departure{prediction: prediction} = departure, headways?, alert?) do
+    cond do
+      is_nil(prediction) -> not headways? and not alert?
+      Departure.cancelled?(departure) -> not headways?
+      true -> true
     end
   end
 

--- a/test/screens/v2/rds_test.exs
+++ b/test/screens/v2/rds_test.exs
@@ -334,6 +334,61 @@ defmodule Screens.V2.RDSTest do
                 ]}
              ]
     end
+
+    test "filters out cancelled departures for stops with headways" do
+      now = ~U[2026-01-01 12:00:00Z]
+
+      stub(@headways, :get, fn "s0", ^now -> {5, 10} end)
+
+      expected_departures = [
+        %Departure{
+          prediction: %Prediction{
+            arrival_time: ~U[2026-01-01 12:27:00Z],
+            departure_time: ~U[2026-01-01 12:28:00Z],
+            route: %Route{id: "r1", line: %Line{id: "l1"}, type: :subway},
+            stop: %Stop{id: "s0"},
+            trip: %Trip{headsign: "other1", pattern_headsign: "h1"}
+          },
+          schedule: nil
+        }
+      ]
+
+      skipped_departure = %Departure{
+        prediction: %Prediction{
+          arrival_time: nil,
+          departure_time: nil,
+          schedule_relationship: :skipped,
+          route: %Route{id: "r1", line: %Line{id: "l1"}, type: :subway},
+          stop: %Stop{id: "s0"},
+          trip: %Trip{headsign: "other1", pattern_headsign: "h1"}
+        },
+        schedule: %Schedule{
+          arrival_time: ~U[2026-01-01 12:37:00Z],
+          departure_time: ~U[2026-01-01 12:38:00Z],
+          route: %Route{id: "r1", line: %Line{id: "l1"}, type: :subway},
+          stop: %Stop{id: "s0"},
+          trip: %Trip{headsign: "other1", pattern_headsign: "h1"}
+        }
+      }
+
+      expect(@departure, :fetch, fn
+        %{direction_id: 0, route_type: :subway, stop_ids: ["s0"]}, [{:now, ^now} | _] ->
+          {:ok, [skipped_departure | expected_departures]}
+      end)
+
+      departures = %Departures{
+        sections: [
+          %Section{
+            query: %Query{
+              params: %Query.Params{direction_id: 0, route_type: :subway, stop_ids: ["s0"]}
+            }
+          }
+        ]
+      }
+
+      assert RDS.get(departures, now) ==
+               [{:ok, [countdowns("s0", "l1", "h1", expected_departures)]}]
+    end
   end
 
   describe "get/1 first trip" do


### PR DESCRIPTION
This was a gap in the spec: we specified that stops with headways shouldn't present "scheduled-only" departures, but not that they also shouldn't present skipped/cancelled departures. This resulted in DUPs showing struck-through clock times for skipped subway departures, instead of not displaying them at all, as non-RDS departures did.