### PR TITLE
feat: Hide alerts from flex-zone when there are multiple

### DIFF
--- a/lib/screens/v2/candidate_generator/pre_fare.ex
+++ b/lib/screens/v2/candidate_generator/pre_fare.ex
@@ -7,6 +7,7 @@ defmodule Screens.V2.CandidateGenerator.PreFare do
   alias Screens.V2.Template.Builder
   alias Screens.V2.WidgetInstance
   alias Screens.V2.WidgetInstance.AudioOnly.{AlertsIntro, AlertsOutro, ContentSummary}
+  alias Screens.V2.WidgetInstance.ReconstructedAlert
   alias ScreensConfig.Screen
   alias ScreensConfig.Screen.PreFare
 
@@ -75,8 +76,34 @@ defmodule Screens.V2.CandidateGenerator.PreFare do
 
   @impl CandidateGenerator
   def candidate_instances(config, now \\ DateTime.utc_now(), instance_fns \\ @instance_fns) do
-    CandidateGenerator.async_stream(instance_fns, & &1.(config, now), timeout: 15_000)
+    instance_fns
+    |> CandidateGenerator.async_stream(& &1.(config, now), timeout: 15_000)
+    |> simplify_flex_zone()
   end
+
+  @spec simplify_flex_zone([WidgetInstance.t()]) :: [WidgetInstance.t()]
+  defp simplify_flex_zone(widgets) do
+    # When multiple reconstructed alerts would compete for the :large slot in the flex zone,
+    # drop them all so Subway Status (which gives a better multi-alert overview) is shown instead.
+    # Rider research shows that people won't stand around and wait through many alerts.
+    reconstructed_alert_count =
+      widgets
+      |> Enum.filter(&flex_zone_reconstructed_alert?/1)
+      |> length()
+
+    if reconstructed_alert_count > 1 and length(widgets) > reconstructed_alert_count do
+      Enum.reject(widgets, &flex_zone_reconstructed_alert?/1)
+    else
+      widgets
+    end
+  end
+
+  @spec flex_zone_reconstructed_alert?(WidgetInstance.t()) :: boolean()
+  defp flex_zone_reconstructed_alert?(%ReconstructedAlert{} = widget) do
+    :large in WidgetInstance.slot_names(widget)
+  end
+
+  defp flex_zone_reconstructed_alert?(_), do: false
 
   @impl CandidateGenerator
   def audio_only_instances(widgets, config, routes_fetch_fn \\ &Route.fetch/1) do

--- a/lib/screens/v2/candidate_generator/pre_fare.ex
+++ b/lib/screens/v2/candidate_generator/pre_fare.ex
@@ -4,6 +4,7 @@ defmodule Screens.V2.CandidateGenerator.PreFare do
   alias Screens.Routes.Route
   alias Screens.V2.CandidateGenerator
   alias Screens.V2.CandidateGenerator.Widgets
+  alias Screens.V2.LocalizedAlert
   alias Screens.V2.Template.Builder
   alias Screens.V2.WidgetInstance
   alias Screens.V2.WidgetInstance.AudioOnly.{AlertsIntro, AlertsOutro, ContentSummary}
@@ -83,16 +84,18 @@ defmodule Screens.V2.CandidateGenerator.PreFare do
 
   @spec simplify_flex_zone([WidgetInstance.t()]) :: [WidgetInstance.t()]
   defp simplify_flex_zone(widgets) do
-    # When multiple reconstructed alerts would compete for the :large slot in the flex zone,
-    # drop them all so Subway Status (which gives a better multi-alert overview) is shown instead.
-    # Rider research shows that people won't stand around and wait through many alerts.
-    reconstructed_alert_count =
+    # If multiple reconstructed alerts would compete for the flex zone, drop (down/up)stream alerts
+    # to spend more time showing Subway Status (which gives a better line-wide overview).
+    # Alerts with other locations (inside, boundary, etc.) should still be shown.
+    flex_zone_alert_count =
       widgets
       |> Enum.filter(&flex_zone_reconstructed_alert?/1)
       |> length()
 
