### PR TITLE
perf: only fetch stop when needed in DUP alerts

### DIFF
--- a/lib/screens/v2/candidate_generator/dup/alerts.ex
+++ b/lib/screens/v2/candidate_generator/dup/alerts.ex
@@ -11,6 +11,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Alerts do
   alias Screens.V2.LocalizedAlert
   alias Screens.V2.WidgetInstance.{DupAlert, DupSpecialCaseAlert}
   alias ScreensConfig.Alerts, as: AlertsConfig
+  alias ScreensConfig.Header.{StopId, StopName}
   alias ScreensConfig.Screen
   alias ScreensConfig.Screen.Dup
 
@@ -21,50 +22,36 @@ defmodule Screens.V2.CandidateGenerator.Dup.Alerts do
   @stop injected(Stop)
   @location_context injected(LocationContext)
 
-  @doc """
-  Fetches alerts + related data from the API and transforms them to candidate
-  widgets for a DUP screen.
-  """
-  def alert_instances(config, now \\ DateTime.utc_now()) do
+  def alert_instances(screen, now \\ DateTime.utc_now())
+
+  def alert_instances(%Screen{app_params: %Dup{alerts: %AlertsConfig{stop_id: nil}}}, _now),
+    do: []
+
+  def alert_instances(
+        %Screen{app_params: %Dup{alerts: %AlertsConfig{stop_id: stop_id}}} = screen,
+        now
+      ) do
     # In this function:
     # - Fetch relevant alerts for all SUBWAY/LIGHT RAIL routes serving this stop
     # - Check for special cases. If there is one, just use that. Otherwise:
     # - Select one alert
     # - Create 3 candidate structs from the alert, one for each rotation
-    %Screen{app_params: %Dup{alerts: %AlertsConfig{stop_id: stop_id}, header: header_config}} =
-      config
 
-    if is_nil(stop_id) do
-      []
+    with {:ok, location_context} <- @location_context.fetch(Dup, stop_id, now),
+         route_ids <- LocationContext.route_ids(location_context),
+         {:ok, alerts} <- @alert.fetch(route_ids: route_ids) do
+      alerts
+      |> relevant_alerts(screen, location_context, now)
+      |> alert_special_cases(screen, location_context)
+      |> create_alert_widgets(screen, location_context)
     else
-      stop_name =
-        case header_config do
-          %{stop_id: stop_id} ->
-            case @stop.fetch_stop_name(stop_id) do
-              nil -> []
-              stop_name -> stop_name
-            end
-
-          %{stop_name: stop_name} ->
-            stop_name
-        end
-
-      with {:ok, location_context} <- @location_context.fetch(Dup, stop_id, now),
-           route_ids <- LocationContext.route_ids(location_context),
-           {:ok, alerts} <- @alert.fetch(route_ids: route_ids) do
-        alerts
-        |> relevant_alerts(config, location_context, now)
-        |> alert_special_cases(config, location_context)
-        |> create_alert_widgets(config, location_context, stop_name)
-      else
-        :error -> []
-      end
+      :error -> []
     end
   end
 
-  def relevant_alerts(alerts, config, location_context, now) do
+  def relevant_alerts(alerts, screen, location_context, now) do
     Enum.filter(alerts, fn alert ->
-      relevant_effect?(alert, config) and Alert.happening_now?(alert, now) and
+      relevant_effect?(alert, screen) and Alert.happening_now?(alert, now) and
         relevant_location?(alert, location_context) and
         not directional_shuttle_or_suspension?(alert)
     end)
@@ -87,23 +74,35 @@ defmodule Screens.V2.CandidateGenerator.Dup.Alerts do
     Enum.min_by(alerts, &{effect_key(&1.effect), -&1.severity, -String.to_integer(&1.id)})
   end
 
-  defp create_alert_widgets({:special, widgets}, _, _, _), do: widgets
+  defp create_alert_widgets({:special, widgets}, _screen, _location_context), do: widgets
 
-  defp create_alert_widgets({:normal, alerts}, config, location_context, stop_name) do
+  defp create_alert_widgets({:normal, alerts}, screen, location_context) do
     alert = choose_alert(alerts)
 
     if is_nil(alert) do
       []
     else
+      stop_name = fetch_stop_name(screen)
+
       for rotation_index <- [:zero, :one, :two] do
         %DupAlert{
-          screen: config,
+          screen: screen,
           alert: alert,
           location_context: location_context,
           rotation_index: rotation_index,
           stop_name: stop_name
         }
       end
