### PR TITLE
feat: Suppress stale alerts on Screens

### DIFF
--- a/lib/screens/alerts/alert.ex
+++ b/lib/screens/alerts/alert.ex
@@ -277,6 +277,19 @@ defmodule Screens.Alerts.Alert do
     DateTime.compare(t, start_t) in [:gt, :eq] && DateTime.compare(t, end_t) in [:lt, :eq]
   end
 
+  @spec stale?(t(), DateTime.t()) :: boolean()
+  def stale?(alert, now \\ DateTime.utc_now())
+
+  def stale?(%__MODULE__{active_period: [{current_start, _current_end} | _]}, now) do
+    five_weeks_ago_in_seconds = -3_024_000
+
+    now
+    |> DateTime.add(five_weeks_ago_in_seconds)
+    |> DateTime.compare(current_start) == :gt
+  end
+
+  def stale?(_, _), do: false
+
   # Rules for grammatically describing alert causes.
   @cause_description_rules %{
     accident: :an,

--- a/lib/screens/v2/candidate_generator/dup/alerts.ex
+++ b/lib/screens/v2/candidate_generator/dup/alerts.ex
@@ -52,7 +52,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.Alerts do
   def relevant_alerts(alerts, screen, location_context, now) do
     Enum.filter(alerts, fn alert ->
       relevant_effect?(alert, screen) and Alert.active?(alert, now) and
-        relevant_location?(alert, location_context) and
+        LocalizedAlert.stop_in_alert_boundary?(alert, location_context) and
         not directional_shuttle_or_suspension?(alert)
     end)
   end
@@ -126,15 +126,6 @@ defmodule Screens.V2.CandidateGenerator.Dup.Alerts do
 
   defp relevant_effect?(%Alert{effect: effect}, _screen) do
     effect in [:station_closure, :shuttle, :suspension, :delay]
-  end
-
-  @spec relevant_location?(Alert.t(), LocationContext.t()) :: boolean()
-  defp relevant_location?(alert, location_context) do
-    LocalizedAlert.location(%{alert: alert, location_context: location_context}) in [
-      :inside,
-      :boundary_upstream,
-      :boundary_downstream
-    ]
   end
 
   defp directional_shuttle_or_suspension?(alert) do

--- a/lib/screens/v2/candidate_generator/widgets/alerts.ex
+++ b/lib/screens/v2/candidate_generator/widgets/alerts.ex
@@ -79,7 +79,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.Alerts do
     |> Stream.filter(&Alert.active?(&1, now))
     |> Stream.filter(&(&1.effect in @relevant_effects))
     |> Stream.filter(&Enum.any?(&1.informed_entities, relevant_ie?))
-    |> Stream.reject(&suppressable_alert?(&1, location_context, now))
+    |> Stream.reject(&LocalizedAlert.suppressable_alert?(&1, location_context, now))
     |> Enum.to_list()
   end
 
@@ -88,10 +88,4 @@ defmodule Screens.V2.CandidateGenerator.Widgets.Alerts do
          home_stop_ids
        ),
        do: home_stop_ids |> MapSet.new() |> MapSet.union(downstream_stops) |> MapSet.to_list()
-
-  @spec suppressable_alert?(Alert.t(), LocationContext.t(), DateTime.t()) :: boolean()
-  defp suppressable_alert?(alert, location_context, now) do
-    Alert.stale?(alert, now) and
-      !LocalizedAlert.stop_in_alert_boundary?(alert, location_context)
-  end
 end

--- a/lib/screens/v2/candidate_generator/widgets/alerts.ex
+++ b/lib/screens/v2/candidate_generator/widgets/alerts.ex
@@ -4,6 +4,8 @@ defmodule Screens.V2.CandidateGenerator.Widgets.Alerts do
   alias Screens.Alerts.Alert
   alias Screens.Alerts.InformedEntity
   alias Screens.LocationContext
+  alias Screens.Routes.Route
+  alias Screens.Stops.Stop
   alias Screens.V2.LocalizedAlert
   alias Screens.V2.WidgetInstance.Alert, as: AlertWidget
   alias ScreensConfig.{Alerts, MultiStopAlerts}
