### PR TITLE
refactor: dedupe "service-eliminating effects"

### DIFF
--- a/lib/screens/alerts/alert.ex
+++ b/lib/screens/alerts/alert.ex
@@ -150,7 +150,17 @@ defmodule Screens.Alerts.Alert do
   @base_includes ~w[facilities stops.child_stops]
   @all_includes ~w[facilities.stop.child_stops facilities.stop.parent_station.child_stops stops]
 
-  @service_eliminating_effects ~w[shuttle station_closure suspension]a
+  @service_eliminating_effects ~w[
+    detour
+    dock_closure
+    no_service
+    shuttle
+    snow_route
+    station_closure
+    stop_closure
+    stop_move
+    suspension
+  ]a
 
   defguard is_service_eliminating_effect(effect) when effect in @service_eliminating_effects
 

--- a/lib/screens/v2/candidate_generator/widgets/reconstructed_alert.ex
+++ b/lib/screens/v2/candidate_generator/widgets/reconstructed_alert.ex
@@ -1,7 +1,7 @@
 defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlert do
   @moduledoc false
 
-  import Screens.Alerts.Alert, only: [is_service_eliminating_effect: 1]
+  require Screens.Alerts.Alert
 
   alias Screens.Alerts.Alert
   alias Screens.Alerts.InformedEntity
@@ -131,14 +131,14 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlert do
        do: {0, nil}
 
   defp relevance(%Alert{effect: effect}, location, _distance)
-       when is_service_eliminating_effect(effect) and location in @inside_locations,
+       when Alert.is_service_eliminating_effect(effect) and location in @inside_locations,
        do: {1, nil}
 
   # "Downstream disruptions": Service is eliminated starting somewhere downstream of the home
   # stop. Riders may need to take action later to continue their trip. Split into sub-categories
   # based on how close to the home stop the disruption begins (only the closest get "priority").
   defp relevance(%Alert{effect: effect}, _location, distance)
-       when is_service_eliminating_effect(effect),
+       when Alert.is_service_eliminating_effect(effect),
        do: {2, distance}
 
   # Severe delays are also considered "downstream disruptions".

--- a/lib/screens/v2/rds.ex
+++ b/lib/screens/v2/rds.ex
@@ -11,6 +11,8 @@ defmodule Screens.V2.RDS do
 
   import Screens.Inject
 
+  require Screens.Alerts.Alert
+
   alias Screens.Alerts.Alert
   alias Screens.Alerts.InformedEntity
   alias Screens.Config.Cache
@@ -44,19 +46,6 @@ defmodule Screens.V2.RDS do
 
   @typep destination :: {Stop.t(), Line.t(), String.t()}
   @typep scheduled_service_state :: :after | :before | :none | :within
-
-  # These alert types eliminate service to a destination.
-  @relevant_alert_effects [
-    :detour,
-    :dock_closure,
-    :no_service,
-    :shuttle,
-    :snow_route,
-    :station_closure,
-    :stop_closure,
-    :stop_move,
-    :suspension
-  ]
 
   @red_trunk [70_061..70_061, 70_063..70_084]
              |> Enum.flat_map(& &1)
@@ -445,15 +434,13 @@ defmodule Screens.V2.RDS do
   @spec fetch_relevant_alerts([Stop.id()], DateTime.t()) :: {:ok, [Alert.t()]} | :error
   defp fetch_relevant_alerts(stop_ids, now) do
     with {:ok, alerts} <- @alert.fetch(activities: [:board], stop_ids: stop_ids) do
-      {:ok, Enum.filter(alerts, &(Alert.active?(&1, now) and relevant_alert_effect?(&1)))}
+      {:ok,
+       Enum.filter(
+         alerts,
+         &(Alert.active?(&1, now) and Alert.is_service_eliminating_effect(&1.effect))
+       )}
     end
   end
-
-  @spec relevant_alert_effect?(Alert.t()) :: boolean()
-  defp relevant_alert_effect?(%Alert{effect: effect}) when effect in @relevant_alert_effects,
-    do: true
-
-  defp relevant_alert_effect?(_), do: false
 
   @spec informed_destinations([destination()], [Alert.t()], [RoutePattern.t()]) ::
           MapSet.t(destination())

--- a/lib/screens/v2/widget_instance/dup_alert.ex
+++ b/lib/screens/v2/widget_instance/dup_alert.ex
@@ -3,6 +3,8 @@ defmodule Screens.V2.WidgetInstance.DupAlert do
   A widget that displays an alert (either full-screen or partial-screen banner) on a DUP screen.
   """
 
+  require Screens.Alerts.Alert
+
   alias Screens.Alerts.Alert
   alias Screens.LocationContext
   alias Screens.Stops.Stop
@@ -99,7 +101,7 @@ defmodule Screens.V2.WidgetInstance.DupAlert do
            }
          } = t
        )
-       when effect in [:shuttle, :station_closure, :suspension] do
+       when Alert.is_service_eliminating_effect(effect) do
     # Assume primary departures is always configured with a section for each subway line at the
     # screen's station. So if we're `inside` a disruption and it affects the same number of lines
     # as the number we show departures for, that means all service is eliminated. Otherwise, only

--- a/lib/screens/v2/widget_instance/reconstructed_alert.ex
+++ b/lib/screens/v2/widget_instance/reconstructed_alert.ex
@@ -1,7 +1,7 @@
 defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
   @moduledoc false
 
-  import Screens.Alerts.Alert, only: [is_service_eliminating_effect: 1]
+  require Screens.Alerts.Alert
 
   alias Screens.Alerts.Alert
   alias Screens.Alerts.InformedEntity
@@ -1412,7 +1412,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
   @spec urgent?(t(), LocalizedAlert.location()) :: boolean()
   defp urgent?(%__MODULE__{alert: %Alert{effect: effect, severity: severity}}, location) do
     severity > 1 and location in @inside_locations and
-      (is_service_eliminating_effect(effect) or severity >= 7)
+      (Alert.is_service_eliminating_effect(effect) or severity >= 7)
   end
 
   def widget_type(%__MODULE__{} = t) do


### PR DESCRIPTION
The same concept was encoded in multiple places, using different subsets of the full list of alert effects that "eliminate service". Use `Alert.is_service_eliminating_effect/1` consistently and expand its definition to include the full list used by `RDS`.