### PR TITLE
feat: suppress alerts five weeks and older

### DIFF
--- a/lib/screens/alerts/alert.ex
+++ b/lib/screens/alerts/alert.ex
@@ -137,6 +137,7 @@ defmodule Screens.Alerts.Alert do
           activities: [activity()] | :all,
           ids: [id()],
           include_all?: boolean(),
+          now: DateTime.t(),
           route_id: Route.id(),
           route_ids: [Route.id()],
           route_types: RouteType.t() | [RouteType.t()],
@@ -156,7 +157,10 @@ defmodule Screens.Alerts.Alert do
 
   @callback fetch(options()) :: result()
   def fetch(opts \\ [], get_json_fn \\ &V3Api.get_json/2) do
-    {options, filters} = Keyword.split(opts, [:include_all?])
+    # This is equivalent to an argument with a default value
+    # credo:disable-for-next-line Screens.Checks.UntestableDateTime
+    now = Keyword.get(opts, :now, DateTime.utc_now())
+    {options, filters} = Keyword.split(opts, [:include_all?, :now])
 
     includes =
       if Keyword.get(options, :include_all?, false),
@@ -171,7 +175,11 @@ defmodule Screens.Alerts.Alert do
 
     case get_json_fn.("alerts", params) do
       {:ok, response} ->
-        {:ok, response |> V3Api.Parser.parse() |> Enum.map(&normalize_informed_entities/1)}
+        {:ok,
+         response
+         |> V3Api.Parser.parse()
+         |> Enum.reject(&stale_alert?(&1, now))
+         |> Enum.map(&normalize_informed_entities/1)}
 
       _ ->
         :error
