### PR TITLE
feat: update alert consolidation for station closures

### DIFF
--- a/lib/screens/v2/widget_instance/subway_status/serialize.ex
+++ b/lib/screens/v2/widget_instance/subway_status/serialize.ex
@@ -7,11 +7,14 @@ defmodule Screens.V2.WidgetInstance.SubwayStatus.Serialize do
   alias Screens.Alerts.InformedEntity
   alias Screens.Routes.Route
   alias Screens.V2.WidgetInstance.SubwayStatus
+  alias Screens.V2.WidgetInstance.SubwayStatus
   alias Screens.V2.WidgetInstance.SubwayStatus.Serialize.GreenLine
   alias Screens.V2.WidgetInstance.SubwayStatus.Serialize.RedLine
   alias Screens.V2.WidgetInstance.SubwayStatus.Serialize.RoutePill
   alias Screens.V2.WidgetInstance.SubwayStatus.Serialize.Utils
 
+  @max_rows 5
+  @max_rows_per_line 2
   @mbta_alerts_url "mbta.com/alerts"
   @normal_service_status "Normal Service"
 
@@ -41,10 +44,7 @@ defmodule Screens.V2.WidgetInstance.SubwayStatus.Serialize do
 
   @spec consolidate_alert_sections(serialized_response()) :: serialized_response()
   def consolidate_alert_sections(sections) do
-    # Subway Status section supports a maximum of 5 status rows
-    total_rows = count_total_rows(sections)
-
-    if total_rows > 5 do
+    if count_total_rows(sections) > @max_rows do
       consolidate_sections(sections)
     else
       sections
@@ -67,7 +67,8 @@ defmodule Screens.V2.WidgetInstance.SubwayStatus.Serialize do
         {:green, _section} ->
           {color, section}
 
-        {_color, %{type: :contracted, alerts: alerts}} when length(alerts) == 2 ->
+        {_color, %{type: :contracted, alerts: alerts}}
+        when length(alerts) == @max_rows_per_line ->
           # Consolidate 2-row sections to a single summary row
           {color, consolidate_two_row_section(section, color)}
 
@@ -195,6 +196,14 @@ defmodule Screens.V2.WidgetInstance.SubwayStatus.Serialize do
 
         [alert] ->
           [serialize_alert_with_route_pill(alert, route_id)]
+
+        [
+          %{alert: %Alert{effect: :station_closure}} = alert1,
+          %{alert: %Alert{effect: :station_closure}} = alert2
+        ] ->
+          subway_alert_with_combined_ies = consolidate_ies_under_one_subway_alert(alert1, alert2)
+
+          [serialize_alert_with_route_pill(subway_alert_with_combined_ies, route_id)]
 
         [alert1, alert2] ->
           [serialize_alert_with_route_pill(alert1, route_id), serialize_alert(alert2, route_id)]
@@ -369,6 +378,22 @@ defmodule Screens.V2.WidgetInstance.SubwayStatus.Serialize do
       ) do
     location = Utils.get_location(informed_entities, route_id)
     %{status: "Service Change", location: location}
+  end
+
+  @spec consolidate_ies_under_one_subway_alert(
+          SubwayStatus.SubwayStatusAlert.t(),
+          SubwayStatus.SubwayStatusAlert.t()
+        ) :: SubwayStatus.SubwayStatusAlert.t()
+  def consolidate_ies_under_one_subway_alert(
+        %{alert: %{} = alert1},
+        %{alert: %{} = alert2}
+      ) do
+    %SubwayStatus.SubwayStatusAlert{
+      alert: %{
+        alert1
+        | informed_entities: alert1.informed_entities ++ alert2.informed_entities
+      }
+    }
   end
 
   @spec serialize_alert_summary(non_neg_integer(), route_pill()) :: alert()

--- a/lib/screens/v2/widget_instance/subway_status/serialize/green_line.ex
+++ b/lib/screens/v2/widget_instance/subway_status/serialize/green_line.ex
@@ -50,6 +50,20 @@ defmodule Screens.V2.WidgetInstance.SubwayStatus.Serialize.GreenLine do
             ]
           }
 
