### PR TITLE
perf: remove empty alerts request

### DIFF
--- a/lib/screens/v2/candidate_generator/widgets/evergreen.ex
+++ b/lib/screens/v2/candidate_generator/widgets/evergreen.ex
@@ -19,9 +19,10 @@ defmodule Screens.V2.CandidateGenerator.Widgets.Evergreen do
       end)
 
     alerts =
-      case @alert.fetch(ids: alert_ids) do
-        {:ok, alerts} -> alerts
-        :error -> []
+      with [_ | _] <- alert_ids, {:ok, alerts} <- @alert.fetch(ids: alert_ids) do
+        alerts
+      else
+        _ -> []
       end
 
     Enum.map(evergreen_content, &evergreen_content_instance(&1, alerts, config, now))


### PR DESCRIPTION
The evergreen content generator would always perform a data fetch to determine active alerts, even if the list of alert IDs it was checking for was empty (which would always yield an empty response). Skip doing this in the common case where no evergreen content is configured with an alert ID.