### PR TITLE
feat: RDS MVP on LCDs

### DIFF
--- a/lib/screens/last_trip/last_trip.ex
+++ b/lib/screens/last_trip/last_trip.ex
@@ -10,7 +10,14 @@ defmodule Screens.LastTrip.LastTrip do
   @callback update_last_trip_cache([Departure.t()], DateTime.t()) :: :ok
   def update_last_trip_cache(departures, now) do
     departures
-    |> Enum.filter(&Departure.last_trip?(&1))
+    |> Enum.filter(fn
+      %Departure{prediction: %Prediction{departure_time: departure_time}} = departure
+      when not is_nil(departure_time) ->
+        Departure.last_trip?(departure)
+
+      _ ->
+        false
+    end)
     |> Enum.group_by(
       &{Departure.stop(&1).id, Departure.route(&1).line.id,
        Departure.representative_headsign(&1)},

--- a/lib/screens/v2/candidate_generator/bus_shelter.ex
+++ b/lib/screens/v2/candidate_generator/bus_shelter.ex
@@ -48,7 +48,7 @@ defmodule Screens.V2.CandidateGenerator.BusShelter do
         config,
         now \\ DateTime.utc_now(),
         header_instances_fn \\ &Widgets.Header.instances/2,
-        departures_instances_fn \\ &Widgets.Departures.departures_instances/2,
+        departures_instances_fn \\ &Widgets.RealtimeDepartures.departures_instances/2,
         alert_instances_fn \\ &Widgets.Alerts.alert_instances/2,
         evergreen_content_instances_fn \\ &Widgets.Evergreen.evergreen_content_instances/2,
         subway_status_instances_fn \\ &Widgets.SubwayStatus.subway_status_instances/2

--- a/lib/screens/v2/candidate_generator/busway.ex
+++ b/lib/screens/v2/candidate_generator/busway.ex
@@ -10,7 +10,7 @@ defmodule Screens.V2.CandidateGenerator.Busway do
   @behaviour CandidateGenerator
 
   @instance_fns [
-    &Widgets.Departures.departures_instances/2,
+    &Widgets.RealtimeDepartures.departures_instances/2,
     &Widgets.Evergreen.evergreen_content_instances/2,
     &Widgets.Header.instances/2,
     &Widgets.EmergencyTakeover.emergency_takeover_instances/2

--- a/lib/screens/v2/candidate_generator/dup/departures.ex
+++ b/lib/screens/v2/candidate_generator/dup/departures.ex
@@ -55,19 +55,12 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
 
     secondary_rds_sections = @rds.get(secondary_departures, now)
 
-    post_process_rows_fn = fn rows, %Section{bidirectional: bidirectional}, total_section_count ->
-      num_departures_per_section = div(@max_departures_per_rotation, total_section_count)
-
-      rows
-      |> RdsDepartures.maybe_make_bidirectional(bidirectional)
-      |> Enum.take(num_departures_per_section)
-    end
-
     primary_departure_sections =
       RdsDepartures.create_departure_sections(
         primary_rds_sections,
         primary_departures,
-        post_process_rows_fn
+        &post_process_rows/4,
+        now
       )
 
     secondary_departure_sections =
@@ -77,7 +70,8 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
         RdsDepartures.create_departure_sections(
           secondary_rds_sections,
           secondary_departures,
-          post_process_rows_fn
+          &post_process_rows/4,
+          now
         )
       end
 
@@ -199,5 +193,13 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
           end
         )
     end
+  end
+
+  defp post_process_rows(rows, %Section{bidirectional: bidirectional}, total_section_count, _now) do
+    num_departures_per_section = div(@max_departures_per_rotation, total_section_count)
+
+    rows
+    |> RdsDepartures.maybe_make_bidirectional(bidirectional)
+    |> Enum.take(num_departures_per_section)
   end
 end

--- a/lib/screens/v2/candidate_generator/dup/departures.ex
+++ b/lib/screens/v2/candidate_generator/dup/departures.ex
@@ -55,19 +55,11 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
 
     secondary_rds_sections = @rds.get(secondary_departures, now)
 
-    post_process_rows_fn = fn rows, %Section{bidirectional: bidirectional}, total_section_count ->
-      num_departures_per_section = div(@max_departures_per_rotation, total_section_count)
-
-      rows
-      |> RdsDepartures.maybe_make_bidirectional(bidirectional)
-      |> Enum.take(num_departures_per_section)
-    end
-
     primary_departure_sections =
       RdsDepartures.create_departure_sections(
         primary_rds_sections,
         primary_departures,
-        post_process_rows_fn
+        &post_process_rows/3
       )
 
     secondary_departure_sections =
@@ -77,7 +69,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
         RdsDepartures.create_departure_sections(
           secondary_rds_sections,
           secondary_departures,
-          post_process_rows_fn
+          &post_process_rows/3
         )
       end
 
@@ -199,5 +191,13 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
           end
         )
     end
+  end
+
+  defp post_process_rows(rows, %Section{bidirectional: bidirectional}, total_section_count) do
+    num_departures_per_section = div(@max_departures_per_rotation, total_section_count)
+
+    rows
+    |> RdsDepartures.maybe_make_bidirectional(bidirectional)
+    |> Enum.take(num_departures_per_section)
   end
 end

--- a/lib/screens/v2/candidate_generator/pre_fare.ex
+++ b/lib/screens/v2/candidate_generator/pre_fare.ex
@@ -21,7 +21,7 @@ defmodule Screens.V2.CandidateGenerator.PreFare do
     &CandidateGenerator.PreFare.ElevatorStatus.instances/2,
     &Widgets.FullLineMap.full_line_map_instances/2,
     &Widgets.Evergreen.evergreen_content_instances/2,
-    &Widgets.Departures.departures_instances/2,
+    &Widgets.RealtimeDepartures.departures_instances/2,
     &Widgets.EmergencyTakeover.emergency_takeover_instances/2
   ]
 

--- a/lib/screens/v2/candidate_generator/widgets/rds_departures.ex
+++ b/lib/screens/v2/candidate_generator/widgets/rds_departures.ex
@@ -1,5 +1,13 @@
 defmodule Screens.V2.CandidateGenerator.Widgets.RdsDepartures do
-  @moduledoc false
+  @moduledoc """
+  Candidate Generator for RDS Items. 
+  Takes in RDS items and generates Screens.V2.WidgetInstance.Departures sections
+  to eventually be serialized and used as a part of the Departures Widget.
+
+  Note: This candidate generator only creates sections, and does not do the roll-up
+  of full screen presentations
+
+  """
 
   alias Screens.Routes.Route
   alias Screens.Schedules.Schedule
@@ -21,13 +29,21 @@ defmodule Screens.V2.CandidateGenerator.Widgets.RdsDepartures do
   alias ScreensConfig.Departures.{Query, Section}
 
   @type post_process_rows_fn_t ::
-          ([NormalSection.row()], Section.t(), non_neg_integer() -> [NormalSection.row()])
+          ([NormalSection.row()], Section.t(), non_neg_integer(), DateTime.t() ->
+             [NormalSection.row()])
   @type widget :: DeparturesNoData.t() | DeparturesWidget.t()
 
+  @spec create_departure_sections(
+          [RDS.item()],
+          Departures.t(),
+          post_process_rows_fn_t(),
+          DateTime.t()
+        ) :: [DeparturesWidget.section()]
   def create_departure_sections(
         rds_sections,
         %Departures{sections: departure_sections},
-        post_process_rows_fn \\ fn rows, _section, _total_section_count -> rows end
+        post_process_rows_fn \\ fn rows, _section, _total_section_count, _now -> rows end,
+        now
       ) do
     total_section_count = length(rds_sections)
 
@@ -37,7 +53,8 @@ defmodule Screens.V2.CandidateGenerator.Widgets.RdsDepartures do
         rds_section,
         section,
         total_section_count,
-        post_process_rows_fn
+        post_process_rows_fn,
+        now
       )
     end)
   end
@@ -46,11 +63,32 @@ defmodule Screens.V2.CandidateGenerator.Widgets.RdsDepartures do
           RDS.data(),
           Section.t(),
           non_neg_integer(),
-          post_process_rows_fn_t()
+          post_process_rows_fn_t(),
+          DateTime.t()
         ) ::
           DeparturesWidget.section()
 