+        {[
+           %{alert: %{effect: :station_closure}} = trunk_alert1,
+           %{alert: %{effect: :station_closure}} = trunk_alert2
+         ], []} ->
+          trunk_alert1
+          |> Serialize.consolidate_ies_under_one_subway_alert(trunk_alert2)
+          |> serialize_trunk_alert()
+          |> then(fn combined_alert ->
+            %{
+              type: :contracted,
+              alerts: [combined_alert]
+            }
+          end)
+
         {[trunk_alert1, trunk_alert2], []} ->
           %{
             type: :contracted,
@@ -90,6 +104,24 @@ defmodule Screens.V2.WidgetInstance.SubwayStatus.Serialize.GreenLine do
             )
           ]
         }
+
+      [
+        %{alert: %Alert{effect: :station_closure}} = alert1,
+        %{alert: %Alert{effect: :station_closure}} = alert2
+      ] ->
+        alert1
+        |> Serialize.consolidate_ies_under_one_subway_alert(alert2)
+        |> then(fn combined_alert ->
+          %{
+            type: :contracted,
+            alerts: [
+              serialize_gl_branch_alert(
+                combined_alert,
+                Utils.alert_routes(combined_alert)
+              )
+            ]
+          }
+        end)
 
       [alert1, alert2] ->
         %{

--- a/lib/screens/v2/widget_instance/subway_status/serialize/red_line.ex
+++ b/lib/screens/v2/widget_instance/subway_status/serialize/red_line.ex
@@ -26,25 +26,44 @@ defmodule Screens.V2.WidgetInstance.SubwayStatus.Serialize.RedLine do
   end
 
   defp serialize_mattapan_only(grouped_alerts) do
-    # Serialzes row(s) for the Mattapan branch
-    mattapan_alerts = Map.get(grouped_alerts, "Mattapan", [])
+    grouped_alerts
+    |> Map.get("Mattapan", [])
+    |> serialize_mattapan_only_station_closures()
+  end
 
-    if length(mattapan_alerts) < 3 do
+  defp serialize_mattapan_only_station_closures([
+         %{alert: %{effect: :station_closure}} = alert1,
+         %{alert: %{effect: :station_closure}} = alert2
+       ]) do
+    alert1
+    |> Serialize.consolidate_ies_under_one_subway_alert(alert2)
+    |> serialize_rl_branch_alert()
+    |> then(fn combined_alert ->
       %{
         type: :contracted,
-        alerts: Enum.map(mattapan_alerts, &serialize_rl_branch_alert/1)
+        alerts: [combined_alert]
       }
-    else
-      %{
-        type: :contracted,
-        alerts: [
-          Serialize.serialize_alert_summary(
-            length(mattapan_alerts),
-            RoutePill.serialize_rl_mattapan_pill()
-          )
-        ]
-      }
-    end
+    end)
+  end
+
+  defp serialize_mattapan_only_station_closures(mattapan_alerts)
+       when is_list(mattapan_alerts) and length(mattapan_alerts) < 3 do
+    %{
+      type: :contracted,
+      alerts: Enum.map(mattapan_alerts, &serialize_rl_branch_alert/1)
+    }
+  end
+
+  defp serialize_mattapan_only_station_closures(mattapan_alerts) do
+    %{
+      type: :contracted,
+      alerts: [
+        Serialize.serialize_alert_summary(
+          length(mattapan_alerts),
+          RoutePill.serialize_rl_mattapan_pill()
+        )
+      ]
+    }
   end
 
   defp serialize_red_and_mattapan(red_alerts, mattapan_alerts) do

--- a/test/screens/v2/widget_instance/subway_status_test.exs
+++ b/test/screens/v2/widget_instance/subway_status_test.exs
@@ -182,6 +182,149 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
       assert expected == WidgetInstance.serialize(instance)
     end
 
+    test "consolidates two station closure alerts with one stop each as '2 Stops Skipped'" do
+      instance = %SubwayStatus{
+        subway_alerts:
+          subway_alerts([
+            %Alert{
+              effect: :station_closure,
+              informed_entities: [
+                ie(route: "Blue", stop_id: "place-aport")
+              ]
+            },
+            %Alert{
+              effect: :station_closure,
+              informed_entities: [
+                ie(route: "Blue", stop_id: "place-aqucl")
+              ]
+            }
+          ])
+      }
+
+      expected = %{
+        @normal_service
+        | blue: %{
+            type: :extended,
+            alert: %{
+              location: %{full: "Airport and Aquarium", abbrev: "Airport and Aquarium"},
+              route_pill: %{type: :text, text: "BL", color: :blue},
+              station_count: 2,
+              status: "2 Stops Skipped"
+            }
+          }
+      }
+
+      assert expected == WidgetInstance.serialize(instance)
+    end
+
+    test "consolidates two station closure alerts with the same stops as 'Stop Skipped'" do
+      instance = %SubwayStatus{
+        subway_alerts:
+          subway_alerts([
+            %Alert{
+              effect: :station_closure,
+              informed_entities: [
+                ie(route: "Blue", stop_id: "place-aqucl")
+              ]
+            },
+            %Alert{
+              effect: :station_closure,
+              informed_entities: [
+                ie(route: "Blue", stop_id: "place-aqucl")
+              ]
+            }
+          ])
+      }
+
+      expected = %{
+        @normal_service
+        | blue: %{
+            type: :extended,
+            alert: %{
+              location: %{full: "Aquarium", abbrev: "Aquarium"},
+              route_pill: %{type: :text, text: "BL", color: :blue},
+              station_count: 1,
+              status: "Stop Skipped"
+            }
+          }
+      }
+
+      assert expected == WidgetInstance.serialize(instance)
+    end
+
+    test "consolidates two station closure alerts with same GL Branch as '2 Stops Skipped'" do
+      instance = %SubwayStatus{
+        subway_alerts:
+          subway_alerts([
+            %Alert{
+              effect: :station_closure,
+              informed_entities: [
+                ie(route: "Green-C", stop_id: "place-hwsst")
+              ]
+            },
+            %Alert{
+              effect: :station_closure,
+              informed_entities: [
+                ie(route: "Green-C", stop_id: "place-kntst")
+              ]
+            }
+          ])
+      }
+
+      expected = %{
+        @normal_service
+        | green: %{
+            alert: %{
+              status: "2 Stops Skipped",
+              location: %{full: "Hawes Street and Kent Street", abbrev: "Hawes St and Kent St"},
+              route_pill: %{type: :text, text: "GL", color: :green, branches: [:c]},
+              station_count: 2
+            },
+            type: :extended
+          }
+      }
+
+      assert expected == WidgetInstance.serialize(instance)
+    end
+
+    test "consolidates two station closure alerts on GL trunk as '2 Stops Skipped'" do
+      instance = %SubwayStatus{
+        subway_alerts:
+          subway_alerts([
+            %Alert{
+              effect: :station_closure,
+              informed_entities: [
+                ie(route: "Green", stop_id: "place-gover")
+              ]
+            },
+            %Alert{
+              effect: :station_closure,
+              informed_entities: [
+                ie(route: "Green", stop_id: "place-pktrm")
+              ]
+            }
+          ])
+      }
+
+      expected = %{
+        @normal_service
+        | green: %{
+            alert: %{
+              status: "2 Stops Skipped",
+              location: %{
+                full: "Government Center and Park Street",
+                abbrev: "Gov't Ctr and Park St"
+              },
+              route_pill: %{type: :text, text: "GL", color: :green},
+              station_count: 2
+            },
+            type: :extended
+          }
+      }
+
+      assert expected == WidgetInstance.serialize(instance)
+    end
+
     test "handles 2 alerts, 1 non-GL route" do
       instance = %SubwayStatus{
         subway_alerts:
@@ -1025,6 +1168,76 @@ defmodule Screens.V2.WidgetInstance.SubwayStatusTest do
                 route_pill: %{type: :text, text: "RL", color: :red, branches: [:m]}
               }
             ]
