### PR TITLE
fix: crash on alert fetching option

### DIFF
--- a/lib/screens/alerts/alert.ex
+++ b/lib/screens/alerts/alert.ex
@@ -156,13 +156,15 @@ defmodule Screens.Alerts.Alert do
 
   @callback fetch(options()) :: result()
   def fetch(opts \\ [], get_json_fn \\ &V3Api.get_json/2) do
+    {options, filters} = Keyword.split(opts, [:include_all?])
+
     includes =
-      if Keyword.get(opts, :include_all?, false),
+      if Keyword.get(options, :include_all?, false),
         do: @all_includes,
         else: @base_includes
 
     params =
-      opts
+      filters
       |> Enum.flat_map(&format_query_param/1)
       |> Map.new()
       |> Map.put("include", Enum.join(includes, ","))


### PR DESCRIPTION
`Alert.fetch/1` treats its argument as an undifferentiated bag of filters-or-other-options. This caused problems once b4a8d32a removed the fallback clause in filter parsing that would silently reject any unknown "filters", such as the `:include_all?` option. Fix this by explicitly splitting out the filters from the other options.