-  defp map_to_departure_section(data, section, _, _)
+  # header_only sections are only supported on LCD screens
+  defp map_to_departure_section(
+         _,
+         %Section{
+           header_only: true,
+           header: header,
+           layout: layout,
+           grouping_type: grouping_type
+         },
+         _,
+         _,
+         _
+       ),
+       do: %NormalSection{
+         rows: [],
+         header: header,
+         layout: layout,
+         grouping_type: grouping_type
+       }
+
+  defp map_to_departure_section(data, section, _, _, _)
        when data == :error or data == {:ok, []},
        do: %NoDataSection{route: maybe_route_from_section(section)}
 
@@ -58,7 +96,8 @@ defmodule Screens.V2.CandidateGenerator.Widgets.RdsDepartures do
          {:ok, items},
          %Section{header: header, layout: layout, grouping_type: grouping_type} = section,
          section_count,
-         post_process_rows_fn
+         post_process_rows_fn,
+         now
        ) do
     case items do
       [%NoService{routes: routes}] ->
@@ -69,16 +108,17 @@ defmodule Screens.V2.CandidateGenerator.Widgets.RdsDepartures do
 
       [
         %Headways{
-          routes: [%Route{id: route_id} | _rest],
+          routes: [first_route | _rest],
           range: range,
           displayed_headsign: displayed_headsign
         }
       ] ->