@@ -52,6 +54,8 @@ defmodule Screens.V2.CandidateGenerator.Widgets.Alerts do
 
   (list describes the `relevant_ie?` function clauses in order)
   """
+  @spec relevant_alerts([Alert.t()], [Stop.id()], [Route.id()], LocationContext.t(), DateTime.t()) ::
+          [Alert.t()]
   def relevant_alerts(alerts, stop_ids, route_ids, location_context, now) do
     stop_id_set = MapSet.new(stop_ids)
     route_id_set = MapSet.new(route_ids)

--- a/lib/screens/v2/candidate_generator/widgets/alerts.ex
+++ b/lib/screens/v2/candidate_generator/widgets/alerts.ex
@@ -4,6 +4,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.Alerts do
   alias Screens.Alerts.Alert
   alias Screens.Alerts.InformedEntity
   alias Screens.LocationContext
+  alias Screens.V2.LocalizedAlert
   alias Screens.V2.WidgetInstance.Alert, as: AlertWidget
   alias ScreensConfig.{Alerts, MultiStopAlerts}
   alias ScreensConfig.Screen
@@ -31,7 +32,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.Alerts do
          {:ok, alerts} <- fetch_alerts_by_stop_and_route_fn.(reachable_stop_ids, route_ids) do
       alerts
       |> Alert.consolidate_whole_route_delays()
-      |> relevant_alerts(reachable_stop_ids, route_ids, now)
+      |> relevant_alerts(reachable_stop_ids, route_ids, location_context, now)
       |> Enum.map(
         &%AlertWidget{alert: &1, screen: config, location_context: location_context, now: now}
       )
@@ -51,7 +52,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.Alerts do
 
   (list describes the `relevant_ie?` function clauses in order)
   """
-  def relevant_alerts(alerts, stop_ids, route_ids, now) do
+  def relevant_alerts(alerts, stop_ids, route_ids, location_context, now) do
     stop_id_set = MapSet.new(stop_ids)
     route_id_set = MapSet.new(route_ids)
 
@@ -78,6 +79,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.Alerts do
     |> Stream.filter(&Alert.active?(&1, now))
     |> Stream.filter(&(&1.effect in @relevant_effects))
     |> Stream.filter(&Enum.any?(&1.informed_entities, relevant_ie?))
+    |> Stream.reject(&suppressable_alert?(&1, location_context, now))
     |> Enum.to_list()
   end
 
@@ -86,4 +88,10 @@ defmodule Screens.V2.CandidateGenerator.Widgets.Alerts do
          home_stop_ids
        ),
        do: home_stop_ids |> MapSet.new() |> MapSet.union(downstream_stops) |> MapSet.to_list()
+
+  @spec suppressable_alert?(Alert.t(), LocationContext.t(), DateTime.t()) :: boolean()
+  defp suppressable_alert?(alert, location_context, now) do
+    Alert.stale?(alert, now) and
+      !LocalizedAlert.stop_in_alert_boundary?(alert, location_context)
+  end
 end

--- a/lib/screens/v2/candidate_generator/widgets/reconstructed_alert.ex
+++ b/lib/screens/v2/candidate_generator/widgets/reconstructed_alert.ex
@@ -73,6 +73,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlert do
         |> Enum.filter(
           &(Alert.active?(&1, now) and relevant_direction?(&1, stop_id, stop_sequences))
         )