-    if reconstructed_alert_count > 1 and length(widgets) > reconstructed_alert_count do
-      Enum.reject(widgets, &flex_zone_reconstructed_alert?/1)
+    if flex_zone_alert_count > 1 do
+      Enum.reject(widgets, fn widget ->
+        flex_zone_reconstructed_alert?(widget) and downstream_or_upstream_alert?(widget)
+      end)
     else
       widgets
     end
@@ -104,6 +107,18 @@ defmodule Screens.V2.CandidateGenerator.PreFare do
   end
 
   defp flex_zone_reconstructed_alert?(_), do: false
+
+  @spec downstream_or_upstream_alert?(ReconstructedAlert.t()) :: boolean()
+  defp downstream_or_upstream_alert?(%ReconstructedAlert{
+         alert: alert,
+         location_context: location_context,
+         is_terminal_station: is_terminal_station
+       }) do
+    LocalizedAlert.location(
+      %{alert: alert, location_context: location_context},
+      is_terminal_station
+    ) in [:downstream, :upstream]
+  end
 
   @impl CandidateGenerator
   def audio_only_instances(widgets, config, routes_fetch_fn \\ &Route.fetch/1) do

--- a/lib/screens/v2/candidate_generator/pre_fare.ex
+++ b/lib/screens/v2/candidate_generator/pre_fare.ex
@@ -86,7 +86,7 @@ defmodule Screens.V2.CandidateGenerator.PreFare do
   defp simplify_flex_zone(widgets) do
     # If multiple reconstructed alerts would compete for the flex zone, drop (down/up)stream alerts
     # to spend more time showing Subway Status (which gives a better line-wide overview).
-    # Alerts with other locations (inside, boundary, etc.) should still be shown.
+    # Alerts with other locations (inside, boundaries) should still be shown.
     flex_zone_alert_count =
       widgets
       |> Enum.filter(&flex_zone_reconstructed_alert?/1)

--- a/test/screens/v2/candidate_generator/pre_fare_test.exs
+++ b/test/screens/v2/candidate_generator/pre_fare_test.exs
@@ -34,14 +34,45 @@ defmodule Screens.V2.CandidateGenerator.PreFareTest do
     location_context = %LocationContext{
       home_stop: "place-gover",
       tagged_stop_sequences: %{},
-      upstream_stops: MapSet.new(),
-      downstream_stops: MapSet.new(),
+      upstream_stops: MapSet.new(["place-pktrm"]),
+      downstream_stops: MapSet.new(["place-dwnxg"]),
       child_stops_at_station: MapSet.new(),
       routes: [],
       alert_route_types: [:light_rail, :subway]
     }
 
-    %{config: config, location_context: location_context}
+    # Informed entities to test different types of alerts
+    downstream_ie = [
+      %Screens.Alerts.InformedEntity{
+        stop: %Screens.Stops.Stop{id: "place-dwnxg"},
+        route: "Red",
+        direction_id: 0
+      }
+    ]
+
+    inside_ie = [
+      %Screens.Alerts.InformedEntity{
+        stop: %Screens.Stops.Stop{id: "place-gover"},
+        route: "Red",
+        direction_id: 0
+      }
+    ]
+
+    upstream_ie = [
+      %Screens.Alerts.InformedEntity{
+        stop: %Screens.Stops.Stop{id: "place-pktrm"},
+        route: "Red",
+        direction_id: 0
+      }
+    ]
+
+    %{
+      config: config,
+      location_context: location_context,
+      downstream_ie: downstream_ie,
+      inside_ie: inside_ie,
+      upstream_ie: upstream_ie
+    }
   end
 
   describe "screen_template/1" do
@@ -110,36 +141,6 @@ defmodule Screens.V2.CandidateGenerator.PreFareTest do
   end
 
   describe "candidate_instances/3" do
