### PR TITLE
fix: incorrect alert filter in RDS logic

### DIFF
--- a/lib/screens/alerts/alert.ex
+++ b/lib/screens/alerts/alert.ex
@@ -254,8 +254,6 @@ defmodule Screens.Alerts.Alert do
     ]
   end
 
-  defp format_query_param(_), do: []
-
   def happening_now?(%{active_period: aps}, now \\ DateTime.utc_now()) do
     Enum.any?(aps, &in_active_period(&1, now))
   end

--- a/lib/screens/v2/rds.ex
+++ b/lib/screens/v2/rds.ex
@@ -445,7 +445,7 @@ defmodule Screens.V2.RDS do
   @spec fetch_relevant_alerts([Stop.id()]) :: {:ok, [Alert.t()]} | :error
   defp fetch_relevant_alerts(stop_ids) do
     with {:ok, alerts} <-
-           @alert.fetch(activities: [:board], stop_id: stop_ids, include_all?: true) do
+           @alert.fetch(activities: [:board], stop_ids: stop_ids, include_all?: true) do
       {:ok, Enum.filter(alerts, &(Alert.happening_now?(&1) and relevant_alert_effect?(&1)))}
     end
   end

--- a/test/screens/v2/rds_test.exs
+++ b/test/screens/v2/rds_test.exs
@@ -849,7 +849,7 @@ defmodule Screens.V2.RDSTest do
       stop_ids = ~w[s0 s1]
       now = ~U[2024-10-11 10:44:00Z]
 
-      expect(@alert, :fetch, fn [activities: [:board], stop_id: ["s0", "s1"], include_all?: true] ->
+      expect(@alert, :fetch, fn [activities: [:board], stop_ids: ["s0", "s1"], include_all?: true] ->
         {:ok,
          [
            %Alert{
@@ -880,7 +880,7 @@ defmodule Screens.V2.RDSTest do
       now = ~U[2024-10-11 10:44:00Z]
 
       # Alert affects entire route r1 (no direction_id, no stop)
-      expect(@alert, :fetch, fn [activities: [:board], stop_id: ["s0", "s1"], include_all?: true] ->
+      expect(@alert, :fetch, fn [activities: [:board], stop_ids: ["s0", "s1"], include_all?: true] ->
         {:ok,
          [
            %Alert{
@@ -911,7 +911,7 @@ defmodule Screens.V2.RDSTest do
       now = ~U[2024-10-11 10:44:00Z]
 
       # Alert affects route r2 in direction 0 only
-      expect(@alert, :fetch, fn [activities: [:board], stop_id: ["s0", "s1"], include_all?: true] ->
+      expect(@alert, :fetch, fn [activities: [:board], stop_ids: ["s0", "s1"], include_all?: true] ->
         {:ok,
          [
            %Alert{
@@ -968,7 +968,7 @@ defmodule Screens.V2.RDSTest do
       now = ~U[2024-10-11 10:44:00Z]
 
       # Alert affects all bus routes (route_type 3)
-      expect(@alert, :fetch, fn [activities: [:board], stop_id: ["s0", "s1"], include_all?: true] ->
+      expect(@alert, :fetch, fn [activities: [:board], stop_ids: ["s0", "s1"], include_all?: true] ->
         {:ok,
          [
            %Alert{
@@ -999,7 +999,7 @@ defmodule Screens.V2.RDSTest do
 
       # Alert that affects another route type, another route, and another stop
       # None of the destinations should be affected
-      expect(@alert, :fetch, fn [activities: [:board], stop_id: ["s0", "s1"], include_all?: true] ->
+      expect(@alert, :fetch, fn [activities: [:board], stop_ids: ["s0", "s1"], include_all?: true] ->
         {:ok,
          [
            %Alert{


### PR DESCRIPTION
Alert fetching accepts either a `stop_id` option which must be a single stop ID, or a `stop_ids` option which must be a list. RDS logic fetched alerts using `stop_id`, but passing a list. Due to a "fallback" clause in query param building, this filter was quietly dropped. As a result, the part of the RDS logic that checked whether there was an active alert impacting a stop would instead check whether there were *any* active alerts that eliminated service, across the entire system.

* Use the correct spelling `stop_ids` in the RDS logic.

* Eliminate the "fallback" clause in alert fetch option parsing. If we make a mistake here, we probably want to crash and be noisy about it rather than carrying on.