+        |> Enum.reject(&suppressable_alert?(&1, location_context, now))
         |> Alert.consolidate_whole_route_delays()
         |> Enum.group_by(fn alert ->
           relevance(
@@ -116,6 +117,12 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlert do
     else
       :error -> []
     end
+  end
+
+  @spec suppressable_alert?(Alert.t(), LocationContext.t(), DateTime.t()) :: boolean()
+  defp suppressable_alert?(alert, location_context, now) do
+    Alert.stale?(alert, now) and
+      !LocalizedAlert.stop_in_alert_boundary?(alert, location_context)
   end
 
   @inside_locations ~w[inside boundary_upstream boundary_downstream]a

--- a/lib/screens/v2/candidate_generator/widgets/reconstructed_alert.ex
+++ b/lib/screens/v2/candidate_generator/widgets/reconstructed_alert.ex
@@ -73,7 +73,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlert do
         |> Enum.filter(
           &(Alert.active?(&1, now) and relevant_direction?(&1, stop_id, stop_sequences))
         )
-        |> Enum.reject(&suppressable_alert?(&1, location_context, now))
+        |> Enum.reject(&LocalizedAlert.suppressable_alert?(&1, location_context, now))
         |> Alert.consolidate_whole_route_delays()
         |> Enum.group_by(fn alert ->
           relevance(
@@ -117,12 +117,6 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlert do
     else
       :error -> []
     end
-  end
-
-  @spec suppressable_alert?(Alert.t(), LocationContext.t(), DateTime.t()) :: boolean()
-  defp suppressable_alert?(alert, location_context, now) do
-    Alert.stale?(alert, now) and
-      !LocalizedAlert.stop_in_alert_boundary?(alert, location_context)
   end
 
   @inside_locations ~w[inside boundary_upstream boundary_downstream]a

--- a/lib/screens/v2/candidate_generator/widgets/subway_status.ex
+++ b/lib/screens/v2/candidate_generator/widgets/subway_status.ex
@@ -4,14 +4,19 @@ defmodule Screens.V2.CandidateGenerator.Widgets.SubwayStatus do
   alias Screens.Alerts.Alert
   alias Screens.V2.WidgetInstance.SubwayStatus
 
-  def subway_status_instances(config, now \\ DateTime.utc_now()) do
+  def subway_status_instances(
+        config,
+        now \\ DateTime.utc_now(),
+        fetch_alerts_fn \\ &Alert.fetch/1
+      ) do
     route_ids = ["Blue", "Orange", "Red", "Green-B", "Green-C", "Green-D", "Green-E", "Mattapan"]
 
-    {:ok, alerts} = Screens.Alerts.Alert.fetch(route_ids: route_ids)
+    {:ok, alerts} = fetch_alerts_fn.(route_ids: route_ids)
 
     relevant_alerts =
       alerts
       |> Enum.filter(&(relevant_alert?(&1) and Alert.active?(&1, now)))
+      |> Enum.reject(&Alert.stale?(&1, now))
       |> Alert.consolidate_whole_route_delays()
       |> Enum.map(&%SubwayStatus.SubwayStatusAlert{alert: &1})
 

--- a/lib/screens/v2/candidate_generator/widgets/subway_status.ex
+++ b/lib/screens/v2/candidate_generator/widgets/subway_status.ex
@@ -2,6 +2,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.SubwayStatus do
   @moduledoc false
 
   alias Screens.Alerts.Alert
+  alias Screens.V2.LocalizedAlert
   alias Screens.V2.WidgetInstance.SubwayStatus
 
   def subway_status_instances(
@@ -16,7 +17,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.SubwayStatus do
     relevant_alerts =
       alerts
       |> Enum.filter(&(relevant_alert?(&1) and Alert.active?(&1, now)))
-      |> Enum.reject(&Alert.stale?(&1, now))
+      |> Enum.reject(&LocalizedAlert.suppressable_alert?(&1, now))
       |> Alert.consolidate_whole_route_delays()
       |> Enum.map(&%SubwayStatus.SubwayStatusAlert{alert: &1})
 

--- a/lib/screens/v2/localized_alert.ex
+++ b/lib/screens/v2/localized_alert.ex
@@ -354,4 +354,13 @@ defmodule Screens.V2.LocalizedAlert do
     |> MapSet.difference(uninformed_routes)
     |> Enum.to_list()
   end
+
+  @spec stop_in_alert_boundary?(Alert.t(), t()) :: boolean()
+  def stop_in_alert_boundary?(alert, location_context) do
+    location(%{alert: alert, location_context: location_context}) in [
+      :inside,
+      :boundary_upstream,
+      :boundary_downstream
+    ]
+  end
 end

--- a/lib/screens/v2/localized_alert.ex
+++ b/lib/screens/v2/localized_alert.ex
@@ -355,7 +355,7 @@ defmodule Screens.V2.LocalizedAlert do
     |> Enum.to_list()
   end
 
-  @spec stop_in_alert_boundary?(Alert.t(), t()) :: boolean()
+  @spec stop_in_alert_boundary?(Alert.t(), LocationContext.t()) :: boolean()
   def stop_in_alert_boundary?(alert, location_context) do
     location(%{alert: alert, location_context: location_context}) in [
       :inside,

--- a/lib/screens/v2/localized_alert.ex
+++ b/lib/screens/v2/localized_alert.ex
@@ -355,6 +355,16 @@ defmodule Screens.V2.LocalizedAlert do
     |> Enum.to_list()
   end
 
+  @spec suppressable_alert?(Alert.t(), LocationContext.t() | nil, DateTime.t()) :: boolean()
+  def suppressable_alert?(alert, location_context \\ nil, now)
+
+  def suppressable_alert?(alert, nil, now), do: Alert.stale?(alert, now)
+
+  def suppressable_alert?(alert, location_context, now) do
+    Alert.stale?(alert, now) and
+      !stop_in_alert_boundary?(alert, location_context)
+  end
+
   @spec stop_in_alert_boundary?(Alert.t(), LocationContext.t()) :: boolean()
   def stop_in_alert_boundary?(alert, location_context) do
     location(%{alert: alert, location_context: location_context}) in [

--- a/test/screens/alerts/alert_test.exs
+++ b/test/screens/alerts/alert_test.exs
@@ -379,6 +379,90 @@ defmodule Screens.Alerts.AlertTest do
     end
   end
 
+  describe "stale?/2" do
+    setup do
+      %{
+        now: ~U[2026-07-01 00:00:00Z],
+        one_week_in_seconds: 604_800
+      }
+    end
+
+    test "returns false when there are no active periods remaining" do
+      refute Alert.stale?(%Alert{
+               active_period: []
+             })
+    end
+
+    test "returns false when the current active period started less than five weeks ago",
+         context do
+      %{
+        now: now,
+        one_week_in_seconds: one_week_in_seconds
+      } = context
+
+      refute Alert.stale?(
+               %Alert{
+                 active_period: [
+                   {DateTime.add(now, -one_week_in_seconds), nil}
+                 ]
+               },
+               now
+             )
+    end
+
+    test "returns false when the current active period started exactly five weeks ago",
+         context do
+      %{
+        now: now,
+        one_week_in_seconds: one_week_in_seconds
+      } = context
+
+      refute Alert.stale?(
+               %Alert{
+                 active_period: [
+                   {DateTime.add(now, -5 * one_week_in_seconds), nil}
+                 ]
+               },
+               now
+             )
+    end
+
+    test "returns true when the current active period started more than five weeks ago",
+         context do
+      %{
+        now: now,
+        one_week_in_seconds: one_week_in_seconds
+      } = context
+
+      assert Alert.stale?(
+               %Alert{
+                 active_period: [
+                   {DateTime.add(now, -5 * one_week_in_seconds - 1), nil}
+                 ]
+               },
+               now
+             )
+    end
+
+    test "returns true when the current active period is stale and there are future active periods",
+         context do
+      %{
+        now: now,
+        one_week_in_seconds: one_week_in_seconds
+      } = context
+
+      assert Alert.stale?(
+               %Alert{
+                 active_period: [
+                   {DateTime.add(now, -5 * one_week_in_seconds - 1), nil},
+                   {DateTime.add(now, 5 * one_week_in_seconds), nil}
+                 ]
+               },
+               now
+             )
+    end
+  end
+
   describe "direction_id/1" do
     test "returns nil when all informed parent stations are affected in both directions" do
       alert = %Alert{

--- a/test/screens/v2/candidate_generator/dup/alert_test.exs
+++ b/test/screens/v2/candidate_generator/dup/alert_test.exs
@@ -95,7 +95,7 @@ defmodule Screens.V2.CandidateGenerator.Dup.AlertTest do
     expect(@location_context, :fetch, fn _, _, _ -> location_context end)
   end
 
-  describe "alert_instances/5" do
+  describe "alert_instances/2" do
     test "returns alert instances" do
       expect_alerts()
       expect_location_context()
@@ -177,6 +177,101 @@ defmodule Screens.V2.CandidateGenerator.Dup.AlertTest do
                      }
                    ],
                    active_period: [{@now, nil}],
+                   lifecycle: "ONGOING",
+                   timeframe: nil,
+                   created_at: @now,
+                   updated_at: @now,
+                   url: nil,
+                   description: nil
+                 },
+                 rotation_index: :two,
+                 stop_name: "Back Bay"
+               }
+             ] = actual_widgets
+    end
+
+    test "does not filter stale alert instances that affect the stop" do
+      one_week_in_seconds = 604_800
+      ten_weeks_ago = DateTime.add(@now, -10 * one_week_in_seconds)
+
+      expect_alerts(%{active_period: [{ten_weeks_ago, nil}]})
+      expect_location_context()
+
+      actual_widgets = Alerts.alert_instances(@config, @now)
+
+      assert [
+               %{
+                 alert: %Alert{
+                   active_period: [{ten_weeks_ago, nil}],
+                   cause: :accident,
+                   created_at: ~U[2025-09-18 02:30:00Z],
+                   description: nil,
+                   effect: :delay,
+                   header: "Orange Line experiencing delays up to 20 minutes.",
+                   id: "999",
+                   informed_entities: [
+                     %InformedEntity{
+                       stop: %Stop{id: "place-bbsta"},
+                       route: "Orange",
+                       direction_id: nil,
+                       route_type: nil,
+                       activities: ~w[board exit ride]a,
+                       facility: nil
+                     }
+                   ],
+                   lifecycle: "ONGOING",
+                   severity: 5,
+                   timeframe: nil,
+                   updated_at: ~U[2025-09-18 02:30:00Z],
+                   url: nil
+                 }
+               },
+               %{
+                 alert: %{
+                   id: "999",
+                   cause: :accident,
+                   effect: :delay,
+                   severity: 5,
+                   header: "Orange Line experiencing delays up to 20 minutes.",
+                   informed_entities: [
+                     %InformedEntity{
+                       stop: %Stop{id: "place-bbsta"},
+                       route: "Orange",
+                       direction_id: nil,
+                       route_type: nil,
+                       activities: [:board, :exit, :ride],
+                       facility: nil
+                     }
+                   ],
+                   active_period: [{ten_weeks_ago, nil}],
+                   lifecycle: "ONGOING",
+                   timeframe: nil,
+                   created_at: @now,
+                   updated_at: @now,
+                   url: nil,
+                   description: nil
+                 },
+                 rotation_index: :one,
+                 stop_name: "Back Bay"
+               },
+               %{
+                 alert: %{
+                   id: "999",
+                   cause: :accident,
+                   effect: :delay,
+                   severity: 5,
+                   header: "Orange Line experiencing delays up to 20 minutes.",
+                   informed_entities: [
+                     %InformedEntity{
+                       stop: %Stop{id: "place-bbsta"},
+                       route: "Orange",
+                       direction_id: nil,
+                       route_type: nil,
+                       activities: [:board, :exit, :ride],
+                       facility: nil
+                     }
+                   ],
+                   active_period: [{ten_weeks_ago, nil}],
                    lifecycle: "ONGOING",
                    timeframe: nil,
                    created_at: @now,

--- a/test/screens/v2/candidate_generator/widgets/alerts_test.exs
+++ b/test/screens/v2/candidate_generator/widgets/alerts_test.exs
@@ -237,11 +237,39 @@ defmodule Screens.V2.CandidateGenerator.Widgets.AlertsTest do
     end
   end
 
-  describe "relevant_alerts/4" do
+  describe "relevant_alerts/5" do
     setup do
+      stop_id = "1"
+      app = BusShelter
+
+      routes_at_stop = [
+        %{route_id: "11", active?: false},
+        %{route_id: "22", active?: true},
+        %{route_id: "33", active?: true}
+      ]
+
+      tagged_stop_sequences = %{
+        "A" => [~w[3 1 2]],
+        "B" => [~w[3 1 2 4]],
+        "C" => [~w[1 2 4]],
+        "D" => [~w[3 1]]
+      }
+
+      stop_sequences = LocationContext.untag_stop_sequences(tagged_stop_sequences)
+
+      location_context = %LocationContext{
+        home_stop: stop_id,
+        tagged_stop_sequences: tagged_stop_sequences,
+        upstream_stops: LocationContext.upstream_stop_id_set([stop_id], stop_sequences),
+        downstream_stops: LocationContext.downstream_stop_id_set([stop_id], stop_sequences),
+        routes: routes_at_stop,
+        alert_route_types: LocationContext.route_type_filter(app, [stop_id])
+      }
+
       %{
         stop_ids: ~w[1 2 3],
         route_ids: ~w[11 22 33],
+        location_context: location_context,
         now: DateTime.utc_now()
       }
     end
@@ -249,6 +277,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.AlertsTest do
     test "filters out alerts that inform routes that do not serve the home stop", %{
       stop_ids: stop_ids,
       route_ids: route_ids,
+      location_context: location_context,
       now: now
     } do
       alerts = [
@@ -285,12 +314,13 @@ defmodule Screens.V2.CandidateGenerator.Widgets.AlertsTest do
       ]
 
       assert [%Alert{id: "1"}, %Alert{id: "2"}, %Alert{id: "3"}] =
-               relevant_alerts(alerts, stop_ids, route_ids, now)
+               relevant_alerts(alerts, stop_ids, route_ids, location_context, now)
     end
 
     test "filters out alerts that inform stops that are not downstream of the home stop", %{
       stop_ids: stop_ids,
       route_ids: route_ids,
+      location_context: location_context,
       now: now
     } do
       alerts = [
@@ -327,12 +357,13 @@ defmodule Screens.V2.CandidateGenerator.Widgets.AlertsTest do
       ]
 
       assert [%Alert{id: "1"}, %Alert{id: "2"}, %Alert{id: "3"}] =
-               relevant_alerts(alerts, stop_ids, route_ids, now)
+               relevant_alerts(alerts, stop_ids, route_ids, location_context, now)
     end
 
     test "keeps alerts that inform an entire route type", %{
       stop_ids: stop_ids,
       route_ids: route_ids,
+      location_context: location_context,
       now: now
     } do
       alerts = [
@@ -356,12 +387,14 @@ defmodule Screens.V2.CandidateGenerator.Widgets.AlertsTest do
         }
       ]
 
-      assert [%Alert{id: "1"}] = relevant_alerts(alerts, stop_ids, route_ids, now)
+      assert [%Alert{id: "1"}] =
+               relevant_alerts(alerts, stop_ids, route_ids, location_context, now)
     end
 
     test "filters out alerts with other informed entities", %{
       stop_ids: stop_ids,
       route_ids: route_ids,
+      location_context: location_context,
       now: now
     } do
       alerts = [
@@ -373,12 +406,13 @@ defmodule Screens.V2.CandidateGenerator.Widgets.AlertsTest do
         }
       ]
 
-      assert [] = relevant_alerts(alerts, stop_ids, route_ids, now)
+      assert [] = relevant_alerts(alerts, stop_ids, route_ids, location_context, now)
     end
 
     test "filters out alerts that do not have a relevant effect", %{
       stop_ids: stop_ids,
       route_ids: route_ids,
+      location_context: location_context,
       now: now
     } do
       alerts = [
@@ -390,12 +424,13 @@ defmodule Screens.V2.CandidateGenerator.Widgets.AlertsTest do
         }
       ]
 
-      assert [] = relevant_alerts(alerts, stop_ids, route_ids, now)
+      assert [] = relevant_alerts(alerts, stop_ids, route_ids, location_context, now)
     end
 
     test "filters out upcoming alerts", %{
       stop_ids: stop_ids,
       route_ids: route_ids,
+      location_context: location_context,
       now: now
     } do
       alerts = [
@@ -407,7 +442,54 @@ defmodule Screens.V2.CandidateGenerator.Widgets.AlertsTest do
         }
       ]
 
-      assert [] = relevant_alerts(alerts, stop_ids, route_ids, now)
+      assert [] = relevant_alerts(alerts, stop_ids, route_ids, location_context, now)
+    end
+
+    test "filters out stale alerts that don't affect the stop", %{
+      stop_ids: stop_ids,
+      route_ids: route_ids,
+      location_context: location_context,
+      now: now
+    } do
+      one_week_in_seconds = 604_800
+      ten_weeks_ago = DateTime.add(now, -10 * one_week_in_seconds)
+
+      home_stop = ie(stop_id: "1")
+      downstream_stop = ie(stop_id: "2")
+      upstream_stop = ie(stop_id: "1")
+
+      alerts = [
+        %Alert{
+          id: "1",
+          effect: :suspension,
+          informed_entities: [home_stop],
+          active_period: [{ten_weeks_ago, nil}]
+        },
+        %Alert{
+          id: "2",
+          effect: :suspension,
+          informed_entities: [home_stop, downstream_stop],
+          active_period: [{ten_weeks_ago, nil}]
+        },
+        %Alert{
+          id: "3",
+          effect: :suspension,
+          informed_entities: [
+            home_stop,
+            upstream_stop
+          ],
+          active_period: [{ten_weeks_ago, nil}]
+        },
+        %Alert{
+          id: "4",
+          effect: :suspension,
+          informed_entities: [ie(route_type: 1)],
+          active_period: [{ten_weeks_ago, nil}]
+        }
+      ]
+
+      assert [%Alert{id: "1"}, %Alert{id: "2"}, %Alert{id: "3"}] =
+               relevant_alerts(alerts, stop_ids, route_ids, location_context, now)
     end
   end
 end

--- a/test/screens/v2/candidate_generator/widgets/reconstructed_alert_test.exs
+++ b/test/screens/v2/candidate_generator/widgets/reconstructed_alert_test.exs
@@ -850,5 +850,127 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlertTest do
                  fetch_location_context_fn
                )
     end
+
+    test "doesn't filter stale alerts that affect the stop", context do
+      %{
+        config: config,
+        location_context: location_context,
+        now: now,
+        fetch_stop_name_fn: fetch_stop_name_fn,
+        fetch_location_context_fn: fetch_location_context_fn
+      } = context
+
+      one_week_in_seconds = 604_800
+      ten_weeks_ago = DateTime.add(now, -10 * one_week_in_seconds)
+
+      alerts = [
+        %Alert{
+          id: "1",
+          effect: :station_closure,
+          informed_entities: [ie(stop: %Stop{id: "place-ogmnl", name: "Oak Grove"})],
+          active_period: [{ten_weeks_ago, nil}]
+        }
+      ]
+
+      fetch_alerts_fn = fn _ -> {:ok, alerts} end
+
+      expected_common_data = %{
+        screen: config,
+        location_context: location_context,
+        now: now,
+        is_terminal_station: true,
+        is_priority: true,
+        home_station_name: "Oak Grove"
+      }
+
+      expected_widget = [
+        struct(
+          %ReconstructedAlertWidget{
+            alert: %Alert{
+              id: "1",
+              effect: :station_closure,
+              informed_entities: [ie(stop: %Stop{id: "place-ogmnl", name: "Oak Grove"})],
+              active_period: [{ten_weeks_ago, nil}]
+            },
+            informed_station_names: ["Oak Grove"],
+            is_priority: false
+          },
+          expected_common_data
+        )
+      ]
+
+      assert expected_widget ==
+               reconstructed_alert_instances(
+                 config,
+                 now,
+                 fetch_alerts_fn,
+                 fetch_stop_name_fn,
+                 fetch_location_context_fn
+               )
+    end
+
+    test "filters stale alerts at an outside an alert's location", context do
+      %{
+        config: config,
+        location_context: location_context,
+        now: now,
+        fetch_stop_name_fn: fetch_stop_name_fn,
+        fetch_location_context_fn: fetch_location_context_fn
+      } = context
+
+      one_week_in_seconds = 604_800
+      ten_weeks_ago = DateTime.add(now, -10 * one_week_in_seconds)
+
+      alerts = [
+        %Alert{
+          id: "1",
+          effect: :station_closure,
+          informed_entities: [ie(stop: %Stop{id: "place-astao", name: "Assembly"})],
+          active_period: [{ten_weeks_ago, nil}]
+        },
+        %Alert{
+          id: "2",
+          effect: :station_closure,
+          informed_entities: [ie(stop: %Stop{id: "place-ogmnl", name: "Oak Grove"})],
+          active_period: [{now, nil}]
+        }
+      ]
+
+      fetch_alerts_fn = fn _ -> {:ok, alerts} end
+
+      expected_common_data = %{
+        screen: config,
+        location_context: location_context,
+        now: now,
+        is_terminal_station: true,
+        is_priority: true,
+        home_station_name: "Oak Grove"
+      }
+
+      expected_widgets = [
+        struct(
+          %ReconstructedAlertWidget{
+            alert: %Alert{
+              id: "2",
+              effect: :station_closure,
+              informed_entities: [ie(stop: %Stop{id: "place-ogmnl", name: "Oak Grove"})],
+              active_period: [{now, nil}]
+            },
+            informed_station_names: ["Oak Grove"],
+            is_priority: false
+          },
+          expected_common_data
+        )
+      ]
+
+      assert expected_widgets ==
+               reconstructed_alert_instances(
+                 config,
+                 now,
+                 fetch_alerts_fn,
+                 fetch_stop_name_fn,
+                 fetch_location_context_fn
+               )
+    end
   end
 end

--- a/test/screens/v2/candidate_generator/widgets/reconstructed_alert_test.exs
+++ b/test/screens/v2/candidate_generator/widgets/reconstructed_alert_test.exs
@@ -38,7 +38,9 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlertTest do
         }
       ]
 
