### PR TITLE
refactor: remove include option on `Stop` fetch

### DIFF
--- a/lib/screens/stops/stop.ex
+++ b/lib/screens/stops/stop.ex
@@ -81,13 +81,6 @@ defmodule Screens.Stops.Stop do
     end
   end
 
-  @spec fetch_subway_platforms_for_stop(id()) :: [t()]
-  def fetch_subway_platforms_for_stop(stop_id) do
-    {:ok, [%__MODULE__{child_stops: child_stops}]} = fetch(%{ids: [stop_id]}, true)
-
-    filter_subway_platforms(child_stops)
-  end
-
   @spec filter_subway_platforms(list(t())) :: list(t())
   def filter_subway_platforms(stops) do
     Enum.filter(stops, fn

--- a/lib/screens/stops/stop.ex
+++ b/lib/screens/stops/stop.ex
@@ -41,27 +41,18 @@ defmodule Screens.Stops.Stop do
           optional(:route_types) => [RouteType.t()]
         }
 
+  @includes ~w[
+    child_stops connecting_stops parent_station.child_stops parent_station.connecting_stops
+  ]
+
   @callback fetch(params()) :: {:ok, [t()]} | :error
   @callback fetch(params(), boolean()) :: {:ok, [t()]} | :error
-  def fetch(params, include_related? \\ false, get_json_fn \\ &V3Api.get_json/2) do
+  def fetch(params, get_json_fn \\ &V3Api.get_json/2) do
     encoded_params =
       params
       |> Enum.flat_map(&encode_param/1)
       |> Map.new()
-      |> then(fn params ->
-        if include_related? do
-          Map.put(
-            params,
-            "include",
-            Enum.join(
-              ~w[child_stops connecting_stops parent_station.child_stops parent_station.connecting_stops],
-              ","
-            )
-          )
-        else
-          params
-        end
-      end)
+      |> Map.put("include", Enum.join(@includes, ","))
 
     case get_json_fn.("stops", encoded_params) do
       {:ok, response} -> {:ok, V3Api.Parser.parse(response)}

--- a/lib/screens/v2/rds.ex
+++ b/lib/screens/v2/rds.ex
@@ -189,7 +189,7 @@ defmodule Screens.V2.RDS do
 
   @spec fetch_child_stops([Stop.id()]) :: {:ok, [Stop.t()]} | :error
   defp fetch_child_stops(stop_ids) do
-    with {:ok, stops} <- @stop.fetch(%{ids: stop_ids}, _include_related? = true) do
+    with {:ok, stops} <- @stop.fetch(%{ids: stop_ids}) do
       stops_by_id = Map.new(stops, fn %Stop{id: id} = stop -> {id, stop} end)
 
       child_stops =

--- a/test/screens/stops/stop_test.exs
+++ b/test/screens/stops/stop_test.exs
@@ -132,7 +132,7 @@ defmodule Screens.Stops.StopTest do
                    }
                  }
                ]
-             } = Stop.fetch(%{ids: ~w[s1 s2 p1 p2 c3]}, true, get_json_fn)
+             } = Stop.fetch(%{ids: ~w[s1 s2 p1 p2 c3]}, get_json_fn)
     end
 
     test "parsing prevents connecting stops from loading more connecting stops" do
@@ -182,7 +182,7 @@ defmodule Screens.Stops.StopTest do
                    vehicle_type: :bus
                  }
                ]
-             } = Stop.fetch(%{ids: ~w[s1 s2]}, true, get_json_fn)
+             } = Stop.fetch(%{ids: ~w[s1 s2]}, get_json_fn)
     end
   end
 end

--- a/test/screens/v2/rds_test.exs
+++ b/test/screens/v2/rds_test.exs
@@ -37,7 +37,7 @@ defmodule Screens.V2.RDSTest do
     stub(@headways, :get, fn _, _ -> nil end)
     stub(@route_pattern, :fetch, fn _ -> {:ok, []} end)
     stub(@schedule, :fetch, fn _, _ -> {:ok, []} end)
-    stub(@stop, :fetch, fn %{ids: ids}, true -> {:ok, Enum.map(ids, &stop/1)} end)
+    stub(@stop, :fetch, fn %{ids: ids} -> {:ok, Enum.map(ids, &stop/1)} end)
     stub(@config_cache, :disabled_modes, fn -> [] end)
     stub(@last_trip, :last_trip_departure_times, fn _ -> [] end)
     :ok
@@ -162,7 +162,7 @@ defmodule Screens.V2.RDSTest do
   end
 
   defp expect_standard_stations(stop_ids) do
-    expect(@stop, :fetch, fn %{ids: ^stop_ids}, true ->
+    expect(@stop, :fetch, fn %{ids: ^stop_ids} ->
       {:ok, [station("s0", ~w[sA sB]), station("s1", ~w[sC])]}
     end)
   end
@@ -698,7 +698,7 @@ defmodule Screens.V2.RDSTest do
 
       expect(@schedule, :fetch, fn %{stop_ids: ^stop_ids}, _now -> {:ok, all_schedules} end)
 
-      expect(@stop, :fetch, fn %{ids: ^stop_ids}, true ->
+      expect(@stop, :fetch, fn %{ids: ^stop_ids} ->
         {:ok, [station("70061", ~w[70061])]}
       end)
 
@@ -1147,7 +1147,7 @@ defmodule Screens.V2.RDSTest do
     test "returns :error when stop fetch fails" do
       stop_ids = ~w[s0 s1]
 
-      expect(@stop, :fetch, fn %{ids: ^stop_ids}, true -> :error end)
+      expect(@stop, :fetch, fn %{ids: ^stop_ids} -> :error end)
 
       departures = %Departures{
         sections: [


### PR DESCRIPTION
Reducing stop fetching from two possible sets of includes to one improves the potential for cache reuse, in particular between RDS and `StopId` headers in the common case where the screen shows departures filtered by the same parent station as the one used for the header. This will cause higher cache memory use for screens that don't otherwise use Stop fetching, but we currently have memory to spare.