### PR TITLE
perf: reduce duplicate self-refresh runs

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -461,9 +461,10 @@ config :screens,
 
 config :screens, :screens_by_alert,
   cache_module: Screens.ScreensByAlert.GenServer,
-  screens_by_alert_ttl_seconds: 40,
+  screens_by_alert_ttl_seconds: 45,
   screens_last_updated_ttl_seconds: 3600,
-  screens_ttl_seconds: 40
+  screens_in_progress_ttl_seconds: 20,
+  screens_ttl_seconds: 45
 
 config :screens, Screens.ScreensByAlert.SelfRefreshRunner, batch_size: 20, concurrency: 1
 

--- a/lib/screens/screens_by_alert.ex
+++ b/lib/screens/screens_by_alert.ex
@@ -28,6 +28,8 @@ defmodule Screens.ScreensByAlert do
   end
 
   defdelegate start_link(opts), to: @cache_module
+  defdelegate get_in_progress(screen_ids), to: @cache_module
+  defdelegate put_in_progress(screen_ids), to: @cache_module
   defdelegate put_data(screen_id, alert_ids), to: @cache_module
   defdelegate get_screens_by_alert(alert_ids), to: @cache_module
   defdelegate get_screens_last_updated(screen_ids), to: @cache_module

--- a/lib/screens/screens_by_alert/behaviour.ex
+++ b/lib/screens/screens_by_alert/behaviour.ex
@@ -19,9 +19,22 @@ defmodule Screens.ScreensByAlert.Behaviour do
   @callback start_link(GenServer.options()) :: GenServer.on_start()
 
   @doc """
-  Takes a screen ID and a list of alert IDs as parameters. With these, it will get an existing object
-  or create a new object in the cache using each alert_id. The key of each object is the `alert_id`, the value
-  is the list of `screen_id`s.
+  Given a list of screen IDs, return the subset of IDs that some app instance is in the process
+  of updating the alerts for, to reduce duplicate work.
+  """
+  @callback get_in_progress(list(screen_id())) :: list(screen_id())
+
+  @doc """
+  Mark screen IDs as being in the process of having their alerts updated. Does not un-mark IDs
+  that were previously marked; this only happens either when alert IDs are put for a screen (see
+  `put_data/2`) or after a short expiration time.
+  """
+  @callback put_in_progress(list(screen_id())) :: :ok
+
+  @doc """
+  Takes a screen ID and a list of alert IDs as parameters. With these, it will get an existing
+  object or create a new object in the cache using each alert_id. The key of each object is the
+  `alert_id`, the value is the list of `screen_id`s.
   """
   @callback put_data(screen_id(), list(alert_id())) :: :ok
 

--- a/lib/screens/screens_by_alert/gen_server.ex
+++ b/lib/screens/screens_by_alert/gen_server.ex
@@ -19,14 +19,16 @@ defmodule Screens.ScreensByAlert.GenServer do
           },
           screens_last_updated: %{
             screen_id() => %{last_updated: timestamp(), timer_reference: reference()}
-          }
+          },
+          screens_in_progress: %{screen_id() => reference()}
         }
 
-  defstruct screens_by_alert: %{}, screens_last_updated: %{}
+  defstruct screens_by_alert: %{}, screens_last_updated: %{}, screens_in_progress: %{}
 
   @config Application.compile_env!(:screens, :screens_by_alert)
   @screens_by_alert_ttl_ms Keyword.fetch!(@config, :screens_by_alert_ttl_seconds) * 1_000
   @screens_last_updated_ttl_ms Keyword.fetch!(@config, :screens_last_updated_ttl_seconds) * 1_000
+  @screens_in_progress_ttl_ms Keyword.fetch!(@config, :screens_in_progress_ttl_seconds) * 1_000
   @screens_ttl_seconds Keyword.fetch!(@config, :screens_ttl_seconds)
 
   ### Client
@@ -34,6 +36,16 @@ defmodule Screens.ScreensByAlert.GenServer do
   @impl Screens.ScreensByAlert.Behaviour
   def start_link(opts \\ []) do
     GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @impl Screens.ScreensByAlert.Behaviour
+  def get_in_progress(pid \\ __MODULE__, screen_ids) do
+    GenServer.call(pid, {:get_in_progress, screen_ids})
+  end
+
+  @impl Screens.ScreensByAlert.Behaviour
+  def put_in_progress(pid \\ __MODULE__, screen_ids) do
+    GenServer.cast(pid, {:put_in_progress, screen_ids})
   end
 
   @impl Screens.ScreensByAlert.Behaviour