@@ -195,11 +203,22 @@ defmodule Screens.Alerts.Alert do
   you're looking for.
   https://app.asana.com/0/0/1200476247539238/f
   """
-  @spec fetch_by_stop_and_route(list(Stop.id()), list(Route.id())) :: {:ok, list(t())} | :error
-  def fetch_by_stop_and_route(stop_ids, route_ids, get_json_fn \\ &V3Api.get_json/2) do
+  @spec fetch_by_stop_and_route(
+          list(Stop.id()),
+          list(Route.id()),
+          (String.t(), %{String.t() => String.t()} -> {:ok, term()} | {:error, Exception.t()}),
+          DateTime.t()
+        ) ::
+          {:ok, list(t())} | :error
+  def fetch_by_stop_and_route(
+        stop_ids,
+        route_ids,
+        get_json_fn \\ &V3Api.get_json/2,
+        now \\ DateTime.utc_now()
+      ) do
     with {:ok, stop_based_alerts} <-
-           fetch([stop_ids: stop_ids, route_ids: route_ids], get_json_fn),
-         {:ok, route_based_alerts} <- fetch([route_ids: route_ids], get_json_fn) do
+           fetch([now: now, stop_ids: stop_ids, route_ids: route_ids], get_json_fn),
+         {:ok, route_based_alerts} <- fetch([now: now, route_ids: route_ids], get_json_fn) do
       merged_alerts =
         [stop_based_alerts, route_based_alerts]
         |> Enum.concat()
@@ -444,6 +463,17 @@ defmodule Screens.Alerts.Alert do
       _ -> false
     end)
   end
+
+  @spec stale_alert?(t(), DateTime.t()) :: boolean()
+  defp stale_alert?(%__MODULE__{active_period: [next_active_period | _]}, now) do
+    in_active_period(next_active_period, now) &&
+      now
+      |> DateTime.shift(week: -5)
+      |> DateTime.compare(elem(next_active_period, 0))
+      |> then(fn result -> result in [:gt, :eq] end)
+  end
+
+  defp stale_alert?(%__MODULE__{active_period: []}, _), do: false
 
   @spec normalize_informed_entities(t()) :: t()
   defp normalize_informed_entities(%__MODULE__{informed_entities: entities} = alert) do

--- a/test/screens/alerts/alert_test.exs
+++ b/test/screens/alerts/alert_test.exs
@@ -8,6 +8,8 @@ defmodule Screens.Alerts.AlertTest do
 
   import Screens.TestSupport.InformedEntityBuilder
 
+  @now ~U[2017-08-21T01:00:00Z]
+
   # Minimal valid attributes by V3 API resource definitions.
   @minimal_attributes %{
     "active_period" => [%{"start" => "2017-08-14T14:54:01-04:00", "end" => nil}],
@@ -64,7 +66,7 @@ defmodule Screens.Alerts.AlertTest do
         url: nil
       }
 
-      assert Alert.fetch([route_ids: ["1"]], get_json_fn) == {:ok, [expected]}
+      assert Alert.fetch([now: @now, route_ids: ["1"]], get_json_fn) == {:ok, [expected]}
     end
 
     test "parses related facilities" do
@@ -97,7 +99,7 @@ defmodule Screens.Alerts.AlertTest do
          }}
       end
 
-      {:ok, [alert]} = Alert.fetch([], get_json_fn)
+      {:ok, [alert]} = Alert.fetch([now: @now], get_json_fn)
 
       assert %Alert{
                informed_entities: [
@@ -167,7 +169,7 @@ defmodule Screens.Alerts.AlertTest do
         }
       end
 
-      {:ok, [alert]} = Alert.fetch([route_ids: ["1"]], get_json_fn)
+      {:ok, [alert]} = Alert.fetch([now: @now, route_ids: ["1"]], get_json_fn)
 
       assert %Alert{
                informed_entities: [
@@ -263,7 +265,7 @@ defmodule Screens.Alerts.AlertTest do
         }
       end
 
-      {:ok, [alert]} = Alert.fetch([route_ids: ["1"]], get_json_fn)
+      {:ok, [alert]} = Alert.fetch([now: @now, route_ids: ["1"]], get_json_fn)
 
       assert %Alert{
                informed_entities: [
@@ -286,9 +288,27 @@ defmodule Screens.Alerts.AlertTest do
                ]
              } = alert
     end
+
+    test "filters stale alerts" do
+      five_weeks_ago = @now |> DateTime.shift(week: -5) |> DateTime.to_string()
+
+      attributes = %{
+        @minimal_attributes
+        | "active_period" => [%{"start" => five_weeks_ago, "end" => nil}]
+      }
+
+      get_json_fn = fn "alerts", %{"filter[route]" => "1"} ->
+        {
+          :ok,
+          %{"data" => [%{"id" => "999", "type" => "alert", "attributes" => attributes}]}
+        }
+      end
+
+      assert Alert.fetch([now: @now, route_ids: ["1"]], get_json_fn) == {:ok, []}
+    end
   end
 
-  describe "fetch_by_stop_and_route/3" do
+  describe "fetch_by_stop_and_route/4" do
     defp alert_json(id), do: %{"id" => id, "type" => "alert", "attributes" => @minimal_attributes}
 
     setup do
@@ -339,7 +359,7 @@ defmodule Screens.Alerts.AlertTest do
                 %Alert{id: "3"},
                 %Alert{id: "4"},
                 %Alert{id: "5"}
-              ]} = Alert.fetch_by_stop_and_route(stop_ids, route_ids, get_json_fn)
+              ]} = Alert.fetch_by_stop_and_route(stop_ids, route_ids, get_json_fn, @now)
     end
 
     test "returns :error if fetch function returns :error", context do
@@ -350,8 +370,8 @@ defmodule Screens.Alerts.AlertTest do
         x_get_json_fn2: x_get_json_fn2
       } = context
 
-      assert :error == Alert.fetch_by_stop_and_route(stop_ids, route_ids, x_get_json_fn1)
-      assert :error == Alert.fetch_by_stop_and_route(stop_ids, route_ids, x_get_json_fn2)
+      assert :error == Alert.fetch_by_stop_and_route(stop_ids, route_ids, x_get_json_fn1, @now)
+      assert :error == Alert.fetch_by_stop_and_route(stop_ids, route_ids, x_get_json_fn2, @now)
     end
   end
 


### PR DESCRIPTION


**Asana task**: [Suppress Stale Alerts on Screens](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1214784349728677?focus=true)

Description

Suppress alerts shown for five weeks or more. Alerts are generally not expected to be this long-lived. However, there are cases where a closure may last for an extended period of time (e.g. Symphony is to close for approximately 3 years). In these scenarios, we wish to suppress alerts to prevent alert fatigue.

- [x] Tests added?


Testing: As luck would have it, Alert 1002417 in AM Staging is 5 weeks and 1 day old. We can see the difference in output when looking at `main` (`a443ae454fc70d23fd24379d6e69645ada055629`) in the first screenshot, against this PR in the second

<img width="544" height="429" alt="Screenshot 2026-06-23 at 12 01 21" src="https://github.com/user-attachments/assets/5729e517-b420-40b2-bc49-40c44d4baa86" />


<img width="544" height="429" alt="Screenshot 2026-06-23 at 12 01 35" src="https://github.com/user-attachments/assets/e8048cfe-1bdf-4533-8416-da3ef7ebfcd6" />