+    end
+  end
+
+  defp fetch_stop_name(%Screen{app_params: %Dup{header: %StopName{stop_name: name}}}), do: name
+
+  defp fetch_stop_name(%Screen{app_params: %Dup{header: %StopId{stop_id: id}}}) do
+    case @stop.fetch_stop_name(id) do
+      # Failure to fetch here, though unlikely, shouldn't block the widget from being displayed
+      nil -> "Alert"
+      stop_name -> stop_name
     end
   end
 

--- a/test/screens/v2/candidate_generator/dup/alert_test.exs
+++ b/test/screens/v2/candidate_generator/dup/alert_test.exs
@@ -8,7 +8,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.AlertTest do
   alias Screens.Stops.Stop
   alias Screens.V2.CandidateGenerator.Dup.Alerts
   alias ScreensConfig.Alerts, as: AlertsConfig
-  alias ScreensConfig.Screen
+  alias ScreensConfig.{Header, Screen}
   alias ScreensConfig.Screen.Dup
 
   import Mox
@@ -53,7 +53,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.AlertTest do
       primary_departures: [],
       secondary_departures: [],
       alerts: %AlertsConfig{stop_id: @stop_id},
-      header: %{stop_name: "Back Bay"}
+      header: %Header.StopName{stop_name: "Back Bay"}
     }
   }
 

--- a/test/screens/v2/widget_instance/dup_special_case_alert_test.exs
+++ b/test/screens/v2/widget_instance/dup_special_case_alert_test.exs
@@ -7,6 +7,7 @@ defmodule Screens.V2.WidgetInstance.DupSpecialCaseAlertTest do
   alias Screens.V2.WidgetInstance.DupAlert
   alias Screens.V2.WidgetInstance.DupSpecialCaseAlert
   alias ScreensConfig.{Alerts, Departures, FreeTextLine, Screen}
+  alias ScreensConfig.Header
   alias ScreensConfig.Screen.Dup
 
   import Screens.TestSupport.InformedEntityBuilder
@@ -149,10 +150,6 @@ defmodule Screens.V2.WidgetInstance.DupSpecialCaseAlertTest do
     expect(@alert, :fetch, fn _route_ids -> {:ok, alerts} end)
   end
 
-  defp expect_stop_name do
-    expect(@stop, :fetch_stop_name, fn _ -> "Test" end)
-  end
-
   defp expect_location_context do
     expect(@location_context, :fetch, fn _, stop_id, _ ->
       tagged_stop_sequences = tagged_stop_sequences(stop_id)
@@ -173,7 +170,6 @@ defmodule Screens.V2.WidgetInstance.DupSpecialCaseAlertTest do
   describe "dup alert_instances/6 > serialize/1" do
     setup do
       stub(@alert, :fetch, fn _ -> [] end)
-      expect_stop_name()
       expect_location_context()
 
       config_kenmore =
@@ -182,7 +178,7 @@ defmodule Screens.V2.WidgetInstance.DupSpecialCaseAlertTest do
             primary_departures: struct(Departures),
             secondary_departures: struct(Departures),
             alerts: %Alerts{stop_id: "place-kencl"},
-            header: %{stop_id: "place-kencl"}
+            header: %Header.StopId{stop_id: "place-kencl"}
           },
           app_id: :dup_v2
         })
@@ -193,7 +189,7 @@ defmodule Screens.V2.WidgetInstance.DupSpecialCaseAlertTest do
             primary_departures: struct(Departures),
             secondary_departures: struct(Departures),
             alerts: %Alerts{stop_id: "place-wtcst"},
-            header: %{stop_id: "place-wtcst"}
+            header: %Header.StopId{stop_id: "place-wtcst"}
           },
           app_id: :dup_v2
         })
@@ -669,6 +665,7 @@ defmodule Screens.V2.WidgetInstance.DupSpecialCaseAlertTest do
       alerts = [context.kenmore_inside_alert]
 
       expect_alerts(["Green-B", "Green-C", "Green-D"], alerts)
+      expect(@stop, :fetch_stop_name, fn _ -> "Test" end)
 
       actual_widgets = DupAlerts.alert_instances(context.config_kenmore, context.now)
 


### PR DESCRIPTION
The DUP Alert widget generator would always make an API call to fetch the name of the screen's stop (if it was configured for alerts and had a `StopId` header), even if no alert widgets were ultimately generated or if the fetched name went unused due to a special case. Move this fetching to be done "just in time" to save a request in the common case where there are no alerts displayed.