### PR TITLE
fix: attempt to show pills for No Data Sections from Section config

### DIFF
--- a/lib/screens/v2/candidate_generator/widgets/rds_departures.ex
+++ b/lib/screens/v2/candidate_generator/widgets/rds_departures.ex
@@ -18,7 +18,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.RdsDepartures do
 
   alias Screens.V2.WidgetInstance.DeparturesNoData
   alias ScreensConfig.Departures
-  alias ScreensConfig.Departures.Section
+  alias ScreensConfig.Departures.{Query, Section}
 
   @type post_process_rows_fn_t ::
           ([NormalSection.row()], Section.t(), non_neg_integer() -> [NormalSection.row()])
@@ -50,9 +50,9 @@ defmodule Screens.V2.CandidateGenerator.Widgets.RdsDepartures do
         ) ::
           DeparturesWidget.section()
 
-  defp map_to_departure_section(:error, _, _, _), do: %NoDataSection{}
-
-  defp map_to_departure_section({:ok, []}, _, _, _), do: %NoDataSection{}
+  defp map_to_departure_section(data, section, _, _)
+       when data == :error or data == {:ok, []},
+       do: %NoDataSection{route: maybe_route_from_section(section)}
 
   defp map_to_departure_section(
          {:ok, items},
@@ -83,6 +83,30 @@ defmodule Screens.V2.CandidateGenerator.Widgets.RdsDepartures do
           header: header,
           grouping_type: grouping_type
         }
+    end
+  end
+
+  @spec maybe_route_from_section(Section.t()) :: Route.t() | nil
+  defp maybe_route_from_section(%Section{
+         query: %Query{params: %Query.Params{route_ids: nil, route_type: nil}}
+       }),
+       do: nil
+
+  defp maybe_route_from_section(%Section{
+         query: %Query{params: %Query.Params{route_ids: route_ids, route_type: route_type}}
+       }) do
+    %Route{id: representative_route_id(route_ids), type: route_type}
+  end
+
+  @spec representative_route_id([String.t()] | nil) :: String.t() | nil
+  defp representative_route_id(nil), do: nil
+  defp representative_route_id([]), do: nil
+
+  defp representative_route_id(route_ids) do
+    if Enum.all?(route_ids, &String.starts_with?(&1, "Green-")) do
+      "Green"
+    else
+      List.first(route_ids)
     end
   end
 

--- a/lib/screens/v2/widget_instance/departures.ex
+++ b/lib/screens/v2/widget_instance/departures.ex
@@ -62,7 +62,7 @@ defmodule Screens.V2.WidgetInstance.Departures do
 
   defmodule NoDataSection do
     @moduledoc "Section consisting of a 'no departures' message."
-    @type t :: %__MODULE__{route: Route.t()}
+    @type t :: %__MODULE__{route: Route.t() | nil}
     defstruct ~w[route]a
   end
 

--- a/test/screens/v2/candidate_generator/dup/departures_test.exs
+++ b/test/screens/v2/candidate_generator/dup/departures_test.exs
@@ -307,6 +307,83 @@ defmodule Screens.V2.CandidateGenerator.Dup.DeparturesTest do
       assert actual_instances == expected_instances
     end
 
+    test "creates no data sections for empty departures states" do
+      primary_departures = [
+        %Section{query: %Query{params: %Query.Params{stop_ids: ["s1"]}}},
+        %Section{
+          query: %Query{
+            params: %Query.Params{stop_ids: ["s2"], route_ids: ["Green-B", "Green-C"]}
+          }
+        }
+      ]
+
+      secondary_departures = []
+
+      expected_departures = [
+        %Departure{
+          prediction: %Prediction{
+            arrival_time: ~U[2024-10-11 12:27:00Z],
+            departure_time: ~U[2024-10-11 12:30:00Z],
+            route: %Route{id: "r1", line: %Line{id: "l1"}, type: :bus},
+            stop: %Stop{id: "s1"},
+            trip: %Trip{headsign: "other1", pattern_headsign: "h1"}
+          },
+          schedule: nil
+        }
+      ]
+
+      expected_primary_sections = [
+        %Screens.V2.WidgetInstance.Departures.NormalSection{
+          header: %ScreensConfig.Departures.Header{
+            arrow: nil,
+            read_as: nil,
+            subtitle: nil,
+            title: nil
+          },
+          layout: %ScreensConfig.Departures.Layout{
+            base: nil,
+            include_later: false,
+            max: nil,
+            min: 1
+          },
+          grouping_type: :time,
+          rows: expected_departures
+        },
+        %Screens.V2.WidgetInstance.Departures.NoDataSection{
+          route: %Screens.Routes.Route{
+            id: "Green",
+            short_name: nil,
+            long_name: nil,
+            direction_names: nil,
+            direction_destinations: nil,
+            type: nil,
+            line: nil
+          }
+        }
+      ]
+
+      config =
+        @config
+        |> put_primary_departures(primary_departures)
+        |> put_secondary_departures_sections(secondary_departures)
+
+      expect(@rds, :get, fn _primary_departures, @now ->
+        [
+          {:ok, [rds_countdown("s1", "l1", "other1", expected_departures)]},
+          {:ok, []}
+        ]
+      end)
+
+      expect(@rds, :get, fn _secondary_departures, @now -> [{:ok, []}, {:ok, []}] end)
+
+      expected_instances =
+        expected_departures_widget(config, expected_primary_sections, expected_primary_sections)
+
+      actual_instances = Dup.Departures.instances(config, @now)
+
+      assert actual_instances == expected_instances
+    end
+
     test "creates no service sections for no service states" do
       primary_departures = [
         %Section{query: %Query{params: %Query.Params{stop_ids: ["s1"]}}},


### PR DESCRIPTION
**Asana task**: [Bug: Green Line pill omitted](https://app.asana.com/1/15492006741476/project/1185117109217422/task/1216600856263981?focus=true)

Description
- in the old departures code, we would purposefully do a route call to try and fetch the route from the API to show a pill for the NoDataSections
- in the new code, we omit this extra API call, but here we can attempt to recreate a route depending on the Section configuration. In cases where we have `route_ids` or a `route_type`, we will attempt to create a route to use for `Route.icon/1`.
- In cases where we don't have either, we will omit the route pill.

Question: Should we just attempt to fetch the route like we do in the `post_process_no_data/4`? I opted not to because of how many network calls we're already making for RDS, but an extra route one (that presumably would be cached and only in cases where we have an error or no data at all) wouldn't hurt that bad in my mind. 

Before:
<img width="965" height="548" alt="Screenshot 2026-07-16 at 3 17 27 PM" src="https://github.com/user-attachments/assets/6a787d50-c82a-4c8c-82d1-5c9ce000b875" />
After:
<img width="967" height="546" alt="Screenshot 2026-07-16 at 3 17 44 PM" src="https://github.com/user-attachments/assets/4674e354-a31e-48ba-8206-d21d783323e3" />

- [x] Tests added?
