### PR TITLE
chore: increase V3 API Realtime cache allocation

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -484,7 +484,7 @@ v3_api_cache_options = [
 
 config :screens,
        Screens.V3Api.Cache.Realtime,
-       Keyword.merge(v3_api_cache_options, allocated_memory: 100 * 1024 * 1024)
+       Keyword.merge(v3_api_cache_options, allocated_memory: 200 * 1024 * 1024)
 
 config :screens,
        Screens.V3Api.Cache.Static,


### PR DESCRIPTION
Max usage of this cache is consistently above the limit, indicating it may be thrashing. Since instance memory usage in production continues to be under 50% of our overall limit, we can afford some extra megabytes.