### PR TITLE
fix: render green line routes on solo prefares

### DIFF
--- a/lib/screens/v2/widget_instance/reconstructed_alert.ex
+++ b/lib/screens/v2/widget_instance/reconstructed_alert.ex
@@ -308,14 +308,18 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
     affected_routes = LocalizedAlert.consolidated_informed_subway_routes(t)
     routes_at_stop = LocalizedAlert.active_routes_at_stop(t)
 
+    collapse_all_green? = all_green_routes_at_stop_affected?(affected_routes, routes_at_stop)
+
     affected_routes
-    # Filter alert-affected routes by which routes are at the current stop
-    # If a green-branch is the affected route, we can generalize it to just "Green-"
-    # because our prefare screens will be on the trunk. Any GL disruption will be
-    # downstream of a GL trunk station.
     |> Enum.filter(fn
       "Green" <> _ -> Enum.find(routes_at_stop, &String.starts_with?(&1, "Green"))
       route -> route in routes_at_stop
+    end)
+    |> Enum.map(fn route ->
+      case route do
+        "Green" <> _ when collapse_all_green? -> "Green"
+        route -> route
+      end
     end)
     |> Enum.flat_map(fn
       route_id ->
@@ -328,6 +332,20 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
         build_pills_from_headsign(route_id, headsign)
     end)
     |> Enum.uniq()
+  end
+
+  @spec all_green_routes_at_stop_affected?([String.t()], MapSet.t(LocalizedAlert.route_id())) ::
+          boolean()
+  defp all_green_routes_at_stop_affected?(affected_routes, routes_at_stop) do
+    routes_at_stop
+    |> Enum.filter(&String.starts_with?(&1, "Green"))
+    |> MapSet.new()
+    |> then(fn green_routes_or_line_at_stop ->
+      case MapSet.size(green_routes_or_line_at_stop) do
+        0 -> false
+        _ -> MapSet.subset?(green_routes_or_line_at_stop, MapSet.new(affected_routes))
+      end
+    end)
   end
 
   defp build_pills_from_headsign(route_id, nil) do
@@ -637,10 +655,16 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
       now: now
     } = t
 
+    affected_routes = LocalizedAlert.consolidated_informed_subway_routes(t)
+    routes_at_stop = LocalizedAlert.active_routes_at_stop(t)
+
+    collapse_all_green? = all_green_routes_at_stop_affected?(affected_routes, routes_at_stop)
+
     route_id =
-      case LocalizedAlert.consolidated_informed_subway_routes(t) do
+      case affected_routes do
         ["Green" <> _] -> "Green"
         [route_id] -> route_id
+        _route_ids when collapse_all_green? -> "Green"
       end
 
     endpoints = get_endpoints(informed_entities, route_id, home_stop)
@@ -705,10 +729,16 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
       now: now
     } = t
 
+    affected_routes = LocalizedAlert.consolidated_informed_subway_routes(t)
+    routes_at_stop = LocalizedAlert.active_routes_at_stop(t)
+
+    collapse_all_green? = all_green_routes_at_stop_affected?(affected_routes, routes_at_stop)
+
     route_id =
-      case LocalizedAlert.consolidated_informed_subway_routes(t) do
+      case affected_routes do
         ["Green" <> _] -> "Green"
         [route_id] -> route_id
+        _route_ids when collapse_all_green? -> "Green"
       end
 
     endpoints = get_endpoints(informed_entities, route_id, home_stop)

--- a/test/screens/v2/widget_instance/reconstructed_alert_test.exs
+++ b/test/screens/v2/widget_instance/reconstructed_alert_test.exs
@@ -3,6 +3,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
 
   alias Screens.Alerts.Alert
   alias Screens.LocationContext
+  alias Screens.Stops.Stop
   alias Screens.Stops.Subway
   alias Screens.V2.AlertsWidget
   alias Screens.V2.CandidateGenerator
