### PR TITLE
fix: hide pills on solo full screen reconstructed alerts

### DIFF
--- a/assets/css/pre_fare/alert-banner.scss
+++ b/assets/css/pre_fare/alert-banner.scss
@@ -35,19 +35,6 @@
   margin: 0 20px;
 }
 
-.alert-banner__route-pill--short--multiple-routes {
-  height: 96px;
-  margin: 0 20px;
-
-  &:first-of-type {
-    margin: 0 10px 0 20px;
-  }
-
-  &:last-of-type {
-    margin: 0 20px 0 10px;
-  }
-}
-
 .alert-banner__route-pill--long {
   margin: 16.2px 0 0.8px;
 }

--- a/assets/src/components/pre_fare_single_screen_alert.tsx
+++ b/assets/src/components/pre_fare_single_screen_alert.tsx
@@ -577,18 +577,7 @@ const PreFareAlertBanner: ComponentType<{
           getAlertColor(routes),
         ])}
       >
-        <span className="alert-banner__attention-text">Attention</span>
-        {routes.map((route) => {
-          const LinePill = STRING_TO_SVG[route.svg_name];
-          return (
-            <LinePill
-              className="alert-banner__route-pill--short--multiple-routes"
-              key={route.svg_name}
-              color={getHexColor(getRouteColor(route.route_id))}
-            />
-          );
-        })}
-        <span>riders</span>
+        <span className="alert-banner__attention-text">Attention riders</span>
       </h5>
     );
   } else if (routes.length === 2) {


### PR DESCRIPTION


**Asana task**: N/A
Description

In b84e89a7, we improved the verbiage in the alerts banner for prefare solo screens when a reconstructed alert took over the whole screen. However, that commit failed to account for the styling of greater than two route pills. As a result, a theoretical station closure with three or more pills would result in cutoff text and/or route pills with no vertical spacing between them (on wrapped text). In discussing this with the design team, we've agreed to remove the pills from this particular case.

- [ ] Tests added?

<details>
  <summary>Before</summary>
<img width="553" height="1007" alt="Screenshot 2026-07-16 at 15 40 51" src="https://github.com/user-attachments/assets/867b774f-9beb-4793-8873-481ed0b8a4d5" />
<img width="553" height="1007" alt="Screenshot 2026-07-16 at 15 41 16" src="https://github.com/user-attachments/assets/fa47bf4e-1e01-4fef-a635-52fbfe834d80" />
<img width="553" height="1007" alt="Screenshot 2026-07-16 at 15 41 43" src="https://github.com/user-attachments/assets/a2b9a4e6-835d-47c0-aafd-e8192aab7d9c" />
</details>


<details>
  <summary>After</summary>
<img width="553" height="977" alt="Screenshot 2026-07-17 at 08 50 52" src="https://github.com/user-attachments/assets/c5f93c9e-4fa7-484e-a84f-c9d09ad29f03" />

</details>
