### PR TITLE
feat: Always prioritize station closures over other service disrupting alerts

### DIFF
--- a/lib/screens/v2/candidate_generator/widgets/reconstructed_alert.ex
+++ b/lib/screens/v2/candidate_generator/widgets/reconstructed_alert.ex
@@ -123,37 +123,42 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlert do
   # Filter out `elsewhere` alerts (should never happen).
   defp relevance(_alert, :elsewhere, _distance), do: nil
 
+  # "Immediate eliminated service": Service is completely eliminated at the rider's station.
+  defp relevance(%Alert{effect: effect}, location, _distance)
+       when effect == :station_closure and location in @inside_locations,
+       do: {0, nil}
+
   # "Immediate disruptions": Service is eliminated in at least one direction at the home stop.
   # Riders may need to take immediate action to continue their trip.
   defp relevance(%Alert{effect: effect}, location, _distance)
        when is_service_eliminating_effect(effect) and location in @inside_locations,
-       do: {0, nil}
+       do: {1, nil}
 
   # "Downstream disruptions": Service is eliminated starting somewhere downstream of the home
   # stop. Riders may need to take action later to continue their trip. Split into sub-categories
   # based on how close to the home stop the disruption begins (only the closest get "priority").
   defp relevance(%Alert{effect: effect}, _location, distance)
        when is_service_eliminating_effect(effect),
-       do: {1, distance}
+       do: {2, distance}
 
   # Severe delays are also considered "downstream disruptions".
   defp relevance(%Alert{effect: :delay, severity: severity}, _location, distance)
        when severity >= 7,
-       do: {1, distance}
+       do: {2, distance}
 
   # "Moderate delays": still important enough to present, but less relevant.
   defp relevance(%Alert{effect: :delay, severity: severity}, _location, _distance)
        when severity >= 5,
-       do: {2, nil}
+       do: {3, nil}
 
   # Low-severity (including "informational") delays are only included when the cause is
   # single-tracking. Relevance is higher when inside the single-tracked segment.
   defp relevance(%Alert{effect: :delay, cause: :single_tracking}, location, _distance)
        when location in @inside_locations,
-       do: {2, nil}
+       do: {3, nil}
 
   defp relevance(%Alert{effect: :delay, cause: :single_tracking}, _location, _distance),
-    do: {3, nil}
+    do: {4, nil}
 
   defp relevance(_alert, _location, _distance), do: nil
 

--- a/lib/screens/v2/candidate_generator/widgets/reconstructed_alert.ex
+++ b/lib/screens/v2/candidate_generator/widgets/reconstructed_alert.ex
@@ -123,13 +123,13 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlert do
   # Filter out `elsewhere` alerts (should never happen).
   defp relevance(_alert, :elsewhere, _distance), do: nil
 
-  # "Immediate eliminated service": Service is completely eliminated at the rider's station.
+  # "Immediate disruptions": Service is eliminated in at least one direction at the home stop.
+  # Riders may need to take immediate action to continue their trip.
+  # Prioritize station_closure over other disrupting effects
   defp relevance(%Alert{effect: effect}, location, _distance)
        when effect == :station_closure and location in @inside_locations,
        do: {0, nil}
 
-  # "Immediate disruptions": Service is eliminated in at least one direction at the home stop.
-  # Riders may need to take immediate action to continue their trip.
   defp relevance(%Alert{effect: effect}, location, _distance)
        when is_service_eliminating_effect(effect) and location in @inside_locations,
        do: {1, nil}

--- a/lib/screens/v2/widget_instance/alert.ex
+++ b/lib/screens/v2/widget_instance/alert.ex
@@ -32,7 +32,7 @@ defmodule Screens.V2.WidgetInstance.Alert do
   @automated_override_priority [1, 2]
 
   # Keep these in descending order of priority--highest priority (lowest integer value) first
-  @relevant_effects ~w[shuttle stop_closure suspension station_closure detour stop_moved snow_route elevator_closure]a
+  @relevant_effects ~w[station_closure shuttle stop_closure suspension detour stop_moved snow_route elevator_closure]a
 
   @effect_priorities Enum.with_index(@relevant_effects, 1)
 
@@ -82,7 +82,7 @@ defmodule Screens.V2.WidgetInstance.Alert do
 
     cond do
       Enum.any?(tiebreakers, &(&1 == :no_render)) -> :no_render
-      takeover_alert?(t) -> @automated_override_priority
+      takeover_alert?(t) -> @automated_override_priority ++ tiebreakers
       true -> tiebreakers
     end
   end

--- a/test/screens/v2/candidate_generator/widgets/reconstructed_alert_test.exs
+++ b/test/screens/v2/candidate_generator/widgets/reconstructed_alert_test.exs
@@ -480,6 +480,93 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlertTest do
                )
     end
 
