### PR TITLE
fix: RDS incorrectly producing no-service states

### DIFF
--- a/lib/screens/v2/rds.ex
+++ b/lib/screens/v2/rds.ex
@@ -333,10 +333,10 @@ defmodule Screens.V2.RDS do
     cond do
       presented_departures != [] -> %Countdowns{departures: presented_departures}
       impacted_by_alert? -> nil
-      service_state == :none -> %NoService{routes: routes_for_section}
+      departures == [] and service_state == :none -> %NoService{routes: routes_for_section}
+      departures == [] and service_state == :after -> %ServiceEnded{last_schedule: last_schedule}
       service_state == :before -> %FirstTrip{first_schedule: first_schedule}
-      service_state == :after -> %ServiceEnded{last_schedule: last_schedule}
-      not is_nil(headways) -> headways_state(headways, first_schedule)
+      not (is_nil(headways) or is_nil(first_schedule)) -> headways_state(headways, first_schedule)
       true -> nil
     end
   end

--- a/test/screens/v2/rds_test.exs
+++ b/test/screens/v2/rds_test.exs
@@ -389,6 +389,49 @@ defmodule Screens.V2.RDSTest do
       assert RDS.get(departures, now) ==
                [{:ok, [countdowns("s0", "l1", "h1", expected_departures)]}]
     end
+
+    test "considers cancelled departures in deciding whether to produce no-service states" do
+      now = ~U[2026-01-01 12:00:00Z]
+
+      stub(@headways, :get, fn "s0", ^now -> {5, 10} end)
+
+      skipped_departure = %Departure{
+        prediction: %Prediction{
+          arrival_time: nil,
+          departure_time: nil,
+          schedule_relationship: :skipped,
+          route: %Route{id: "r1", line: %Line{id: "l1"}, type: :subway},
+          stop: %Stop{id: "s0"},
+          trip: %Trip{headsign: "other1", pattern_headsign: "h1"}
+        },
+        schedule: %Schedule{
+          arrival_time: ~U[2026-01-01 12:37:00Z],
+          departure_time: ~U[2026-01-01 12:38:00Z],
+          route: %Route{id: "r1", line: %Line{id: "l1"}, type: :subway},
+          stop: %Stop{id: "s0"},
+          trip: %Trip{headsign: "other1", pattern_headsign: "h1"}
+        }
+      }
+
+      expect(@departure, :fetch, fn
+        %{direction_id: 0, route_type: :subway, stop_ids: ["s0"]}, [{:now, ^now} | _] ->
+          {:ok, [skipped_departure]}
+      end)
+
+      departures = %Departures{
+        sections: [
+          %Section{
+            query: %Query{
+              params: %Query.Params{direction_id: 0, route_type: :subway, stop_ids: ["s0"]}
+            }
+          }
+        ]
+      }
+
+      # The destination has a cancelled departure which is not presented (due to the stop having
+      # headways); we should not produce "no service today" or "service ended"
+      assert RDS.get(departures, now) == [{:ok, []}]
+    end
   end
 
   describe "get/1 first trip" do


### PR DESCRIPTION
The change in cde98925 to filter out some departures for presentation surfaced a bug where, if the only departures for a destination were filtered out, the produced state could be incorrect. A real-world example occurred recently with an unplanned disruption on the Blue Line that caused northbound trains to terminate at Orient Heights. Since there *are* a few early-morning scheduled trips to Orient Heights each day, if Orient Heights had a live departure and it was cancelled, the logic would fall through to "Service Ended". While technically *true*, telling riders that service to an atypical destination has ended is not relevant and potentially confusing.

Fix this by requiring that there *were* no departures associated with a destination, pre-filtering, to produce Service Ended or No Service.