### PR TITLE
fix: update first departure text styling

### DIFF
--- a/assets/css/dup/departures/row.scss
+++ b/assets/css/dup/departures/row.scss
@@ -59,6 +59,7 @@
 
 .departure-row__first {
   display: inline-block;
-  margin-right: 32px;
+  margin-right: 0.5ex;
   font-size: 108px;
+  vertical-align: center;
 }


### PR DESCRIPTION


**Asana task**: [RDS DUP Polish: First Trip State](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1215451542447463)

Description


Update the departure text "First" styling updating the margin to the right of the text per design's request.

The vertical alignment of the text has been centered with respect to its parent container, effectively vertically centering the text in the row. This option has been selected as opposed to aligning the bottom of the text with the two letter line abbreviation text (e.g. "RL" for "Red Line"). The latter would require a more significant refactor of the DUPs departure row component, as the current structure & CSS rely heavily on `display: inline-block`, making the positioning of "First" to align with "RL" difficult to do without affecting other positioning in its parent.

Screenshots



(Note: I had to do some hardcoding on the backend/frontend to get these to show, so times will be nonsensical relative to when first trips actually begin)

<img width="975" height="543" alt="Screenshot 2026-06-25 at 13 04 13" src="https://github.com/user-attachments/assets/f5842fbc-a455-4bb4-87c7-0469ac0e6db9" />
<img width="975" height="543" alt="Screenshot 2026-06-25 at 13 04 17" src="https://github.com/user-attachments/assets/18727ad6-442b-4713-a5a0-cf4eccbd6c3e" />
<img width="965" height="543" alt="Screenshot 2026-06-25 at 13 04 39" src="https://github.com/user-attachments/assets/2f464f93-fbeb-4cc2-bdf7-bf32fbad216b" />
<img width="965" height="543" alt="Screenshot 2026-06-25 at 13 05 32" src="https://github.com/user-attachments/assets/41b27eaa-4d2d-47f7-bdc6-813cb5cd65ac" />
<img width="965" height="543" alt="Screenshot 2026-06-25 at 13 06 33" src="https://github.com/user-attachments/assets/a65c8821-ba0c-483c-a36f-8efbfe3ce6cb" />