+      now = ~U[2021-01-01T00:00:00Z]
       happening_now_active_period = [{~U[2020-12-31T00:00:00Z], ~U[2021-01-02T00:00:00Z]}]
+      ten_weeks_ago = DateTime.add(now, -10 * 604_800)
 
       oak_grove_sb = %Stop{
         id: "70036",
@@ -175,7 +177,8 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlertTest do
         config: config,
         bad_config: bad_config,
         location_context: location_context,
-        now: ~U[2021-01-01T00:00:00Z],
+        now: now,
+        ten_weeks_ago: ten_weeks_ago,
         happening_now_active_period: happening_now_active_period,
         malden_center_nb: malden_center_nb,
         malden_center_sb: malden_center_sb,
@@ -856,12 +859,10 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlertTest do
         config: config,
         location_context: location_context,
         now: now,
+        ten_weeks_ago: ten_weeks_ago,
         fetch_stop_name_fn: fetch_stop_name_fn,
         fetch_location_context_fn: fetch_location_context_fn
       } = context
-
-      one_week_in_seconds = 604_800
-      ten_weeks_ago = DateTime.add(now, -10 * one_week_in_seconds)
 
       alerts = [
         %Alert{
@@ -878,6 +879,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlertTest do
         screen: config,
         location_context: location_context,
         now: now,
+        ten_weeks_ago: ten_weeks_ago,
         is_terminal_station: true,
         is_priority: true,
         home_station_name: "Oak Grove"
@@ -914,12 +916,10 @@ defmodule Screens.V2.CandidateGenerator.Widgets.ReconstructedAlertTest do
         config: config,
         location_context: location_context,
         now: now,
+        ten_weeks_ago: ten_weeks_ago,
         fetch_stop_name_fn: fetch_stop_name_fn,
         fetch_location_context_fn: fetch_location_context_fn
       } = context
-
-      one_week_in_seconds = 604_800
-      ten_weeks_ago = DateTime.add(now, -10 * one_week_in_seconds)
 
       alerts = [
         %Alert{

--- a/test/screens/v2/candidate_generator/widgets/subway_status_test.exs
+++ b/test/screens/v2/candidate_generator/widgets/subway_status_test.exs
@@ -1,0 +1,46 @@
+defmodule Screens.V2.CandidateGenerator.Widgets.SubwayStatusTest do
+  use ExUnit.Case
+
+  alias Screens.Alerts.Alert
+  alias Screens.V2.CandidateGenerator.Widgets.SubwayStatus
+  alias Screens.V2.WidgetInstance.SubwayStatus, as: SubwayStatusWidget
+  alias ScreensConfig.Screen
+
+  describe "subway_status_instances/3" do
+    setup do
+      config =
+        struct(Screen, %{
+          app_id: :pre_fare_v2
+        })
+
+      %{
+        config: config,
+        now: ~U[2026-07-07T01:00:00Z]
+      }
+    end
+
+    test "filters out stale alerts", context do
+      %{
+        config: config,
+        now: now
+      } = context
+
+      one_week_in_seconds = 604_800
+      ten_weeks_ago = DateTime.add(now, -10 * one_week_in_seconds)
+
+      alerts = [
+        %Alert{
+          id: "1",
+          effect: :station_closure,
+          informed_entities: [],
+          active_period: [{ten_weeks_ago, nil}]
+        }
+      ]
+
+      fetch_alerts_fn = fn _ -> {:ok, alerts} end
+
+      assert [%SubwayStatusWidget{screen: config, subway_alerts: []}] ==
+               SubwayStatus.subway_status_instances(config, now, fetch_alerts_fn)
+    end
+  end
+end


### PR DESCRIPTION
**Asana task**: [Suppress stale alerts on Screens](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1214784349728677?focus=truerl)

**Description**

Suppress stale alerts on Screens. A stale alert is an alert whose
current active period began greater than five weeks ago. Unless
otherwise noted, stale alerts that are suppressed unless they occur at
a stop or the stop is within the alert's boundary.

This commit changes alert filtering logic for several widgets:
- DUP Alerts: Prior to this commit, DUPs only showed alerts when the
stop was inside of, or at the boundary of the alert's location scope.
DUP alert widgets do not have new filtering logic, as we never want to
suppress an alert based on its staleness on a stop that it pertains to.
- Alert Widget (Eink, Bus shelters): Suppress alerts as described above
- Reconstructed Alert Widget (Prefares): Suppress alerts as described
above
- Subway Status: This widget does not have location information, which
keeps it lightweight. For the initial implementation, only filter stale
alerts, per the tasks's engineering notes. In order to introduce the
first test to this widget, `Screens.Alerts.Alert.fetch` has been
replaced with `fetch_alerts_fn` as an argument.

A new `Screens.V2.LocalizedAlert#stop_in_alert_boundary?/3` function
has been extracted from the DUPs Alert widget to for reuse. Regarding
other/future extractions:
1. There are additional cases where this helper can be used. Since the
total LoC of this commit was reaching 500, those will be done in a
follow-up PR.
2. a `suppressable_alert?/3` helper function is repeated in 2 files.
It's current usage didn't merit a common helper (in the author's
opinion)

- [x] Tests added?

**Screenshots**

Note: 
- Since Symphony doesn't have screens, and I didn't filter them out for eink/dups, you may see those in the screenshots from other folks' alerts
- This isn't every combination of all widgets and screens. Please LMK if you'd like me to add additional ones
  - Did not add DUPs, since behavior not changing
 
<details>
<summary>Bus Eink - Stop Closure at Blue Hill Ave at Mattapan Sq</summary>
At the stop:
<img width="610" height="821" alt="bus_eink_stale_in_boundary" src="https://github.com/user-attachments/assets/1f2b9d8a-8b2c-4847-b0bc-716b98562895" />

Not at the stop, same line:
<img width="610" height="821" alt="bus_eink_stale_out_boundary" src="https://github.com/user-attachments/assets/3273c338-8fa5-40fc-b678-07ce8a30db1b" />
</details>

<details>
<summary>GL Eink - Station Closure at Coolidge Corner</summary>

Station closure at Coolidge Corner, non-stale alert (screen at Govt Center):
<img width="330" height="822" alt="gl_eink_not_stale_out_of_boundary_not_stale" src="https://github.com/user-attachments/assets/4aec7429-4b75-44b5-868c-16e95ade0a5c" />


Station closure at Coolidge Corner, non-stale alert, subway widget (screen at Govt Center):
<img width="330" height="822" alt="gl_eink_not_stale_out_of_boundary" src="https://github.com/user-attachments/assets/d5d74826-7b3b-4f19-838e-5c3c8fb46a03" />


Station closure at Coolidge Corner, non-stale alert, alert shown (screen at Coolidge Corner):
<img width="330" height="822" alt="gl_eink_not_stale_station_focus_" src="https://github.com/user-attachments/assets/8f31102f-badd-4baa-85b1-72230aa63ddf" />

Station closure at Coolidge Corner, non-stale alert, subway widget (screen at Coolidge Corner):
<img width="330" height="822" alt="gl_eink_not_stale_station_focus" src="https://github.com/user-attachments/assets/1f7c471e-c7ff-4397-beaf-edb9cc4d481e" />


Station closure at Coolidge Corner, stale alert (screen at Govt Center):
<img width="330" height="822" alt="gl_eink_stale_not_station_in_boundary" src="https://github.com/user-attachments/assets/41638c87-9060-4f6a-97fb-ead5abff301d" />


Station closure at Coolidge Corner, stale alert, subway widget (screen at Govt Center):
<img width="330" height="822" alt="gl_ink_stale_not_station_in_focus" src="https://github.com/user-attachments/assets/c62c4e0f-7e78-4885-9846-ab5beb85d24e" />

Station closure at Coolidge Corner, stale alert (screen at Coolidge Corner):
<img width="330" height="822" alt="gl_eink_stale_station_focus" src="https://github.com/user-attachments/assets/ded48b75-6891-4961-b374-803f81cca8a7" />

Station closure at Coolidge Corner, stale alert, subway widget (screen at Coolidge Corner):
<img width="330" height="822" alt="gl_eink_stale_station_focus_" src="https://github.com/user-attachments/assets/cbd8ee26-97bb-4772-a5b5-1b84ae631c18" />

</details>

<details>
<summary>Prefares</summary>
Station closure at Hynes, stale and not stale alert (screen at Hynes):
<img width="1103" height="980" alt="prefare_stale_and_not_station_focus" src="https://github.com/user-attachments/assets/508b43c6-340b-4d80-be41-91bf64e6b210" />

Station closure at Hynes, stale alert (screen at Prudential):
<img width="559" height="980" alt="prefare_not_stale_station_not_focus" src="https://github.com/user-attachments/assets/7c603b42-06a7-40c2-803a-65a7191dd246" />

Station closure at Hynes, non-stale alert (screen at Prudential):
<img width="559" height="980" alt="prefare_stale_station_not_focus" src="https://github.com/user-attachments/assets/ff8d0e2a-e994-4c8f-8d10-84942a23aea3" />

</details>



