### PR TITLE
refactor: correct name for alert activity filter

### DIFF
--- a/lib/screens/alerts/alert.ex
+++ b/lib/screens/alerts/alert.ex
@@ -245,12 +245,12 @@ defmodule Screens.Alerts.Alert do
     format_query_param({:route_types, [route_type]})
   end
 
-  defp format_query_param({:activities, :all}), do: [{"activity", "ALL"}]
+  defp format_query_param({:activities, :all}), do: [{"filter[activity]", "ALL"}]
 
   defp format_query_param({:activities, activities}) when is_list(activities) do
     [
       {
-        "activity",
+        "filter[activity]",
         Enum.map_join(activities, ",", fn value -> value |> to_string() |> String.upcase() end)
       }
     ]


### PR DESCRIPTION
When fetching alerts, the activity filter (and only this one) was encoded as just `activity=X` rather than `filter[activity]=X`. For unclear reasons, this works anyway in the current version of the V3 API, but we should use the documented name.