-        %HeadwaySection{route_id: route_id, time_range: range, headsign: displayed_headsign}
+        %HeadwaySection{route: first_route, time_range: range, headsign: displayed_headsign}
 
       _ ->
         %NormalSection{
-          rows: items |> create_and_sort_rows() |> post_process_rows_fn.(section, section_count),
+          rows:
+            items |> create_and_sort_rows() |> post_process_rows_fn.(section, section_count, now),
           layout: layout,
           header: header,
           grouping_type: grouping_type
@@ -194,7 +234,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.RdsDepartures do
   defp departure_time(%Departure{} = departure), do: Departure.time(departure)
   defp departure_time({%Schedule{} = schedule, _type}), do: Schedule.time(schedule)
 
-  defp departure_direction_id(%Departure{} = departure), do: Departure.direction_id(departure)
-  defp departure_direction_id({%Schedule{direction_id: direction_id}, _type}), do: direction_id
-  defp departure_direction_id({_line, direction_id, _range, _headsign}), do: direction_id
+  def departure_direction_id(%Departure{} = departure), do: Departure.direction_id(departure)
+  def departure_direction_id({%Schedule{direction_id: direction_id}, _type}), do: direction_id
+  def departure_direction_id({_line, direction_id, _range, _headsign}), do: direction_id
 end

--- a/lib/screens/v2/candidate_generator/widgets/rds_departures.ex
+++ b/lib/screens/v2/candidate_generator/widgets/rds_departures.ex
@@ -1,5 +1,13 @@
 defmodule Screens.V2.CandidateGenerator.Widgets.RdsDepartures do
-  @moduledoc false
+  @moduledoc """
+  Candidate Generator for RDS Items. 
+  Takes in RDS items and generates Screens.V2.WidgetInstance.Departures sections
+  to eventually be serialized and used as a part of the Departures Widget.
+
+  Note: This candidate generator only creates sections, and does not do the roll-up
+  of full screen presentations
+
+  """
 
   alias Screens.Routes.Route
   alias Screens.Schedules.Schedule
@@ -20,10 +28,15 @@ defmodule Screens.V2.CandidateGenerator.Widgets.RdsDepartures do
   alias ScreensConfig.Departures
   alias ScreensConfig.Departures.{Query, Section}
 
-  @type post_process_rows_fn_t ::
-          ([NormalSection.row()], Section.t(), non_neg_integer() -> [NormalSection.row()])
+  @type post_process_rows_fn_t :: ([NormalSection.row()], Section.t(), non_neg_integer() ->
+                                     [NormalSection.row()])
   @type widget :: DeparturesNoData.t() | DeparturesWidget.t()
 
+  @spec create_departure_sections(
+          [RDS.item()],
+          Departures.t(),
+          post_process_rows_fn_t()
+        ) :: [DeparturesWidget.section()]
   def create_departure_sections(
         rds_sections,
         %Departures{sections: departure_sections},
@@ -50,6 +63,25 @@ defmodule Screens.V2.CandidateGenerator.Widgets.RdsDepartures do
         ) ::
           DeparturesWidget.section()
 
+  # header_only sections are only supported on LCD screens
+  defp map_to_departure_section(
+         _,
+         %Section{
+           header_only: true,
+           header: header,
+           layout: layout,
+           grouping_type: grouping_type
+         },
+         _,
+         _
+       ),
+       do: %NormalSection{
+         rows: [],
+         header: header,
+         layout: layout,
+         grouping_type: grouping_type
+       }
+
   defp map_to_departure_section(data, section, _, _)
        when data == :error or data == {:ok, []},
        do: %NoDataSection{route: maybe_route_from_section(section)}
@@ -69,12 +101,12 @@ defmodule Screens.V2.CandidateGenerator.Widgets.RdsDepartures do
 
       [
         %Headways{
-          routes: [%Route{id: route_id} | _rest],
+          routes: [first_route | _rest],
           range: range,
           displayed_headsign: displayed_headsign
         }
       ] ->
-        %HeadwaySection{route_id: route_id, time_range: range, headsign: displayed_headsign}
+        %HeadwaySection{route: first_route, time_range: range, headsign: displayed_headsign}
 
       _ ->
         %NormalSection{
@@ -194,7 +226,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.RdsDepartures do
   defp departure_time(%Departure{} = departure), do: Departure.time(departure)
   defp departure_time({%Schedule{} = schedule, _type}), do: Schedule.time(schedule)
 
-  defp departure_direction_id(%Departure{} = departure), do: Departure.direction_id(departure)
-  defp departure_direction_id({%Schedule{direction_id: direction_id}, _type}), do: direction_id
-  defp departure_direction_id({_line, direction_id, _range, _headsign}), do: direction_id
+  def departure_direction_id(%Departure{} = departure), do: Departure.direction_id(departure)
+  def departure_direction_id({%Schedule{direction_id: direction_id}, _type}), do: direction_id
+  def departure_direction_id({_line, direction_id, _range, _headsign}), do: direction_id
 end

--- a/lib/screens/v2/candidate_generator/widgets/realtime_departures.ex
+++ b/lib/screens/v2/candidate_generator/widgets/realtime_departures.ex
@@ -1,0 +1,297 @@
+defmodule Screens.V2.CandidateGenerator.Widgets.RealtimeDepartures do
+  @moduledoc """
+  Candidate generator for LCD RDS Items
+  Takes in the generated sections from Screens.V2.CandidateGenerator.Widgets.RdsDepartures and
+  handles the roll-up and creation of the actual widget that will be serialized and used on
+  the screen itself. 
+  """
+
+  alias Screens.Routes.Route
+  alias Screens.Schedules.Schedule
+  alias Screens.Trips.Trip
+  alias Screens.V2.CandidateGenerator.Widgets.RdsDepartures
+  alias Screens.V2.Departure
+  alias Screens.V2.RDS
+  alias Screens.V2.WidgetInstance.Departures, as: DeparturesWidget
+
+  alias Screens.V2.WidgetInstance.Departures.{
+    HeadwaySection,
+    NoDataSection,
+    NormalSection,
+    NoServiceSection,
+    OvernightSection
+  }
+
+  alias Screens.V2.WidgetInstance.DeparturesNoData
+  alias ScreensConfig.{Departures, FreeTextLine, Screen}
+  alias ScreensConfig.Departures.{Filters, Query, Section}
+  alias ScreensConfig.Departures.Filters.{RouteDirections, RouteDirections.RouteDirection}
+  alias ScreensConfig.Screen.{Busway, PreFare}
+
+  import Screens.Inject
+  @rds injected(RDS)
+
+  @type widget :: DeparturesNoData.t() | DeparturesWidget.t()
+
+  @spec departures_instances(Screen.t(), DateTime.t()) :: [widget()]
+  def departures_instances(%Screen{app_params: app_params} = screen, now) do
+    app_params
+    |> departures_slots()
+    |> Enum.with_index()
+    |> Enum.flat_map(fn {{departures, slots}, index} ->
+      generate_instances(departures, slots, index, screen, now)
+    end)
+  end
+
+  @spec generate_instances(Departures.t(), [atom()], non_neg_integer(), Screen.t(), DateTime.t()) ::
+          [widget()]
+  defp generate_instances(departures, _slot_names, _order, _screen, _now)
+       when is_nil(departures) or departures.sections == [],
+       do: []
+
+  defp generate_instances(
+         %Departures{sections: sections} = departures,
+         slot_names,
+         order,
+         screen,
+         now
+       ) do
+    sections_data =
+      departures
+      |> @rds.get(now)
+      |> RdsDepartures.create_departure_sections(departures, &post_process_rows/4, now)
+
+    [create_departures_instance(sections_data, sections, screen, slot_names, order, now)]
+  end
+
+  @spec create_departures_instance(
+          [DeparturesWidget.section()],
+          Section.t(),
+          Screen.t(),
+          [atom()],
+          non_neg_integer(),
+          DateTime.t()
+        ) :: widget()
+  defp create_departures_instance(
+         sections_data,
+         sections,
+         screen,
+         slot_names,
+         order,
+         now
+       ) do
+    sections_data_with_sections_config = Enum.zip(sections_data, sections)
+
+    # As we begin to support other rows/sections/widgets, add them in here
+    if has_valid_normal_section?(sections_data_with_sections_config) do
+      %DeparturesWidget{
+        screen: screen,
+        sections:
+          sections_data_with_sections_config
+          |> Enum.map(fn
+            {%NormalSection{rows: rows} = normal_section, _section} ->
+              %{
+                normal_section
+                | rows:
+                    Enum.map(rows, fn
+                      %Departure{} = departure -> departure
+                      # Treat First Trips as Countdowns while we don't support them yet
+                      {%Schedule{} = schedule, :first_trip} -> %Departure{schedule: schedule}
+                    end)
+              }
+
+            {unsupported_section, section} ->
+              handle_unsupported_sections(unsupported_section, section)
+          end),
+        slot_names: slot_names,
+        order: order,
+        now: now
+      }
+    else
+      %DeparturesNoData{screen: screen, show_alternatives?: true}
+    end
+  end
+
+  defp has_valid_normal_section?(sections_data) do
+    Enum.any?(sections_data, fn {section_data, %Section{header_only: header_only}} ->
+      header_only ||
+        (is_struct(section_data, NormalSection) && has_valid_normal_section_row?(section_data))
+    end)
+  end
+
+  defp has_valid_normal_section_row?(%NormalSection{rows: rows}) do
+    Enum.any?(rows, fn row ->
+      is_struct(row, Departure) || match?({%Schedule{}, :first_trip}, row)
+    end)
+  end
+
+  defp handle_unsupported_sections(
+         section_to_change,
+         %Section{
+           header: header,
+           layout: layout,
+           grouping_type: grouping_type,
+           query: %Query{params: %Query.Params{direction_id: direction_id}}
+         }
+       ) do
+    text =
+      case section_to_change do
+        %HeadwaySection{route: route, headsign: headsign} ->
+          headway_text(route, headsign)
+
+        %NoDataSection{route: route} ->
+          no_data_text(route, direction_id)
+
+        %OvernightSection{routes: routes} ->
+          no_data_text(List.first(routes), direction_id)
+
+        %NoServiceSection{routes: routes} ->
+          no_data_text(List.first(routes), direction_id)
+      end
+
+    %NormalSection{
+      rows: [text],
+      header: header,
+      layout: layout,
+      grouping_type: grouping_type
+    }
+  end
+
+  defp post_process_rows(
+         rows,
+         %Section{filters: filters, bidirectional: bidirectional, grouping_type: grouping_type},
+         _total_section_count,
+         now
+       ) do
+    rows
+    |> filter_rows(filters, now)
+    |> maybe_sort_by_direction_id(grouping_type)
+    |> RdsDepartures.maybe_make_bidirectional(bidirectional)
+  end
+
+  defp headway_text(route, headsign) do
+    %FreeTextLine{
+      icon: if(route, do: Route.icon(route), else: nil),
+      text: [no_departures_message(headsign)]
+    }
+  end
+
+  @spec no_data_text(Route.t() | nil, Trip.direction() | :both) :: FreeTextLine.t()
+  defp no_data_text(nil, _direction_id) do
+    %FreeTextLine{
+      icon: nil,
+      text: [no_departures_message()]
+    }
+  end
+
+  defp no_data_text(route, direction_id) when direction_id == :both do
+    %FreeTextLine{
+      icon: Route.icon(route),
+      text: [no_departures_message()]
+    }
+  end
+
+  defp no_data_text(%Route{direction_names: direction_names} = route, direction_id) do
+    %FreeTextLine{
+      icon: Route.icon(route),
+      text: [
+        # In cases where we have NoDataSections, we might have only a route_id for the icon
+        # Omit the normalized direction name in this instance
+        if direction_names == nil do
+          no_departures_message()
+        else
+          route
+          |> Route.normalized_direction_names()
+          |> Enum.at(direction_id, "")
+          |> no_departures_message()
+        end
+      ]
+    }
+  end
+
+  defp no_departures_message, do: "No departures currently available"
+  defp no_departures_message(name), do: "No #{name} departures available"
+
+  defp filter_rows(
+         rows,
+         %Filters{max_minutes: max_minutes, route_directions: route_directions},
+         now
+       ) do
+    rows
+    |> filter_unsupported_rows()
+    |> filter_by_time(max_minutes, now)
+    |> filter_by_route_direction(route_directions)
+  end
+
+  defp filter_unsupported_rows(rows) do
+    Enum.filter(rows, fn
+      %Departure{} -> true
+      {%Schedule{}, :first_trip} -> true
+      _ -> false
+    end)
+  end
+
+  @spec filter_by_time([NormalSection.row()], non_neg_integer() | nil, DateTime.t()) :: [
+          NormalSection.row()
+        ]
+  defp filter_by_time(rows, nil, _now), do: rows
+
+  defp filter_by_time(rows, max_minutes, now) do
+    latest_time = DateTime.add(now, max_minutes, :minute)
+
+    Enum.filter(rows, fn
+      %Departure{} = departure ->
+        DateTime.compare(Departure.time(departure), latest_time) != :gt
+
+      {%Schedule{} = schedule, :first_trip} ->
+        DateTime.compare(Schedule.time(schedule), latest_time) != :gt
+    end)
+  end
+
+  @spec filter_by_route_direction([NormalSection.row()], RouteDirections.t() | nil) :: [
+          NormalSection.row()
+        ]
+  defp filter_by_route_direction(rows, %RouteDirections{
+         action: :include,
+         targets: targets
+       }) do
+    Enum.filter(rows, &row_in_route_directions?(&1, targets))
+  end
+
+  defp filter_by_route_direction(rows, %RouteDirections{
+         action: :exclude,
+         targets: targets
+       }) do
+    Enum.reject(rows, &row_in_route_directions?(&1, targets))
+  end
+
+  defp filter_by_route_direction(departures, nil) do
+    departures
+  end
+
+  defp row_in_route_directions?(row, route_directions) do
+    route_direction(row) in route_directions
+  end
+
+  defp route_direction(%Departure{} = d) do
+    %RouteDirection{route_id: Departure.route(d).id, direction_id: Departure.direction_id(d)}
+  end
+
+  defp route_direction(
+         {%Schedule{route: %Route{id: id}, direction_id: direction_id}, :first_trip}
+       ) do
+    %RouteDirection{route_id: id, direction_id: direction_id}
+  end
+
+  defp maybe_sort_by_direction_id(departures, :destination),
+    do: Enum.sort_by(departures, &(1 - RdsDepartures.departure_direction_id(&1)))
+
+  defp maybe_sort_by_direction_id(departures, _grouping_type), do: departures
+
+  defp departures_slots(%Busway{departures: d1, secondary_departures: d2}),
+    do: [{d1, [:main_content, :main_content_left]}, {d2, [:main_content_right]}]
+
+  defp departures_slots(%PreFare{departures: d, template: :duo}), do: [{d, [:main_content_left]}]
+  defp departures_slots(%PreFare{departures: d, template: :solo}), do: [{d, [:large]}]
+  defp departures_slots(%_app{departures: d}), do: [{d, [:main_content]}]
+end

--- a/lib/screens/v2/candidate_generator/widgets/realtime_departures.ex
+++ b/lib/screens/v2/candidate_generator/widgets/realtime_departures.ex
@@ -1,0 +1,274 @@
+defmodule Screens.V2.CandidateGenerator.Widgets.RealtimeDepartures do
+  @moduledoc """
+  Candidate generator for LCD RDS Items
+  Takes in the generated sections from Screens.V2.CandidateGenerator.Widgets.RdsDepartures and
+  handles the roll-up and creation of the actual widget that will be serialized and used on
+  the screen itself. 
+  """
+
+  alias Screens.Routes.Route
+  alias Screens.Schedules.Schedule
+  alias Screens.Trips.Trip
+  alias Screens.V2.CandidateGenerator.Widgets.RdsDepartures
+  alias Screens.V2.Departure
+  alias Screens.V2.RDS
+  alias Screens.V2.WidgetInstance.Departures, as: DeparturesWidget
+
+  alias Screens.V2.WidgetInstance.Departures.{
+    HeadwaySection,
+    NoDataSection,
+    NormalSection,
+    NoServiceSection,
+    OvernightSection
+  }
+
+  alias Screens.V2.WidgetInstance.DeparturesNoData
+  alias ScreensConfig.{Departures, FreeTextLine, Screen}
+  alias ScreensConfig.Departures.{Filters, Query, Section}
+  alias ScreensConfig.Departures.Filters.{RouteDirections, RouteDirections.RouteDirection}
+  alias ScreensConfig.Screen.{Busway, PreFare}
+
+  import Screens.Inject
+  @rds injected(RDS)
+
+  @type widget :: DeparturesNoData.t() | DeparturesWidget.t()
+
+  @spec departures_instances(Screen.t(), DateTime.t()) :: [widget()]
+  def departures_instances(%Screen{app_params: app_params} = screen, now) do
+    app_params
+    |> departures_slots()
+    |> Enum.with_index()
+    |> Enum.flat_map(fn {{departures, slots}, index} ->
+      generate_instances(departures, slots, index, screen, now)
+    end)
+  end
+
+  @spec generate_instances(Departures.t(), [atom()], non_neg_integer(), Screen.t(), DateTime.t()) ::
+          [widget()]
+  defp generate_instances(departures, _slot_names, _order, _screen, _now)
+       when is_nil(departures) or departures.sections == [],
+       do: []
+
+  defp generate_instances(
+         %Departures{sections: sections} = departures,
+         slot_names,
+         order,
+         screen,
+         now
+       ) do
+    sections_data =
+      departures
+      |> @rds.get(now)
+      |> RdsDepartures.create_departure_sections(departures, &post_process_rows/3)
+
+    [create_departures_instance(sections_data, sections, screen, slot_names, order, now)]
+  end
+
+  @spec create_departures_instance(
+          [DeparturesWidget.section()],
+          Section.t(),
+          Screen.t(),
+          [atom()],
+          non_neg_integer(),
+          DateTime.t()
+        ) :: widget()
+  defp create_departures_instance(
+         sections_data,
+         sections,
+         screen,
+         slot_names,
+         order,
+         now
+       ) do
+    sections_data_with_sections_config = Enum.zip(sections_data, sections)
+
+    # As we begin to support other rows/sections/widgets, add them in here
+    if has_valid_normal_section?(sections_data_with_sections_config) do
+      %DeparturesWidget{
+        screen: screen,
+        sections:
+          sections_data_with_sections_config
+          |> Enum.map(fn
+            {%NormalSection{rows: rows} = normal_section, _section} ->
+              %{
+                normal_section
+                | rows:
+                    Enum.map(rows, fn
+                      %Departure{} = departure -> departure
+                      # Treat First Trips as Countdowns while we don't support them yet
+                      {%Schedule{} = schedule, :first_trip} -> %Departure{schedule: schedule}
+                    end)
+              }
+
+            {unsupported_section, section} ->
+              handle_unsupported_sections(unsupported_section, section)
+          end),
+        slot_names: slot_names,
+        order: order,
+        now: now
+      }
+    else
+      %DeparturesNoData{screen: screen, show_alternatives?: true}
+    end
+  end
+
+  defp has_valid_normal_section?(sections_data) do
+    Enum.any?(sections_data, fn {section_data, %Section{header_only: header_only}} ->
+      header_only ||
+        (is_struct(section_data, NormalSection) && has_valid_normal_section_row?(section_data))
+    end)
+  end
+
+  defp has_valid_normal_section_row?(%NormalSection{rows: rows}) do
+    Enum.any?(rows, fn row ->
+      is_struct(row, Departure) || match?({%Schedule{}, :first_trip}, row)
+    end)
+  end
+
+  defp handle_unsupported_sections(
+         section_to_change,
+         %Section{
+           header: header,
+           layout: layout,
+           grouping_type: grouping_type,
+           query: %Query{params: %Query.Params{direction_id: direction_id}}
+         }
+       ) do
+    text =
+      case section_to_change do
+        %HeadwaySection{route: route, headsign: headsign} ->
+          headway_text(route, headsign)
+
+        %NoDataSection{route: route} ->
+          no_data_text(route, direction_id)
+
+        %OvernightSection{routes: routes} ->
+          no_data_text(List.first(routes), direction_id)
+
+        %NoServiceSection{routes: routes} ->
+          no_data_text(List.first(routes), direction_id)
+      end
+
+    %NormalSection{
+      rows: [text],
+      header: header,
+      layout: layout,
+      grouping_type: grouping_type
+    }
+  end
+
+  defp post_process_rows(
+         rows,
+         %Section{filters: filters, bidirectional: bidirectional, grouping_type: grouping_type},
+         _total_section_count
+       ) do
+    rows
+    |> filter_rows(filters)
+    |> maybe_sort_by_direction_id(grouping_type)
+    |> RdsDepartures.maybe_make_bidirectional(bidirectional)
+  end
+
+  defp headway_text(route, headsign) do
+    %FreeTextLine{
+      icon: if(route, do: Route.icon(route), else: nil),
+      text: [no_departures_message(headsign)]
+    }
+  end
+
+  @spec no_data_text(Route.t() | nil, Trip.direction() | :both) :: FreeTextLine.t()
+  defp no_data_text(nil, _direction_id) do
+    %FreeTextLine{
+      icon: nil,
+      text: [no_departures_message()]
+    }
+  end
+
+  defp no_data_text(route, direction_id) when direction_id == :both do
+    %FreeTextLine{
+      icon: Route.icon(route),
+      text: [no_departures_message()]
+    }
+  end
+
+  defp no_data_text(%Route{direction_names: direction_names} = route, direction_id) do
+    %FreeTextLine{
+      icon: Route.icon(route),
+      text: [
+        # In cases where we have NoDataSections, we might have only a route_id for the icon
+        # Omit the normalized direction name in this instance
+        if direction_names == nil do
+          no_departures_message()
+        else
+          route
+          |> Route.normalized_direction_names()
+          |> Enum.at(direction_id, "")
+          |> no_departures_message()
+        end
+      ]
+    }
+  end
+
+  defp no_departures_message, do: "No departures currently available"
+  defp no_departures_message(name), do: "No #{name} departures available"
+
+  defp filter_rows(rows, %Filters{route_directions: route_directions}) do
+    rows
+    |> filter_unsupported_rows()
+    |> filter_by_route_direction(route_directions)
+  end
+
+  defp filter_unsupported_rows(rows) do
+    Enum.filter(rows, fn
+      %Departure{} -> true
+      {%Schedule{}, :first_trip} -> true
+      _ -> false
+    end)
+  end
+
+  @spec filter_by_route_direction([NormalSection.row()], RouteDirections.t() | nil) :: [
+          NormalSection.row()
+        ]
+  defp filter_by_route_direction(rows, %RouteDirections{
+         action: :include,
+         targets: targets
+       }) do
+    Enum.filter(rows, &row_in_route_directions?(&1, targets))
+  end
+
+  defp filter_by_route_direction(rows, %RouteDirections{
+         action: :exclude,
+         targets: targets
+       }) do
+    Enum.reject(rows, &row_in_route_directions?(&1, targets))
+  end
+
+  defp filter_by_route_direction(departures, nil) do
+    departures
+  end
+
+  defp row_in_route_directions?(row, route_directions) do
+    route_direction(row) in route_directions
+  end
+
+  defp route_direction(%Departure{} = d) do
+    %RouteDirection{route_id: Departure.route(d).id, direction_id: Departure.direction_id(d)}
+  end
+
+  defp route_direction(
+         {%Schedule{route: %Route{id: id}, direction_id: direction_id}, :first_trip}
+       ) do
+    %RouteDirection{route_id: id, direction_id: direction_id}
+  end
+
+  defp maybe_sort_by_direction_id(departures, :destination),
+    do: Enum.sort_by(departures, &(1 - RdsDepartures.departure_direction_id(&1)))
+
+  defp maybe_sort_by_direction_id(departures, _grouping_type), do: departures
+
+  defp departures_slots(%Busway{departures: d1, secondary_departures: d2}),
+    do: [{d1, [:main_content, :main_content_left]}, {d2, [:main_content_right]}]
+
+  defp departures_slots(%PreFare{departures: d, template: :duo}), do: [{d, [:main_content_left]}]
+  defp departures_slots(%PreFare{departures: d, template: :solo}), do: [{d, [:large]}]
+  defp departures_slots(%_app{departures: d}), do: [{d, [:main_content]}]
+end

--- a/lib/screens/v2/rds.ex
+++ b/lib/screens/v2/rds.ex
@@ -156,6 +156,8 @@ defmodule Screens.V2.RDS do
       end)
 
   @spec from_section(Section.t(), DateTime.t()) :: data()
+  defp from_section(%Section{header_only: true}, _now), do: {:ok, []}
+
   defp from_section(
          %Section{query: %Query{params: %Query.Params{stop_ids: stop_ids} = params}},
          now

--- a/lib/screens/v2/widget_instance/departures.ex
+++ b/lib/screens/v2/widget_instance/departures.ex
@@ -48,10 +48,10 @@ defmodule Screens.V2.WidgetInstance.Departures do
 
     @type t :: %__MODULE__{
             headsign: String.t() | nil,
-            route_id: Route.id(),
+            route: Route.t(),
             time_range: Headways.range()
           }
-    defstruct ~w[headsign route_id time_range]a
+    defstruct ~w[headsign route time_range]a
   end
 
   defmodule OvernightSection do
@@ -208,7 +208,11 @@ defmodule Screens.V2.WidgetInstance.Departures do
   end
 
   def serialize_section(
-        %HeadwaySection{route_id: route_id, time_range: time_range, headsign: headsign},
+        %HeadwaySection{
+          route: %Route{id: route_id},
+          time_range: time_range,
+          headsign: headsign
+        },
         _screen,
         _now,
         is_only_section

--- a/test/screens/v2/candidate_generator/dup/departures_test.exs
+++ b/test/screens/v2/candidate_generator/dup/departures_test.exs
@@ -1014,7 +1014,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
       expected_primary_sections = [
         %Screens.V2.WidgetInstance.Departures.HeadwaySection{
           headsign: expected_headsign,
-          route_id: expected_route_id,
+          route: %Route{id: expected_route_id},
           time_range: expected_time_range
         }
       ]
@@ -1060,7 +1060,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
       expected_primary_sections = [
         %Screens.V2.WidgetInstance.Departures.HeadwaySection{
           headsign: expected_direction_name,
-          route_id: expected_route_id,
+          route: %Route{id: expected_route_id},
           time_range: expected_time_range
         }
       ]

--- a/test/screens/v2/candidate_generator/widgets/realtime_departures_test.exs
+++ b/test/screens/v2/candidate_generator/widgets/realtime_departures_test.exs
@@ -1,0 +1,469 @@
+defmodule Screens.V2.CandidateGenerator.Widgets.RealtimeDeparturesTest do
+  use ExUnit.Case, async: true
+
+  alias Screens.Lines.Line
+  alias Screens.Predictions.Prediction
+  alias Screens.Routes.Route
+  alias Screens.Schedules.Schedule
+  alias Screens.Stops.Stop
+  alias Screens.Trips.Trip
+  alias Screens.V2.CandidateGenerator.Widgets.RealtimeDepartures
+  alias Screens.V2.Departure
+  alias Screens.V2.RDS
+  alias Screens.V2.WidgetInstance.Departures, as: DeparturesWidget
+  alias Screens.V2.WidgetInstance.Departures.NormalSection
+  alias Screens.V2.WidgetInstance.DeparturesNoData
+  alias ScreensConfig.Departures, as: DeparturesConfig
+  alias ScreensConfig.Departures.{Filters, Header, Layout, Query, Section}
+  alias ScreensConfig.Departures.Filters.RouteDirections
+  alias ScreensConfig.Departures.Filters.RouteDirections.RouteDirection
+  alias ScreensConfig.Screen
+  alias ScreensConfig.Screen.BusShelter
+
+  import Screens.Inject
+  import Mox
+  setup :verify_on_exit!
+  @rds injected(RDS)
+
+  @now ~U[2020-04-06T10:00:00Z]
+
+  defp build_schedule(route_id, line_id, type \\ :bus, direction_id \\ 0) do
+    %Schedule{
+      arrival_time: ~U[2026-01-01 12:37:00Z],
+      departure_time: ~U[2026-01-01 12:38:00Z],
+      route: %Route{id: route_id, line: %Line{id: line_id}, type: type},
+      trip: %Trip{direction_id: direction_id}
+    }
+  end
+
+  defp build_departure(
+         route_id,
+         direction_id,
+         route_type \\ :bus,
+         arrival_time \\ ~U[2026-01-01 12:37:00Z]
+       ) do
+    %Departure{
+      prediction: %Prediction{
+        route: %Route{id: route_id, type: route_type},
+        trip: %Trip{direction_id: direction_id},
+        arrival_time: arrival_time
+      }
+    }
+  end
+
+  defp no_service(stop_id, line_id, headsign) do
+    %RDS.NoService{
+      destinations: [{%Stop{id: stop_id}, %Line{id: line_id}, headsign}],
+      routes: [
+        %Screens.Routes.Route{
+          id: "r1",
+          short_name: nil,
+          long_name: nil,
+          direction_names: nil,
+          direction_destinations: nil,
+          type: :bus,
+          line: %Screens.Lines.Line{
+            id: "l1",
+            long_name: nil,
+            short_name: nil,
+            sort_order: nil
+          }
+        },
+        %Screens.Routes.Route{
+          id: "r2",
+          short_name: nil,
+          long_name: nil,
+          direction_names: nil,
+          direction_destinations: nil,
+          type: :bus,
+          line: %Screens.Lines.Line{
+            id: "l2",
+            long_name: nil,
+            short_name: nil,
+            sort_order: nil
+          }
+        }
+      ]
+    }
+  end
+
+  defp countdowns(stop_id, line_id, headsign, departures) do
+    %RDS.Countdowns{
+      destinations: [{%Stop{id: stop_id}, %Line{id: line_id}, headsign}],
+      departures: departures
+    }
+  end
+
+  defp first_trip(stop_id, line_id, headsign, schedule) do
+    %RDS.FirstTrip{
+      destinations: [{%Stop{id: stop_id}, %Line{id: line_id}, headsign}],
+      first_schedule: schedule
+    }
+  end
+
+  defp service_ended(stop_id, line_id, headsign, schedule) do
+    %RDS.ServiceEnded{
+      destinations: [{%Stop{id: stop_id}, %Line{id: line_id}, headsign}],
+      last_schedule: schedule
+    }
+  end
+
+  defp headways(
+         stop_id,
+         line_id,
+         headsign,
+         route_id,
+         direction_name,
+         direction_id
+       ) do
+    %RDS.Headways{
+      destinations: [{%Stop{id: stop_id}, %Line{id: line_id}, headsign}],
+      routes: [%Route{id: route_id}],
+      displayed_headsign: direction_name,
+      direction_id: direction_id,
+      range: {5, 10}
+    }
+  end
+
+  setup do
+    stub(@rds, :get, fn _departures, @now -> [] end)
+    :ok
+  end
+
+  describe "departures_instances/2" do
+    defp build_config(sections_or_route_ids) do
+      %Screen{
+        app_params: %BusShelter{
+          departures: build_departures_config(sections_or_route_ids),
+          header: nil,
+          footer: nil,
+          alerts: nil
+        },
+        vendor: nil,
+        device_id: nil,
+        name: nil,
+        app_id: :bus_shelter_v2
+      }
+    end
+
+    defp build_departures_config(sections_or_route_ids) do
+      %DeparturesConfig{
+        sections:
+          case sections_or_route_ids do
+            [%Section{} | _] = sections ->
+              sections
+
+            route_ids ->
+              Enum.map(
+                route_ids,
+                &%Section{query: %Query{params: %Query.Params{route_ids: [&1]}}}
+              )
+          end
+      }
+    end
+
+    test "returns DeparturesNoData when all sections come back empty or with errors" do
+      config = build_config(["route_A"])
+
+      expect(@rds, :get, fn _departures, @now ->
+        [:error, {:ok, []}, :error]
+      end)
+
+      assert [%DeparturesNoData{}] = RealtimeDepartures.departures_instances(config, @now)
+    end
+
+    test "returns DeparturesNoData when all sections are sections we don't support" do
+      config = build_config(["route_A"])
+
+      expect(@rds, :get, fn _departures, @now ->
+        [
+          {:ok,
+           [
+             no_service("stop_id_one", "line_id_one", "test_headsign_one"),
+             service_ended(
+               "stop_id_two",
+               "line_id_two",
+               "test_headsign_two",
+               build_schedule("route_two", "line_id_two")
+             ),
+             headways(
+               "stop_id_three",
+               "line_id_three",
+               "test_headsign_three",
+               "route_id_three",
+               "direction_zero",
+               0
+             )
+           ]}
+        ]
+      end)
+
+      assert [%DeparturesNoData{}] = RealtimeDepartures.departures_instances(config, @now)
+    end
+
+    test "returns NormalSection with departures when RDS returns supported and unsupported states" do
+      config = build_config(["route_A"])
+
+      schedule = build_schedule("route_two", "line_id_two")
+      departure = build_departure("r1", 0, :bus)
+
+      expect(@rds, :get, fn _departures, @now ->
+        [
+          {:ok,
+           [
+             countdowns("stop_id_one", "line_id_one", "headsign", [departure]),
+             first_trip("stop_id_two", "line_id_two", "test_headsign_two", schedule),
+             no_service("stop_id_three", "line_id_three", "test_headsign_three")
+           ]}
+        ]
+      end)
+
+      assert [
+               %DeparturesWidget{
+                 now: @now,
+                 order: 0,
+                 screen: ^config,
+                 sections: [
+                   %NormalSection{
+                     header: %Header{},
+                     grouping_type: :time,
+                     layout: %Layout{},
+                     rows: [^departure, %Departure{schedule: ^schedule, prediction: nil}]
+                   }
+                 ]
+               }
+             ] = RealtimeDepartures.departures_instances(config, @now)
+    end
+
+    test "returns NormalSection with departures and no data sections when we have one section with supported rows and one without" do
+      config = build_config(["route_A", "route_B"])
+
+      schedule = build_schedule("route_two", "line_id_two")
+      departure = build_departure("r1", 0, :bus)
+
+      expect(@rds, :get, fn _departures, @now ->
+        [
+          {:ok,
+           [
+             countdowns("stop_id_one", "line_id_one", "headsign", [departure]),
+             first_trip("stop_id_two", "line_id_two", "test_headsign_two", schedule),
+             no_service("stop_id_three", "line_id_three", "test_headsign_three")
+           ]},
+          {:ok,
+           [
+             no_service("stop_id_three", "line_id_three", "test_headsign_three")
+           ]}
+        ]
+      end)
+
+      assert [
+               %DeparturesWidget{
+                 now: @now,
+                 order: 0,
+                 screen: ^config,
+                 sections: [
+                   %NormalSection{
+                     header: %Header{},
+                     grouping_type: :time,
+                     layout: %Layout{},
+                     rows: [^departure, %Departure{schedule: ^schedule, prediction: nil}]
+                   },
+                   %NormalSection{
+                     header: %Header{},
+                     grouping_type: :time,
+                     layout: %Layout{},
+                     rows: [
+                       %ScreensConfig.FreeTextLine{
+                         icon: :bus,
+                         text: ["No departures currently available"]
+                       }
+                     ]
+                   }
+                 ]
+               }
+             ] = RealtimeDepartures.departures_instances(config, @now)
+    end
+
+    test "returns NormalSection to display if it's header only, even if other sections have no data" do
+      config =
+        build_config([
+          %Section{
+            header: %Header{title: "Test Header"},
+            header_only: true,
+            query: %Query{params: %Query.Params{route_ids: []}}
+          },
+          %Section{query: %Query{params: %Query.Params{route_ids: ["route_one"]}}}
+        ])
+
+      expect(@rds, :get, fn _departures, @now ->
+        [
+          {:ok, []},
+          {:ok,
+           [
+             no_service("stop_id_three", "line_id_three", "test_headsign_three")
+           ]}
+        ]
+      end)
+
+      assert [
+               %DeparturesWidget{
+                 now: @now,
+                 order: 0,
+                 screen: ^config,
+                 sections: [
+                   %NormalSection{header: %Header{title: "Test Header"}, rows: []},
+                   %NormalSection{
+                     header: %Header{},
+                     grouping_type: :time,
+                     layout: %Layout{},
+                     rows: [
+                       %ScreensConfig.FreeTextLine{
+                         icon: :bus,
+                         text: ["No departures currently available"]
+                       }
+                     ]
+                   }
+                 ]
+               }
+             ] = RealtimeDepartures.departures_instances(config, @now)
+    end
+
+    test "post process filters departures by time when a section has a max_minutes" do
+      config =
+        build_config([
+          %Section{
+            query: %Query{params: %Query.Params{stop_ids: ["S"]}},
+            filters: %Filters{max_minutes: 10}
+          }
+        ])
+
+      included_departures = [
+        build_departure("1", 0, nil, DateTime.add(@now, 8, :minute)),
+        build_departure("1", 0, nil, DateTime.add(@now, 9, :minute))
+      ]
+
+      excluded_departure = [
+        build_departure("1", 0, nil, DateTime.add(@now, 11, :minute))
+      ]
+
+      all_departures = included_departures ++ excluded_departure
+
+      expect(@rds, :get, fn _departures, @now ->
+        [
+          {:ok,
+           [
+             countdowns("stop_id_one", "line_id_one", "headsign", all_departures)
+           ]}
+        ]
+      end)
+
+      assert [%DeparturesWidget{sections: [%NormalSection{rows: ^included_departures}]}] =
+               RealtimeDepartures.departures_instances(config, @now)
+    end
+
+    test "post process filters departures with included route-directions" do
+      config =
+        build_config([
+          %Section{
+            query: %Query{params: %Query.Params{stop_ids: ["S"]}},
+            filters: %Filters{
+              route_directions: %RouteDirections{
+                action: :include,
+                targets: [
+                  %RouteDirection{route_id: "39", direction_id: 0},
+                  %RouteDirection{route_id: "41", direction_id: 0}
+                ]
+              }
+            }
+          }
+        ])
+
+      included_departure = build_departure("41", 0)
+      all_departures = [build_departure("41", 1), included_departure, build_departure("1", 1)]
+
+      expect(@rds, :get, fn _departures, @now ->
+        [
+          {:ok,
+           [
+             countdowns("bus_route", "line_id_one", "headsign", all_departures)
+           ]}
+        ]
+      end)
+
+      assert [%DeparturesWidget{sections: [%NormalSection{rows: [^included_departure]}]}] =
+               RealtimeDepartures.departures_instances(config, @now)
+    end
+
+    test "post process filters departures with excludes route-directions" do
+      config =
+        build_config([
+          %Section{
+            query: %Query{params: %Query.Params{stop_ids: ["S"]}},
+            filters: %Filters{
+              route_directions: %RouteDirections{
+                action: :exclude,
+                targets: [
+                  %RouteDirection{route_id: "39", direction_id: 0},
+                  %RouteDirection{route_id: "41", direction_id: 0}
+                ]
+              }
+            }
+          }
+        ])
+
+      excluded_departures = [build_departure("41", 0), build_departure("39", 0)]
+      included_departures = [build_departure("41", 1), build_departure("1", 1)]
+      all_departures = excluded_departures ++ included_departures
+
+      expect(@rds, :get, fn _departures, @now ->
+        [
+          {:ok,
+           [
+             countdowns("bus_route", "line_id_one", "headsign", all_departures)
+           ]}
+        ]
+      end)
+
+      assert [%DeparturesWidget{sections: [%NormalSection{rows: ^included_departures}]}] =
+               RealtimeDepartures.departures_instances(config, @now)
+    end
+
+    test "post process filters departures for sections configured as bidirectional" do
+      config =
+        build_config([
+          %Section{query: %Query{params: %Query.Params{route_ids: ["A"]}}, bidirectional: true},
+          %Section{query: %Query{params: %Query.Params{route_ids: ["B"]}}}
+        ])
+
+      departure_a_0 = build_departure("A", 0)
+      departure_a_1 = build_departure("A", 1)
+      departure_b_0 = build_departure("B", 0)
+
+      expect(@rds, :get, fn _departures, @now ->
+        [
+          {:ok,
+           [
+             countdowns("bus_route", "line_id_one", "headsign", [
+               departure_a_0,
+               departure_a_0,
+               departure_a_1,
+               departure_a_0
+             ])
+           ]},
+          {:ok,
+           [countdowns("bus_route", "line_id_one", "headsign", [departure_b_0, departure_b_0])]}
+        ]
+      end)
+
+      assert [
+               %DeparturesWidget{
+                 screen: ^config,
+                 sections: [
+                   %{rows: [^departure_a_0, ^departure_a_1]},
+                   %{rows: [^departure_b_0, ^departure_b_0]}
+                 ]
+               }
+             ] = RealtimeDepartures.departures_instances(config, @now)
+    end
+  end
+end

--- a/test/screens/v2/candidate_generator/widgets/realtime_departures_test.exs
+++ b/test/screens/v2/candidate_generator/widgets/realtime_departures_test.exs
@@ -1,0 +1,436 @@
+defmodule Screens.V2.CandidateGenerator.Widgets.RealtimeDeparturesTest do
+  use ExUnit.Case, async: true
+
+  alias Screens.Lines.Line
+  alias Screens.Predictions.Prediction
+  alias Screens.Routes.Route
+  alias Screens.Schedules.Schedule
+  alias Screens.Stops.Stop
+  alias Screens.Trips.Trip
+  alias Screens.V2.CandidateGenerator.Widgets.RealtimeDepartures
+  alias Screens.V2.Departure
+  alias Screens.V2.RDS
+  alias Screens.V2.WidgetInstance.Departures, as: DeparturesWidget
+  alias Screens.V2.WidgetInstance.Departures.NormalSection
+  alias Screens.V2.WidgetInstance.DeparturesNoData
+  alias ScreensConfig.Departures, as: DeparturesConfig
+  alias ScreensConfig.Departures.{Filters, Header, Layout, Query, Section}
+  alias ScreensConfig.Departures.Filters.RouteDirections
+  alias ScreensConfig.Departures.Filters.RouteDirections.RouteDirection
+  alias ScreensConfig.Screen
+  alias ScreensConfig.Screen.BusShelter
+
+  import Screens.Inject
+  import Mox
+  setup :verify_on_exit!
+  @rds injected(RDS)
+
+  @now ~U[2020-04-06T10:00:00Z]
+
+  defp build_schedule(route_id, line_id, type \\ :bus, direction_id \\ 0) do
+    %Schedule{
+      arrival_time: ~U[2026-01-01 12:37:00Z],
+      departure_time: ~U[2026-01-01 12:38:00Z],
+      route: %Route{id: route_id, line: %Line{id: line_id}, type: type},
+      trip: %Trip{direction_id: direction_id}
+    }
+  end
+
+  defp build_departure(
+         route_id,
+         direction_id,
+         route_type \\ :bus,
+         arrival_time \\ ~U[2026-01-01 12:37:00Z]
+       ) do
+    %Departure{
+      prediction: %Prediction{
+        route: %Route{id: route_id, type: route_type},
+        trip: %Trip{direction_id: direction_id},
+        arrival_time: arrival_time
+      }
+    }
+  end
+
+  defp no_service(stop_id, line_id, headsign) do
+    %RDS.NoService{
+      destinations: [{%Stop{id: stop_id}, %Line{id: line_id}, headsign}],
+      routes: [
+        %Screens.Routes.Route{
+          id: "r1",
+          short_name: nil,
+          long_name: nil,
+          direction_names: nil,
+          direction_destinations: nil,
+          type: :bus,
+          line: %Screens.Lines.Line{
+            id: "l1",
+            long_name: nil,
+            short_name: nil,
+            sort_order: nil
+          }
+        },
+        %Screens.Routes.Route{
+          id: "r2",
+          short_name: nil,
+          long_name: nil,
+          direction_names: nil,
+          direction_destinations: nil,
+          type: :bus,
+          line: %Screens.Lines.Line{
+            id: "l2",
+            long_name: nil,
+            short_name: nil,
+            sort_order: nil
+          }
+        }
+      ]
+    }
+  end
+
+  defp countdowns(stop_id, line_id, headsign, departures) do
+    %RDS.Countdowns{
+      destinations: [{%Stop{id: stop_id}, %Line{id: line_id}, headsign}],
+      departures: departures
+    }
+  end
+
+  defp first_trip(stop_id, line_id, headsign, schedule) do
+    %RDS.FirstTrip{
+      destinations: [{%Stop{id: stop_id}, %Line{id: line_id}, headsign}],
+      first_schedule: schedule
+    }
+  end
+
+  defp service_ended(stop_id, line_id, headsign, schedule) do
+    %RDS.ServiceEnded{
+      destinations: [{%Stop{id: stop_id}, %Line{id: line_id}, headsign}],
+      last_schedule: schedule
+    }
+  end
+
+  defp headways(
+         stop_id,
+         line_id,
+         headsign,
+         route_id,
+         direction_name,
+         direction_id
+       ) do
+    %RDS.Headways{
+      destinations: [{%Stop{id: stop_id}, %Line{id: line_id}, headsign}],
+      routes: [%Route{id: route_id}],
+      displayed_headsign: direction_name,
+      direction_id: direction_id,
+      range: {5, 10}
+    }
+  end
+
+  setup do
+    stub(@rds, :get, fn _departures, @now -> [] end)
+    :ok
+  end
+
+  describe "departures_instances/2" do
+    defp build_config(sections_or_route_ids) do
+      %Screen{
+        app_params: %BusShelter{
+          departures: build_departures_config(sections_or_route_ids),
+          header: nil,
+          footer: nil,
+          alerts: nil
+        },
+        vendor: nil,
+        device_id: nil,
+        name: nil,
+        app_id: :bus_shelter_v2
+      }
+    end
+
+    defp build_departures_config(sections_or_route_ids) do
+      %DeparturesConfig{
+        sections:
+          case sections_or_route_ids do
+            [%Section{} | _] = sections ->
+              sections
+
+            route_ids ->
+              Enum.map(
+                route_ids,
+                &%Section{query: %Query{params: %Query.Params{route_ids: [&1]}}}
+              )
+          end
+      }
+    end
+
+    test "returns DeparturesNoData when all sections come back empty or with errors" do
+      config = build_config(["route_A"])
+
+      expect(@rds, :get, fn _departures, @now ->
+        [:error, {:ok, []}, :error]
+      end)
+
+      assert [%DeparturesNoData{}] = RealtimeDepartures.departures_instances(config, @now)
+    end
+
+    test "returns DeparturesNoData when all sections are sections we don't support" do
+      config = build_config(["route_A"])
+
+      expect(@rds, :get, fn _departures, @now ->
+        [
+          {:ok,
+           [
+             no_service("stop_id_one", "line_id_one", "test_headsign_one"),
+             service_ended(
+               "stop_id_two",
+               "line_id_two",
+               "test_headsign_two",
+               build_schedule("route_two", "line_id_two")
+             ),
+             headways(
+               "stop_id_three",
+               "line_id_three",
+               "test_headsign_three",
+               "route_id_three",
+               "direction_zero",
+               0
+             )
+           ]}
+        ]
+      end)
+
+      assert [%DeparturesNoData{}] = RealtimeDepartures.departures_instances(config, @now)
+    end
+
+    test "returns NormalSection with departures when RDS returns supported and unsupported states" do
+      config = build_config(["route_A"])
+
+      schedule = build_schedule("route_two", "line_id_two")
+      departure = build_departure("r1", 0, :bus)
+
+      expect(@rds, :get, fn _departures, @now ->
+        [
+          {:ok,
+           [
+             countdowns("stop_id_one", "line_id_one", "headsign", [departure]),
+             first_trip("stop_id_two", "line_id_two", "test_headsign_two", schedule),
+             no_service("stop_id_three", "line_id_three", "test_headsign_three")
+           ]}
+        ]
+      end)
+
+      assert [
+               %DeparturesWidget{
+                 now: @now,
+                 order: 0,
+                 screen: ^config,
+                 sections: [
+                   %NormalSection{
+                     header: %Header{},
+                     grouping_type: :time,
+                     layout: %Layout{},
+                     rows: [^departure, %Departure{schedule: ^schedule, prediction: nil}]
+                   }
+                 ]
+               }
+             ] = RealtimeDepartures.departures_instances(config, @now)
+    end
+
+    test "returns NormalSection with departures and no data sections when we have one section with supported rows and one without" do
+      config = build_config(["route_A", "route_B"])
+
+      schedule = build_schedule("route_two", "line_id_two")
+      departure = build_departure("r1", 0, :bus)
+
+      expect(@rds, :get, fn _departures, @now ->
+        [
+          {:ok,
+           [
+             countdowns("stop_id_one", "line_id_one", "headsign", [departure]),
+             first_trip("stop_id_two", "line_id_two", "test_headsign_two", schedule),
+             no_service("stop_id_three", "line_id_three", "test_headsign_three")
+           ]},
+          {:ok,
+           [
+             no_service("stop_id_three", "line_id_three", "test_headsign_three")
+           ]}
+        ]
+      end)
+
+      assert [
+               %DeparturesWidget{
+                 now: @now,
+                 order: 0,
+                 screen: ^config,
+                 sections: [
+                   %NormalSection{
+                     header: %Header{},
+                     grouping_type: :time,
+                     layout: %Layout{},
+                     rows: [^departure, %Departure{schedule: ^schedule, prediction: nil}]
+                   },
+                   %NormalSection{
+                     header: %Header{},
+                     grouping_type: :time,
+                     layout: %Layout{},
+                     rows: [
+                       %ScreensConfig.FreeTextLine{
+                         icon: :bus,
+                         text: ["No departures currently available"]
+                       }
+                     ]
+                   }
+                 ]
+               }
+             ] = RealtimeDepartures.departures_instances(config, @now)
+    end
+
+    test "returns NormalSection to display if it's header only, even if other sections have no data" do
+      config =
+        build_config([
+          %Section{
+            header: %Header{title: "Test Header"},
+            header_only: true,
+            query: %Query{params: %Query.Params{route_ids: []}}
+          },
+          %Section{query: %Query{params: %Query.Params{route_ids: ["route_one"]}}}
+        ])
+
+      expect(@rds, :get, fn _departures, @now ->
+        [
+          {:ok, []},
+          {:ok,
+           [
+             no_service("stop_id_three", "line_id_three", "test_headsign_three")
+           ]}
+        ]
+      end)
+
+      assert [
+               %DeparturesWidget{
+                 now: @now,
+                 order: 0,
+                 screen: ^config,
+                 sections: [
+                   %NormalSection{header: %Header{title: "Test Header"}, rows: []},
+                   %NormalSection{
+                     header: %Header{},
+                     grouping_type: :time,
+                     layout: %Layout{},
+                     rows: [
+                       %ScreensConfig.FreeTextLine{
+                         icon: :bus,
+                         text: ["No departures currently available"]
+                       }
+                     ]
+                   }
+                 ]
+               }
+             ] = RealtimeDepartures.departures_instances(config, @now)
+    end
+
+    test "post process filters departures with included route-directions" do
+      config =
+        build_config([
+          %Section{
+            query: %Query{params: %Query.Params{stop_ids: ["S"]}},
+            filters: %Filters{
+              route_directions: %RouteDirections{
+                action: :include,
+                targets: [
+                  %RouteDirection{route_id: "39", direction_id: 0},
+                  %RouteDirection{route_id: "41", direction_id: 0}
+                ]
+              }
+            }
+          }
+        ])
+
+      included_departure = build_departure("41", 0)
+      all_departures = [build_departure("41", 1), included_departure, build_departure("1", 1)]
+
+      expect(@rds, :get, fn _departures, @now ->
+        [
+          {:ok,
+           [
+             countdowns("bus_route", "line_id_one", "headsign", all_departures)
+           ]}
+        ]
+      end)
+
+      assert [%DeparturesWidget{sections: [%NormalSection{rows: [^included_departure]}]}] =
+               RealtimeDepartures.departures_instances(config, @now)
+    end
+
+    test "post process filters departures with excludes route-directions" do
+      config =
+        build_config([
+          %Section{
+            query: %Query{params: %Query.Params{stop_ids: ["S"]}},
+            filters: %Filters{
+              route_directions: %RouteDirections{
+                action: :exclude,
+                targets: [
+                  %RouteDirection{route_id: "39", direction_id: 0},
+                  %RouteDirection{route_id: "41", direction_id: 0}
+                ]
+              }
+            }
+          }
+        ])
+
+      excluded_departures = [build_departure("41", 0), build_departure("39", 0)]
+      included_departures = [build_departure("41", 1), build_departure("1", 1)]
+      all_departures = excluded_departures ++ included_departures
+
+      expect(@rds, :get, fn _departures, @now ->
+        [
+          {:ok,
+           [
+             countdowns("bus_route", "line_id_one", "headsign", all_departures)
+           ]}
+        ]
+      end)
+
+      assert [%DeparturesWidget{sections: [%NormalSection{rows: ^included_departures}]}] =
+               RealtimeDepartures.departures_instances(config, @now)
+    end
+
+    test "post process filters departures for sections configured as bidirectional" do
+      config =
+        build_config([
+          %Section{query: %Query{params: %Query.Params{route_ids: ["A"]}}, bidirectional: true},
+          %Section{query: %Query{params: %Query.Params{route_ids: ["B"]}}}
+        ])
+
+      departure_a_0 = build_departure("A", 0)
+      departure_a_1 = build_departure("A", 1)
+      departure_b_0 = build_departure("B", 0)
+
+      expect(@rds, :get, fn _departures, @now ->
+        [
+          {:ok,
+           [
+             countdowns("bus_route", "line_id_one", "headsign", [
+               departure_a_0,
+               departure_a_0,
+               departure_a_1,
+               departure_a_0
+             ])
+           ]},
+          {:ok,
+           [countdowns("bus_route", "line_id_one", "headsign", [departure_b_0, departure_b_0])]}
+        ]
+      end)
+
+      assert [
+               %DeparturesWidget{
+                 screen: ^config,
+                 sections: [
+                   %{rows: [^departure_a_0, ^departure_a_1]},
+                   %{rows: [^departure_b_0, ^departure_b_0]}
+                 ]
+               }
+             ] = RealtimeDepartures.departures_instances(config, @now)
+    end
+  end
+end

--- a/test/screens/v2/widget_instance/departures_test.exs
+++ b/test/screens/v2/widget_instance/departures_test.exs
@@ -114,7 +114,7 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
       dup_screen: dup_screen,
       now: now
     } do
-      section = %HeadwaySection{route_id: "Red", time_range: {1, 2}, headsign: "Test"}
+      section = %HeadwaySection{route: %Route{id: "Red"}, time_range: {1, 2}, headsign: "Test"}
 
       expected_text = %{
         icon: "subway-negative-black",
@@ -137,7 +137,7 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
            now: now
          } do
       section = %HeadwaySection{
-        route_id: "Red",
+        route: %Route{id: "Red"},
         time_range: {1, 2},
         headsign: "Ashmont/Braintree"
       }
@@ -160,7 +160,7 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
       dup_screen: dup_screen,
       now: now
     } do
-      section = %HeadwaySection{route_id: "Red", time_range: {1, 2}, headsign: nil}
+      section = %HeadwaySection{route: %Route{id: "Red"}, time_range: {1, 2}, headsign: nil}
 
       expected_text = %{
         icon: :red,
@@ -175,7 +175,11 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
       dup_screen: dup_screen,
       now: now
     } do
-      section = %HeadwaySection{route_id: "Red", time_range: {12, 15}, headsign: "Alewife"}
+      section = %HeadwaySection{
+        route: %Route{id: "Red"},
+        time_range: {12, 15},
+        headsign: "Alewife"
+      }
 
       expected_text = %{
         icon: :red,


### PR DESCRIPTION
**Asana task**: [Implement RDS MVP on LCDs](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1214589221132185?focus=true)

Description
Adds the `RealtimeDepartures` candidate generator that uses the previously pulled out shared code and filters sections that we don't support and filters out rows that we don't support within `NormalSections`. 

Depending on if we have a valid `NormalSection` during generation, we either display the `DeparturesNoData` widget, or a `DeparturesWidget` with sections that have `NormalSections`, or a `NormalSection` that displays a `FreeTextLine` with a `No departures currently available` message (adjusted from the sections we don't support). 

It uses the current `no_departures_message()` in the old `Screens.V2.CandidateGenerator.Widgets.Departures`. There should currently be no UI changes from the current pre-RDS impelementation. 

One small difference in this logic is that in the old `Departures` code, we would try and fetch an associated route every time we have no data hitting the route endpoint. In the new code, we depend on the different types of Sections to pass the route and create a `no_departures_message` based on that route, and so I slightly modified HeadwaySections to include the `route` instead of just the `route_id`. 

- [x] Tests added?