+          }
+      }
+
+      assert expected == WidgetInstance.serialize(instance)
+    end
+
+    test "consolidates two station closure alerts on RL trunk as '2 Stops Skipped'" do
+      instance = %SubwayStatus{
+        subway_alerts:
+          subway_alerts([
+            %Alert{
+              effect: :station_closure,
+              informed_entities: [
+                ie(route: "Red", stop_id: "place-portr")
+              ]
+            },
+            %Alert{
+              effect: :station_closure,
+              informed_entities: [
+                ie(route: "Red", stop_id: "place-davis")
+              ]
+            }
+          ])
+      }
+
+      expected = %{
+        @normal_service
+        | red: %{
+            alert: %{
+              status: "2 Stops Skipped",
+              location: %{full: "Porter and Davis", abbrev: "Porter and Davis"},
+              route_pill: %{type: :text, text: "RL", color: :red},
+              station_count: 2
+            },
+            type: :extended
+          }
+      }
+
+      assert expected == WidgetInstance.serialize(instance)
+    end
+
+    test "consolidates two Mattapan station closure alerts with the same stops as '2 Stops Skipped'" do
+      instance = %SubwayStatus{
+        subway_alerts:
+          subway_alerts([
+            %Alert{
+              effect: :station_closure,
+              informed_entities: [
+                ie(route: "Mattapan", stop_id: "place-valrd")
+              ]
+            },
+            %Alert{
+              effect: :station_closure,
+              informed_entities: [
+                ie(route: "Mattapan", stop_id: "place-capst")
+              ]
+            }
+          ])
+      }
+
+      expected = %{
+        @normal_service
+        | red: %{
+            type: :extended,
+            alert: %{
+              status: "2 Stops Skipped",
+              location: %{full: "Valley Road and Capen Street", abbrev: "Valley Rd and Capen St"},
+              route_pill: %{type: :text, text: "RL", color: :red, branches: [:m]},
+              station_count: 2
+            }
           }
       }
 


