### PR TITLE
feat: increase Finch connection pool size

### DIFF
--- a/lib/screens/application.ex
+++ b/lib/screens/application.ex
@@ -12,7 +12,7 @@ defmodule Screens.Application do
         {Screens.Cache.Owner, engine_module: Screens.Config.Cache.Engine},
         {Screens.Cache.Owner, engine_module: Screens.SignsUiConfig.Cache.Engine},
         {Finch,
-         name: Screens.V3Api.Finch, pools: %{default: [size: 100, start_pool_metrics?: true]}},
+         name: Screens.V3Api.Finch, pools: %{default: [size: 200, start_pool_metrics?: true]}},
         Screens.V3Api.Cache.Realtime,
         Screens.V3Api.Cache.Static,
         Screens.LastTrip.Cache,


### PR DESCRIPTION
- it looks like RDS DUPs are causing our connection pool to hit the ceiling of what we have configured
- bumping this value up to 200 in order to see if it helps stabilize performance across all screens


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215780122518173