@@ -90,8 +102,30 @@ defmodule Screens.ScreensByAlert.GenServer do
      %__MODULE__{
        state
        | screens_by_alert: updated_screens_by_alert,
-         screens_last_updated: updated_screens_last_updated
+         screens_last_updated: updated_screens_last_updated,
+         screens_in_progress: Map.delete(state.screens_in_progress, screen_id)
      }}
+  end
+
+  @impl GenServer
+  def handle_cast({:put_in_progress, screen_ids}, %__MODULE__{} = state) do
+    new_in_progress =
+      Enum.reduce(screen_ids, state.screens_in_progress, fn screen_id, in_progress ->
+        old_ref = Map.get(in_progress, screen_id)
+        _ = if not is_nil(old_ref), do: Process.cancel_timer(old_ref, async: true, info: false)
+
+        Map.put(
+          in_progress,
+          screen_id,
+          Process.send_after(
+            self(),
+            {:expire_in_progress, screen_id},
+            @screens_in_progress_ttl_ms
+          )
+        )
+      end)
+
+    {:noreply, %__MODULE__{state | screens_in_progress: new_in_progress}}
   end
 
   @impl GenServer
@@ -142,11 +176,27 @@ defmodule Screens.ScreensByAlert.GenServer do
   end
 
   @impl GenServer
+  def handle_call({:get_in_progress, screen_ids}, _from, %__MODULE__{} = state) do
+    subset =
+      state.screens_in_progress
+      |> Map.keys()
+      |> MapSet.new()
+      |> MapSet.intersection(MapSet.new(screen_ids))
+
+    {:reply, subset, state}
+  end
+
+  @impl GenServer
   def handle_info(
         {:expire_alert, alert_id},
         %__MODULE__{} = state
       ) do
     {:noreply, %{state | screens_by_alert: Map.delete(state.screens_by_alert, alert_id)}}
+  end
+
+  @impl GenServer
+  def handle_info({:expire_in_progress, screen_id}, %__MODULE__{} = state) do
+    {:noreply, %{state | screens_in_progress: Map.delete(state.screens_in_progress, screen_id)}}
   end
 
   @impl GenServer

--- a/lib/screens/screens_by_alert/memcache.ex
+++ b/lib/screens/screens_by_alert/memcache.ex
@@ -23,6 +23,9 @@ defmodule Screens.ScreensByAlert.Memcache do
 
     # Metadata to make the "self-refresh" mechanism possible
     "screens_last_updated." <> screen_id => timestamp
