### PR TITLE
chore: Remove audio time restriction for pre-fares

### DIFF
--- a/lib/screens/v2/screen_data/parameters.ex
+++ b/lib/screens/v2/screen_data/parameters.ex
@@ -41,7 +41,7 @@ defmodule Screens.V2.ScreenData.Parameters do
       refresh_rate: 30
     },
     pre_fare_v2: %Static{
-      audio_active_time: {~T[04:45:00], ~T[01:45:00]},
+      audio_active_time: @all_times,
       candidate_generator: CandidateGenerator.PreFare,
       refresh_rate: 20
     }


### PR DESCRIPTION
**Asana task**: [Remove audio time restriction for Pre-Fares](https://app.asana.com/1/15492006741476/project/1185117109217422/task/1215076233813264?focus=true)

Out of curiosity when looking at a story to pick up, I went to see how this behavior worked and realized it was an extremely simple one line change. 

Sets the `audio_active_time` for pre-fares to `{~T[00:00:00], ~T[23:59:59]}`, which is the same configuration as Sectionals.