### PR TITLE
chore: update asana permissions

### DIFF
--- a/.github/workflows/asana.yml
+++ b/.github/workflows/asana.yml
@@ -3,7 +3,8 @@ on:
   pull_request:
     types: [edited, opened]
 
-permissions: {}
+permissions:
+  pull-requests: read # Needed to read Asana ticket info from PR description
 
 jobs:
   asana:


### PR DESCRIPTION
Updates the permissions for the asana workflow.
When the workflow was updated in 988cd33, we did
not update the permissions set in the workflow in
https://github.com/mbta/workflows/commit/c76e5ccd9556fbea52bc41548f7ceed5985ad775

Prior to this commit, the Asana workflow would fail
to run with the following error:

>  Invalid workflow file: .github/workflows/asana.yml#L9
> The workflow is not valid. .github/workflows/asana.yml (Line: 9, Col: 3): 
> Error calling workflow  'mbta/workflows/.github/workflows/asana.yml@c76e5ccd9556fbea52bc41548f7ceed5985ad775'. 
> The workflow is requesting 'pull-requests: read', but is only allowed 'pull-requests: none'.

Notes for Reviewers
- Link to failed Asana run https://github.com/mbta/screens/actions/runs/28581970522
  - Note this will expire in 90 days, hence the error message being put above/in the commit message when we merge this


**Asana task**: N/A

Description

- [ ] Tests added?
