### PR TITLE
feat: increase static cache size for RDS LCDs

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -502,7 +502,7 @@ config :screens,
 
 config :screens,
        Screens.V3Api.Cache.Static,
-       Keyword.merge(v3_api_cache_options, allocated_memory: 300 * 1024 * 1024)
+       Keyword.merge(v3_api_cache_options, allocated_memory: 600 * 1024 * 1024)
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.


### PR DESCRIPTION
- from RDS LCD testing in dev-green with Screenplay, we are seeing our cache go beyond our cache limit and seeing an increased number of connection pools that are timing out
- in preparation for RDS on LCDs, increase the cache size to accommodate the increased number of network calls we will be making (and subsequently the cached results)
