### PR TITLE
refactor(RDS): don't "include all" for alerts

### DIFF
--- a/lib/screens/v2/rds.ex
+++ b/lib/screens/v2/rds.ex
@@ -444,8 +444,7 @@ defmodule Screens.V2.RDS do
 
   @spec fetch_relevant_alerts([Stop.id()]) :: {:ok, [Alert.t()]} | :error
   defp fetch_relevant_alerts(stop_ids) do
-    with {:ok, alerts} <-
-           @alert.fetch(activities: [:board], stop_ids: stop_ids, include_all?: true) do
+    with {:ok, alerts} <- @alert.fetch(activities: [:board], stop_ids: stop_ids) do
       {:ok, Enum.filter(alerts, &(Alert.happening_now?(&1) and relevant_alert_effect?(&1)))}
     end
   end

--- a/test/screens/v2/rds_test.exs
+++ b/test/screens/v2/rds_test.exs
@@ -849,7 +849,7 @@ defmodule Screens.V2.RDSTest do
       stop_ids = ~w[s0 s1]
       now = ~U[2024-10-11 10:44:00Z]
 
-      expect(@alert, :fetch, fn [activities: [:board], stop_ids: ["s0", "s1"], include_all?: true] ->
+      expect(@alert, :fetch, fn [activities: [:board], stop_ids: ["s0", "s1"]] ->
         {:ok,
          [
            %Alert{
@@ -880,7 +880,7 @@ defmodule Screens.V2.RDSTest do
       now = ~U[2024-10-11 10:44:00Z]
 
       # Alert affects entire route r1 (no direction_id, no stop)
-      expect(@alert, :fetch, fn [activities: [:board], stop_ids: ["s0", "s1"], include_all?: true] ->
+      expect(@alert, :fetch, fn [activities: [:board], stop_ids: ["s0", "s1"]] ->
         {:ok,
          [
            %Alert{
@@ -911,7 +911,7 @@ defmodule Screens.V2.RDSTest do
       now = ~U[2024-10-11 10:44:00Z]
 
       # Alert affects route r2 in direction 0 only
-      expect(@alert, :fetch, fn [activities: [:board], stop_ids: ["s0", "s1"], include_all?: true] ->
+      expect(@alert, :fetch, fn [activities: [:board], stop_ids: ["s0", "s1"]] ->
         {:ok,
          [
            %Alert{
@@ -968,7 +968,7 @@ defmodule Screens.V2.RDSTest do
       now = ~U[2024-10-11 10:44:00Z]
 
       # Alert affects all bus routes (route_type 3)
-      expect(@alert, :fetch, fn [activities: [:board], stop_ids: ["s0", "s1"], include_all?: true] ->
+      expect(@alert, :fetch, fn [activities: [:board], stop_ids: ["s0", "s1"]] ->
         {:ok,
          [
            %Alert{
@@ -999,7 +999,7 @@ defmodule Screens.V2.RDSTest do
 
       # Alert that affects another route type, another route, and another stop
       # None of the destinations should be affected
-      expect(@alert, :fetch, fn [activities: [:board], stop_ids: ["s0", "s1"], include_all?: true] ->
+      expect(@alert, :fetch, fn [activities: [:board], stop_ids: ["s0", "s1"]] ->
         {:ok,
          [
            %Alert{


### PR DESCRIPTION
RDS logic did not use any of the extra data that is included when this option is given, so we don't need to take up extra memory caching it. This is also a precursor to aligning RDS alert fetching with DUP alert widget fetching so they can share a cache key.