### PR TITLE
chore: remove dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,11 @@ updates:
     cooldown:
       default-days: 7
     open-pull-requests-limit: 5
+    groups:
+      mix-minor:
+        update-types:
+          - "patch"
+          - "minor"
   - package-ecosystem: npm
     directory: "/assets"
     schedule:
@@ -31,3 +36,8 @@ updates:
       # with the actual Node version used by the project.
       - dependency-name: "@types/node"
         update-types: ["version-update:semver-major"]
+    groups:
+      npm-minor:
+        update-types:
+          - "patch"
+          - "minor"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,11 +18,6 @@ updates:
     cooldown:
       default-days: 7
     open-pull-requests-limit: 5
-    groups:
-      mix-minor:
-        update-types:
-          - "patch"
-          - "minor"
   - package-ecosystem: npm
     directory: "/assets"
     schedule:
@@ -36,41 +31,3 @@ updates:
       # with the actual Node version used by the project.
       - dependency-name: "@types/node"
         update-types: ["version-update:semver-major"]
-    groups:
-      npm-minor:
-        update-types:
-          - "patch"
-          - "minor"
-      eslint:
-        patterns:
-          - "eslint*"
-          - "*-eslint"
-          - "@eslint*"
-      stylelint:
-        patterns:
-          - "stylelint*"
-      react:
-        patterns:
-          - "react"
-          - "react-dom"
-          - "@types/react"
-          - "@types/react-dom"
-      testing-tools:
-        patterns:
-          - "ts-jest"
-          - "jest*"
-          - "@jest*"
-      babel:
-        patterns:
-          - "@babel*"
-      webpack:
-        patterns:
-          - "webpack*"
-          - "*webpack-plugin"
-          - "@svgr/webpack"
-          - "@types/webpack-env"
-          - "*-loader"
-          - "terser*"
-      moment:
-        patterns:
-          - "moment*"


### PR DESCRIPTION


**Asana task**: N/A
Description

Remove package-specific dependency groupings from the Dependabot configuration. Prior to this commit, we were seeing cases where NPM major version updates were falling into the `npm-minor` group. This caused related packages that were peer-dependent on one another's new major version to be split into separate PRs, causing each created PR to fail. The outcome following this PR is the same,
but will require manual intervention from the dev team to fix cases of broken major version updates.

One approach in https://github.com/mbta/screens/pull/3142 was to move `npm-minor` to the bottom of the group list, and explicitly exclude each package in any group from `npm-minor`. This was tested to fix the above issue in a separate repo, but adds maintenance burden. As a result, we choose to simply remove the groups as they exist today



- [ ] Tests added?
