### PR TITLE
refactor: Reduce calls to schedule API in RDS

### DIFF
--- a/lib/screens/v2/departure.ex
+++ b/lib/screens/v2/departure.ex
@@ -48,7 +48,7 @@ defmodule Screens.V2.Departure do
     fetch_predictions_fn = Keyword.get(opts, :fetch_predictions_fn, &Prediction.fetch/1)
 
     with {:ok, predictions} <- fetch_predictions_fn.(params),
-         {:ok, schedules} <- fetch_schedules(params, opts) do
+         {:ok, schedules} <- get_schedules(params, opts) do
       departures = Builder.build(predictions, schedules, now, opts)
       @last_trip.update_last_trip_cache(departures, now)
       {:ok, departures}
@@ -57,6 +57,7 @@ defmodule Screens.V2.Departure do
     end
   end
 
+  @callback fetch_schedules(params(), opts()) :: Schedule.result()
   def fetch_schedules(params, opts) do
     fetch_fn = Keyword.get(opts, :fetch_schedules_fn, &Schedule.fetch/1)
 
@@ -80,6 +81,13 @@ defmodule Screens.V2.Departure do
       ^all_types -> params |> Map.delete(:route_type) |> fetch_fn.()
       # We have a final route type filter that is neither "everything" nor "nothing".
       route_types -> params |> Map.put(:route_type, route_types) |> fetch_fn.()
+    end
+  end
+
+  defp get_schedules(params, opts) do
+    case Keyword.fetch(opts, :schedules) do
+      {:ok, schedules} -> {:ok, schedules}
+      :error -> fetch_schedules(params, opts)
     end
   end
 

--- a/lib/screens/v2/rds.ex
+++ b/lib/screens/v2/rds.ex
@@ -111,7 +111,7 @@ defmodule Screens.V2.RDS do
     State for if we're in an active period, but we have no predictions
     and there are no alerts associated with the destination.
 
