### PR TITLE
refactor: RDS items and RDS departure widget logic

### DIFF
--- a/lib/screens/v2/candidate_generator/dup/departures.ex
+++ b/lib/screens/v2/candidate_generator/dup/departures.ex
@@ -1,22 +1,13 @@
 defmodule Screens.V2.CandidateGenerator.Dup.Departures do
   @moduledoc false
 
-  import Screens.Inject
-
-  alias Screens.Lines.Line
   alias Screens.Routes.Route
-  alias Screens.Schedules.Schedule
-  alias Screens.Trips.Trip
-
-  alias Screens.V2.Departure
   alias Screens.V2.RDS
-  alias Screens.V2.RDS.{Countdowns, FirstTrip, Headways, NoService, ServiceEnded}
 
+  alias Screens.V2.CandidateGenerator.Widgets.RdsDepartures
   alias Screens.V2.WidgetInstance.Departures, as: DeparturesWidget
 
   alias Screens.V2.WidgetInstance.Departures.{
-    HeadwayRow,
-    HeadwaySection,
     NoDataSection,
     NormalSection,
     NoServiceSection,
@@ -25,13 +16,20 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
 
   alias Screens.V2.WidgetInstance.{DeparturesNoData, DeparturesNoService, OvernightDepartures}
 
-  alias ScreensConfig.Departures
-  alias ScreensConfig.Departures.{Header, Layout, Section}
+  alias ScreensConfig.Departures.Section
   alias ScreensConfig.Screen
   alias ScreensConfig.Screen.Dup
 
-  @type widget :: DeparturesNoData.t() | DeparturesWidget.t() | OvernightDepartures.t()
+  import Screens.Inject
   @rds injected(RDS)
+
+  @type widget ::
+          DeparturesNoData.t()
+          | DeparturesNoService.t()
+          | DeparturesWidget.t()
+          | OvernightDepartures.t()
+
+  @type sections_state :: :all_no_data | :all_service_ended | :normal
 
   @max_departures_per_rotation 4
 
@@ -57,34 +55,55 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
 
     secondary_rds_sections = @rds.get(secondary_departures, now)
 
+    post_process_rows_fn = fn rows, %Section{bidirectional: bidirectional}, total_section_count ->
+      num_departures_per_section = div(@max_departures_per_rotation, total_section_count)
+
+      rows
+      |> RdsDepartures.maybe_make_bidirectional(bidirectional)
+      |> Enum.take(num_departures_per_section)
+    end
+
     primary_departure_sections =
-      create_departure_sections(primary_rds_sections, primary_departures)
+      RdsDepartures.create_departure_sections(
+        primary_rds_sections,
+        primary_departures,
+        post_process_rows_fn
+      )
 
     secondary_departure_sections =
       if secondary_rds_sections == [] or Enum.all?(secondary_rds_sections, &(&1 == {:ok, []})) do
         primary_departure_sections
       else
-        create_departure_sections(secondary_rds_sections, secondary_departures)
+        RdsDepartures.create_departure_sections(
+          secondary_rds_sections,
+          secondary_departures,
+          post_process_rows_fn
+        )
       end
 
-    all_sections_no_data =
-      Enum.all?(
-        primary_departure_sections ++ secondary_departure_sections,
-        &is_struct(&1, NoDataSection)
-      )
+    sections_state =
+      cond do
+        Enum.all?(
+          primary_departure_sections ++ secondary_departure_sections,
+          &is_struct(&1, NoDataSection)
+        ) ->
+          :all_no_data
 
-    all_sections_service_ended =
-      Enum.all?(
-        primary_departure_sections ++ secondary_departure_sections,
-        &is_struct(&1, OvernightSection)
-      )
+        Enum.all?(
+          primary_departure_sections ++ secondary_departure_sections,
+          &is_struct(&1, OvernightSection)
+        ) ->
+          :all_service_ended
+
+        true ->
+          :normal
+      end
 
     primary_instances =
       build_instances(
         @primary_slot_names,
         primary_departure_sections,
-        all_sections_no_data,
-        all_sections_service_ended,
+        sections_state,
         config,
         now
       )
@@ -93,8 +112,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
       build_instances(
         @secondary_slot_names,
         secondary_departure_sections,
-        all_sections_no_data,
-        all_sections_service_ended,
+        sections_state,
         config,
         now
       )
@@ -102,161 +120,43 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
     primary_instances ++ secondary_instances
   end
 
-  defp create_departure_sections(rds_sections, %Departures{sections: departure_sections}) do
-    section_count = length(rds_sections)
-
-    Enum.zip(rds_sections, departure_sections)
-    |> Enum.map(fn {rds_section, %Section{bidirectional: bidirectional}} ->
-      map_to_departure_section(rds_section, bidirectional, section_count)
-    end)
-  end
-
-  @spec map_to_departure_section(RDS.section_t(), boolean(), number()) ::
-          DeparturesWidget.section()
-
-  defp map_to_departure_section(:error, _, _), do: %NoDataSection{}
-
-  defp map_to_departure_section({:ok, []}, _, _), do: %NoDataSection{}
-
-  defp map_to_departure_section({:ok, rds_list}, bidirectional, section_count) do
-    num_departures_per_section = div(@max_departures_per_rotation, section_count)
-
-    cond do
-      no_service?(rds_list) ->
-        %NoServiceSection{
-          routes:
-            rds_list
-            |> Enum.flat_map(fn %RDS{state: %NoService{routes: routes}} -> routes end)
-            |> Enum.uniq()
-        }
-
-      service_ended?(rds_list) ->
-        %OvernightSection{
-          routes:
-            rds_list
-            |> Enum.map(fn %RDS{state: %ServiceEnded{last_schedule: %Schedule{route: route}}} ->
-              route
-            end)
-            |> Enum.uniq()
-        }
-
-      headways?(rds_list) ->
-        create_headway_section(rds_list)
-
-      true ->
-        %NormalSection{
-          rows:
-            create_and_sort_rows(rds_list)
-            |> maybe_make_bidirectional(bidirectional)
-            |> Enum.take(num_departures_per_section),
-          layout: %Layout{},
-          header: %Header{}
-        }
-    end
-  end
-
-  defp no_service?(rds_list) do
-    Enum.all?(rds_list, &is_struct(&1.state, NoService))
-  end
-
-  defp service_ended?(rds_list) do
-    Enum.all?(rds_list, &is_struct(&1.state, ServiceEnded))
-  end
-
-  defp headways?(rds_list) do
-    Enum.all?(rds_list, &is_struct(&1.state, Headways))
-  end
-
-  @spec create_headway_section([RDS.t()]) :: HeadwaySection.t()
-
-  # Bidirectional -> Use no headsign for the trains message
-  defp create_headway_section([
-         %RDS{state: %{route_id: route_id, direction_id: direction_id_one, range: range}}
-         | [%RDS{state: %{route_id: route_id, direction_id: direction_id_two, range: range}}]
-       ])
-       when direction_id_one != direction_id_two do
-    %HeadwaySection{
-      route: route_id,
-      time_range: range,
-      headsign: nil
-    }
-  end
-
-  # Use the headsign if the destinations have the same headsign,
-  # use the direction name if they have the same direction name,
-  # otherwise default to no headsign
-  defp create_headway_section(
-         [
-           %RDS{
-             headsign: headsign,
-             line: %Line{id: first_line_id},
-             state: %Headways{
-               route_id: route_id,
-               direction_name: direction_name,
-               direction_id: direction_id,
-               range: range
-             }
-           }
-           | _
-         ] = destinations
-       ) do
-    %HeadwaySection{
-      route: route_id,
-      time_range: range,
-      headsign:
-        cond do
-          Enum.all?(destinations, fn %RDS{headsign: other_headsign} ->
-            headsign == other_headsign
-          end) ->
-            headsign
-
-          Enum.all?(
-            destinations,
-            fn %RDS{
-                 line: %Line{id: other_line_id},
-                 state: %Headways{direction_id: other_direction_id}
-               } ->
-              first_line_id == other_line_id and direction_id == other_direction_id
-            end
-          ) ->
-            direction_name
-
-          true ->
-            nil
-        end
-    }
-  end
-
-  defp build_instances(
-         slot_names,
-         _departure_sections,
-         true = _all_section_no_data,
-         _all_section_service_ended,
-         config,
-         _now
-       ) do
+  @spec build_instances(
+          [atom()],
+          [NormalSection.row()],
+          sections_state(),
+          Screen.t(),
+          DateTime.t()
+        ) ::
+          [widget()]
+  def(
+    build_instances(
+      slot_names,
+      _departure_sections,
+      :all_no_data,
+      config,
+      _now
+    )
+  ) do
     Enum.map(slot_names, &%DeparturesNoData{screen: config, slot_name: &1})
   end
 
-  defp build_instances(
-         slot_names,
-         _departure_sections,
-         _all_section_no_data,
-         true = _all_section_service_ended,
-         config,
-         _now
-       ) do
+  def build_instances(
+        slot_names,
+        _departure_sections,
+        :all_service_ended,
+        config,
+        _now
+      ) do
     Enum.map(slot_names, &%OvernightDepartures{screen: config, slot_names: [&1]})
   end
 
-  defp build_instances(
-         slot_names,
-         departure_sections,
-         _all_section_no_data,
-         _all_section_service_ended,
-         config,
-         now
-       ) do
+  def build_instances(
+        slot_names,
+        departure_sections,
+        _sections_state,
+        config,
+        now
+      ) do
     cond do
       Enum.all?(departure_sections, &is_struct(&1, NoServiceSection)) ->
         Enum.map(
@@ -289,153 +189,15 @@ defmodule Screens.V2.CandidateGenerator.Dup.Departures do
       true ->
         Enum.map(
           slot_names,
-          &sections_to_departure_widget(&1, departure_sections, config, now)
+          fn slot_name ->
+            %DeparturesWidget{
+              screen: config,
+              sections: departure_sections,
+              slot_names: [slot_name],
+              now: now
+            }
+          end
         )
-    end
-  end
-
-  defp sections_to_departure_widget(slot_name, departure_sections, config, now) do
-    %DeparturesWidget{
-      screen: config,
-      sections: departure_sections,
-      slot_names: [slot_name],
-      now: now
-    }
-  end
-
-  @spec create_and_sort_rows([RDS.t()]) :: [NormalSection.row()]
-  defp create_and_sort_rows(rds_list) do
-    grouped_rds =
-      Enum.group_by(rds_list, fn
-        %RDS{state: %ServiceEnded{}} -> :service_ended
-        %RDS{state: %Headways{}} -> :headways
-        _ -> :other
-      end)
-
-    service_ended_rds = Map.get(grouped_rds, :service_ended, [])
-    headway_rds = Map.get(grouped_rds, :headways, [])
-    rds = Map.get(grouped_rds, :other, [])
-
-    sorted_departures_from_rds(rds) ++
-      headways_from_rds(rds ++ service_ended_rds, headway_rds) ++
-      sorted_departures_from_rds(service_ended_rds, true)
-  end
-
-  @spec maybe_make_bidirectional([Departure.t()], boolean()) :: [Departure.t()]
-  defp maybe_make_bidirectional([], _), do: []
-  defp maybe_make_bidirectional(departures, false), do: departures
-
-  defp maybe_make_bidirectional([first | rest], true) do
-    first_direction = departure_direction_id(first)
-
-    opposite? =
-      Enum.find(rest, Enum.at(rest, 0), &(departure_direction_id(&1) == 1 - first_direction))
-
-    Enum.reject([first, opposite?], &is_nil/1)
-  end
-
-  @spec sorted_departures_from_rds([RDS.t()], boolean()) :: [Departure.t()]
-  defp sorted_departures_from_rds(rds, reverse \\ false) do
-    sort_order =
-      if reverse do
-        :desc
-      else
-        :asc
-      end
-
-    rds
-    |> Enum.flat_map(&departure_rows_from_state(&1))
-    |> Enum.sort_by(
-      &departure_time(&1),
-      {
-        sort_order,
-        DateTime
-      }
-    )
-  end
-
-  @spec headways_from_rds([RDS.t()], [RDS.t()]) :: [HeadwayRow.t()]
-  defp headways_from_rds(
-         rds,
-         headway_rds
-       ) do
-    # If there are other similar line/direction_id destinations that are in one of the other states,
-    # disregard the headway for that particular destination
-    lines_in_other_states =
-      rds
-      |> Enum.flat_map(&extract_line_direction_pairs/1)
-      |> MapSet.new()
-
-    headway_rds
-    |> Enum.reject(fn %RDS{
-                        line: %Line{id: line_id},
-                        state: %Headways{direction_id: direction_id}
-                      } ->
-      MapSet.member?(lines_in_other_states, {line_id, direction_id})
-    end)
-    |> Enum.group_by(fn %RDS{
-                          line: line,
-                          state: %Headways{direction_id: direction_id}
-                        } ->
-      {line, direction_id}
-    end)
-    |> Enum.flat_map(fn {{line, direction_id}, rds_list} ->
-      %RDS{headsign: headsign, state: %Headways{direction_name: direction_name, range: range}} =
-        hd(rds_list)
-
-      # If there are multiple headways with the same line but different headsigns,
-      # combine them and use the direction name
-      displayed_headsign = if length(rds_list) == 1, do: headsign, else: direction_name
-
-      [
-        %HeadwayRow{
-          line: line,
-          direction_id: direction_id,
-          range: range,
-          headsign: displayed_headsign
-        }
-      ]
-    end)
-  end
-
-  @spec departure_rows_from_state(RDS.t()) ::
-          [Departure.t()] | [NormalSection.special_trip()]
-  defp departure_rows_from_state(%RDS{state: %Countdowns{departures: departures}}), do: departures
-
-  defp departure_rows_from_state(%RDS{state: %FirstTrip{first_schedule: first_schedule}}) do
-    [{first_schedule, :first_trip}]
-  end
-
-  defp departure_rows_from_state(%RDS{state: %ServiceEnded{last_schedule: last_schedule}}) do
-    [{last_schedule, :service_ended}]
-  end
-
-  defp departure_rows_from_state(%RDS{state: %NoService{}}), do: []
-
-  @spec departure_time(Departure.t() | NormalSection.special_trip()) :: DateTime.t()
-  defp departure_time(%Departure{} = departure), do: Departure.time(departure)
-  defp departure_time({%Schedule{} = schedule, _type}), do: Schedule.time(schedule)
-
-  defp departure_direction_id(%Departure{} = departure), do: Departure.direction_id(departure)
-  defp departure_direction_id({%Schedule{direction_id: direction_id}, _type}), do: direction_id
-  defp departure_direction_id(%HeadwayRow{direction_id: direction_id}), do: direction_id
-
-  defp extract_line_direction_pairs(%RDS{line: %Line{id: line_id}, state: state}) do
-    case state do
-      %NoService{direction_id: nil} ->
-        []
-
-      %NoService{direction_id: direction_id} ->
-        [{line_id, direction_id}]
-
-      %Countdowns{departures: [departure | _]} ->
-        [{line_id, Departure.direction_id(departure)}]
-
-      %FirstTrip{first_schedule: %Schedule{trip: %Trip{direction_id: direction_id}}} ->
-        [{line_id, direction_id}]
-
-      %ServiceEnded{last_schedule: %Schedule{trip: %Trip{direction_id: direction_id}}} ->
-        [{line_id, direction_id}]
     end
   end
 end

--- a/lib/screens/v2/candidate_generator/widgets/rds_departures.ex
+++ b/lib/screens/v2/candidate_generator/widgets/rds_departures.ex
@@ -1,0 +1,176 @@
+defmodule Screens.V2.CandidateGenerator.Widgets.RdsDepartures do
+  @moduledoc false
+
+  alias Screens.Routes.Route
+  alias Screens.Schedules.Schedule
+  alias Screens.V2.Departure
+  alias Screens.V2.RDS
+  alias Screens.V2.RDS.{Countdowns, FirstTrip, Headways, NoService, ServiceEnded}
+  alias Screens.V2.WidgetInstance.Departures, as: DeparturesWidget
+
+  alias Screens.V2.WidgetInstance.Departures.{
+    HeadwaySection,
+    NoDataSection,
+    NormalSection,
+    NoServiceSection,
+    OvernightSection
+  }
+
+  alias Screens.V2.WidgetInstance.DeparturesNoData
+  alias ScreensConfig.Departures
+  alias ScreensConfig.Departures.Section
+
+  @type post_process_rows_fn_t ::
+          ([NormalSection.row()], Section.t(), non_neg_integer() -> [NormalSection.row()])
+  @type widget :: DeparturesNoData.t() | DeparturesWidget.t()
+
+  def create_departure_sections(
+        rds_sections,
+        %Departures{sections: departure_sections},
+        post_process_rows_fn \\ fn rows, _section, _total_section_count -> rows end
+      ) do
+    total_section_count = length(rds_sections)
+
+    Enum.zip(rds_sections, departure_sections)
+    |> Enum.map(fn {rds_section, section} ->
+      map_to_departure_section(
+        rds_section,
+        section,
+        total_section_count,
+        post_process_rows_fn
+      )
+    end)
+  end
+
+  @spec map_to_departure_section(
+          RDS.data(),
+          Section.t(),
+          non_neg_integer(),
+          post_process_rows_fn_t()
+        ) ::
+          DeparturesWidget.section()
+
+  defp map_to_departure_section(:error, _, _, _), do: %NoDataSection{}
+
+  defp map_to_departure_section({:ok, []}, _, _, _), do: %NoDataSection{}
+
+  defp map_to_departure_section(
+         {:ok, items},
+         %Section{header: header, layout: layout, grouping_type: grouping_type} = section,
+         section_count,
+         post_process_rows_fn
+       ) do
+    case items do
+      [%NoService{routes: routes}] ->
+        %NoServiceSection{routes: routes}
+
+      [%ServiceEnded{routes: routes}] ->
+        %OvernightSection{routes: routes}
+
+      [
+        %Headways{
+          routes: [%Route{id: route_id} | _rest],
+          range: range,
+          displayed_headsign: displayed_headsign
+        }
+      ] ->
+        %HeadwaySection{route_id: route_id, time_range: range, headsign: displayed_headsign}
+
+      _ ->
+        %NormalSection{
+          rows: items |> create_and_sort_rows() |> post_process_rows_fn.(section, section_count),
+          layout: layout,
+          header: header,
+          grouping_type: grouping_type
+        }
+    end
+  end
+
+  @spec create_and_sort_rows([RDS.item()]) :: [NormalSection.row()]
+  defp create_and_sort_rows(rds_items) do
+    grouped_items =
+      Enum.group_by(rds_items, fn
+        %ServiceEnded{} -> :service_ended
+        %Headways{} -> :headways
+        _ -> :other
+      end)
+
+    service_ended_items = Map.get(grouped_items, :service_ended, [])
+    headway_items = Map.get(grouped_items, :headways, [])
+    other_items = Map.get(grouped_items, :other, [])
+
+    sorted_departures_from_rds(other_items) ++
+      headways_from_rds(headway_items) ++
+      sorted_departures_from_rds(service_ended_items, true)
+  end
+
+  # "Bidirectional" mode: take only the first departure, and the next departure in the opposite
+  # direction from the first, if one exists.
+  @spec maybe_make_bidirectional([Departure.t()], boolean()) :: [Departure.t()]
+  def maybe_make_bidirectional([], _), do: []
+  def maybe_make_bidirectional(departures, false), do: departures
+
+  def maybe_make_bidirectional([first | rest], true) do
+    first_direction = departure_direction_id(first)
+
+    opposite? =
+      Enum.find(rest, Enum.at(rest, 0), &(departure_direction_id(&1) == 1 - first_direction))
+
+    Enum.reject([first, opposite?], &is_nil/1)
+  end
+
+  @spec sorted_departures_from_rds([RDS.item()], boolean()) :: [Departure.t()]
+  defp sorted_departures_from_rds(rds, reverse \\ false) do
+    sort_order =
+      if reverse do
+        :desc
+      else
+        :asc
+      end
+
+    rds
+    |> Enum.flat_map(&departure_rows_from_state(&1))
+    |> Enum.sort_by(
+      &departure_time(&1),
+      {
+        sort_order,
+        DateTime
+      }
+    )
+  end
+
+  @spec headways_from_rds([RDS.Headways.t()]) :: [NormalSection.headway_row()]
+  defp headways_from_rds(headway_states) do
+    Enum.flat_map(headway_states, fn
+      %Headways{
+        destinations: [{_stop, line, _headsign} | _],
+        direction_id: direction_id,
+        range: range,
+        displayed_headsign: displayed_headsign
+      } ->
+        [{line, direction_id, range, displayed_headsign}]
+    end)
+  end
+
+  @spec departure_rows_from_state(RDS.item()) ::
+          [Departure.t()] | [NormalSection.special_trip()]
+  defp departure_rows_from_state(%Countdowns{departures: departures}), do: departures
+
+  defp departure_rows_from_state(%FirstTrip{first_schedule: first_schedule}) do
+    [{first_schedule, :first_trip}]
+  end
+
+  defp departure_rows_from_state(%ServiceEnded{last_schedule: last_schedule}) do
+    [{last_schedule, :service_ended}]
+  end
+
+  defp departure_rows_from_state(%NoService{}), do: []
+
+  @spec departure_time(Departure.t() | NormalSection.special_trip()) :: DateTime.t()
+  defp departure_time(%Departure{} = departure), do: Departure.time(departure)
+  defp departure_time({%Schedule{} = schedule, _type}), do: Schedule.time(schedule)
+
+  defp departure_direction_id(%Departure{} = departure), do: Departure.direction_id(departure)
+  defp departure_direction_id({%Schedule{direction_id: direction_id}, _type}), do: direction_id
+  defp departure_direction_id({_line, direction_id, _range, _headsign}), do: direction_id
+end

--- a/lib/screens/v2/rds.ex
+++ b/lib/screens/v2/rds.ex
@@ -3,6 +3,7 @@ defmodule Screens.V2.RDS do
   Real-time Destination State. Represents a "destination" a rider could reach (ordinarily or
   currently) by taking a line from a stop, and the "state" of that destination, in the form of
   departure countdowns, a headway estimate, a message that service has ended for the day, etc.
+  These states are then potentially rolled up into items which are passed to the consumer.
 
   Conceptually, screen configuration is translated into a set of "destinations", each of which is
   assigned a "state", containing all the data required to present it. These can then be translated
@@ -35,16 +36,15 @@ defmodule Screens.V2.RDS do
 
   alias __MODULE__.{Countdowns, FirstTrip, Headways, NoService, ServiceEnded}
 
-  @type state :: NoService.t() | Countdowns.t() | FirstTrip.t() | ServiceEnded.t() | Headways.t()
+  @type item :: NoService.t() | Countdowns.t() | FirstTrip.t() | ServiceEnded.t() | Headways.t()
 
-  @type t :: %__MODULE__{stop: Stop.t(), line: Line.t(), headsign: String.t(), state: state()}
-  @enforce_keys ~w[stop line headsign state]a
+  @enforce_keys ~w[data]a
   defstruct @enforce_keys
 
-  @type section_t :: {:ok, [t()]} | :error
+  @type data :: {:ok, [item()]} | :error
   @type destination_key :: {Stop.id(), Line.id(), String.t()}
+  @type destination :: {Stop.t(), Line.t(), String.t()}
 
-  @typep destination :: {Stop.t(), Line.t(), String.t()}
   @typep scheduled_service_state :: :after | :before | :none | :within
 
   @red_trunk [70_061..70_061, 70_063..70_084]
@@ -58,8 +58,12 @@ defmodule Screens.V2.RDS do
     has no relevant live data (alerts or predictions)
     and no scheduled departures for the day.
     """
-    @type t :: %__MODULE__{routes: [Route.t()], direction_id: Trip.direction() | nil}
-    defstruct ~w[routes direction_id]a
+    @type t :: %__MODULE__{
+            destinations: [Screens.V2.RDS.destination()],
+            routes: [Route.t()],
+            direction_id: Trip.direction() | nil
+          }
+    defstruct ~w[destinations routes direction_id]a
   end
 
   defmodule Countdowns do
@@ -67,8 +71,11 @@ defmodule Screens.V2.RDS do
     State when there is upcoming service to a destination
     and/or alerts which affect service to the destination.
     """
-    @type t :: %__MODULE__{departures: [Departure.t(), ...]}
-    defstruct ~w[departures]a
+    @type t :: %__MODULE__{
+            destinations: [Screens.V2.RDS.destination()],
+            departures: [Departure.t(), ...]
+          }
+    defstruct ~w[destinations departures]a
   end
 
   defmodule FirstTrip do
@@ -77,17 +84,26 @@ defmodule Screens.V2.RDS do
     showing the first scheduled trip of the day for a
     given destination.
     """
-    @type t :: %__MODULE__{first_schedule: Schedule.t()}
-    defstruct ~w[first_schedule]a
+    @type t :: %__MODULE__{
+            destinations: [Screens.V2.RDS.destination()],
+            first_schedule: Schedule.t()
+          }
+    defstruct ~w[destinations first_schedule]a
   end
 
   defmodule ServiceEnded do
     @moduledoc """
     State for after the end of the last scheduled departure
-    or if we observe a departure that is the Last Trip of the Day
+    or if we observe a departure that is the Last Trip of the Day.
+    If last_schedule is nil, it means that we have consolidated
+    all of the `ServiceEnded` states into one item.
     """
-    @type t :: %__MODULE__{last_schedule: Schedule.t()}
-    defstruct ~w[last_schedule]a
+    @type t :: %__MODULE__{
+            destinations: [Screens.V2.RDS.destination()],
+            routes: [Route.t()],
+            last_schedule: Schedule.t() | nil
+          }
+    defstruct ~w[destinations routes last_schedule]a
   end
 
   defmodule Headways do
@@ -98,12 +114,13 @@ defmodule Screens.V2.RDS do
     Shows an every “X-Y” minutes message. 
     """
     @type t :: %__MODULE__{
-            route_id: Route.id(),
-            direction_name: String.t(),
-            direction_id: Trip.direction(),
-            range: Headway.range()
+            destinations: [Screens.V2.RDS.destination()],
+            routes: [Route.t()],
+            displayed_headsign: String.t(),
+            range: Headway.range(),
+            direction_id: Trip.direction() | nil
           }
-    defstruct ~w[route_id direction_name direction_id range]a
+    defstruct ~w[destinations routes displayed_headsign range direction_id]a
   end
 
   @alert injected(Alert)
@@ -125,8 +142,8 @@ defmodule Screens.V2.RDS do
 
   ⚠️ Enforces that every section's query contains at least one ID in `stop_ids`.
   """
-  @callback get(Departures.t()) :: [section_t()]
-  @callback get(Departures.t(), DateTime.t()) :: [section_t()]
+  @callback get(Departures.t()) :: [data()]
+  @callback get(Departures.t(), DateTime.t()) :: [data()]
   def get(%Departures{sections: sections}, now \\ DateTime.utc_now()),
     do:
       sections
@@ -140,7 +157,7 @@ defmodule Screens.V2.RDS do
           :error
       end)
 
-  @spec from_section(Section.t(), DateTime.t()) :: section_t()
+  @spec from_section(Section.t(), DateTime.t()) :: data()
   defp from_section(
          %Section{query: %Query{params: %Query.Params{stop_ids: stop_ids} = params}},
          now
@@ -215,30 +232,25 @@ defmodule Screens.V2.RDS do
     # Destinations that are affected by current alerts at the present stop ID
     impacted_destinations = informed_destinations(destinations, alerts, typical_patterns)
 
-    section_rds =
+    items =
       destinations
-      |> Enum.map(fn {%Stop{id: stop_id} = stop, line, headsign} = destination ->
+      |> Enum.map(fn destination ->
         key = to_destination_key(destination)
 
-        %__MODULE__{
-          stop: stop,
-          line: line,
-          headsign: headsign,
-          state:
-            destination_state(
-              Map.get(departures_by_destination, key, []),
-              Map.get(schedules_by_destination, key, []),
-              @headways.get(stop_id, now),
-              routes_for_section,
-              last_trip_departed?(key, now),
-              destination in impacted_destinations,
-              now
-            )
-        }
+        destination_state(
+          destination,
+          Map.get(departures_by_destination, key, []),
+          Map.get(schedules_by_destination, key, []),
+          routes_for_section,
+          last_trip_departed?(key, now),
+          destination in impacted_destinations,
+          now
+        )
       end)
-      |> Enum.reject(&is_nil(&1.state))
+      |> Enum.reject(&is_nil(&1))
+      |> maybe_combine_states()
 
-    {:ok, section_rds}
+    {:ok, items}
   end
 
   @spec tuples_from_departures([Departure.t()], DateTime.t()) :: [destination()]
@@ -264,23 +276,25 @@ defmodule Screens.V2.RDS do
   end
 
   @spec destination_state(
+          destination(),
           [Departure.t()],
           [Schedule.t()],
-          Headway.range() | nil,
           [Route.t()],
           boolean(),
           boolean(),
           DateTime.t()
-        ) :: state() | nil
+        ) :: item() | nil
   defp destination_state(
+         {%Stop{id: stop_id}, _line, _headsign} = destination,
          departures,
          schedules,
-         headways,
          routes_for_section,
          last_trip_departed?,
          impacted_by_alert?,
          now
        ) do
+    headways = @headways.get(stop_id, now)
+
     {first_schedule, last_schedule} =
       schedules
       |> Enum.sort_by(&Schedule.time(&1), DateTime)
@@ -293,13 +307,35 @@ defmodule Screens.V2.RDS do
       scheduled_service_state(first_schedule, last_schedule, headways, last_trip_departed?, now)
 
     cond do
-      presented_departures != [] -> %Countdowns{departures: presented_departures}
-      impacted_by_alert? -> nil
-      departures == [] and service_state == :none -> %NoService{routes: routes_for_section}
-      departures == [] and service_state == :after -> %ServiceEnded{last_schedule: last_schedule}
-      service_state == :before -> %FirstTrip{first_schedule: first_schedule}
-      not (is_nil(headways) or is_nil(first_schedule)) -> headways_state(headways, first_schedule)
-      true -> nil
+      presented_departures != [] ->
+        %Countdowns{destinations: [destination], departures: presented_departures}
+
+      impacted_by_alert? ->
+        nil
+
+      departures == [] and service_state == :none ->
+        %NoService{
+          destinations: [destination],
+          routes: routes_for_section,
+          direction_id:
+            case first_schedule || last_schedule do
+              %Schedule{trip: %Trip{direction_id: direction_id}} -> direction_id
+              nil -> nil
+            end
+        }
+
+      departures == [] and service_state == :after ->
+        %Schedule{route: route} = last_schedule
+        %ServiceEnded{destinations: [destination], last_schedule: last_schedule, routes: [route]}
+
+      service_state == :before ->
+        %FirstTrip{destinations: [destination], first_schedule: first_schedule}
+
+      not (is_nil(headways) or is_nil(first_schedule)) ->
+        headways_item(destination, headways, first_schedule)
+
+      true ->
+        nil
     end
   end
 
@@ -311,17 +347,169 @@ defmodule Screens.V2.RDS do
     end
   end
 
-  defp headways_state(headways, %Schedule{
-         route: %Route{id: route_id} = route,
-         trip: %Trip{direction_id: direction_id}
-       }) do
+  defp headways_item(
+         {_stop, _line, headsign} = destination,
+         headways,
+         %Schedule{
+           route: route,
+           trip: %Trip{direction_id: direction_id}
+         }
+       ) do
     %Headways{
-      route_id: route_id,
-      direction_name: route |> Route.normalized_direction_names() |> Enum.at(direction_id),
+      destinations: [destination],
+      routes: [route],
+      displayed_headsign: headsign,
       direction_id: direction_id,
       range: headways
     }
   end
+
+  @spec maybe_combine_states([item()]) :: [item()]
+  defp maybe_combine_states([]), do: []
+
+  defp maybe_combine_states(states) do
+    cond do
+      no_service?(states) ->
+        [
+          %NoService{
+            destinations: states |> Enum.flat_map(& &1.destinations) |> Enum.uniq(),
+            routes: states |> Enum.flat_map(& &1.routes) |> Enum.uniq(),
+            direction_id: nil
+          }
+        ]
+
+      service_ended?(states) ->
+        [
+          %ServiceEnded{
+            destinations: states |> Enum.flat_map(& &1.destinations) |> Enum.uniq(),
+            routes: states |> Enum.flat_map(& &1.routes) |> Enum.uniq(),
+            last_schedule: nil
+          }
+        ]
+
+      headways?(states) ->
+        combine_headway_states_for_section(states)
+
+      true ->
+        grouped_rds =
+          Enum.group_by(states, fn
+            %Headways{} -> :headways
+            %Countdowns{} -> :countdowns
+            _ -> :other
+          end)
+
+        other_states = Map.get(grouped_rds, :other, [])
+        countdowns_states = Map.get(grouped_rds, :countdowns, [])
+
+        lines_in_other_states =
+          (other_states ++ countdowns_states)
+          |> Enum.flat_map(&extract_line_direction_pairs/1)
+          |> MapSet.new()
+
+        headway_states =
+          grouped_rds
+          |> Map.get(:headways, [])
+          |> maybe_combine_headway_states(lines_in_other_states)
+
+        countdowns_states ++ headway_states ++ other_states
+    end
+  end
+
+  defp combine_headway_states_for_section(
+         [
+           %Headways{
+             destinations: [{_stop, %Line{id: line_id}, first_headsign}],
+             routes: [route],
+             range: range
+           }
+           | _
+         ] = states
+       ) do
+    destinations = Enum.flat_map(states, & &1.destinations)
+
+    direction_id =
+      states
+      |> Enum.map(& &1.direction_id)
+      |> Enum.uniq()
+      |> case do
+        [one_direction] -> one_direction
+        _ -> nil
+      end
+
+    displayed_headsign =
+      cond do
+        # Use the headsign if all destinations have the same headsign,
+        Enum.all?(destinations, fn {_stop, _line, other_headsign} ->
+          first_headsign == other_headsign
+        end) ->
+          first_headsign
+
+        # Use the direction name if destinations have the same direction name,
+        direction_id != nil and
+            Enum.all?(
+              destinations,
+              fn {_stop, %Line{id: other_line_id}, _other_headsign} ->
+                line_id == other_line_id
+              end
+            ) ->
+          route |> Route.normalized_direction_names() |> Enum.at(direction_id)
+
+        true ->
+          nil
+      end
+
+    [
+      %Headways{
+        destinations: destinations,
+        routes: states |> Enum.flat_map(& &1.routes) |> Enum.uniq(),
+        displayed_headsign: displayed_headsign,
+        range: range
+      }
+    ]
+  end
+
+  defp maybe_combine_headway_states(headway_states, lines_in_other_states)
+       when length(headway_states) > 1 do
+    headway_states
+    |> Enum.reject(fn %Headways{
+                        destinations: [
+                          {_stop, %Line{id: line_id}, _headsign}
+                        ],
+                        direction_id: direction_id
+                      } ->
+      MapSet.member?(lines_in_other_states, {line_id, direction_id})
+    end)
+    |> Enum.group_by(fn %Headways{
+                          destinations: [
+                            {_stop, %Line{id: line_id}, _headsign}
+                          ],
+                          direction_id: direction_id
+                        } ->
+      {line_id, direction_id}
+    end)
+    |> Enum.flat_map(fn {{_line_id, direction_id}, states} ->
+      %Headways{routes: [route], displayed_headsign: headsign, range: range} = hd(states)
+
+      # If there are multiple headways with the same line but different headsigns,
+      # combine them and use the direction name
+      displayed_headsign =
+        if length(states) == 1,
+          do: headsign,
+          else: route |> Route.normalized_direction_names() |> Enum.at(direction_id)
+
+      [
+        %Headways{
+          destinations: states |> Enum.flat_map(& &1.destinations),
+          routes: states |> Enum.flat_map(& &1.routes),
+          direction_id: direction_id,
+          range: range,
+          displayed_headsign: displayed_headsign
+        }
+      ]
+    end)
+  end
+
+  defp maybe_combine_headway_states(headways, _line_direction_pairs), do: headways
 
   @spec scheduled_service_state(
           Schedule.t() | nil,
@@ -476,6 +664,18 @@ defmodule Screens.V2.RDS do
     end)
   end
 
+  defp no_service?(states) do
+    Enum.all?(states, &is_struct(&1, NoService))
+  end
+
+  defp service_ended?(states) do
+    Enum.all?(states, &is_struct(&1, ServiceEnded))
+  end
+
+  defp headways?(states) do
+    Enum.all?(states, &is_struct(&1, Headways))
+  end
+
   @spec ie_affects_destination?(InformedEntity.t(), RoutePattern.t(), Stop.t()) :: boolean()
   # Alert effects the entire route
   defp ie_affects_destination?(
@@ -526,5 +726,26 @@ defmodule Screens.V2.RDS do
       )
 
     DateTime.after?(now, departure_time_with_buffer)
+  end
+
+  defp extract_line_direction_pairs(
+         %{destinations: [{_stop, %Line{id: line_id}, _headsign}]} = state
+       ) do
+    case state do
+      %NoService{direction_id: nil} ->
+        []
+
+      %NoService{direction_id: direction_id} ->
+        [{line_id, direction_id}]
+
+      %Countdowns{departures: [departure | _]} ->
+        [{line_id, Departure.direction_id(departure)}]
+
+      %FirstTrip{first_schedule: %Schedule{trip: %Trip{direction_id: direction_id}}} ->
+        [{line_id, direction_id}]
+
+      %ServiceEnded{last_schedule: %Schedule{trip: %Trip{direction_id: direction_id}}} ->
+        [{line_id, direction_id}]
+    end
   end
 end

--- a/lib/screens/v2/widget_instance/departures.ex
+++ b/lib/screens/v2/widget_instance/departures.ex
@@ -20,27 +20,16 @@ defmodule Screens.V2.WidgetInstance.Departures do
   alias ScreensConfig.{FreeTextLine, Screen}
   alias ScreensConfig.Screen.PreFare
 
-  defmodule HeadwayRow do
-    @moduledoc "A row that shows headway values in a NormalSection, X every Y - Z minutes"
-    @type t :: %__MODULE__{
-            line: Line.t(),
-            direction_id: Trip.direction(),
-            range: Headways.range(),
-            headsign: String.t()
-          }
-
-    defstruct id: nil, line: nil, direction_id: nil, range: nil, headsign: nil
-  end
-
   defmodule NormalSection do
     @moduledoc "Section which includes a number of independent 'rows' or items."
 
     @type special_trip :: {Schedule.t(), :first_trip | :service_ended}
+    @type headway_row :: {Line.t(), Trip.direction(), Headways.range(), String.t()}
 
     @type row ::
             Departure.t()
             | special_trip()
-            | HeadwayRow.t()
+            | headway_row()
             | FreeTextLine.t()
 
     @type t :: %__MODULE__{
@@ -58,10 +47,10 @@ defmodule Screens.V2.WidgetInstance.Departures do
 
     @type t :: %__MODULE__{
             headsign: String.t() | nil,
-            route: Route.id(),
+            route_id: Route.id(),
             time_range: Headways.range()
           }
-    defstruct ~w[headsign route time_range]a
+    defstruct ~w[headsign route_id time_range]a
   end
 
   defmodule OvernightSection do
@@ -208,12 +197,12 @@ defmodule Screens.V2.WidgetInstance.Departures do
   end
 
   def serialize_section(
-        %HeadwaySection{route: route, time_range: time_range, headsign: headsign},
+        %HeadwaySection{route_id: route_id, time_range: time_range, headsign: headsign},
         _screen,
         _now,
         is_only_section
       ) do
-    pill_color = Route.color(route)
+    pill_color = Route.color(route_id)
 
     layout =
       cond do
@@ -222,7 +211,7 @@ defmodule Screens.V2.WidgetInstance.Departures do
         true -> :row_with_headsign
       end
 
-    text = get_headway_text(headsign, time_range, pill_color, route, is_only_section)
+    text = get_headway_text(headsign, time_range, pill_color, route_id, is_only_section)
 
     %{type: :headway_section, text: FreeTextLine.to_json(text), layout: layout}
   end
@@ -481,15 +470,7 @@ defmodule Screens.V2.WidgetInstance.Departures do
   end
 
   defp serialize_departure_group(
-         [
-           %HeadwayRow{
-             line: line,
-             direction_id: direction_id,
-             range: {lo, hi},
-             headsign: headsign
-           }
-           | _
-         ],
+         [{line, direction_id, {lo, hi}, headsign} | _],
          screen,
          _now,
          route_pill_serializer

--- a/test/screens/v2/candidate_generator/dup/departures_test.exs
+++ b/test/screens/v2/candidate_generator/dup/departures_test.exs
@@ -11,7 +11,6 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
   alias Screens.V2.Departure
   alias Screens.V2.RDS
   alias Screens.V2.WidgetInstance.Departures, as: DeparturesWidget
-  alias Screens.V2.WidgetInstance.Departures.HeadwayRow
   alias Screens.V2.WidgetInstance.{DeparturesNoData, DeparturesNoService}
   alias Screens.V2.WidgetInstance.OvernightDepartures
   alias ScreensConfig.{Alerts, Departures, Header}
@@ -45,54 +44,52 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
   }
 
   defp rds_countdown(stop_id, line_id, headsign, expected_departures) do
-    %RDS{
-      stop: %Stop{id: stop_id},
-      line: %Line{id: line_id},
-      headsign: headsign,
-      state: %RDS.Countdowns{
-        departures: expected_departures
-      }
+    destination = {%Stop{id: stop_id}, %Line{id: line_id}, headsign}
+
+    %RDS.Countdowns{
+      destinations: [destination],
+      departures: expected_departures
     }
   end
 
   defp no_service(stop_id, line_id, headsign, routes \\ []) do
-    %RDS{
-      stop: %Stop{id: stop_id},
-      line: %Line{id: line_id},
-      headsign: headsign,
-      state: %RDS.NoService{routes: routes, direction_id: 0}
+    destination = {%Stop{id: stop_id}, %Line{id: line_id}, headsign}
+
+    %RDS.NoService{
+      destinations: [destination],
+      routes: routes,
+      direction_id: 0
     }
   end
 
   defp first_trip(stop_id, line_id, headsign, first_schedule) do
-    %RDS{
-      stop: %Stop{id: stop_id},
-      line: %Line{id: line_id},
-      headsign: headsign,
-      state: %RDS.FirstTrip{first_schedule: first_schedule}
+    destination = {%Stop{id: stop_id}, %Line{id: line_id}, headsign}
+
+    %RDS.FirstTrip{
+      destinations: [destination],
+      first_schedule: first_schedule
     }
   end
 
   defp service_ended(stop_id, line_id, headsign, last_schedule) do
-    %RDS{
-      stop: %Stop{id: stop_id},
-      line: %Line{id: line_id},
-      headsign: headsign,
-      state: %RDS.ServiceEnded{last_schedule: last_schedule}
+    destination = {%Stop{id: stop_id}, %Line{id: line_id}, headsign}
+
+    %RDS.ServiceEnded{
+      destinations: [destination],
+      routes: [last_schedule.route],
+      last_schedule: last_schedule
     }
   end
 
-  defp headways(stop_id, line_id, headsign, route_id, direction_name, direction_id, range) do
-    %RDS{
-      stop: %Stop{id: stop_id},
-      line: %Line{id: line_id},
-      headsign: headsign,
-      state: %RDS.Headways{
-        route_id: route_id,
-        direction_name: direction_name,
-        direction_id: direction_id,
-        range: range
-      }
+  defp headways(stop_id, line_id, headsign, route_id, direction_id, range) do
+    destination = {%Stop{id: stop_id}, %Line{id: line_id}, headsign}
+
+    %RDS.Headways{
+      destinations: [destination],
+      routes: [%Route{id: route_id}],
+      displayed_headsign: headsign,
+      direction_id: direction_id,
+      range: range
     }
   end
 
@@ -297,9 +294,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
         |> put_secondary_departures_sections(secondary_departures)
 
       expect(@rds, :get, fn _primary_departures, @now ->
-        [
-          {:ok, [rds_countdown("s1", "l1", "other1", expected_departures)]}
-        ]
+        [{:ok, [rds_countdown("s1", "l1", "other1", expected_departures)]}]
       end)
 
       expect(@rds, :get, fn _secondary_departures, @now -> [{:ok, []}, {:ok, []}] end)
@@ -360,10 +355,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
 
       expect(@rds, :get, fn _primary_departures, @now ->
         [
-          {:ok,
-           [
-             rds_countdown("s1", "l1", "other1", expected_departures)
-           ]},
+          {:ok, [rds_countdown("s1", "l1", "other1", expected_departures)]},
           {:ok, [no_service("s2", "l2", "other2")]}
         ]
       end)
@@ -636,9 +628,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
         [{:ok, [rds_countdown("s1", "l1", "other1", all_departures)]}]
       end)
 
-      expect(@rds, :get, fn _secondary_departures, @now ->
-        [{:ok, []}]
-      end)
+      expect(@rds, :get, fn _secondary_departures, @now -> [{:ok, []}] end)
 
       expected_instances =
         expected_departures_widget(config, expected_sections, expected_sections)
@@ -787,9 +777,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
         }
       ]
 
-      config =
-        @config
-        |> put_primary_departures(primary_departures)
+      config = @config |> put_primary_departures(primary_departures)
 
       expect(@rds, :get, fn _primary_departures, _now ->
         [
@@ -867,20 +855,12 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
         }
       ]
 
-      config =
-        @config
-        |> put_primary_departures(primary_departures)
+      config = @config |> put_primary_departures(primary_departures)
 
       expect(@rds, :get, fn _primary_departures, _now ->
         [
-          {:ok,
-           [
-             first_trip("s1", "l3", "other3", expected_first_schedule)
-           ]},
-          {:ok,
-           [
-             service_ended("s3", "l1", "other1", expected_last_schedule)
-           ]}
+          {:ok, [first_trip("s1", "l3", "other3", expected_first_schedule)]},
+          {:ok, [service_ended("s3", "l1", "other1", expected_last_schedule)]}
         ]
       end)
 
@@ -930,14 +910,8 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
 
       expect(@rds, :get, fn _primary_departures, _now ->
         [
-          {:ok,
-           [
-             service_ended("s1", "l1", "other1", expected_last_schedule_one)
-           ]},
-          {:ok,
-           [
-             service_ended("s3", "l3", "other3", expected_last_schedule_two)
-           ]}
+          {:ok, [service_ended("s1", "l1", "other1", expected_last_schedule_one)]},
+          {:ok, [service_ended("s3", "l3", "other3", expected_last_schedule_two)]}
         ]
       end)
 
@@ -963,14 +937,12 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
       expected_primary_sections = [
         %Screens.V2.WidgetInstance.Departures.HeadwaySection{
           headsign: expected_headsign,
-          route: expected_route_id,
+          route_id: expected_route_id,
           time_range: expected_time_range
         }
       ]
 
-      config =
-        @config
-        |> put_primary_departures(primary_departures)
+      config = @config |> put_primary_departures(primary_departures)
 
       expect(@rds, :get, fn _primary_departures, @now ->
         [
@@ -981,16 +953,6 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
                "l1",
                "headsign",
                expected_route_id,
-               "Northbound",
-               0,
-               expected_time_range
-             ),
-             headways(
-               "s1",
-               "l1",
-               "headsign",
-               expected_route_id,
-               "Northbound",
                0,
                expected_time_range
              )
@@ -1008,7 +970,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
       assert actual_instances == expected_instances
     end
 
-    test "creates HeadwaySections for destinations with headways with different headsigns" do
+    test "creates HeadwaySections for only headway sections" do
       primary_departures = [
         %Section{query: %Query{params: %Query.Params{stop_ids: ["s1"]}}},
         %Section{query: %Query{params: %Query.Params{stop_ids: ["s2"]}}}
@@ -1021,14 +983,12 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
       expected_primary_sections = [
         %Screens.V2.WidgetInstance.Departures.HeadwaySection{
           headsign: expected_direction_name,
-          route: expected_route_id,
+          route_id: expected_route_id,
           time_range: expected_time_range
         }
       ]
 
-      config =
-        @config
-        |> put_primary_departures(primary_departures)
+      config = @config |> put_primary_departures(primary_departures)
 
       expect(@rds, :get, fn _primary_departures, @now ->
         [
@@ -1037,18 +997,8 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
              headways(
                "s1",
                "l1",
-               "headsign",
+               "Northbound",
                expected_route_id,
-               expected_direction_name,
-               0,
-               expected_time_range
-             ),
-             headways(
-               "s1",
-               "l1",
-               "other_headsign",
-               expected_route_id,
-               expected_direction_name,
                0,
                expected_time_range
              )
@@ -1069,7 +1019,6 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
     test "creates NormalSections for departures and headways" do
       expected_route_id = "r1"
       expected_time_range = {6, 10}
-      expected_direction_name = "Northbound"
 
       primary_departures = [
         %Section{query: %Query{params: %Query.Params{stop_ids: ["s1"]}}},
@@ -1105,19 +1054,12 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
           grouping_type: :time,
           rows: [
             expected_primary_departure,
-            %HeadwayRow{
-              line: %Line{id: "l1"},
-              direction_id: 0,
-              range: {6, 10},
-              headsign: "other_headsign"
-            }
+            {%Line{id: "l1"}, 0, {6, 10}, "other_headsign"}
           ]
         }
       ]
 
-      config =
-        @config
-        |> put_primary_departures(primary_departures)
+      config = @config |> put_primary_departures(primary_departures)
 
       expect(@rds, :get, fn _primary_departures, @now ->
         [
@@ -1129,173 +1071,6 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
                "l1",
                "other_headsign",
                expected_route_id,
-               expected_direction_name,
-               0,
-               expected_time_range
-             )
-           ]}
-        ]
-      end)
-
-      expect(@rds, :get, fn _secondary_departures, @now -> [{:ok, []}] end)
-
-      expected_instances =
-        expected_departures_widget(config, expected_primary_sections, expected_primary_sections)
-
-      actual_instances = Dup.Departures.instances(config, @now)
-
-      assert actual_instances == expected_instances
-    end
-
-    test "creates NormalSections but removes headways when similar line/direction_id destinations in Countdown state" do
-      expected_route_id = "r1"
-      expected_time_range = {6, 10}
-      expected_direction_name = "Northbound"
-
-      primary_departures = [
-        %Section{query: %Query{params: %Query.Params{stop_ids: ["s1"]}}},
-        %Section{query: %Query{params: %Query.Params{stop_ids: ["s2"]}}}
-      ]
-
-      expected_primary_departure =
-        %Departure{
-          prediction: %Prediction{
-            arrival_time: ~U[2024-10-11 12:27:00Z],
-            departure_time: ~U[2024-10-11 12:30:00Z],
-            route: %Route{id: "r1", line: %Line{id: "l1"}, type: :subway},
-            stop: %Stop{id: "s1"},
-            trip: %Trip{headsign: "other1", pattern_headsign: "h1", direction_id: 0}
-          },
-          schedule: nil
-        }
-
-      expected_primary_sections = [
-        %Screens.V2.WidgetInstance.Departures.NormalSection{
-          header: %ScreensConfig.Departures.Header{
-            arrow: nil,
-            read_as: nil,
-            subtitle: nil,
-            title: nil
-          },
-          layout: %ScreensConfig.Departures.Layout{
-            base: nil,
-            include_later: false,
-            max: nil,
-            min: 1
-          },
-          grouping_type: :time,
-          rows: [
-            expected_primary_departure
-          ]
-        }
-      ]
-
-      config =
-        @config
-        |> put_primary_departures(primary_departures)
-
-      expect(@rds, :get, fn _primary_departures, @now ->
-        [
-          {:ok,
-           [
-             rds_countdown("s1", "l1", "other1", [expected_primary_departure]),
-             headways(
-               "s1",
-               "l1",
-               "other_headsign",
-               expected_route_id,
-               expected_direction_name,
-               0,
-               expected_time_range
-             )
-           ]}
-        ]
-      end)
-
-      expect(@rds, :get, fn _secondary_departures, @now -> [{:ok, []}] end)
-
-      expected_instances =
-        expected_departures_widget(config, expected_primary_sections, expected_primary_sections)
-
-      actual_instances = Dup.Departures.instances(config, @now)
-
-      assert actual_instances == expected_instances
-    end
-
-    test "creates NormalSections but removes headways when similar line/direction_id destinations are in No Service state" do
-      expected_route_id = "r1"
-      expected_time_range = {6, 10}
-      expected_direction_name = "Northbound"
-
-      primary_departures = [
-        %Section{query: %Query{params: %Query.Params{stop_ids: ["s1"]}}},
-        %Section{query: %Query{params: %Query.Params{stop_ids: ["s2"]}}}
-      ]
-
-      expected_primary_departure =
-        %Departure{
-          prediction: %Prediction{
-            arrival_time: ~U[2024-10-11 12:27:00Z],
-            departure_time: ~U[2024-10-11 12:30:00Z],
-            route: %Route{id: "r1", line: %Line{id: "l1"}, type: :subway},
-            stop: %Stop{id: "s1"},
-            trip: %Trip{headsign: "other1", pattern_headsign: "h1", direction_id: 0}
-          },
-          schedule: nil
-        }
-
-      expected_primary_sections = [
-        %Screens.V2.WidgetInstance.Departures.NormalSection{
-          header: %ScreensConfig.Departures.Header{
-            arrow: nil,
-            read_as: nil,
-            subtitle: nil,
-            title: nil
-          },
-          layout: %ScreensConfig.Departures.Layout{
-            base: nil,
-            include_later: false,
-            max: nil,
-            min: 1
-          },
-          grouping_type: :time,
-          rows: [
-            expected_primary_departure
-          ]
-        }
-      ]
-
-      config =
-        @config
-        |> put_primary_departures(primary_departures)
-
-      expect(@rds, :get, fn _primary_departures, @now ->
-        [
-          {:ok,
-           [
-             rds_countdown("s1", "l1", "other1", [expected_primary_departure]),
-             no_service("s1", "l2", "some_headsign", [
-               %Screens.Routes.Route{
-                 id: "r1",
-                 short_name: nil,
-                 long_name: nil,
-                 direction_names: nil,
-                 direction_destinations: nil,
-                 type: :bus,
-                 line: %Screens.Lines.Line{
-                   id: "l2",
-                   long_name: nil,
-                   short_name: nil,
-                   sort_order: nil
-                 }
-               }
-             ]),
-             headways(
-               "s1",
-               "l2",
-               "other_headsign",
-               expected_route_id,
-               expected_direction_name,
                0,
                expected_time_range
              )

--- a/test/screens/v2/rds_test.exs
+++ b/test/screens/v2/rds_test.exs
@@ -43,91 +43,98 @@ defmodule Screens.V2.RDSTest do
     :ok
   end
 
-  defp no_service(stop_id, line_id, headsign) do
-    %RDS{
-      stop: %Stop{id: stop_id},
-      line: %Line{id: line_id},
-      headsign: headsign,
-      state: %RDS.NoService{
-        routes: [
-          %Screens.Routes.Route{
-            id: "r1",
-            short_name: nil,
+  defp no_service(destination_keys) do
+    destinations =
+      Enum.map(destination_keys, fn {stop_id, line_id, headsign} ->
+        {%Stop{id: stop_id}, %Line{id: line_id}, headsign}
+      end)
+
+    %RDS.NoService{
+      destinations: destinations,
+      routes: [
+        %Screens.Routes.Route{
+          id: "r1",
+          short_name: nil,
+          long_name: nil,
+          direction_names: nil,
+          direction_destinations: nil,
+          type: :bus,
+          line: %Screens.Lines.Line{
+            id: "l1",
             long_name: nil,
-            direction_names: nil,
-            direction_destinations: nil,
-            type: :bus,
-            line: %Screens.Lines.Line{
-              id: "l1",
-              long_name: nil,
-              short_name: nil,
-              sort_order: nil
-            }
-          },
-          %Screens.Routes.Route{
-            id: "r2",
             short_name: nil,
-            long_name: nil,
-            direction_names: nil,
-            direction_destinations: nil,
-            type: :bus,
-            line: %Screens.Lines.Line{
-              id: "l2",
-              long_name: nil,
-              short_name: nil,
-              sort_order: nil
-            }
+            sort_order: nil
           }
-        ]
-      }
+        },
+        %Screens.Routes.Route{
+          id: "r2",
+          short_name: nil,
+          long_name: nil,
+          direction_names: nil,
+          direction_destinations: nil,
+          type: :bus,
+          line: %Screens.Lines.Line{
+            id: "l2",
+            long_name: nil,
+            short_name: nil,
+            sort_order: nil
+          }
+        }
+      ]
     }
   end
 
-  defp countdowns(stop_id, line_id, headsign, departures) do
-    %RDS{
-      stop: %Stop{id: stop_id},
-      line: %Line{id: line_id},
-      headsign: headsign,
-      state: %RDS.Countdowns{departures: departures}
+  defp countdowns(destination_keys, departures) do
+    destinations =
+      Enum.map(destination_keys, fn {stop_id, line_id, headsign} ->
+        {%Stop{id: stop_id}, %Line{id: line_id}, headsign}
+      end)
+
+    %RDS.Countdowns{
+      destinations: destinations,
+      departures: departures
     }
   end
 
   defp first_trip(stop_id, line_id, headsign, schedule) do
-    %RDS{
-      stop: %Stop{id: stop_id},
-      line: %Line{id: line_id},
-      headsign: headsign,
-      state: %RDS.FirstTrip{first_schedule: schedule}
+    destinations = [{%Stop{id: stop_id}, %Line{id: line_id}, headsign}]
+
+    %RDS.FirstTrip{
+      destinations: destinations,
+      first_schedule: schedule
     }
   end
 
-  defp service_ended(stop_id, line_id, headsign, schedule) do
-    %RDS{
-      stop: %Stop{id: stop_id},
-      line: %Line{id: line_id},
-      headsign: headsign,
-      state: %RDS.ServiceEnded{last_schedule: schedule}
+  defp service_ended(destination_keys, schedule, routes) do
+    destinations =
+      Enum.map(destination_keys, fn {stop_id, line_id, headsign} ->
+        {%Stop{id: stop_id}, %Line{id: line_id}, headsign}
+      end)
+
+    %RDS.ServiceEnded{
+      destinations: destinations,
+      last_schedule: schedule,
+      routes: routes
     }
   end
 
   defp headways(
-         stop_id,
-         line_id,
+         destination_keys,
          headsign,
-         route_id,
-         direction_name,
+         routes,
          direction_id
        ) do
-    %RDS{
-      stop: %Stop{id: stop_id},
-      line: %Line{id: line_id},
-      headsign: headsign,
-      state: %RDS.Headways{
-        route_id: route_id,
-        direction_name: direction_name,
-        direction_id: direction_id,
-        range: {5, 10}
-      }
+    destinations =
+      Enum.map(destination_keys, fn {stop_id, line_id, headsign} ->
+        {%Stop{id: stop_id}, %Line{id: line_id}, headsign}
+      end)
+
+    %RDS.Headways{
+      destinations: destinations,
+      routes: routes,
+      displayed_headsign: headsign,
+      direction_id: direction_id,
+      range: {5, 10}
     }
   end
 
@@ -176,7 +183,7 @@ defmodule Screens.V2.RDSTest do
   end
 
   describe "get/1 no service" do
-    test "creates no service destinations from typical route patterns with no departures" do
+    test "creates no service destination from typical route patterns with no departures" do
       stop_ids = ~w[s0 s1]
 
       expect_standard_stations(stop_ids)
@@ -189,12 +196,7 @@ defmodule Screens.V2.RDSTest do
       }
 
       assert RDS.get(departures) == [
-               {:ok,
-                [
-                  no_service("sA", "l1", "hA"),
-                  no_service("sB", "l2", "hB"),
-                  no_service("sC", "l2", "hC")
-                ]}
+               {:ok, [no_service([{"sA", "l1", "hA"}, {"sB", "l2", "hB"}, {"sC", "l2", "hC"}])]}
              ]
     end
   end
@@ -268,8 +270,14 @@ defmodule Screens.V2.RDSTest do
       assert RDS.get(departures, now) == [
                {:ok,
                 [
-                  countdowns("s1", "l1", "h1", expected_departures_one),
-                  countdowns("s2", "l2", "h2", expected_departures_two)
+                  countdowns(
+                    [{"s1", "l1", "h1"}],
+                    expected_departures_one
+                  ),
+                  countdowns(
+                    [{"s2", "l2", "h2"}],
+                    expected_departures_two
+                  )
                 ]}
              ]
     end
@@ -329,8 +337,8 @@ defmodule Screens.V2.RDSTest do
       assert RDS.get(departures, now) == [
                {:ok,
                 [
-                  countdowns("s1", "l1", "h1", expected_departures),
-                  no_service("s1", "l2", "h2")
+                  countdowns([{"s1", "l1", "h1"}], expected_departures),
+                  no_service([{"s1", "l2", "h2"}])
                 ]}
              ]
     end
@@ -387,7 +395,7 @@ defmodule Screens.V2.RDSTest do
       }
 
       assert RDS.get(departures, now) ==
-               [{:ok, [countdowns("s0", "l1", "h1", expected_departures)]}]
+               [{:ok, [countdowns([{"s0", "l1", "h1"}], expected_departures)]}]
     end
 
     test "considers cancelled departures in deciding whether to produce no-service states" do
@@ -566,6 +574,11 @@ defmodule Screens.V2.RDSTest do
 
       all_schedules = [first_schedule, second_schedule, third_schedule]
 
+      expected_routes = [
+        %Route{id: "r1", line: %Line{id: "l1"}, type: :bus},
+        %Route{id: "r2", line: %Line{id: "l2"}, type: :bus}
+      ]
+
       departures = %Departures{
         sections: [
           %Section{query: %Query{params: %Query.Params{route_type: :bus, stop_ids: stop_ids}}}
@@ -581,9 +594,11 @@ defmodule Screens.V2.RDSTest do
       assert RDS.get(departures, now) == [
                {:ok,
                 [
-                  service_ended("sA", "l1", "hA", first_schedule),
-                  service_ended("sB", "l2", "hB", second_schedule),
-                  service_ended("sC", "l2", "hC", third_schedule)
+                  service_ended(
+                    [{"sA", "l1", "hA"}, {"sB", "l2", "hB"}, {"sC", "l2", "hC"}],
+                    nil,
+                    expected_routes
+                  )
                 ]}
              ]
     end
@@ -630,6 +645,21 @@ defmodule Screens.V2.RDSTest do
           trip: %Trip{headsign: "hC", pattern_headsign: "hC", direction_id: 0}
         }
 
+      expected_routes = [
+        %Route{
+          id: "r1",
+          line: %Line{id: "l1"},
+          type: :bus,
+          direction_names: ["Northbound", "Southbound"]
+        },
+        %Route{
+          id: "r2",
+          line: %Line{id: "l2"},
+          type: :bus,
+          direction_names: ["Northbound", "Southbound"]
+        }
+      ]
+
       all_schedules = [first_schedule, second_schedule, third_schedule]
 
       departures = %Departures{
@@ -664,9 +694,11 @@ defmodule Screens.V2.RDSTest do
       assert RDS.get(departures, now) == [
                {:ok,
                 [
-                  service_ended("sA", "l1", "hA", first_schedule),
-                  service_ended("sB", "l2", "hB", second_schedule),
-                  service_ended("sC", "l2", "hC", third_schedule)
+                  service_ended(
+                    [{"sA", "l1", "hA"}, {"sB", "l2", "hB"}, {"sC", "l2", "hC"}],
+                    nil,
+                    expected_routes
+                  )
                 ]}
              ]
     end
@@ -720,7 +752,12 @@ defmodule Screens.V2.RDSTest do
       end)
 
       assert RDS.get(departures, now) == [
-               {:ok, [service_ended("70061", "l1", "Alewife", first_schedule)]}
+               {:ok,
+                [
+                  service_ended([{"70061", "l1", "Alewife"}], nil, [
+                    %Route{id: "r1", line: %Line{id: "l1"}, type: :bus}
+                  ])
+                ]}
              ]
     end
   end
@@ -822,6 +859,27 @@ defmodule Screens.V2.RDSTest do
         last_schedule_three
       ]
 
+      expected_routes = [
+        %Screens.Routes.Route{
+          direction_destinations: nil,
+          direction_names: ["Northbound", "Southbound"],
+          id: "r1",
+          line: %Screens.Lines.Line{id: "l1", long_name: nil, short_name: nil, sort_order: nil},
+          long_name: nil,
+          short_name: nil,
+          type: :bus
+        },
+        %Screens.Routes.Route{
+          id: "r2",
+          short_name: nil,
+          long_name: nil,
+          direction_names: ["Eastbound", "Westbound"],
+          direction_destinations: nil,
+          type: :bus,
+          line: %Screens.Lines.Line{id: "l2", long_name: nil, short_name: nil, sort_order: nil}
+        }
+      ]
+
       departures = %Departures{
         sections: [
           %Section{query: %Query{params: %Query.Params{route_type: :bus, stop_ids: stop_ids}}}
@@ -836,9 +894,174 @@ defmodule Screens.V2.RDSTest do
       assert RDS.get(departures, now) == [
                {:ok,
                 [
-                  headways("sA", "l1", "hA", "r1", "Northbound", 0),
-                  headways("sB", "l2", "hB", "r2", "Westbound", 1),
-                  headways("sC", "l2", "hC", "r2", "Eastbound", 0)
+                  headways(
+                    [{"sA", "l1", "hA"}, {"sB", "l2", "hB"}, {"sC", "l2", "hC"}],
+                    nil,
+                    expected_routes,
+                    nil
+                  )
+                ]}
+             ]
+    end
+
+    test "removes headways when similar destination with line/direction_id is in Countdowns state" do
+      now = ~U[2024-10-11 11:44:00Z]
+      stop_ids = ~w[s0 s1]
+
+      first_schedule_one =
+        %Schedule{
+          id: "Test ID 11",
+          departure_time: ~U[2024-10-11 10:45:00Z],
+          route: %Route{
+            id: "r1",
+            line: %Line{id: "l1"},
+            type: :bus,
+            direction_names: ["Northbound", "Southbound"]
+          },
+          stop: %Stop{id: "sA"},
+          trip: %Trip{headsign: "h1", pattern_headsign: "hA", direction_id: 0}
+        }
+
+      last_schedule_one =
+        %Schedule{
+          id: "Test ID 12",
+          departure_time: ~U[2024-10-12 01:45:00Z],
+          route: %Route{
+            id: "r1",
+            line: %Line{id: "l1"},
+            type: :bus,
+            direction_names: ["Northbound", "Southbound"]
+          },
+          stop: %Stop{id: "sA"},
+          trip: %Trip{headsign: "h1", pattern_headsign: "hA", direction_id: 0}
+        }
+
+      first_schedule_two = %Schedule{
+        id: "Test ID 21",
+        departure_time: ~U[2024-10-11 10:45:00Z],
+        route: %Route{
+          id: "r2",
+          line: %Line{id: "l2"},
+          type: :bus,
+          direction_names: ["Eastbound", "Westbound"]
+        },
+        stop: %Stop{id: "sB"},
+        trip: %Trip{headsign: "h2", pattern_headsign: "hB", direction_id: 1}
+      }
+
+      last_schedule_two =
+        %Schedule{
+          id: "Test ID 22",
+          departure_time: ~U[2024-10-12 01:45:00Z],
+          route: %Route{
+            id: "r2",
+            line: %Line{id: "l2"},
+            type: :bus,
+            direction_names: ["Eastbound", "Westbound"]
+          },
+          stop: %Stop{id: "sB"},
+          trip: %Trip{headsign: "h2", pattern_headsign: "hB", direction_id: 1}
+        }
+
+      first_schedule_three =
+        %Schedule{
+          id: "Test ID 31",
+          departure_time: ~U[2024-10-11 10:45:00Z],
+          route: %Route{
+            id: "r2",
+            line: %Line{id: "l2"},
+            type: :bus,
+            direction_names: ["Eastbound", "Westbound"]
+          },
+          stop: %Stop{id: "sC"},
+          trip: %Trip{headsign: "h3", pattern_headsign: "hC", direction_id: 0}
+        }
+
+      last_schedule_three =
+        %Schedule{
+          id: "Test ID 32",
+          departure_time: ~U[2024-10-12 01:45:00Z],
+          route: %Route{
+            id: "r2",
+            line: %Line{id: "l2"},
+            type: :bus,
+            direction_names: ["Eastbound", "Westbound"]
+          },
+          stop: %Stop{id: "sC"},
+          trip: %Trip{headsign: "h3", pattern_headsign: "hC", direction_id: 0}
+        }
+
+      all_schedules = [
+        first_schedule_one,
+        last_schedule_one,
+        first_schedule_two,
+        last_schedule_two,
+        first_schedule_three,
+        last_schedule_three
+      ]
+
+      expected_route_a = [
+        %Screens.Routes.Route{
+          direction_destinations: nil,
+          direction_names: ["Northbound", "Southbound"],
+          id: "r1",
+          line: %Screens.Lines.Line{id: "l1", long_name: nil, short_name: nil, sort_order: nil},
+          long_name: nil,
+          short_name: nil,
+          type: :bus
+        }
+      ]
+
+      expected_route_c = [
+        %Screens.Routes.Route{
+          id: "r2",
+          short_name: nil,
+          long_name: nil,
+          direction_names: ["Eastbound", "Westbound"],
+          direction_destinations: nil,
+          type: :bus,
+          line: %Screens.Lines.Line{id: "l2", long_name: nil, short_name: nil, sort_order: nil}
+        }
+      ]
+
+      departures = %Departures{
+        sections: [
+          %Section{query: %Query{params: %Query.Params{route_type: :bus, stop_ids: stop_ids}}}
+        ]
+      }
+
+      departure_overlapping_with_headway = %Departure{
+        prediction: %Prediction{
+          departure_time: ~U[2024-10-11 10:45:00Z],
+          route: %Route{
+            id: "r2",
+            line: %Line{id: "l2"},
+            type: :bus,
+            direction_names: ["Eastbound", "Westbound"]
+          },
+          stop: %Stop{id: "sE"},
+          trip: %Trip{headsign: "h2", pattern_headsign: "hB", direction_id: 1}
+        },
+        schedule: nil
+      }
+
+      stub(@headways, :get, fn _, _ -> {5, 10} end)
+      expect(@schedule, :fetch, fn %{stop_ids: ^stop_ids}, _now -> {:ok, all_schedules} end)
+
+      expect(@departure, :fetch, fn
+        %{direction_id: :both, route_type: :bus, stop_ids: ^stop_ids}, [{:now, ^now} | _] ->
+          {:ok, [departure_overlapping_with_headway]}
+      end)
+
+      expect_standard_stations(stop_ids)
+      expect_standard_route_patterns(stop_ids)
+
+      assert RDS.get(departures, now) == [
+               {:ok,
+                [
+                  countdowns([{"sE", "l2", "hB"}], [departure_overlapping_with_headway]),
+                  headways([{"sA", "l1", "hA"}], "hA", expected_route_a, 0),
+                  headways([{"sC", "l2", "hC"}], "hC", expected_route_c, 0)
                 ]}
              ]
     end
@@ -871,7 +1094,7 @@ defmodule Screens.V2.RDSTest do
       }
 
       assert RDS.get(departures) == [
-               {:ok, [no_service("sB", "l2", "hB"), no_service("sC", "l2", "hC")]}
+               {:ok, [no_service([{"sB", "l2", "hB"}, {"sC", "l2", "hC"}])]}
              ]
     end
 
@@ -902,7 +1125,7 @@ defmodule Screens.V2.RDSTest do
       }
 
       assert RDS.get(departures) == [
-               {:ok, [no_service("sB", "l2", "hB"), no_service("sC", "l2", "hC")]}
+               {:ok, [no_service([{"sB", "l2", "hB"}, {"sC", "l2", "hC"}])]}
              ]
     end
 
@@ -959,7 +1182,7 @@ defmodule Screens.V2.RDSTest do
       }
 
       assert RDS.get(departures) == [
-               {:ok, [no_service("sA", "l1", "hA"), no_service("sC", "l2", "hC")]}
+               {:ok, [no_service([{"sA", "l1", "hA"}, {"sC", "l2", "hC"}])]}
              ]
     end
 
@@ -1021,12 +1244,7 @@ defmodule Screens.V2.RDSTest do
       }
 
       assert RDS.get(departures) == [
-               {:ok,
-                [
-                  no_service("sA", "l1", "hA"),
-                  no_service("sB", "l2", "hB"),
-                  no_service("sC", "l2", "hC")
-                ]}
+               {:ok, [no_service([{"sA", "l1", "hA"}, {"sB", "l2", "hB"}, {"sC", "l2", "hC"}])]}
              ]
     end
   end
@@ -1224,7 +1442,10 @@ defmodule Screens.V2.RDSTest do
       }
 
       assert RDS.get(departures, now) ==
-               [{:ok, [countdowns("s1", "l1", "h1", expected_departures)]}, :error]
+               [
+                 {:ok, [countdowns([{"s1", "l1", "h1"}], expected_departures)]},
+                 :error
+               ]
     end
 
     test "returns :error when a section has a disabled mode" do
@@ -1292,7 +1513,7 @@ defmodule Screens.V2.RDSTest do
 
       assert RDS.get(departures, now) == [
                {:ok, []},
-               {:ok, [countdowns("s1", "l2", "h2", subway_departures)]}
+               {:ok, [countdowns([{"s1", "l2", "h2"}], subway_departures)]}
              ]
     end
   end

--- a/test/screens/v2/widget_instance/departures_test.exs
+++ b/test/screens/v2/widget_instance/departures_test.exs
@@ -12,7 +12,6 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
   alias Screens.V2.WidgetInstance.Departures
 
   alias Screens.V2.WidgetInstance.Departures.{
-    HeadwayRow,
     HeadwaySection,
     NoDataSection,
     NormalSection
@@ -115,7 +114,7 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
       dup_screen: dup_screen,
       now: now
     } do
-      section = %HeadwaySection{route: "Red", time_range: {1, 2}, headsign: "Test"}
+      section = %HeadwaySection{route_id: "Red", time_range: {1, 2}, headsign: "Test"}
 
       expected_text = %{
         icon: "subway-negative-black",
@@ -137,7 +136,11 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
            dup_screen: dup_screen,
            now: now
          } do
-      section = %HeadwaySection{route: "Red", time_range: {1, 2}, headsign: "Ashmont/Braintree"}
+      section = %HeadwaySection{
+        route_id: "Red",
+        time_range: {1, 2},
+        headsign: "Ashmont/Braintree"
+      }
 
       expected_text = %{
         icon: "subway-negative-black",
@@ -157,7 +160,7 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
       dup_screen: dup_screen,
       now: now
     } do
-      section = %HeadwaySection{route: "Red", time_range: {1, 2}, headsign: nil}
+      section = %HeadwaySection{route_id: "Red", time_range: {1, 2}, headsign: nil}
 
       expected_text = %{
         icon: :red,
@@ -172,7 +175,7 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
       dup_screen: dup_screen,
       now: now
     } do
-      section = %HeadwaySection{route: "Red", time_range: {12, 15}, headsign: "Alewife"}
+      section = %HeadwaySection{route_id: "Red", time_range: {12, 15}, headsign: "Alewife"}
 
       expected_text = %{
         icon: :red,
@@ -340,13 +343,7 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
             stop: %Stop{}
           }
         },
-        %HeadwayRow{
-          id: "Test ID",
-          line: %Line{id: "line-Green"},
-          direction_id: 0,
-          range: {20, 30},
-          headsign: "Westbound"
-        }
+        {%Line{id: "line-Green"}, 0, {20, 30}, "Westbound"}
       ]
 
       section = %NormalSection{


### PR DESCRIPTION
Description
18937ccad06408639e63f2304b498d887d7df818 is just a small refactor to clean up how we handle headways compared to other row type

bb25cafe4a6102ff6e02dce7091442a900ca6eee is a refactor to pull out the common RDS Departure Section generation into a common generator. This is currently only used within the DUP Candidate generator, but is a setup for the new candidate generator that will be created for LCDs. It is almost exactly the same code as before, except we added a post_process_rows_fn to allow for the different app types to filter out rows in ways that they want. DUPs can have bidirectional filtering and also have a max number of rows, so we filter and truncated rows based on those values.

[1217ac4](https://github.com/mbta/screens/pull/3163/commits/1217ac4e4e95bf17b4b466f33d77ae8041125c8a) is the refactor from states to items. States will now be potentially rolled up into a list of items, which can contain multiple destinations. Also moves much of the flattening logic into the RDS module now, so in cases where we have exclusively NoService/ServiceEnded/Headways, we roll them up into one state that is passed to the consumer. This allows the consumer to just scan for the single one item when creating the full screen treatments. This code explicitly doesn't roll up Countdowns/sort the states though, due to the need for sorting departures for rows in the consumers anyway. This also introduces the `destinations` field which normally holds a single destination, but in cases where we roll up states will hold onto all of the destinations that item is representing. 

- [x] Tests added?