@@ -3266,6 +3267,392 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
         urgent: true,
         region: :boundary,
         remedy: "Use shuttle bus"
+      }
+
+      assert expected == ReconstructedAlert.serialize(%{alert_widget | is_priority: false})
+    end
+  end
+
+  describe "Real-world GL alerts:" do
+    setup do
+      stop_id = "place-spmnl"
+
+      config =
+        struct(Screen, %{
+          app_id: :pre_fare_v2,
+          app_params:
+            struct(PreFare, %{
+              reconstructed_alert_widget: %ScreensConfig.Alerts{stop_id: stop_id},
+              template: :solo
+            })
+        })
+
+      routes_at_stop = [
+        %{
+          route_id: "Green-B",
+          active?: false,
+          direction_destinations: nil,
+          long_name: nil,
+          short_name: nil,
+          type: :light_rail
+        },
+        %{
+          route_id: "Green-C",
+          active?: false,
+          direction_destinations: nil,
+          long_name: nil,
+          short_name: nil,
+          type: :light_rail
+        },
+        %{
+          route_id: "Green-D",
+          active?: true,
+          direction_destinations: nil,
+          long_name: nil,
+          short_name: nil,
+          type: :light_rail
+        },
+        %{
+          route_id: "Green-E",
+          active?: true,
+          direction_destinations: nil,
+          long_name: nil,
+          short_name: nil,
+          type: :light_rail
+        }
+      ]
+
+      gl_ies = [
+        ie(stop_id: "70201", route: "Green-D", route_type: "0", direction_id: "1"),
+        ie(stop_id: "70201", route: "Green-E", route_type: "0", direction_id: "1"),
+        ie(stop_id: "70202", route: "Green-D", route_type: "0", direction_id: "0"),
+        ie(stop_id: "70202", route: "Green-E", route_type: "0", direction_id: "0"),
+        ie(stop_id: "70203", route: "Green-D", route_type: "0", direction_id: "1"),
+        ie(stop_id: "70203", route: "Green-E", route_type: "0", direction_id: "1"),
+        ie(stop_id: "70204", route: "Green-D", route_type: "0", direction_id: "0"),
+        ie(stop_id: "70204", route: "Green-E", route_type: "0", direction_id: "0"),
+        ie(stop_id: "70205", route: "Green-D", route_type: "0", direction_id: "1"),
+        ie(stop_id: "70205", route: "Green-E", route_type: "0", direction_id: "1"),
+        ie(stop_id: "70206", route: "Green-D", route_type: "0", direction_id: "0"),
+        ie(stop_id: "70206", route: "Green-E", route_type: "0", direction_id: "0"),
+        ie(stop_id: "70207", route: "Green-D", route_type: "0", direction_id: "1"),
+        ie(stop_id: "70207", route: "Green-E", route_type: "0", direction_id: "1"),
+        ie(stop_id: "70208", route: "Green-D", route_type: "0", direction_id: "0"),
+        ie(stop_id: "70208", route: "Green-E", route_type: "0", direction_id: "0"),
+        ie(
+          stop: %Stop{id: "70501", name: "Lechmere"},
+          route: "Green-D",
+          route_type: "0",
+          direction_id: "1"
+        ),
+        ie(
+          stop: %Stop{id: "70501", name: "Lechmere"},
+          route: "Green-E",
+          route_type: "0",
+          direction_id: "1"
+        ),
+        ie(
+          stop: %Stop{id: "70502", name: "Lechmere"},
+          route: "Green-D",
+          route_type: "0",
+          direction_id: "0"
+        ),
+        ie(
+          stop: %Stop{id: "70502", name: "Lechmere"},
+          route: "Green-E",
+          route_type: "0",
+          direction_id: "0"
+        ),
+        ie(stop_id: "place-gover", route: "Green-D", route_type: "0"),
+        ie(stop_id: "place-gover", route: "Green-E", route_type: "0"),
+        ie(stop_id: "place-haecl", route: "Green-D", route_type: "0"),
+        ie(stop_id: "place-haecl", route: "Green-E", route_type: "0"),
+        ie(stop: %Stop{id: "place-lech", name: "Lechmere"}, route: "Green-D", route_type: "0"),
+        ie(stop: %Stop{id: "place-lech", name: "Lechmere"}, route: "Green-E", route_type: "0"),
+        ie(stop_id: "place-north", route: "Green-D", route_type: "0"),
+        ie(stop_id: "place-north", route: "Green-E", route_type: "0"),
+        ie(stop_id: "place-spmnl", route: "Green-D", route_type: "0"),
+        ie(stop_id: "place-spmnl", route: "Green-E", route_type: "0")
+      ]
+
+      base_alert =
+        %Screens.Alerts.Alert{
+          active_period: [{~U[2027-07-14 09:00:00Z], nil}],
+          cause: :unknown,
+          created_at: ~U[2027-07-14 09:00:00Z],
+          description:
+            "Affected stops:\r\nLechmere\r\nScience Park/West End\r\nNorth Station\r\nHaymarket\r\nGovernment Center",
+          effect: :suspension,
+          header: "Green Line: service is suspended between Lechmere and Government Center.",
+          id: "450522",
+          informed_entities: gl_ies,
+          lifecycle: "NEW",
+          severity: 7,
+          timeframe: nil,
+          updated_at: ~U[2027-07-13 09:00:00Z],
+          url: nil
+        }
+
+      now = ~U[2027-07-15 09:00:00Z]
+      tagged_station_sequences = %{"Green" => [Subway.route_stop_sequence("Green")]}
+      station_sequences = LocationContext.untag_stop_sequences(tagged_station_sequences)
+
+      fetch_stop_name_fn = fn _ -> "Science Park/West End" end
+
+      fetch_location_context_fn = fn _, _, _ ->
+        {:ok,
+         %LocationContext{
+           home_stop: stop_id,
+           tagged_stop_sequences: tagged_station_sequences,
+           upstream_stops: LocationContext.upstream_stop_id_set([stop_id], station_sequences),
+           downstream_stops: LocationContext.downstream_stop_id_set([stop_id], station_sequences),
+           routes: routes_at_stop,
+           alert_route_types: LocationContext.route_type_filter(PreFare, [stop_id])
+         }}
+      end
+
+      %{
+        base_alert: base_alert,
+        config: config,
+        fetch_stop_name_fn: fetch_stop_name_fn,
+        fetch_location_context_fn: fetch_location_context_fn,
+        now: now
+      }
+    end
+
+    test "handles GL suspension with multiple routes at Science Park solo prefare", context do
+      %{
+        config: config,
+        base_alert: base_alert,
+        fetch_stop_name_fn: fetch_stop_name_fn,
+        fetch_location_context_fn: fetch_location_context_fn,
+        now: now
+      } = context
+
+      alert = %{
+        base_alert
+        | description:
+            "Affected stops:\r\nLechmere\r\nScience Park/West End\r\nNorth Station\r\nHaymarket\r\nGovernment Center",
+          effect: :suspension,
+          header: "Green Line: service is suspended between Lechmere and Government Center."
+      }
+
+      fetch_alerts_fn = fn _ -> {:ok, [alert]} end
+
+      alert_widget =
+        config
+        |> CandidateGenerator.Widgets.ReconstructedAlert.reconstructed_alert_instances(
+          now,
+          fetch_alerts_fn,
+          fetch_stop_name_fn,
+          fetch_location_context_fn
+        )
+        |> List.first()
+
+      # Fullscreen test
+      expected = %{
+        alternate_route_url: "mbta.com/alerts",
+        qr_code_url: "go.mbta.com/a/450522/s/place-spmnl",
+        cause: nil,
+        effect: :suspension,
+        issue: "No Green Line trains",
+        location: "Green Line service is suspended between Government Center and Lechmere",
+        region: :here,
+        routes: [%{route_id: "Green", svg_name: "gl"}],
+        updated_at: "Jul 13",
+        end_time: nil,
+        remedy: nil,
+        disruption_diagram: %{
+          line: :green,
+          effect: :suspension,
+          current_station_slot_index: 4,
+          effect_region_slot_index_range: {1, 5},
+          slots: [
+            %{type: :arrow, label_id: "place-coecl+west"},
+            %{label: %{full: "Government Center", abbrev: "Gov't Ctr"}, show_symbol: true},
+            %{label: %{full: "Haymarket", abbrev: "Haymarket"}, show_symbol: true},
+            %{label: %{full: "North Station", abbrev: "North Sta"}, show_symbol: true},
+            %{label: %{full: "Science Park/West End", abbrev: "Science Pk"}, show_symbol: true},
+            %{label: %{full: "Lechmere", abbrev: "Lechmere"}, show_symbol: true},
+            %{type: :arrow, label_id: "place-mdftf+place-unsqu"}
+          ]
+        },
+        endpoints: {"Government Center", "Lechmere"},
+        is_transfer_station: true,
+        show_alternate_route_text: true
+      }
+
+      assert expected == ReconstructedAlert.serialize(alert_widget)
+
+      # Flexzone test
+      expected = %{
+        issue: "Green Line: service is suspended between Lechmere and Government Center.",
+        location: "",
+        cause: "",
+        routes: [%{color: :green, text: "GL", type: :text, branches: ["D", "E"]}],
+        effect: :suspension,
+        urgent: true,
+        region: :here,
+        remedy: ""
+      }
+
+      assert expected == ReconstructedAlert.serialize(%{alert_widget | is_priority: false})
+    end
+
+    test "handles GL shuttle service with multiple routes at Science Park solo prefare",
+         context do
+      %{
+        config: config,
+        base_alert: base_alert,
+        fetch_stop_name_fn: fetch_stop_name_fn,
+        fetch_location_context_fn: fetch_location_context_fn,
+        now: now
+      } = context
+
+      alert = %{
+        base_alert
+        | description:
+            "Affected stops:\r\nLechmere\r\nScience Park/West End\r\nNorth Station\r\nHaymarket\r\nGovernment Center",
+          effect: :shuttle,
+          header:
+            "Green Line: Shuttle buses replace service between Lechmere and Government Center."
+      }
+
+      fetch_alerts_fn = fn _ -> {:ok, [alert]} end
+
+      alert_widget =
+        config
+        |> CandidateGenerator.Widgets.ReconstructedAlert.reconstructed_alert_instances(
+          now,
+          fetch_alerts_fn,
+          fetch_stop_name_fn,
+          fetch_location_context_fn
+        )
+        |> List.first()
+
+      # Fullscreen test
+      expected = %{
+        alternate_route_url: "mbta.com/alerts",
+        qr_code_url: "go.mbta.com/a/450522/s/place-spmnl",
+        cause: nil,
+        effect: :shuttle,
+        issue: "No Green Line trains",
+        location: "Shuttle buses replace trains between Government Center and Lechmere",
+        region: :here,
+        routes: [%{route_id: "Green", svg_name: "gl"}],
+        updated_at: "Jul 13",
+        end_time: nil,
+        remedy: "Use shuttle bus",
+        disruption_diagram: %{
+          line: :green,
+          effect: :shuttle,
+          current_station_slot_index: 4,
+          effect_region_slot_index_range: {1, 5},
+          slots: [
+            %{type: :arrow, label_id: "place-coecl+west"},
+            %{label: %{full: "Government Center", abbrev: "Gov't Ctr"}, show_symbol: true},
+            %{label: %{full: "Haymarket", abbrev: "Haymarket"}, show_symbol: true},
+            %{label: %{full: "North Station", abbrev: "North Sta"}, show_symbol: true},
+            %{label: %{full: "Science Park/West End", abbrev: "Science Pk"}, show_symbol: true},
+            %{label: %{full: "Lechmere", abbrev: "Lechmere"}, show_symbol: true},
+            %{type: :arrow, label_id: "place-mdftf+place-unsqu"}
+          ]
+        },
+        endpoints: {"Government Center", "Lechmere"},
+        is_transfer_station: true
+      }
+
+      assert expected == ReconstructedAlert.serialize(alert_widget)
+
+      # Flexzone test
+      expected = %{
+        issue:
+          "Green Line: Shuttle buses replace service between Lechmere and Government Center.",
+        location: "",
+        cause: "",
+        routes: [%{color: :green, text: "GL", type: :text, branches: ["D", "E"]}],
+        effect: :shuttle,
+        urgent: true,
+        region: :here,
+        remedy: ""
+      }
+
+      assert expected == ReconstructedAlert.serialize(%{alert_widget | is_priority: false})
+    end
+
+    test "handles GL station closures with multiple routes at Science Park solo prefare",
+         context do
+      %{
+        config: config,
+        base_alert: base_alert,
+        fetch_stop_name_fn: fetch_stop_name_fn,
+        fetch_location_context_fn: fetch_location_context_fn,
+        now: now
+      } = context
+
+      alert = %{
+        base_alert
+        | description: "Affected lines:\r\nGreen Line D\r\nGreen Line E",
+          effect: :station_closure,
+          header: "Lechmere is closed."
+      }
+
+      fetch_alerts_fn = fn _ -> {:ok, [alert]} end
+
+      alert_widget =
+        config
+        |> CandidateGenerator.Widgets.ReconstructedAlert.reconstructed_alert_instances(
+          now,
+          fetch_alerts_fn,
+          fetch_stop_name_fn,
+          fetch_location_context_fn
+        )
+        |> List.first()
+
+      # Fullscreen test
+      expected = %{
+        alternate_route_url: "mbta.com/alerts",
+        qr_code_url: "go.mbta.com/a/450522/s/place-spmnl",
+        cause: nil,
+        effect: :station_closure,
+        issue: "Station closed",
+        region: :here,
+        routes: [%{route_id: "Green", svg_name: "gl"}],
+        updated_at: "Jul 13",
+        end_time: nil,
+        remedy: nil,
+        disruption_diagram: %{
+          line: :green,
+          effect: :station_closure,
+          current_station_slot_index: 5,
+          slots: [
+            %{type: :arrow, label_id: "place-coecl+west"},
+            %{label: %{full: "Park Street", abbrev: "Park St"}, show_symbol: true},
+            %{label: %{full: "Government Center", abbrev: "Gov't Ctr"}, show_symbol: true},
+            %{label: %{full: "Haymarket", abbrev: "Haymarket"}, show_symbol: true},
+            %{label: %{full: "North Station", abbrev: "North Sta"}, show_symbol: true},
+            %{label: %{full: "Science Park/West End", abbrev: "Science Pk"}, show_symbol: true},
+            %{label: %{full: "Lechmere", abbrev: "Lechmere"}, show_symbol: true},
+            %{type: :arrow, label_id: "place-mdftf+place-unsqu"}
+          ],
+          closed_station_slot_indices: [2, 3, 4, 5, 6]
+        },
+        show_alternate_route_text: true,
+        unaffected_routes: []
+      }
+
+      assert expected == ReconstructedAlert.serialize(alert_widget)
+
+      # Flexzone test
+      expected = %{
+        issue: "Trains will skip Lechmere",
+        location: "",
+        cause: "",
+        routes: [%{color: :green, text: "GL", type: :text, branches: ["D", "E"]}],
+        effect: :station_closure,
+        urgent: true,
+        region: :here,
+        remedy: "Seek alternate route"
       }
 
       assert expected == ReconstructedAlert.serialize(%{alert_widget | is_priority: false})