-    test "drops all reconstructed alerts in the :large slot when there are more than one",
-         %{config: config, location_context: location_context} do
-      alert1 = %Alert{id: "1", effect: :delay, severity: 5, informed_entities: []}
-      alert2 = %Alert{id: "2", effect: :station_closure, severity: 5, informed_entities: []}
-
-      alert_widget_1 = %ReconstructedAlert{
-        screen: config,
-        alert: alert1,
-        location_context: location_context,
-        is_priority: false
-      }
-
-      alert_widget_2 = %ReconstructedAlert{
-        screen: config,
-        alert: alert2,
-        location_context: location_context,
-        is_priority: false
-      }
-
-      other_widget = %MockWidget{slot_names: [:large]}
-
-      instance_fns = [
-        fn _config, _now -> [alert_widget_1, alert_widget_2, other_widget] end
-      ]
-
-      candidates = PreFare.candidate_instances(config, DateTime.utc_now(), instance_fns)
-
-      assert candidates == [other_widget]
-    end
-
     test "keeps a single reconstructed alert in the :large slot",
          %{config: config, location_context: location_context} do
       alert = %Alert{id: "1", effect: :delay, severity: 5, informed_entities: []}
@@ -158,6 +159,85 @@ defmodule Screens.V2.CandidateGenerator.PreFareTest do
       ]
 
       assert [alert_widget, other_widget] ==
+               PreFare.candidate_instances(config, DateTime.utc_now(), instance_fns)
+    end
+
+    test "drops multiple downstream/upstream reconstructed alerts in the :large slot",
+         %{
+           config: config,
+           location_context: location_context,
+           downstream_ie: downstream_ie,
+           upstream_ie: upstream_ie
+         } do
+      alert_widget_1 = %ReconstructedAlert{
+        screen: config,
+        alert: %Alert{id: "1", effect: :delay, severity: 5, informed_entities: downstream_ie},
+        location_context: location_context,
+        is_priority: false
+      }
+
+      alert_widget_2 = %ReconstructedAlert{
+        screen: config,
+        alert: %Alert{id: "2", effect: :delay, severity: 4, informed_entities: upstream_ie},
+        location_context: location_context,
+        is_priority: false
+      }
+
+      other_widget = %MockWidget{slot_names: [:large]}
+
+      instance_fns = [
+        fn _config, _now -> [alert_widget_1, alert_widget_2, other_widget] end
+      ]
+
+      assert [other_widget] ==
+               PreFare.candidate_instances(config, DateTime.utc_now(), instance_fns)
+    end
+
+    test "keeps inside alerts even when multiple downstream alerts exist",
+         %{
+           config: config,
+           location_context: location_context,
+           downstream_ie: downstream_ie,
+           inside_ie: inside_ie,
+           upstream_ie: upstream_ie
+         } do
+      downstream_widget = %ReconstructedAlert{
+        screen: config,
+        alert: %Alert{id: "1", effect: :delay, severity: 5, informed_entities: downstream_ie},
+        location_context: location_context,
+        is_priority: false
+      }
+
+      upstream_widget = %ReconstructedAlert{
+        screen: config,
+        alert: %Alert{id: "2", effect: :delay, severity: 4, informed_entities: upstream_ie},
+        location_context: location_context,
+        is_priority: false
+      }
+
+      inside_widget1 = %ReconstructedAlert{
+        screen: config,
+        alert: %Alert{id: "3", effect: :delay, severity: 5, informed_entities: inside_ie},
+        location_context: location_context,
+        is_priority: false
+      }
+
+      inside_widget2 = %ReconstructedAlert{
+        screen: config,
+        alert: %Alert{id: "4", effect: :delay, severity: 5, informed_entities: inside_ie},
+        location_context: location_context,
+        is_priority: false
+      }
+
+      other_widget = %MockWidget{slot_names: [:large]}
+
+      instance_fns = [
+        fn _config, _now ->
+          [downstream_widget, upstream_widget, inside_widget1, inside_widget2, other_widget]
+        end
+      ]
+
+      assert [inside_widget1, inside_widget2, other_widget] ==
                PreFare.candidate_instances(config, DateTime.utc_now(), instance_fns)
     end
   end

--- a/test/screens/v2/candidate_generator/pre_fare_test.exs
+++ b/test/screens/v2/candidate_generator/pre_fare_test.exs
@@ -1,9 +1,12 @@
 defmodule Screens.V2.CandidateGenerator.PreFareTest do
   use ExUnit.Case, async: true
 
