### PR TITLE
perf: avoid racing duplicate V3 API requests

### DIFF
--- a/lib/screens/v3_api.ex
+++ b/lib/screens/v3_api.ex
@@ -12,15 +12,27 @@ defmodule Screens.V3Api do
     meta = Map.merge(ctx, %{path: path, query: URI.encode_query(params)})
 
     Screens.Telemetry.span_with_stop_meta([:screens, :v3_api, :get_json], meta, fn ->
-      case Cache.get({path, params}) do
-        {:fresh, {_last_modified, response}} ->
-          {{:ok, response}, %{cache: "local"}}
+      transaction_result =
+        Cache.transaction({path, params}, fn ->
+          case Cache.get({path, params}) do
+            {:fresh, {_last_modified, response}} ->
+              {{:ok, response}, %{cache: "local"}}
 
-        {:stale, {last_modified, response}} ->
-          fetch_json_with_meta(path, params, last_modified, response)
+            {:stale, {last_modified, response}} ->
+              fetch_json_with_meta(path, params, last_modified, response)
 
-        nil ->
-          fetch_json_with_meta(path, params)
+            nil ->
+              fetch_json_with_meta(path, params)
+          end
+        end)
+
+      case transaction_result do
+        {:ok, result_with_meta} ->
+          result_with_meta
+
+        {:error, error} ->
+          Logster.error(["api_v3_cache_error", error: inspect(error)])
+          {{:error, error}, %{}}
       end
     end)
   end

--- a/lib/screens/v3_api/cache.ex
+++ b/lib/screens/v3_api/cache.ex
@@ -54,6 +54,14 @@ defmodule Screens.V3Api.Cache do
     :ok
   end
 
+  @doc "Wrap the given function in a transaction with an exclusive lock on the given key."
+  @spec transaction(key(), (-> ret)) :: {:ok, ret} | {:error, Nebulex.Error.t()} when ret: term
+  def transaction(key, func) do
+    # API requests can take a few seconds; wait long enough that if another process is still
+    # holding the lock, the app is probably overloaded and the best thing we can do is fail.
+    cache_for(key).transaction(func, keys: [key], retries: 50, retry_interval: 100)
+  end
+
   # Imperfectly check whether a request could return any data derived from GTFS-RT, and assign
   # it to the appropriate cache. Should err on the side of over-categorizing data as `Realtime`,
   # since we give static data a very long unconditional TTL.

--- a/test/screens/v3_api/cache_test.exs
+++ b/test/screens/v3_api/cache_test.exs
@@ -54,4 +54,30 @@ defmodule Screens.V3Api.CacheTest do
     rt_params = Map.put(params, "include", "shape,predictions,route_pattern.route")
     assert {:stale, "resp2"} = put_and_get_after({"trips", rt_params}, "resp2", now, 10, :second)
   end
+
+  describe "transaction/2" do
+    test "locks the given key for the duration of a function", %{params: params} do
+      pid = self()
+
+      # Someone is sitting on "one" for a while
+      spawn_link(fn ->
+        Cache.transaction({"one", params}, fn ->
+          send(pid, :got1)
+          Process.sleep(1000)
+        end)
+      end)
+
+      assert_receive :got1
+
+      # Someone else wanting to lock "one" should wait behind the above
+      spawn_link(fn ->
+        Cache.transaction({"one", params}, fn -> send(pid, :waited1) end)
+      end)
+
+      # Meanwhile, someone wanting to lock "two" should have no wait
+      assert {:ok, :got2} = Cache.transaction({"two", params}, fn -> :got2 end)
+
+      refute_receive :waited1
+    end
+  end
 end


### PR DESCRIPTION
If the app made multiple requests for the same data very close to each other, more than one could end up seeing no cache entry and calling the API to populate it, multiplying the resource usage. Add transactions to ensure that if this happens, only the request that comes first calls the API; others will wait behind it and then be immediately fulfilled by the now-cached data.

**Asana task**: https://app.asana.com/1/15492006741476/project/1185117109217413/task/1215780122518148?focus=true