### PR DESCRIPTION
**Asana task**: [Prefares Erroring for GL Branches](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1216425679839848?focus=true)

**Description**

Render GL routes in alert banners properly in solo prefare screens.

Prior to this commit, solo prefare screens would fail to properly render
the following full screen alert types:
- station closures: GL route pills would take up half of the screen
- suspensions: GL route pills would take up half of the screen
- shuttles: screen would show "Live updates temporarily unavailable" for
the entirety of the screen

The root cause was twofold:
1. `LocalizedAlert.consolidated_informed_subway_routes/1` returning
multiple lines for alert types that included multiple GL routes, such as
a shuttle buses at Science Center, which can affect the GL-D and GL-E
routes. This resulted in
`(CaseClauseError) no case clause matching: ["Green-D", "Green-E"]`
errors bubbling up.
2. In cases where we would serialize a reconstructed alert wiht multiple
Green Line routes, the serialized result would be rendered such that
they took up half the screen.

In speaking with design, we'd like to collapse all GL routes if all
routes that service the stop are affected by the stop. This PR fixes
the former of the two root causes, and uses the collapsing logic to
work around the latter. Similarly, this commit does not resolve the case
where an alert affects multiple lines (e.g. a station closure at State,
which is serviced by the OL and BL).

- [X] Tests added?

