### PR TITLE
refactor: use "now" consistently for alert display

### DIFF
--- a/lib/screens/alerts/alert.ex
+++ b/lib/screens/alerts/alert.ex
@@ -256,9 +256,8 @@ defmodule Screens.Alerts.Alert do
     ]
   end
 
-  def happening_now?(%{active_period: aps}, now \\ DateTime.utc_now()) do
-    Enum.any?(aps, &in_active_period(&1, now))
-  end
+  def active?(%__MODULE__{active_period: periods}, datetime),
+    do: Enum.any?(periods, &in_active_period(&1, datetime))
 
   defp in_active_period({start_t, nil}, t) do
     DateTime.compare(t, start_t) in [:gt, :eq]

--- a/lib/screens/v2/candidate_generator/dup/alerts.ex
+++ b/lib/screens/v2/candidate_generator/dup/alerts.ex
@@ -51,7 +51,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Alerts do
 
   def relevant_alerts(alerts, screen, location_context, now) do
     Enum.filter(alerts, fn alert ->
-      relevant_effect?(alert, screen) and Alert.happening_now?(alert, now) and
+      relevant_effect?(alert, screen) and Alert.active?(alert, now) and
         relevant_location?(alert, location_context) and
         not directional_shuttle_or_suspension?(alert)
     end)

--- a/lib/screens/v2/candidate_generator/pre_fare/elevator_status.ex
+++ b/lib/screens/v2/candidate_generator/pre_fare/elevator_status.ex
@@ -19,13 +19,13 @@ defmodule Screens.V2.CandidateGenerator.PreFare.ElevatorStatus do
             elevator_status: %ScreensConfig.ElevatorStatus{parent_station_id: station_id}
           }
         },
-        _now
+        now
       ) do
     {:ok, alerts} = @alert.fetch(activities: [:using_wheelchair], include_all?: true)
 
     active_closures =
       alerts
-      |> Enum.filter(&Alert.happening_now?/1)
+      |> Enum.filter(&Alert.active?(&1, now))
       |> Enum.flat_map(fn alert ->
         case Closure.from_alert(alert) do
           {:ok, closure} -> [closure]

--- a/lib/screens/v2/candidate_generator/widgets/alerts.ex
+++ b/lib/screens/v2/candidate_generator/widgets/alerts.ex
@@ -75,7 +75,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.Alerts do
     end
 
     alerts
-    |> Stream.filter(&Alert.happening_now?(&1, now))
+    |> Stream.filter(&Alert.active?(&1, now))
     |> Stream.filter(&(&1.effect in @relevant_effects))
     |> Stream.filter(&Enum.any?(&1.informed_entities, relevant_ie?))
     |> Enum.to_list()

--- a/lib/screens/v2/candidate_generator/widgets/reconstructed_alert.ex
+++ b/lib/screens/v2/candidate_generator/widgets/reconstructed_alert.ex
@@ -71,7 +71,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlert do
       {priority_alert_groups, other_alert_groups} =
         alerts
         |> Enum.filter(
-          &(Alert.happening_now?(&1, now) and relevant_direction?(&1, stop_id, stop_sequences))
+          &(Alert.active?(&1, now) and relevant_direction?(&1, stop_id, stop_sequences))
         )
         |> Alert.consolidate_whole_route_delays()
         |> Enum.group_by(fn alert ->

--- a/lib/screens/v2/candidate_generator/widgets/subway_status.ex
+++ b/lib/screens/v2/candidate_generator/widgets/subway_status.ex
@@ -11,7 +11,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.SubwayStatus do
 
     relevant_alerts =
       alerts
-      |> Enum.filter(&(relevant_alert?(&1) and Alert.happening_now?(&1, now)))
+      |> Enum.filter(&(relevant_alert?(&1) and Alert.active?(&1, now)))
       |> Alert.consolidate_whole_route_delays()
       |> Enum.map(&%SubwayStatus.SubwayStatusAlert{alert: &1})
 

--- a/lib/screens/v2/rds.ex
+++ b/lib/screens/v2/rds.ex
@@ -162,7 +162,7 @@ defmodule Screens.V2.RDS do
            params_struct |> Map.put(:typicality, 1) |> @route_pattern.fetch(),
          {:ok, child_stops} <- fetch_child_stops(stop_ids),
          {:ok, schedules} <- @schedule.fetch(params_struct, Util.service_date(now)),
-         {:ok, alerts} <- fetch_relevant_alerts(stop_ids),
+         {:ok, alerts} <- fetch_relevant_alerts(stop_ids, now),
          {:ok, departures} <-
            params_struct |> @departure.fetch(now: now, include_scheduled_cancelled?: true) do
       case create_routes_for_section(departures, schedules, typical_patterns, params) do
@@ -442,10 +442,10 @@ defmodule Screens.V2.RDS do
   defp reject_disabled_modes(all_routes, disabled_modes),
     do: Enum.reject(all_routes, fn route -> route.type in disabled_modes end)
 
-  @spec fetch_relevant_alerts([Stop.id()]) :: {:ok, [Alert.t()]} | :error
-  defp fetch_relevant_alerts(stop_ids) do
+  @spec fetch_relevant_alerts([Stop.id()], DateTime.t()) :: {:ok, [Alert.t()]} | :error
+  defp fetch_relevant_alerts(stop_ids, now) do
     with {:ok, alerts} <- @alert.fetch(activities: [:board], stop_ids: stop_ids) do
-      {:ok, Enum.filter(alerts, &(Alert.happening_now?(&1) and relevant_alert_effect?(&1)))}
+      {:ok, Enum.filter(alerts, &(Alert.active?(&1, now) and relevant_alert_effect?(&1)))}
     end
   end
 

--- a/lib/screens/v2/widget_instance/evergreen_content.ex
+++ b/lib/screens/v2/widget_instance/evergreen_content.ex
@@ -100,7 +100,7 @@ defmodule Screens.V2.WidgetInstance.EvergreenContent do
         now: now
       }) do
     Enum.any?(alerts, fn %Alert{id: id} = alert ->
-      id in alert_ids and Alert.happening_now?(alert, now)
+      id in alert_ids and Alert.active?(alert, now)
     end)
   end
 
@@ -171,7 +171,7 @@ defmodule Screens.V2.WidgetInstance.EvergreenContent do
           schedule: %AlertSchedule{alert_ids: alert_ids, suppress_alert_widgets: true}
         }) do
       alerts
-      |> Enum.filter(&(&1.id in alert_ids and Alert.happening_now?(&1, now)))
+      |> Enum.filter(&(&1.id in alert_ids and Alert.active?(&1, now)))
       |> Enum.map(& &1.id)
     end
 


### PR DESCRIPTION
The RDS and Elevator Status generators did not pass their "now" value to `Alert.happening_now?`. This would mostly not have any impact on screens currently, but we should be consistent about this, given we'd like to eventually add a "time travel" preview function for upcoming alerts.

Fix these and also:

* make this function require a datetime instead of being optional, so we can't forget to do this in the future
* rename it to better align with this (that there is no assumed "now"; the datetime you pass in could be anything, it might not be "now")