### PR TITLE
perf: increase GC interval for V3 API static cache

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -470,26 +470,30 @@ config :screens, Screens.ScreensByAlert.SelfRefreshRunner, batch_size: 20, concu
 
 config :screens, Screens.DeviceMonitor.Store, backend: Screens.DeviceMonitor.Store.Local
 
-v3_api_cache_options = [
-  # Set with reference to the "slowest" refresh rate among screen types. In general should be
-  # chosen to minimize the impact of pruning data that hasn't been accessed in (2 * interval);
-  # see documentation for `Nebulex.Adapters.Local`.
-  gc_interval: :timer.seconds(30),
-  stats: true,
-  telemetry_prefix: ~w[screens v3_api cache]a
-]
+v3_api_cache_options = [stats: true, telemetry_prefix: ~w[screens v3_api cache]a]
 
 # Memory limits for V3 API response caches are based on stats measured in a deployed environment.
 # To avoid thrashing and overloading the HTTP connection pool, these can and should be tweaked as
 # the V3 API usage patterns and requirements of the app change over time.
+#
+# GC intervals should be chosen to minimize the impact of pruning data that hasn't been accessed
+# in (2 * interval); see documentation for `Nebulex.Adapters.Local`. Note the interval between
+# two instances of the same V3 API request will typically be much longer than the longest screen
+# refresh rate, because requests from a given screen won't always go to the same app instance.
 
 config :screens,
        Screens.V3Api.Cache.Realtime,
-       Keyword.merge(v3_api_cache_options, allocated_memory: 200 * 1024 * 1024)
+       Keyword.merge(v3_api_cache_options,
+         allocated_memory: 200 * 1024 * 1024,
+         gc_interval: :timer.seconds(30)
+       )
 
 config :screens,
        Screens.V3Api.Cache.Static,
-       Keyword.merge(v3_api_cache_options, allocated_memory: 600 * 1024 * 1024)
+       Keyword.merge(v3_api_cache_options,
+         allocated_memory: 600 * 1024 * 1024,
+         gc_interval: :timer.minutes(5)
+       )
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.


### PR DESCRIPTION
This was originally an experiment, hence the branch name — while it didn't put much of a dent in overall request times, it did dramatically reduce the incidence of timeouts when I tested it in prod, so I'm promoting it to PR.

V3 API static data responses can be unconditionally cached for 30 minutes (and might remain valid for much longer), but they would be evicted from the cache if not accessed in a 60-second period. Despite screen refresh cycles being ≤30 seconds, this is a problem in deployed environments because there is more than one instance of the app, and subsequent data requests from the same screen are unlikely to go to the same instance.

Increase the GC interval to 5 minutes, so even if an instance is "unlucky" (given the current maximum of 5 instances) and receives only 1 in 20 data requests for a given screen, static data will remain available in the cache.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216761382898831