### PR DESCRIPTION


**Asana task**: ["Stops Skipped" consolidation for Subway Status](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1215144952667263?focus=true)

Description

Update the alert consolidation logic for station closures to collapse alerts on the same route to a single row. Prior to this commit, station closures that spanned multiple alerts on the same route could result in two rows per route. This could cause one or both rows to display "mbta.com/alerts", when there was room to display the station names.

This commit does not prevent "2 Stops Skipped mbta.com/alerts" from being displayed in every possible case. Multiple routes may have alerts, causing consolidation logic to fallback to the above text for a single row. This commit does not change existing logic to prioritize showing two green line alerts when there are multiple alerts over multiple lines.

- [X] Tests added?

**Screenshots**

2 GL Branch Stations Skipped (2 Examples)
<img width="553" height="317" alt="Screenshot 2026-06-23 at 09 02 24" src="https://github.com/user-attachments/assets/5f4fbc37-c18a-40ae-9a73-9ac6a72178ac" />
<img width="553" height="317" alt="Screenshot 2026-06-23 at 09 05 24" src="https://github.com/user-attachments/assets/0f6a14d6-79e6-4d0c-a155-37e2755f4c53" />

<hr/>

2 Mattapan Stations Skipped
<img width="553" height="317" alt="Screenshot 2026-06-23 at 09 06 32" src="https://github.com/user-attachments/assets/b43ff920-891f-47f3-8613-36c95948fac8" />

<hr/>

1 RL, 1 Mattapan Stations Skipped (Not Consolidated)
<img width="553" height="317" alt="Screenshot 2026-06-23 at 09 07 18" src="https://github.com/user-attachments/assets/1e7fea84-6d5c-4b50-a542-4da898791ecf" />

<hr />

2 BL Stations Skipped
<img width="553" height="317" alt="Screenshot 2026-06-23 at 09 09 41" src="https://github.com/user-attachments/assets/621ee54a-1ce9-4f04-a7fd-32ed6009cb86" />

<hr/>

1 GL Trunk, 1 GL Branch Skipped (location set to mbta.com/info)
<img width="553" height="317" alt="Screenshot 2026-06-23 at 09 10 40" src="https://github.com/user-attachments/assets/9c94d155-a527-48d6-8955-d9e254008005" />
<img width="553" height="317" alt="Screenshot 2026-06-23 at 09 11 29" src="https://github.com/user-attachments/assets/3bb640c2-3ad9-4d25-bc2b-14e33dbdaae4" />

<hr/>

2 Separate GL Branches Skipped
<img width="553" height="317" alt="Screenshot 2026-06-23 at 09 12 41" src="https://github.com/user-attachments/assets/d34dff44-46bc-4a39-8d8a-b8f65911ead6" />