-    Shows an every “X-Y” minutes message. 
+    Shows an every “X-Y” minutes message.
     """
     @type t :: %__MODULE__{
             destinations: [Screens.V2.RDS.destination()],
@@ -127,7 +127,6 @@ defmodule Screens.V2.RDS do
   @departure injected(Departure)
   @headways injected(Headway)
   @route_pattern injected(RoutePattern)
-  @schedule injected(Schedule)
   @stop injected(Stop)
   @config_cache injected(Cache)
   @last_trip injected(LastTrip)
@@ -167,10 +166,13 @@ defmodule Screens.V2.RDS do
          {:ok, typical_patterns} <-
            params_struct |> Map.put(:typicality, 1) |> @route_pattern.fetch(),
          {:ok, child_stops} <- fetch_child_stops(stop_ids),
-         {:ok, schedules} <- @schedule.fetch(params_struct, Util.service_date(now)),
          {:ok, alerts} <- fetch_relevant_alerts(stop_ids, now),
-         {:ok, departures} <-
-           params_struct |> @departure.fetch(now: now, include_scheduled_cancelled?: true) do
+         {:ok, schedules} <-
+           @departure.fetch_schedules(params_struct,
+             date: Util.service_date(now),
+             include_scheduled_cancelled?: true
+           ),
+         {:ok, departures} <- @departure.fetch(params_struct, schedules: schedules) do
       case create_routes_for_section(departures, schedules, typical_patterns, params) do
         {[_ | _] = enabled_routes_for_section, _} ->
           create_section_rds(

--- a/test/screens/v2/rds_test.exs
+++ b/test/screens/v2/rds_test.exs
@@ -26,7 +26,6 @@ defmodule Screens.V2.RDSTest do
   @departure injected(Departure)
   @headways injected(Headways)
   @route_pattern injected(RoutePattern)
-  @schedule injected(Schedule)
   @stop injected(Stop)
   @config_cache injected(Cache)
   @last_trip injected(LastTrip)
@@ -34,9 +33,9 @@ defmodule Screens.V2.RDSTest do
   setup do
     stub(@alert, :fetch, fn _ -> {:ok, []} end)
     stub(@departure, :fetch, fn _, _ -> {:ok, []} end)
+    stub(@departure, :fetch_schedules, fn _, _ -> {:ok, []} end)
     stub(@headways, :get, fn _, _ -> nil end)
     stub(@route_pattern, :fetch, fn _ -> {:ok, []} end)
-    stub(@schedule, :fetch, fn _, _ -> {:ok, []} end)
     stub(@stop, :fetch, fn %{ids: ids} -> {:ok, Enum.map(ids, &stop/1)} end)
     stub(@config_cache, :disabled_modes, fn -> [] end)
     stub(@last_trip, :last_trip_departure_times, fn _ -> [] end)
@@ -233,7 +232,7 @@ defmodule Screens.V2.RDSTest do
       ]
 
       expect(@departure, :fetch, fn
-        %{direction_id: 0, route_type: :bus, stop_ids: ["s0"]}, [{:now, ^now} | _] ->
+        %{direction_id: 0, route_type: :bus, stop_ids: ["s0"]}, [schedules: []] ->
           {
             :ok,
             expected_departures_one ++
@@ -300,7 +299,7 @@ defmodule Screens.V2.RDSTest do
       ]
 
       expect(@departure, :fetch, fn
-        %{direction_id: 0, route_type: :bus, stop_ids: ^stop_ids}, [{:now, ^now} | _] ->
+        %{direction_id: 0, route_type: :bus, stop_ids: ^stop_ids}, [schedules: []] ->
           {
             :ok,
             expected_departures
@@ -380,7 +379,7 @@ defmodule Screens.V2.RDSTest do
       }
 
       expect(@departure, :fetch, fn
-        %{direction_id: 0, route_type: :subway, stop_ids: ["s0"]}, [{:now, ^now} | _] ->
+        %{direction_id: 0, route_type: :subway, stop_ids: ["s0"]}, [schedules: []] ->
           {:ok, [skipped_departure | expected_departures]}
       end)
 
@@ -422,7 +421,7 @@ defmodule Screens.V2.RDSTest do
       }
 
       expect(@departure, :fetch, fn
-        %{direction_id: 0, route_type: :subway, stop_ids: ["s0"]}, [{:now, ^now} | _] ->
+        %{direction_id: 0, route_type: :subway, stop_ids: ["s0"]}, [schedules: []] ->
           {:ok, [skipped_departure]}
       end)
 
@@ -478,7 +477,10 @@ defmodule Screens.V2.RDSTest do
         ]
       }
 
-      expect(@schedule, :fetch, fn %{stop_ids: ^stop_ids}, _now -> {:ok, all_schedules} end)
+      expect(@departure, :fetch_schedules, fn %{stop_ids: ^stop_ids}, _now ->
+        {:ok, all_schedules}
+      end)
+
       expect_standard_stations(stop_ids)
       expect_standard_route_patterns(stop_ids)
 
@@ -529,7 +531,10 @@ defmodule Screens.V2.RDSTest do
 
       stub(@headways, :get, fn _, _ -> {5, 10} end)
 
-      expect(@schedule, :fetch, fn %{stop_ids: ^stop_ids}, _now -> {:ok, all_schedules} end)
+      expect(@departure, :fetch_schedules, fn %{stop_ids: ^stop_ids}, _now ->
+        {:ok, all_schedules}
+      end)
+
       expect_standard_stations(stop_ids)
       expect_standard_route_patterns(stop_ids)
 
@@ -587,7 +592,10 @@ defmodule Screens.V2.RDSTest do
 
       stub(@headways, :get, fn _, _ -> {5, 10} end)
 
-      expect(@schedule, :fetch, fn %{stop_ids: ^stop_ids}, _now -> {:ok, all_schedules} end)
+      expect(@departure, :fetch_schedules, fn %{stop_ids: ^stop_ids}, _now ->
+        {:ok, all_schedules}
+      end)
+
       expect_standard_stations(stop_ids)
       expect_standard_route_patterns(stop_ids)
 
@@ -671,11 +679,15 @@ defmodule Screens.V2.RDSTest do
       stub(@headways, :get, fn _, _ -> {5, 10} end)
 
       expect(@departure, :fetch, fn
-        %{direction_id: :both, route_type: :bus, stop_ids: ^stop_ids}, [{:now, ^now} | _] ->
+        %{direction_id: :both, route_type: :bus, stop_ids: ^stop_ids},
+        [schedules: ^all_schedules] ->
           {:ok, []}
       end)
 
-      expect(@schedule, :fetch, fn %{stop_ids: ^stop_ids}, _now -> {:ok, all_schedules} end)
+      expect(@departure, :fetch_schedules, fn %{stop_ids: ^stop_ids}, _now ->
+        {:ok, all_schedules}
+      end)
+
       expect_standard_stations(stop_ids)
       expect_standard_route_patterns(stop_ids)
 
@@ -724,11 +736,14 @@ defmodule Screens.V2.RDSTest do
       }
 
       expect(@departure, :fetch, fn
-        %{direction_id: :both, route_type: :bus, stop_ids: ^stop_ids}, [{:now, ^now} | _] ->
+        %{direction_id: :both, route_type: :bus, stop_ids: ^stop_ids},
+        [schedules: ^all_schedules] ->
           {:ok, []}
       end)
 
-      expect(@schedule, :fetch, fn %{stop_ids: ^stop_ids}, _now -> {:ok, all_schedules} end)
+      expect(@departure, :fetch_schedules, fn %{stop_ids: ^stop_ids}, _now ->
+        {:ok, all_schedules}
+      end)
 
       expect(@stop, :fetch, fn %{ids: ^stop_ids} ->
         {:ok, [station("70061", ~w[70061])]}
@@ -887,7 +902,11 @@ defmodule Screens.V2.RDSTest do
       }
 
       stub(@headways, :get, fn _, _ -> {5, 10} end)
-      expect(@schedule, :fetch, fn %{stop_ids: ^stop_ids}, _now -> {:ok, all_schedules} end)
+
+      expect(@departure, :fetch_schedules, fn %{stop_ids: ^stop_ids}, _now ->
+        {:ok, all_schedules}
+      end)
+
       expect_standard_stations(stop_ids)
       expect_standard_route_patterns(stop_ids)
 
@@ -1046,10 +1065,14 @@ defmodule Screens.V2.RDSTest do
       }
 
       stub(@headways, :get, fn _, _ -> {5, 10} end)
-      expect(@schedule, :fetch, fn %{stop_ids: ^stop_ids}, _now -> {:ok, all_schedules} end)
+
+      expect(@departure, :fetch_schedules, fn %{stop_ids: ^stop_ids}, _now ->
+        {:ok, all_schedules}
+      end)
 
       expect(@departure, :fetch, fn
-        %{direction_id: :both, route_type: :bus, stop_ids: ^stop_ids}, [{:now, ^now} | _] ->
+        %{direction_id: :both, route_type: :bus, stop_ids: ^stop_ids},
+        [schedules: ^all_schedules] ->
           {:ok, [departure_overlapping_with_headway]}
       end)
 
@@ -1353,7 +1376,11 @@ defmodule Screens.V2.RDSTest do
       }
 
       stub(@headways, :get, fn _, _ -> nil end)
-      expect(@schedule, :fetch, fn %{stop_ids: ^stop_ids}, _now -> {:ok, all_schedules} end)
+
+      expect(@departure, :fetch_schedules, fn %{stop_ids: ^stop_ids}, _now ->
+        {:ok, all_schedules}
+      end)
+
       expect_standard_stations(stop_ids)
       expect_standard_route_patterns(stop_ids)
 
@@ -1396,7 +1423,7 @@ defmodule Screens.V2.RDSTest do
       now = ~U[2024-10-11 12:00:00Z]
       stop_ids = ~w[s0]
 
-      expect(@departure, :fetch, fn %{stop_ids: ^stop_ids}, [{:now, ^now} | _] ->
+      expect(@departure, :fetch, fn %{stop_ids: ^stop_ids}, [schedules: []] ->
         :error
       end)
 
@@ -1427,7 +1454,7 @@ defmodule Screens.V2.RDSTest do
         }
       ]
 
-      stub(@departure, :fetch, fn %{stop_ids: stop_ids}, [{:now, ^now} | _] ->
+      stub(@departure, :fetch, fn %{stop_ids: stop_ids}, [schedules: []] ->
         case stop_ids do
           ^stop_ids_primary -> {:ok, expected_departures}
           ^stop_ids_secondary -> :error
@@ -1479,10 +1506,10 @@ defmodule Screens.V2.RDSTest do
       ]
 
       stub(@departure, :fetch, fn
-        %{direction_id: 0, route_type: :bus, stop_ids: ^stop_ids}, [{:now, ^now} | _] ->
+        %{direction_id: 0, route_type: :bus, stop_ids: ^stop_ids}, [schedules: []] ->
           {:ok, bus_departures}
 
-        %{direction_id: 0, route_type: :subway, stop_ids: ^stop_ids}, [{:now, ^now} | _] ->
+        %{direction_id: 0, route_type: :subway, stop_ids: ^stop_ids}, [schedules: []] ->
           {:ok, subway_departures}
       end)
 


### PR DESCRIPTION
Thought of this improvement while looking through RDS and thinking about the resource usage issues we've been seeing. We currently make two slightly different calls to the Schedules API each time through RDS. By passing the first result of fetching schedules to `Departure.fetch`, we can just use those `Schedule` results to figure out upcoming scheduled `Departures` rather than fetching Schedules a second time.

I don't think this is the cause of any issues with resource usage we've seen, but I think cleaning this up could only help.