+
+    # Keeps track of data updates in progress to reduce duplicate work
+    "screens_in_progress." <> screen_id => true
   }
   ```
   """
@@ -37,15 +40,39 @@ defmodule Screens.ScreensByAlert.Memcache do
 
   @screens_by_alert_key_prefix "screens_by_alert."
   @screens_last_updated_key_prefix "screens_last_updated."
+  @screens_in_progress_key_prefix "screens_in_progress."
 
   @config Application.compile_env!(:screens, :screens_by_alert)
   @screens_by_alert_ttl Keyword.fetch!(@config, :screens_by_alert_ttl_seconds)
   @screens_last_updated_ttl Keyword.fetch!(@config, :screens_last_updated_ttl_seconds)
+  @screens_in_progress_ttl Keyword.fetch!(@config, :screens_in_progress_ttl_seconds)
   @screens_ttl Keyword.fetch!(@config, :screens_ttl_seconds)
 
   @impl true
   def start_link(_opts \\ []) do
     Screens.Memcache.start_link(name: @server)
+  end
+
+  @impl true
+  def get_in_progress(screen_ids) do
+    case Memcache.multi_get(@server, Enum.map(screen_ids, &in_progress_key/1)) do
+      {:ok, result} ->
+        result |> Map.keys() |> Enum.map(&key_to_id/1)
+
+      {:error, message} ->
+        log_warning(message, :get_in_progress)
+        []
+    end
+  end
+
+  @impl true
+  def put_in_progress(screen_ids) do
+    key_values = screen_ids |> Enum.map(&in_progress_key/1) |> Map.new(fn key -> {key, true} end)
+
+    case Memcache.multi_set(@server, key_values, ttl: @screens_in_progress_ttl) do
+      {:ok, _result} -> :ok
+      {:error, message} -> log_warning(message, :put_in_progress)
+    end
   end
 
   @impl true
@@ -60,6 +87,7 @@ defmodule Screens.ScreensByAlert.Memcache do
           fn ->
             update_screens_last_updated_key(screen_id, now)
             Enum.each(alert_ids, &update_alert_key(&1, screen_id, now))
+            delete_screens_in_progress_key(screen_id)
           end,
           10_000
         )
@@ -107,6 +135,19 @@ defmodule Screens.ScreensByAlert.Memcache do
     case Memcache.set(@server, last_updated_key(screen_id), now, ttl: @screens_last_updated_ttl) do
       {:error, message} ->
         log_warning(message, :update_screens_last_updated_key, screen_id: screen_id)
+
+      _ ->
+        :ok
+    end
+  end
+
+  defp delete_screens_in_progress_key(screen_id) do
+    case Memcache.delete(@server, in_progress_key(screen_id)) do
+      {:error, "Key not found"} ->
+        :ok
+
+      {:error, message} ->
+        log_warning(message, :delete_screens_in_progress_key, screen_id: screen_id)
 
       _ ->
         :ok
@@ -171,9 +212,11 @@ defmodule Screens.ScreensByAlert.Memcache do
 
   defp alert_key(alert_id), do: @screens_by_alert_key_prefix <> alert_id
   defp last_updated_key(screen_id), do: @screens_last_updated_key_prefix <> screen_id
+  defp in_progress_key(screen_id), do: @screens_in_progress_key_prefix <> screen_id
 
   defp key_to_id(@screens_by_alert_key_prefix <> alert_id), do: alert_id
   defp key_to_id(@screens_last_updated_key_prefix <> screen_id), do: screen_id
+  defp key_to_id(@screens_in_progress_key_prefix <> screen_id), do: screen_id
 
   defp log_warning(message, source, extra \\ []) do
     Report.warning("memcache_error", [message: message, source: source] ++ extra)

--- a/lib/screens/screens_by_alert/self_refresh_runner.ex
+++ b/lib/screens/screens_by_alert/self_refresh_runner.ex
@@ -32,7 +32,7 @@ defmodule Screens.ScreensByAlert.SelfRefreshRunner do
   @outdated_threshold_secs Application.compile_env!(:screens, [
                              :screens_by_alert,
                              :screens_by_alert_ttl_seconds
-                           ]) - 5
+                           ]) - 10
 
   @empty_set MapSet.new()
 
@@ -53,8 +53,13 @@ defmodule Screens.ScreensByAlert.SelfRefreshRunner do
       |> Enum.filter(fn {_screen_id, timestamp} -> now - timestamp > @outdated_threshold_secs end)
       |> Enum.sort_by(fn {_screen_id, timestamp} -> timestamp end)
       |> Enum.map(fn {screen_id, _timestamp} -> screen_id end)
+      |> then(fn screen_ids ->
+        in_progress = screen_ids |> @screens_by_alert.get_in_progress() |> MapSet.new()
+        Enum.reject(screen_ids, &(&1 in in_progress))
+      end)
       |> Enum.split(@batch_size)
 
+    @screens_by_alert.put_in_progress(ids_to_refresh)
     _ = start_refresh(ids_to_refresh, rest_ids)
     schedule_check()
 

--- a/lib/screens/v2/screen_data.ex
+++ b/lib/screens/v2/screen_data.ex
@@ -40,6 +40,7 @@ defmodule Screens.V2.ScreenData do
   @spec select_variant(Screen.t(), options(), (Layout.t(), Screen.t() -> data)) :: data
         when data: t() | simulation_data()
   defp select_variant(screen, opts, then_fn) do
+    update_visible_alerts_in_progress(screen, opts)
     selected_variant = Keyword.get(opts, :generator_variant)
 
     if Keyword.get(opts, :run_all_variants?, false) do
@@ -164,6 +165,14 @@ defmodule Screens.V2.ScreenData do
       # some children are not "leaf nodes". go down a level.
       Enum.find_value(children, &get_containing_slot(&1, target_slot_ids))
     end
+  end
+
+  defp update_visible_alerts_in_progress(%Screen{hidden_from_screenplay: true}, _opts), do: :ok
+
+  defp update_visible_alerts_in_progress(_screen, opts) do
+    screen_id = Keyword.get(opts, :update_visible_alerts_for_screen_id, nil)
+    if not is_nil(screen_id), do: ScreensByAlert.put_in_progress([screen_id])
+    :ok
   end
 
   defp update_visible_alerts(_, %Screen{hidden_from_screenplay: true}, _opts), do: :ok

--- a/lib/screens_web/controllers/v2/screen_api_controller.ex
+++ b/lib/screens_web/controllers/v2/screen_api_controller.ex
@@ -31,8 +31,14 @@ defmodule ScreensWeb.V2.ScreenApiController do
 
   def show_dup(conn, params), do: show(conn, params)
 
-  def simulation(%{assigns: %{screen: screen, variant: variant}} = conn, _params) do
-    json(conn, simulation_response(screen, variant))
+  def simulation(
+        %{assigns: %{screen_id: screen_id, screen: screen, variant: variant}} = conn,
+        _params
+      ) do
+    json(
+      conn,
+      simulation_response(screen, variant, update_visible_alerts_for_screen_id: screen_id)
+    )
   end
 
   def show_pending(%{assigns: %{screen: screen}} = conn, _params) do
@@ -97,10 +103,6 @@ defmodule ScreensWeb.V2.ScreenApiController do
     %{@base_response | data: data}
   end
 
-  defp merge_options(variant, opts) do
-    Keyword.put(opts, :generator_variant, variant)
-  end
-
   # See `docs/mercury_api.md`
   defp put_extra_fields(response, %Screen{vendor: :mercury} = screen) do
     response
@@ -120,13 +122,17 @@ defmodule ScreensWeb.V2.ScreenApiController do
     end
   end
 
-  defp simulation_response(screen, "all") do
+  defp simulation_response(screen, "all", _opts) do
     {default, variants} = ScreenData.simulation_variants(screen)
     Map.put(%{@base_response | data: default}, :variants, variants)
   end
 
-  defp simulation_response(screen, variant) do
-    %{@base_response | data: ScreenData.simulation(screen, generator_variant: variant)}
+  defp simulation_response(screen, variant, opts) do
+    %{@base_response | data: ScreenData.simulation(screen, merge_options(variant, opts))}
+  end
+
+  defp merge_options(variant, opts) do
+    Keyword.put(opts, :generator_variant, variant)
   end
 
   defp disabled_response(%{assigns: %{screen: %Screen{disabled: true}}} = conn, _) do

--- a/test/screens/screens_by_alert/self_refresh_runner_test.exs
+++ b/test/screens/screens_by_alert/self_refresh_runner_test.exs
@@ -19,23 +19,27 @@ defmodule Screens.ScreensByAlert.SelfRefreshRunnerTest do
       %{"1001" => now - 61, "1002" => now - 62, "1301" => now - 63, "1401" => now - 64}
     end)
 
-    # Only the 2 most-outdated screens should be refreshed, per the batch size in test
+    # Pretend another instance is refreshing 1301. Per the batch size in test, the 2 most outdated
+    # screens should be refreshed (that are not already being refreshed), which are 1401 and 1002.
+    expect(ScreensByAlert.Mock, :get_in_progress, fn _screen_ids -> ["1301"] end)
+    expect(ScreensByAlert.Mock, :put_in_progress, fn ~w[1401 1002] -> :ok end)
+
     expect(ScreenData.Mock, :get, fn %Screen{app_id: :bus_shelter_v2},
                                      [update_visible_alerts_for_screen_id: "1401"] ->
       %{type: :x}
     end)
 
-    expect(ScreenData.Mock, :get, fn %Screen{app_id: :busway_v2},
-                                     [update_visible_alerts_for_screen_id: "1301"] ->
+    expect(ScreenData.Mock, :get, fn %Screen{app_id: :bus_eink_v2},
+                                     [update_visible_alerts_for_screen_id: "1002"] ->
       raise "oops"
     end)
 
-    screen_ids = MapSet.new(~w[1301 1401])
+    screen_ids = MapSet.new(~w[1002 1401])
     assert {:noreply, ^screen_ids} = SelfRefreshRunner.handle_info(:check, MapSet.new())
 
     # Wait longer than the default 100ms to avoid occasional timeouts
     assert_receive({:done, :ok, "1401"}, 200)
-    assert_receive({:done, :exit, "1301"}, 200)
+    assert_receive({:done, :exit, "1002"}, 200)
   end
 
   test "skips refreshing if any refreshes are in progress" do


### PR DESCRIPTION
The primary change here is that `ScreensByAlert` can now keep track of screen IDs for which a data refresh is in progress. At the *start* of a screen data request or self-refresh, the relevant screen IDs are added to this list, and when displayed alert IDs are updated for a screen ID, it is removed from the list. In case data refreshing does not complete successfully, screen IDs also expire from the list after a short time.

This dramatically reduces the resources used by the self-refresh runner on screens that are already being refreshed by either a data request or another instance's self-refresh runner, though it does not *guarantee* this never happens; doing so would require a lock/transaction mechanism, which Memcache does not have. This is essentially a partial, quick-fix version of the upcoming "resilience" changes, for which we plan to use Redis, which does support these.

Other changes:

* Increase the TTL on alerts data from 40 to 45 seconds, allowing us to increase the buffer time between when the self-refresh runner picks up a screen and its alerts data expires from 5 to 10 seconds. This should improve the reliability of the alerts-on-screens feature, since screen data often does take more than 5 seconds to generate.

* In addition to "normal" screen data requests, also update alerts data on simulation requests. Unclear why we didn't do this before; the data should be identical and equally valid. This mostly cuts resource usage in non-prod environments, where most requests are from Screenplay.

**Asana task**: https://app.asana.com/1/15492006741476/project/1185117109217413/task/1216641767742099?focus=true