+    test "prioritizes station_closure over other disruptions at the same location",
+         context do
+      %{
+        config: config,
+        location_context: location_context,
+        now: now,
+        happening_now_active_period: happening_now_active_period,
+        fetch_stop_name_fn: fetch_stop_name_fn,
+        fetch_location_context_fn: fetch_location_context_fn
+      } = context
+
+      alerts = [
+        %Alert{
+          id: "1",
+          effect: :shuttle,
+          informed_entities: [
+            ie(stop: %Stop{id: "place-ogmnl", name: "Oak Grove"}),
+            ie(stop: %Stop{id: "place-mlmnl", name: "Malden Center"}),
+            ie(stop: %Stop{id: "place-welln", name: "Wellington"}),
+            ie(stop: %Stop{id: "place-astao", name: "Assembly"})
+          ],
+          active_period: happening_now_active_period
+        },
+        %Alert{
+          id: "2",
+          effect: :station_closure,
+          informed_entities: [ie(stop: %Stop{id: "place-ogmnl", name: "Oak Grove"})],
+          active_period: happening_now_active_period
+        }
+      ]
+
+      fetch_alerts_fn = fn _ -> {:ok, alerts} end
+
+      expected_common_data = %{
+        screen: config,
+        location_context: location_context,
+        now: now,
+        is_terminal_station: true,
+        home_station_name: "Oak Grove"
+      }
+
+      expected_widgets = [
+        struct(
+          %ReconstructedAlertWidget{
+            alert: %Alert{
+              id: "2",
+              effect: :station_closure,
+              informed_entities: [ie(stop: %Stop{id: "place-ogmnl", name: "Oak Grove"})],
+              active_period: [{~U[2020-12-31T00:00:00Z], ~U[2021-01-02T00:00:00Z]}]
+            },
+            is_priority: true,
+            informed_station_names: ["Oak Grove"],
+            partial_closure_platform_names: []
+          },
+          expected_common_data
+        ),
+        struct(
+          %ReconstructedAlertWidget{
+            alert: %Alert{
+              id: "1",
+              effect: :shuttle,
+              informed_entities: [
+                ie(stop: %Stop{id: "place-ogmnl", name: "Oak Grove"}),
+                ie(stop: %Stop{id: "place-mlmnl", name: "Malden Center"}),
+                ie(stop: %Stop{id: "place-welln", name: "Wellington"}),
+                ie(stop: %Stop{id: "place-astao", name: "Assembly"})
+              ],
+              active_period: [{~U[2020-12-31T00:00:00Z], ~U[2021-01-02T00:00:00Z]}]
+            },
+            informed_station_names: [],
+            partial_closure_platform_names: [],
+            is_priority: false
+          },
+          expected_common_data
+        )
+      ]
+
+      assert expected_widgets ==
+               reconstructed_alert_instances(
+                 config,
+                 now,
+                 fetch_alerts_fn,
+                 fetch_stop_name_fn,
+                 fetch_location_context_fn
+               )
+    end
+
     test "fails when passed config for an unsupported screen type", context do
       %{
         bad_config: bad_config,

--- a/test/screens/v2/widget_instance/alert_test.exs
+++ b/test/screens/v2/widget_instance/alert_test.exs
@@ -189,8 +189,8 @@ defmodule Screens.V2.WidgetInstance.AlertTest do
   describe "priority/1" do
     setup @valid_alert_setup_group
 
-    test "returns [1, 2] when slot_names(widget) == [:full_body]", %{widget: widget} do
-      assert [1, 2] == AlertWidget.priority(widget)
+    test "returns [1, 2, ...] when slot_names(widget) == [:full_body]", %{widget: widget} do
+      assert [1, 2] == Enum.take(AlertWidget.priority(widget), 2)
     end
 
     test "returns a list of tiebreaker values when widget should be considered for placement", %{
@@ -213,6 +213,15 @@ defmodule Screens.V2.WidgetInstance.AlertTest do
       widget = put_active_period(widget, active_period)
 
       assert :no_render == AlertWidget.priority(widget)
+    end
+
+    test "can rank priorities among two takeover alert effects", %{
+      widget: widget
+    } do
+      closure_widget = put_effect(widget, :station_closure)
+      shuttle_widget = put_effect(widget, :shuttle)
+
+      assert AlertWidget.priority(closure_widget) < AlertWidget.priority(shuttle_widget)
     end
   end
 


### PR DESCRIPTION
**Asana task**: [Prioritize station closure alert over other alerts ](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1215344534320213?focus=true)

We had a case recently when a station was closed, but there was also a shuttle alert affecting it since it was inside the shuttle boundary. We should prioritize displaying the station closure alert with a higher priority in this case.