### PR TITLE
refactor: use stop_in_boundary?/2 for alert widgets

### DIFF
--- a/lib/screens/v2/widget_instance/alert.ex
+++ b/lib/screens/v2/widget_instance/alert.ex
@@ -156,11 +156,13 @@ defmodule Screens.V2.WidgetInstance.Alert do
       LocalizedAlert.informs_all_active_routes_at_home_stop?(t)
   end
 
-  def takeover_alert?(
-        %__MODULE__{screen: %Screen{app_id: :gl_eink_v2}, alert: %Alert{effect: effect}} = t
-      ) do
+  def takeover_alert?(%__MODULE__{
+        screen: %Screen{app_id: :gl_eink_v2},
+        alert: %Alert{effect: effect} = alert,
+        location_context: location_context
+      }) do
     effect in [:station_closure, :suspension, :shuttle] and
-      LocalizedAlert.location(t) in [:inside, :boundary_upstream, :boundary_downstream]
+      LocalizedAlert.stop_in_alert_boundary?(alert, location_context)
   end
 
   defp takeover_slot_names(%__MODULE__{screen: %Screen{app_id: :bus_shelter_v2}}) do
@@ -201,10 +203,15 @@ defmodule Screens.V2.WidgetInstance.Alert do
   end
 
   # For all other bus alert effects, all stops in the `informed_entities` are directly affected by the alert and would be useful for riders to see.
-  def valid_candidate?(%__MODULE__{screen: %Screen{app_id: screen_type}} = t)
+  def valid_candidate?(
+        %__MODULE__{
+          screen: %Screen{app_id: screen_type},
+          alert: alert,
+          location_context: location_context
+        } = t
+      )
       when screen_type in [:bus_shelter_v2, :bus_eink_v2] do
-    priority(t) != :no_render and
-      LocalizedAlert.location(t) in [:inside, :boundary_upstream, :boundary_downstream]
+    priority(t) != :no_render and LocalizedAlert.stop_in_alert_boundary?(alert, location_context)
   end
 
   # Any subway alert that is not filtered out in the candidate_generator is valid and should appear on screens›.

--- a/lib/screens/v2/widget_instance/alert.ex
+++ b/lib/screens/v2/widget_instance/alert.ex
@@ -156,6 +156,7 @@ defmodule Screens.V2.WidgetInstance.Alert do
       LocalizedAlert.informs_all_active_routes_at_home_stop?(t)
   end
 
+  @spec takeover_alert?(t()) :: boolean()
   def takeover_alert?(%__MODULE__{
         screen: %Screen{app_id: :gl_eink_v2},
         alert: %Alert{effect: effect} = alert,
@@ -203,6 +204,7 @@ defmodule Screens.V2.WidgetInstance.Alert do
   end
 
   # For all other bus alert effects, all stops in the `informed_entities` are directly affected by the alert and would be useful for riders to see.
+  @spec valid_candidate?(t()) :: boolean()
   def valid_candidate?(
         %__MODULE__{
           screen: %Screen{app_id: screen_type},

--- a/lib/screens/v2/widget_instance/dup_alert.ex
+++ b/lib/screens/v2/widget_instance/dup_alert.ex
@@ -118,12 +118,12 @@ defmodule Screens.V2.WidgetInstance.DupAlert do
   # eliminated, even though service is still running. We expect live predictions to not be fully
   # available within single-tracked segments, so it's okay for this message to take up more space
   # when the severity warrants it.
-  defp eliminated_service_type(
-         %__MODULE__{alert: %Alert{cause: :single_tracking, effect: :delay, severity: severity}} =
-           t
-       )
+  defp eliminated_service_type(%__MODULE__{
+         alert: %Alert{cause: :single_tracking, effect: :delay, severity: severity} = alert,
+         location_context: location_context
+       })
        when severity >= 5 do
-    if LocalizedAlert.location(t) in [:inside, :boundary_downstream, :boundary_upstream],
+    if LocalizedAlert.stop_in_alert_boundary?(alert, location_context),
       do: :some,
       else: :none
   end

--- a/lib/screens/v2/widget_instance/dup_alert.ex
+++ b/lib/screens/v2/widget_instance/dup_alert.ex
@@ -118,6 +118,7 @@ defmodule Screens.V2.WidgetInstance.DupAlert do
   # eliminated, even though service is still running. We expect live predictions to not be fully
   # available within single-tracked segments, so it's okay for this message to take up more space
   # when the severity warrants it.
+  @spec eliminated_service_type(t()) :: :some | :none
   defp eliminated_service_type(%__MODULE__{
          alert: %Alert{cause: :single_tracking, effect: :delay, severity: severity} = alert,
          location_context: location_context


### PR DESCRIPTION
**Asana task**: N/A

Description

In https://github.com/mbta/screens/commit/8af1c92b76b1593a3cb2501d0965ec4a07385718, we introduced `LocalizedAlert.stop_in_alert_boundary?/2`
and used it solely for determining if a screen's location was within
an alert boundary for the purpose of alert suppression. This helper can
be used in other locations as well, if for reasons other than alert
suppression.

- [ ] Tests added?
