### PR TITLE
chore: fix dependabot grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,10 +37,6 @@ updates:
       - dependency-name: "@types/node"
         update-types: ["version-update:semver-major"]
     groups:
-      npm-minor:
-        update-types:
-          - "patch"
-          - "minor"
       eslint:
         patterns:
           - "eslint*"
@@ -73,4 +69,28 @@ updates:
           - "terser*"
       moment:
         patterns:
+          - "moment*"
+      npm-minor:
+        update-types:
+          - "patch"
+          - "minor"
+        exclude-patterns:
+          - "eslint*"
+          - "*-eslint"
+          - "@eslint*"
+          - "stylelint*"
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
+          - "ts-jest"
+          - "jest*"
+          - "@jest*"
+          - "@babel*"
+          - "webpack*"
+          - "*webpack-plugin"
+          - "@svgr/webpack"
+          - "@types/webpack-env"
+          - "*-loader"
+          - "terser*"
           - "moment*"


### PR DESCRIPTION


**Asana task**: N/A

Description

This commit changes the ordering of Dependabot update grouping such that the predefined groups take precedence over the `npm-minor` group. Prior to this commit, major version bumps of groups (e.g. eslint) were being captured by the `npm-minor` group, causing major version bumps from the same family of packages to be split up (and likely unmergable due to peer dependencies)

- [ ] Tests added?
