### PR TITLE
fix: consolidate informed entity activities

### DIFF
--- a/lib/screens/alerts/alert.ex
+++ b/lib/screens/alerts/alert.ex
@@ -462,12 +462,26 @@ defmodule Screens.Alerts.Alert do
 
   defp do_normalize_informed_entities(entities) do
     entities
-    |> Enum.group_by(&Map.put(&1, :direction_id, nil))
-    |> Enum.map(fn
-      {_directionless_entity, [entity]} -> entity
-      {directionless_entity, _multiple} -> directionless_entity
+    |> Enum.group_by(&%InformedEntity{&1 | activities: [], direction_id: nil})
+    |> Enum.map(fn {_key, entities} ->
+      Enum.reduce(entities, fn entity, merged ->
+        %InformedEntity{
+          merged
+          | activities: merge_activities(entity.activities, merged.activities),
+            direction_id: merge_direction_ids(entity.direction_id, merged.direction_id)
+        }
+      end)
     end)
   end
+
+  defp merge_activities(same, same), do: same
+  defp merge_activities(a, b), do: Enum.uniq(a ++ b)
+
+  defp merge_direction_ids(0, 1), do: nil
+  defp merge_direction_ids(1, 0), do: nil
+  defp merge_direction_ids(nil, _any), do: nil
+  defp merge_direction_ids(_any, nil), do: nil
+  defp merge_direction_ids(same, same), do: same
 
   @doc """
   Consolidates delay alerts affecting entire routes by keeping only the highest

--- a/lib/screens/v2/widget_instance/reconstructed_alert.ex
+++ b/lib/screens/v2/widget_instance/reconstructed_alert.ex
@@ -280,12 +280,15 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
        do: {direction_id, route}
 
   # Select 1 direction + route from this list of directions + routes for multiple branches
-  defp select_direction_and_route([]), do: {nil, nil}
   defp select_direction_and_route([direction_and_route]), do: direction_and_route
 
   # If there are multiple route ids in that informed entities list, then the alert includes branching
   defp select_direction_and_route([{direction_id, "Red" <> _} | _]), do: {direction_id, "Red"}
-  defp select_direction_and_route([{direction_id, _} | _]), do: {direction_id, "Green-trunk"}
+
+  defp select_direction_and_route([{direction_id, "Green" <> _} | _]),
+    do: {direction_id, "Green-trunk"}
+
+  defp select_direction_and_route(_), do: {nil, nil}
 
   defp get_route_pills(t, location \\ nil)
 

--- a/test/screens/alerts/alert_test.exs
+++ b/test/screens/alerts/alert_test.exs
@@ -286,6 +286,30 @@ defmodule Screens.Alerts.AlertTest do
                ]
              } = alert
     end
+
+    test "combine informed entities by activity" do
+      attributes = %{
+        @minimal_attributes
+        | "informed_entity" => [
+            %{"activities" => ~w[BOARD], "route" => "1"},
+            %{"activities" => ~w[EXIT], "route" => "1"}
+          ]
+      }
+
+      get_json_fn = fn "alerts", %{"filter[route]" => "1"} ->
+        {
+          :ok,
+          %{
+            "data" => [%{"id" => "999", "type" => "alert", "attributes" => attributes}],
+            "included" => []
+          }
+        }
+      end
+
+      {:ok, [alert]} = Alert.fetch([route_ids: ["1"]], get_json_fn)
+
+      assert %Alert{informed_entities: [%InformedEntity{activities: ~w[exit board]a}]} = alert
+    end
   end
 
   describe "fetch_by_stop_and_route/3" do


### PR DESCRIPTION
Similar to the previous change in the alerts feed which "denormalized" direction IDs, informed entities for the same stop/route/etc. may have different sets of activities; these should be merged to align with the assumptions of downstream code.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216075819206645