+  alias Screens.Alerts.Alert
+  alias Screens.LocationContext
   alias Screens.V2.CandidateGenerator.PreFare
   alias Screens.V2.WidgetInstance.AudioOnly.{AlertsIntro, AlertsOutro, ContentSummary}
   alias Screens.V2.WidgetInstance.MockWidget
+  alias Screens.V2.WidgetInstance.ReconstructedAlert
   alias ScreensConfig, as: Config
   alias ScreensConfig.Screen
 
@@ -28,7 +31,17 @@ defmodule Screens.V2.CandidateGenerator.PreFareTest do
       app_id: :pre_fare_v2
     }
 
-    %{config: config}
+    location_context = %LocationContext{
+      home_stop: "place-gover",
+      tagged_stop_sequences: %{},
+      upstream_stops: MapSet.new(),
+      downstream_stops: MapSet.new(),
+      child_stops_at_station: MapSet.new(),
+      routes: [],
+      alert_route_types: [:light_rail, :subway]
+    }
+
+    %{config: config, location_context: location_context}
   end
 
   describe "screen_template/1" do
@@ -93,6 +106,59 @@ defmodule Screens.V2.CandidateGenerator.PreFareTest do
                 screen_normal: [:header, {:body, %{body_normal: [body_right: @body_right]}}],
                 screen_split_takeover: [:full_right_screen]
               }} == PreFare.screen_template(put_in(config.app_params.template, :solo))
+    end
+  end
+
+  describe "candidate_instances/3" do
+    test "drops all reconstructed alerts in the :large slot when there are more than one",
+         %{config: config, location_context: location_context} do
+      alert1 = %Alert{id: "1", effect: :delay, severity: 5, informed_entities: []}
+      alert2 = %Alert{id: "2", effect: :station_closure, severity: 5, informed_entities: []}
+
+      alert_widget_1 = %ReconstructedAlert{
+        screen: config,
+        alert: alert1,
+        location_context: location_context,
+        is_priority: false
+      }
+
+      alert_widget_2 = %ReconstructedAlert{
+        screen: config,
+        alert: alert2,
+        location_context: location_context,
+        is_priority: false
+      }
+
+      other_widget = %MockWidget{slot_names: [:large]}
+
+      instance_fns = [
+        fn _config, _now -> [alert_widget_1, alert_widget_2, other_widget] end
+      ]
+
+      candidates = PreFare.candidate_instances(config, DateTime.utc_now(), instance_fns)
+
+      assert candidates == [other_widget]
+    end
+
+    test "keeps a single reconstructed alert in the :large slot",
+         %{config: config, location_context: location_context} do
+      alert = %Alert{id: "1", effect: :delay, severity: 5, informed_entities: []}
+
+      alert_widget = %ReconstructedAlert{
+        screen: config,
+        alert: alert,
+        location_context: location_context,
+        is_priority: false
+      }
+
+      other_widget = %MockWidget{slot_names: [:large]}
+
+      instance_fns = [
+        fn _config, _now -> [alert_widget, other_widget] end
+      ]
+
+      assert [alert_widget, other_widget] ==
+               PreFare.candidate_instances(config, DateTime.utc_now(), instance_fns)
     end
   end
 


### PR DESCRIPTION
**Asana task**: [Pre-Fare Alerts - Many Downstream Alerts](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1215510478728893?focus=true)

Added a function to the the `pre_fare` candidate generator to simplify the flex zone once all candidates are generated. Although this doesn't specifically check for the Subway Status, if there's any other widget in the same `:large` slot and multiple alert widgets, we'll filter out the multiple alert widgets. 

Unit tests added and behavior validated . See below for an example of the flex zone with this first enabled, and then disabled:
<img width="405" height="352" alt="Park Street" src="https://github.com/user-attachments/assets/0ad08442-9b23-4603-9a2c-48a2075218e3" />
<img width="405" height="351" alt="Park Street" src="https://github.com/user-attachments/assets/61519cc0-f573-4dcd-96c7-444fdaaf0f97" />
