### PR TITLE
fix: center non-green line routes on solo prefares

### DIFF
--- a/assets/css/pre_fare/alert-banner.scss
+++ b/assets/css/pre_fare/alert-banner.scss
@@ -35,6 +35,19 @@
   margin: 0 20px;
 }
 
+.alert-banner__route-pill--short--multiple-routes {
+  height: 96px;
+  margin: 0 20px;
+
+  &:first-of-type {
+    margin: 0 10px 0 20px;
+  }
+
+  &:last-of-type {
+    margin: 0 20px 0 10px;
+  }
+}
+
 .alert-banner__route-pill--long {
   margin: 16.2px 0 0.8px;
 }

--- a/assets/src/components/pre_fare_single_screen_alert.tsx
+++ b/assets/src/components/pre_fare_single_screen_alert.tsx
@@ -15,6 +15,8 @@ import InfoIcon from "Images/info.svg";
 import ISAIcon from "Images/isa.svg";
 import ShuttleBusIcon from "Images/bus.svg";
 
+type Region = "here" | "boundary" | "outside";
+
 interface PreFareSingleScreenAlertProps {
   issue: string;
   location: string;
@@ -30,7 +32,7 @@ interface PreFareSingleScreenAlertProps {
     | "station_closure"
     | "delay"
     | "information";
-  region: "here" | "boundary" | "outside";
+  region: Region;
   updated_at: string;
   end_time?: string;
   disruption_diagram?: DisruptionDiagramData;
@@ -455,7 +457,7 @@ const PreFareSingleScreenAlert: ComponentType<PreFareSingleScreenAlertProps> = (
 
   return (
     <div className="pre-fare-alert__page">
-      {showBanner && <PreFareAlertBanner routes={routes} />}
+      {showBanner && <PreFareAlertBanner region={region} routes={routes} />}
       <div
         className={classWithModifiers("alert-container", [
           "single-page",
@@ -516,9 +518,10 @@ const getAlertColor = (routes: EnrichedRoute[]) => {
   return uniqueColors === 1 ? colors[0] : "yellow";
 };
 
-const PreFareAlertBanner: ComponentType<{ routes: EnrichedRoute[] }> = ({
-  routes,
-}) => {
+const PreFareAlertBanner: ComponentType<{
+  region: Region;
+  routes: EnrichedRoute[];
+}> = ({ region, routes }) => {
   let banner;
 
   if (
@@ -563,6 +566,29 @@ const PreFareAlertBanner: ComponentType<{ routes: EnrichedRoute[] }> = ({
           className="alert-banner__route-pill--long"
           color={getHexColor(color)}
         />
+      </h5>
+    );
+  } else if (routes.length >= 2 && region === "here") {
+    // Two or more lines, and the banner is at an affected stop
+    banner = (
+      <h5
+        className={classWithModifiers("alert-banner", [
+          "small",
+          getAlertColor(routes),
+        ])}
+      >
+        <span className="alert-banner__attention-text">Attention</span>
+        {routes.map((route) => {
+          const LinePill = STRING_TO_SVG[route.svg_name];
+          return (
+            <LinePill
+              className="alert-banner__route-pill--short--multiple-routes"
+              key={route.svg_name}
+              color={getHexColor(getRouteColor(route.route_id))}
+            />
+          );
+        })}
+        <span>riders</span>
       </h5>
     );
   } else if (routes.length === 2) {


### PR DESCRIPTION
**Asana task**: Spun off of [Prefares Erroring for GL Branches](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1216425679839848?focus=true)

Description

Resolves the case where two or more routes were construed as
destinations when rendering a full screen alert. Previously, "Attention,
riders to <route pills>" would render, even in the case of a station
closure that affected two lines at that station.

- [ ] Tests added?

Before:
<img width="556" height="972" alt="Screenshot 2026-07-15 at 12 12 40" src="https://github.com/user-attachments/assets/24cca350-49a8-4e49-8dc0-410726a5e047" />
After:
<img width="556" height="972" alt="Screenshot 2026-07-15 at 12 20 10" src="https://github.com/user-attachments/assets/29c94b5d-0960-4ef5-8e8b-451cc7e65ebc" />
