### PR TITLE
feat: Process BE headsign abbreviations for DUP departures

### DIFF
--- a/assets/src/components/departures/destination.tsx
+++ b/assets/src/components/departures/destination.tsx
@@ -7,6 +7,7 @@ const abbreviate = (headsign: string): string => {
 
 type Destination = {
   headsign: string;
+  abbreviations?: string[];
   variation?: string;
 };
 

--- a/assets/src/components/dup/departures/destination.tsx
+++ b/assets/src/components/dup/departures/destination.tsx
@@ -56,6 +56,7 @@ const RenderedDestination = ({ parts, index1, index2, classModifier }) => {
 
 const Destination: ComponentType<DupDestination> = ({
   headsign,
+  abbreviations,
   classModifier,
 }) => {
   const firstLineRef = useRef<HTMLDivElement>(null);
@@ -65,11 +66,16 @@ const Destination: ComponentType<DupDestination> = ({
 
   const [index1, setIndex1] = useState(parts.length);
   const [index2, setIndex2] = useState(parts.length);
-  const [abbreviate, setAbbreviate] = useState(false);
+  const [abbreviationIndex, setAbbreviationIndex] = useState(-1);
   const [phase, setPhase] = useState(PHASES.ONE_LINE_FULL);
 
-  if (abbreviate) {
-    parts = parts.map((p) => ABBREVIATIONS[p] || p);
+  if (abbreviationIndex >= 0) {
+    // abbreviationIndex
+    if (abbreviations && abbreviations.length > abbreviationIndex) {
+      parts = abbreviations[abbreviationIndex].split(" ");
+    } else {
+      parts = parts.map((part) => ABBREVIATIONS[part] || part);
+    }
   }
 
   /* eslint-disable react-hooks/set-state-in-effect --
@@ -85,6 +91,7 @@ const Destination: ComponentType<DupDestination> = ({
     if (firstLineRef.current && secondLineRef.current) {
       const firstLineFits = !hasOverflowX(firstLineRef.current);
       const secondLineFits = !hasOverflowX(secondLineRef.current);
+      const hasAbbreviations = abbreviations && abbreviations.length > 0;
 
       switch (phase) {
         case PHASES.ONE_LINE_FULL:
@@ -92,7 +99,7 @@ const Destination: ComponentType<DupDestination> = ({
           if (firstLineFits) {
             setPhase(PHASES.DONE);
           } else {
-            setAbbreviate(true);
+            setAbbreviationIndex(abbreviationIndex + 1);
             setPhase(PHASES.ONE_LINE_ABBREV);
           }
           break;
@@ -102,8 +109,11 @@ const Destination: ComponentType<DupDestination> = ({
           if (firstLineFits) {
             setPhase(PHASES.DONE);
           } else {
-            setAbbreviate(false);
-            setPhase(PHASES.TWO_LINES_FULL);
+            setAbbreviationIndex(abbreviationIndex + 1);
+            if (!abbreviations || abbreviations.length <= abbreviationIndex) {
+              setPhase(PHASES.TWO_LINES_FULL);
+              setAbbreviationIndex(-1);
+            }
           }
           break;
 
@@ -118,7 +128,7 @@ const Destination: ComponentType<DupDestination> = ({
             } else {
               setIndex1(parts.length);
               setIndex2(parts.length);
-              setAbbreviate(true);
+              setAbbreviationIndex(0);
               setPhase(PHASES.TWO_LINES_ABBREV);
             }
           }
@@ -133,7 +143,17 @@ const Destination: ComponentType<DupDestination> = ({
           } else if (!secondLineFits && index2 > index1 + 1) {
             // Find position of second line break
             setIndex2((n) => n - 1);
+          } else if (
+            (!firstLineFits || !secondLineFits) &&
+            hasAbbreviations &&
+            abbreviations.length > abbreviationIndex + 1
+          ) {
+            // If we can't fit on two lines, try abbreviating further
+            setIndex1(parts.length);
+            setIndex2(parts.length);
+            setAbbreviationIndex(abbreviationIndex + 1);
           } else {
+            // If we can't fit on two lines, just show the first two words and an ellipsis.
             setPhase(PHASES.DONE);
           }
           break;


### PR DESCRIPTION
**Asana task**: [Screens Abbreviation Logic](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1213973277663100?focus=true)

To move all screens onto a new shared abbreviation system, I’m planning to do this overall change in three parts to avoid breaking DUP application behavior in production. 
1. Update DUP FE to interpret both BE abbreviations and old system. Once this is merged, deploy the package to DUPs
2. Pass headsign abbreviations from the BE
3. Remove old system from the DUP FE and deploy a final package to DUPs. 

This PR is part 1, and has been tested with part 2, available as a draft PR shortly

See below for an example of the full integrated abbreviation system working on DUPs with more complex headsigns:


https://github.com/user-attachments/assets/4eba9fe8-93c1-438d-9b3c-1d6ced1bde4a

