### PR TITLE
feat: Use headsign abbreviations on LCDs

### DIFF
--- a/assets/css/lcd/departures/destination.scss
+++ b/assets/css/lcd/departures/destination.scss
@@ -9,7 +9,6 @@
   line-height: 64px;
   color: colors.$cool-black-15;
   white-space: nowrap;
-  user-select: none;
 }
 
 .departure-destination__variation {

--- a/assets/css/lcd/departures/destination.scss
+++ b/assets/css/lcd/departures/destination.scss
@@ -2,13 +2,14 @@
 
 .departure-destination__headsign {
   padding-bottom: 6px;
-  overflow: hidden;
+  overflow: clip;
   text-overflow: ellipsis;
   font-size: 64px;
   font-weight: 600;
   line-height: 64px;
   color: colors.$cool-black-15;
   white-space: nowrap;
+  user-select: none;
 }
 
 .departure-destination__variation {

--- a/assets/src/components/departures/destination.tsx
+++ b/assets/src/components/departures/destination.tsx
@@ -1,6 +1,6 @@
 import type { ComponentType } from "react";
 
-import useAutoSize from "Hooks/use_auto_size";
+import { useHorizontalAutoSize } from "Hooks/use_auto_size";
 
 type Destination = {
   headsigns: string[];
@@ -8,7 +8,7 @@ type Destination = {
 };
 
 const Destination: ComponentType<Destination> = ({ headsigns, variation }) => {
-  const { ref, step: headsign } = useAutoSize(headsigns);
+  const { ref, step: headsign } = useHorizontalAutoSize(headsigns);
 
   return (
     <div className="departure-destination">

--- a/assets/src/components/departures/destination.tsx
+++ b/assets/src/components/departures/destination.tsx
@@ -1,21 +1,19 @@
 import type { ComponentType } from "react";
 
-const abbreviate = (headsign: string): string => {
-  if (headsign === "Government Center") return "Government Ctr";
-  return headsign;
-};
+import useAutoSize from "Hooks/use_auto_size";
 
 type Destination = {
-  headsign: string;
   headsigns: string[];
   variation?: string;
 };
 
-const Destination: ComponentType<Destination> = ({ headsign, variation }) => {
+const Destination: ComponentType<Destination> = ({ headsigns, variation }) => {
+  const { ref, step: headsign } = useAutoSize(headsigns);
+
   return (
     <div className="departure-destination">
-      <div className="departure-destination__headsign">
-        {abbreviate(headsign)}
+      <div className="departure-destination__headsign" ref={ref}>
+        {headsign}
       </div>
       {variation && (
         <div className="departure-destination__variation">{variation}</div>

--- a/assets/src/hooks/use_auto_size.ts
+++ b/assets/src/hooks/use_auto_size.ts
@@ -93,7 +93,7 @@ export const useHorizontalAutoSize = <T extends Value>(
   steps: readonly T[],
   key?: Value,
 ): { ref: RefCallback<Element>; step: T } => {
-  return useAutoSize(steps, key);
+  return useAutoSize(steps, key, hasOverflowX);
 };
 
 export default useAutoSize;

--- a/assets/src/hooks/use_auto_size.ts
+++ b/assets/src/hooks/use_auto_size.ts
@@ -84,7 +84,7 @@ const useAutoSize = <T extends Value>(
     if (remainingSteps.length > 1 && element && overflowCheckFn(element)) {
       setRemainingSteps(remainingSteps.slice(1));
     }
-  }, [element, remainingSteps]);
+  }, [element, remainingSteps, overflowCheckFn]);
 
   return { ref: setElement, step: remainingSteps[0] };
 };

--- a/assets/src/hooks/use_auto_size.ts
+++ b/assets/src/hooks/use_auto_size.ts
@@ -1,6 +1,6 @@
 import { type RefCallback, useLayoutEffect, useState, useRef } from "react";
 
-import { hasOverflow } from "Util/utils";
+import { hasOverflow, hasOverflowX } from "Util/utils";
 
 // Types which use value equality
 type Value = undefined | null | boolean | number | string | bigint;
@@ -54,6 +54,7 @@ type Value = undefined | null | boolean | number | string | bigint;
 const useAutoSize = <T extends Value>(
   steps: readonly T[],
   key?: Value,
+  overflowCheckFn: (element: Element) => boolean = hasOverflow,
 ): { ref: RefCallback<Element>; step: T } => {
   const initialSteps = useRef(steps);
   const [element, setElement] = useState<Element | null>(null);
@@ -80,12 +81,19 @@ const useAutoSize = <T extends Value>(
   // step. This is a change to `remainingSteps` and so itself causes the effect
   // to run again, but on the next render, with the new step value.
   useLayoutEffect(() => {
-    if (remainingSteps.length > 1 && element && hasOverflow(element)) {
+    if (remainingSteps.length > 1 && element && overflowCheckFn(element)) {
       setRemainingSteps(remainingSteps.slice(1));
     }
   }, [element, remainingSteps]);
 
   return { ref: setElement, step: remainingSteps[0] };
+};
+
+export const useHorizontalAutoSize = <T extends Value>(
+  steps: readonly T[],
+  key?: Value,
+): { ref: RefCallback<Element>; step: T } => {
+  return useAutoSize(steps, key);
 };
 
 export default useAutoSize;


### PR DESCRIPTION
**Asana task**: [Screens Abbreviation Logic](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1213973277663100?focus=true)

Uses the list of headsign abbreviations on LCD screens. Some notes
- This should not apply to bus e-inks on Screens Admin because those wrap the overflow onto the next line, and this is specifically looking for horizontal overflow. We specifically look for horizontal overflow because using both horizontal and vertical overflow causes issues with bus e-inks setup, but also makes more sense in the context of headsigns. We have only used `useAutoSize` for text sizing in the past, which is concerned with both horizontal and vertical space; shortening headsigns is only concerned with the horizontal space. 
- Changed the `overflow` type of the headsign name to `clip` because `hidden` would technically create a hidden scroll container that would cause no overflow to register
- Added `user-select: none;` because it really bothered me when testing that interacting would cause the overflow to show. This behavior has always existed and is not technically a problem because our users don't interact with these screens, so I'm fine with removing if there's an argument against. 
- An easy way to see this in action and test it is by overriding the list of headsigns sent by the widget instance or just within the FE component.