### PR TITLE
feat: Alert tied to Evergreen Content should be shifted to single_screen

### DIFF
--- a/lib/screens/v2/widget_instance/reconstructed_alert.ex
+++ b/lib/screens/v2/widget_instance/reconstructed_alert.ex
@@ -442,7 +442,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
          %__MODULE__{
            alert: %Alert{id: alert_id, effect: effect} = alert,
            screen: %Screen{
-             app_params: %PreFare{
+             app_params: %_app{
                evergreen_content: evergreen_content
              }
            },
@@ -477,7 +477,10 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
   defp adjust_placement(:single_screen, _location, :solo, _, _), do: :flex_zone
   defp adjust_placement(:flex_zone, _location, :solo, _, _), do: :flex_zone
 
+  @spec evergreen_content_for_alert?(integer(), [EvergreenContentItem.t()]) :: boolean()
   defp evergreen_content_for_alert?(alert_id, evergreen_content) do
+    # If a high priority alert is paired with evergreen content having suppress_alert_widgets=false,
+    # we want to show the the alert on a single instead of dual screen.
     Enum.any?(evergreen_content, fn
       %EvergreenContentItem{
         schedule: %AlertSchedule{alert_ids: alert_ids, suppress_alert_widgets: false}

--- a/lib/screens/v2/widget_instance/reconstructed_alert.ex
+++ b/lib/screens/v2/widget_instance/reconstructed_alert.ex
@@ -1403,8 +1403,6 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
         # Two situations in which we show an alert on the full_body right of a screen
         # When a section contains CR departures, we want this to be fully displayed
         # For single screens, we want it to be visible on the right as well
-        IO.inspect(template == :duo and !departures_contains_commuter_rail?(departures))
-
         if template == :duo and !departures_contains_commuter_rail?(departures),
           do: [:paged_main_content_left],
           else: [:full_body_right]

--- a/lib/screens/v2/widget_instance/reconstructed_alert.ex
+++ b/lib/screens/v2/widget_instance/reconstructed_alert.ex
@@ -440,7 +440,12 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
 
   defp base_placement(
          %__MODULE__{
-           alert: %Alert{effect: effect} = alert,
+           alert: %Alert{id: alert_id, effect: effect} = alert,
+           screen: %Screen{
+             app_params: %PreFare{
+               evergreen_content: evergreen_content
+             }
+           },
            is_priority: true,
            is_terminal_station: is_terminal_station,
            partial_closure_platform_names: []
@@ -450,9 +455,12 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
        when effect in [:station_closure, :suspension, :shuttle] do
     if location == :inside and
          LocalizedAlert.informs_all_active_routes_at_home_stop?(t) and
-         (is_nil(Alert.direction_id(alert)) or is_terminal_station),
-       do: :dual_screen,
-       else: :single_screen
+         (is_nil(Alert.direction_id(alert)) or is_terminal_station) and
+         not evergreen_content_for_alert?(alert_id, evergreen_content) do
+      :dual_screen
+    else
+      :single_screen
+    end
   end
 
   defp base_placement(%__MODULE__{is_priority: true}, _location), do: :single_screen
@@ -468,6 +476,18 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
   defp adjust_placement(:single_screen, :inside, :solo, _, _), do: :single_screen
   defp adjust_placement(:single_screen, _location, :solo, _, _), do: :flex_zone
   defp adjust_placement(:flex_zone, _location, :solo, _, _), do: :flex_zone
+
+  defp evergreen_content_for_alert?(alert_id, evergreen_content) do
+    Enum.any?(evergreen_content, fn
+      %EvergreenContentItem{
+        schedule: %AlertSchedule{alert_ids: alert_ids, suppress_alert_widgets: false}
+      } ->
+        alert_id in alert_ids
+
+      _ ->
+        false
+    end)
+  end
 
   # Two screen alert, suspension
   defp dual_screen_fields(%__MODULE__{alert: %Alert{effect: :suspension}} = t) do
@@ -1383,6 +1403,8 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
         # Two situations in which we show an alert on the full_body right of a screen
         # When a section contains CR departures, we want this to be fully displayed
         # For single screens, we want it to be visible on the right as well
+        IO.inspect(template == :duo and !departures_contains_commuter_rail?(departures))
+
         if template == :duo and !departures_contains_commuter_rail?(departures),
           do: [:paged_main_content_left],
           else: [:full_body_right]

--- a/lib/screens/v2/widget_instance/reconstructed_alert.ex
+++ b/lib/screens/v2/widget_instance/reconstructed_alert.ex
@@ -441,11 +441,7 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlert do
   defp base_placement(
          %__MODULE__{
            alert: %Alert{id: alert_id, effect: effect} = alert,
-           screen: %Screen{
-             app_params: %_app{
-               evergreen_content: evergreen_content
-             }
-           },
+           screen: %Screen{app_params: %_app{evergreen_content: evergreen_content}},
            is_priority: true,
            is_terminal_station: is_terminal_station,
            partial_closure_platform_names: []

--- a/test/screens/v2/widget_instance/reconstructed_alert_test.exs
+++ b/test/screens/v2/widget_instance/reconstructed_alert_test.exs
@@ -567,6 +567,22 @@ defmodule Screens.V2.WidgetInstance.ReconstructedAlertTest do
 
       assert_values(widget, {3, @flex_zone})
     end
+
+    test "service eliminating alert with corresponding evergreen content", %{widget: widget} do
+      widget =
+        widget
+        |> put_is_priority(true)
+        |> put_in(
+          [Access.key(:screen), Access.key(:app_params), Access.key(:evergreen_content)],
+          [
+            struct(EvergreenContentItem,
+              schedule: %AlertSchedule{alert_ids: ["123"], suppress_alert_widgets: false}
+            )
+          ]
+        )
+
+      assert_values(widget, {1, @left_screen}, {1, @right_screen})
+    end
   end
 
   describe "priority: single-line station" do


### PR DESCRIPTION
**Asana task**: [[extra] Modify Evergreen Content alert_suppression for upcoming RL diversion](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1216636756096278?focus=true)

This case came out of supporting the upcoming RL closure. We would like to show both custom Evergreen Content and the left side of a high priority alert on duo screens when `suppress_alert_widgets` is true. Adds a check on if there is an Evergreen Content Item with the alert ID we're creating a Reconstructed Alert Widget for. If there is, then we bump the placement of the alert down to `:single_screen`. This will not affect any existing behavior for `:solo` screens. 