### PR TITLE
fix: timestamps overflowing with dual route pill

### DIFF
--- a/assets/css/dup/departures/destination.scss
+++ b/assets/css/dup/departures/destination.scss
@@ -11,7 +11,7 @@
   // The width of the destination is reduced if either/both of the
   // route pill and time columns need to take up more space.
   .departure-row--extended-route_pill & {
-    width: 967px;
+    width: 810px;
   }
 
   .departures-section--extended-times & {

--- a/assets/css/dup/departures/row.scss
+++ b/assets/css/dup/departures/row.scss
@@ -17,16 +17,19 @@
 
 .departure-row__route {
   display: inline-block;
+  width: 248px;
+  height: 144px;
+  margin: 32px;
   vertical-align: middle;
 
   .departure-row--extended-route_pill & {
     width: 351px;
   }
 
-  &:not(.departure-row__route--yellow) {
-    width: 248px;
-    height: 144px;
-    margin: 32px;
+  &.departure-row__route--yellow {
+    width: auto;
+    height: auto;
+    margin: 0;
   }
 }
 


### PR DESCRIPTION
Description
- the dual route pill takes up slightly more space on DUPs, leading to
  overflow for the time
- cuts the destination width even further to make up for extended times
  and extended pills

<details>
<summary>Screenshots</summary>
<img width="964" height="419" alt="Screenshot 2026-07-22 at 10 50 41 AM" src="https://github.com/user-attachments/assets/6c5b6b35-a1a3-4357-8b21-956cd7e505dc" />
<img width="545" height="455" alt="Screenshot 2026-07-22 at 10 51 13 AM" src="https://github.com/user-attachments/assets/d05a21d0-9fb0-4aa2-81b0-054ec63c50ce" />
</details>