**Notes for Reviewers**

- In the screenshots, it appears that the disruption diagram's view box is smaller than it should be. I didn't dive too far into this as to validate this PR was worth pursuing in its current state. Assuming its generally OK, any thoughts as to how to best work through this without breaking it elsewhere?

**Screenshots**

<details>
<summary>Subway Suspension</summary>
For a subway suspension: 
<img width="676" height="748" alt="Screenshot 2026-07-15 at 11 05 49" src="https://github.com/user-attachments/assets/739a17ff-0c03-404f-8b43-83311a5eb7b6" />

Before:
<img width="550" height="970" alt="Screenshot 2026-07-15 at 11 08 17" src="https://github.com/user-attachments/assets/552522a1-dbaf-4c88-aed2-7e468581e7a9" />

After:
I'm unsure why the disruption diagram is off - need to look at that
<img width="550" height="970" alt="Screenshot 2026-07-15 at 11 13 04" src="https://github.com/user-attachments/assets/38ef36cf-151d-4a5f-b65b-0d4ee5bb0044" />
</details>

<details>
<summary>Shuttles</summary>
For shuttle buses: 
<img width="683" height="801" alt="Screenshot 2026-07-15 at 11 15 58" src="https://github.com/user-attachments/assets/2851c2a4-dd92-4b87-8179-915a6dc82fae" />

Before:

<img width="554" height="978" alt="Screenshot 2026-07-15 at 11 16 46" src="https://github.com/user-attachments/assets/5dbc779e-749a-49a4-b923-c600f9c5cdf1" />

After:
<img width="550" height="960" alt="Screenshot 2026-07-15 at 11 15 22" src="https://github.com/user-attachments/assets/10cefee8-e820-494d-beb7-47955031d733" />
</details>

<details>
<summary>Station Closure</summary>
For a station closure: 
<img width="633" height="694" alt="Screenshot 2026-07-15 at 11 20 07" src="https://github.com/user-attachments/assets/1a31dd71-ebca-438b-b30d-3727d4be0da4" />

Before:
<img width="556" height="972" alt="Screenshot 2026-07-15 at 11 20 45" src="https://github.com/user-attachments/assets/fb0435d1-c8fb-4c99-8eb8-6324cd532d5b" />


After:
I'm unsure why the disruption diagram is off - need to look at that
<img width="556" height="972" alt="Screenshot 2026-07-15 at 11 21 43" src="https://github.com/user-attachments/assets/9037ddb9-fae0-43e5-8ca8-4c963eee69cb" />


</details>



