### PR TITLE
chore: revert connection pool change and increase static cache limit

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -502,7 +502,7 @@ config :screens,
 
 config :screens,
        Screens.V3Api.Cache.Static,
-       Keyword.merge(v3_api_cache_options, allocated_memory: 250 * 1024 * 1024)
+       Keyword.merge(v3_api_cache_options, allocated_memory: 300 * 1024 * 1024)
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/lib/screens/application.ex
+++ b/lib/screens/application.ex
@@ -12,7 +12,7 @@ defmodule Screens.Application do
         {Screens.Cache.Owner, engine_module: Screens.Config.Cache.Engine},
         {Screens.Cache.Owner, engine_module: Screens.SignsUiConfig.Cache.Engine},
         {Finch,
-         name: Screens.V3Api.Finch, pools: %{default: [size: 200, start_pool_metrics?: true]}},
+         name: Screens.V3Api.Finch, pools: %{default: [size: 100, start_pool_metrics?: true]}},
         Screens.V3Api.Cache.Realtime,
         Screens.V3Api.Cache.Static,
         Screens.LastTrip.Cache,


### PR DESCRIPTION
### revert: V3 API connection pool size change

Set this back to 100 (increased to 200 in 0bf16fa). We are currently almost never using more than 50 connections in production; it turned out that changing the minimum instance count from 2 to 3 was much more impactful, and just 2 instances could not effectively make use of the larger pool to relieve performance issues.

### chore: increase V3 API static cache limit

The static data cache is consistently using all the memory we give it, our instances have memory to spare, and we've recently made some changes (in particular shipping RDS departures on DUPs) that result in more static data fetching. Increase the allocation from 250MB to 300MB.