### PR TITLE
feat: filter subway shuttles from departures

### DIFF
--- a/assets/css/dup/departures/destination.scss
+++ b/assets/css/dup/departures/destination.scss
@@ -11,7 +11,7 @@
   // The width of the destination is reduced if either/both of the
   // route pill and time columns need to take up more space.
   .departure-row--extended-route_pill & {
-    width: 967px;
+    width: 810px;
   }
 
   .departures-section--extended-times & {

--- a/assets/css/dup/departures/row.scss
+++ b/assets/css/dup/departures/row.scss
@@ -17,16 +17,19 @@
 
 .departure-row__route {
   display: inline-block;
+  width: 248px;
+  height: 144px;
+  margin: 32px;
   vertical-align: middle;
 
   .departure-row--extended-route_pill & {
     width: 351px;
   }
 
-  &:not(.departure-row__route--yellow) {
-    width: 248px;
-    height: 144px;
-    margin: 32px;
+  &.departure-row__route--yellow {
+    width: auto;
+    height: auto;
+    margin: 0;
   }
 }
 

--- a/lib/screens/lines/line.ex
+++ b/lib/screens/lines/line.ex
@@ -11,4 +11,16 @@ defmodule Screens.Lines.Line do
           short_name: String.t(),
           sort_order: integer()
         }
+
+  @spec cr_line?(t()) :: boolean()
+  def cr_line?(%__MODULE__{id: "line-CR-" <> _line}), do: true
+  def cr_line?(_), do: false
+
+  @spec subway_or_light_rail_line?(t()) :: boolean()
+  def subway_or_light_rail_line?(%__MODULE__{id: "line-Blue"}), do: true
+  def subway_or_light_rail_line?(%__MODULE__{id: "line-Orange"}), do: true
+  def subway_or_light_rail_line?(%__MODULE__{id: "line-Red"}), do: true
+  def subway_or_light_rail_line?(%__MODULE__{id: "line-Green"}), do: true
+  def subway_or_light_rail_line?(%__MODULE__{id: "line-Mattapan"}), do: true
+  def subway_or_light_rail_line?(_), do: false
 end

--- a/lib/screens/routes/route.ex
+++ b/lib/screens/routes/route.ex
@@ -153,4 +153,11 @@ defmodule Screens.Routes.Route do
       other -> other
     end)
   end
+
+  @spec shuttle_route?(t() | nil) :: boolean()
+  def shuttle_route?(%__MODULE__{id: route_id}) do
+    route_id |> String.downcase() |> String.contains?("shuttle")
+  end
+
+  def shuttle_route?(_), do: false
 end

--- a/lib/screens/v2/departure/builder.ex
+++ b/lib/screens/v2/departure/builder.ex
@@ -2,7 +2,9 @@ defmodule Screens.V2.Departure.Builder do
   @moduledoc false
 
   alias Screens.Departures.Departure
+  alias Screens.Lines.Line
   alias Screens.Predictions.Prediction
+  alias Screens.Routes.Route
   alias Screens.Schedules.Schedule
   alias Screens.Stops.Stop
   alias Screens.Trips.Trip
@@ -45,6 +47,7 @@ defmodule Screens.V2.Departure.Builder do
 
   defp relevant_departures(departures, now, opts) do
     departures
+    |> Stream.reject(&subway_shuttle?(&1))
     |> Stream.reject(&unscheduled_cancelled?(&1))
     |> maybe_reject_scheduled_cancelled(opts)
     |> Stream.reject(&in_past_or_nil_time?(&1, now))
@@ -61,6 +64,15 @@ defmodule Screens.V2.Departure.Builder do
       prediction: prediction,
       schedule: Map.get(schedules_by_trip_id, trip_id)
     }
+
+  defp subway_shuttle?(%Departure{
+         prediction: nil,
+         schedule: %Schedule{route: %Route{line: line} = route}
+       }) do
+    Route.shuttle_route?(route) and Line.subway_or_light_rail_line?(line)
+  end
+
+  defp subway_shuttle?(_), do: false
 
   # There isn't much we can do with a cancelled departure with no schedule information other than
   # not present it at all, so always reject those (unclear whether we'd even produce them)

--- a/lib/screens/v2/widget_instance/serializer/route_pill.ex
+++ b/lib/screens/v2/widget_instance/serializer/route_pill.ex
@@ -303,21 +303,14 @@ defmodule Screens.V2.WidgetInstance.Serializer.RoutePill do
   end
 
   @spec shuttle_route?(Route.t() | nil, Screen.t()) :: boolean()
-  def shuttle_route?(%Route{id: route_id, line: %Line{id: line_id}}, %Screen{app_id: app_id}) do
+  def shuttle_route?(%Route{line: line} = route, %Screen{app_id: app_id}) do
     # Shuttle routes have special pills on specific screens
-    # We only show special pills for shuttles replacing subway or CR lines
-    route_id |> String.downcase() |> String.contains?("shuttle") and
-      rail_line?(line_id) and
+    # We only show special pills for shuttles replacing CR lines
+    Route.shuttle_route?(route) and Line.cr_line?(line) and
       app_id in @shuttle_pill_enabled_screens
   end
 
   def shuttle_route?(_, _), do: false
-
-  defp rail_line?("line-Blue"), do: true
-  defp rail_line?("line-Orange"), do: true
-  defp rail_line?("line-Red"), do: true
-  defp rail_line?("line-CR-" <> _line), do: true
-  defp rail_line?(_), do: false
 
   @spec do_serialize_shuttle_pill(Line.id()) :: dual_route_pill()
   defp do_serialize_shuttle_pill(line_id) do

--- a/test/screens/v2/departure/builder_test.exs
+++ b/test/screens/v2/departure/builder_test.exs
@@ -1,6 +1,7 @@
 defmodule Screens.V2.Departure.BuilderTest do
   use ExUnit.Case, async: true
 
+  alias Screens.Lines.Line
   alias Screens.Predictions.Prediction
   alias Screens.Routes.Route
   alias Screens.Schedules.Schedule
@@ -190,6 +191,51 @@ defmodule Screens.V2.Departure.BuilderTest do
       expected = to_departures([p1, p4, p5, p6])
 
       assert Enum.sort(actual) == Enum.sort(expected)
+    end
+
+    test "filters out subway shuttle schedules" do
+      predictions = []
+
+      s1 = %Schedule{
+        id: "s1",
+        route: %Route{id: "Red Shuttle (shuttle)", line: %Line{id: "line-Red"}},
+        departure_time: ~U[2020-02-01T00:01:00Z],
+        trip: %Trip{route_id: "Red Shuttle (shuttle)", id: "t1"}
+      }
+
+      s2 = %Schedule{
+        id: "s2",
+        route: %Route{id: "Blue Shuttle (shuttle)", line: %Line{id: "line-Blue"}},
+        departure_time: ~U[2020-02-01T00:01:00Z],
+        trip: %Trip{route_id: "Blue Shuttle (shuttle)", id: "t2"}
+      }
+
+      s3 = %Schedule{
+        id: "s3",
+        route: %Route{id: "Green Shuttle (shuttle)", line: %Line{id: "line-Green"}},
+        departure_time: ~U[2020-02-01T00:01:00Z],
+        trip: %Trip{route_id: "Green Shuttle (shuttle)", id: "t3"}
+      }
+
+      s4 = %Schedule{
+        id: "s4",
+        route: %Route{id: "Orange Shuttle (shuttle)", line: %Line{id: "line-Orange"}},
+        departure_time: ~U[2020-02-01T00:01:00Z],
+        trip: %Trip{route_id: "Orange Shuttle (shuttle)", id: "t4"}
+      }
+
+      s5 = %Schedule{
+        id: "s5",
+        route: %Route{id: "CR Lowell Shuttle (shuttle)", line: %Line{id: "line-CR-Lowell"}},
+        departure_time: ~U[2020-02-01T00:01:00Z],
+        trip: %Trip{route_id: "CR Lowell Shuttle (shuttle)", id: "t5"}
+      }
+
+      schedules = [s1, s2, s3, s4, s5]
+
+      expected = [%Departure{prediction: nil, schedule: s5}]
+
+      assert expected == Builder.build(predictions, schedules, @now)
     end
 
     test "sorts departures by arrival time if present, departure time if not" do

--- a/test/screens/v2/widget_instance/departures_test.exs
+++ b/test/screens/v2/widget_instance/departures_test.exs
@@ -766,34 +766,31 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
       departure = %Departure{
         prediction: %Prediction{
           trip: %Trip{
-            headsign: "Alewife (Shuttle)"
+            headsign: "Lowell (Shuttle)"
           },
-          route: route(id: "AlewifeShuttle", line_id: "line-Red")
+          route: route(id: "CR-Lowell Shuttle (shuttle)", line_id: "line-CR-Lowell")
         }
       }
 
-      assert %{headsigns: ["Alewife"], variation: nil} ==
+      assert %{variation: nil, headsigns: ["Lowell"]} ==
                Departures.serialize_headsign([departure], bus_shelter_screen)
 
-      assert %{headsigns: ["Alewife"], variation: nil} ==
+      assert %{variation: nil, headsigns: ["Lowell"]} ==
                Departures.serialize_headsign([departure], dup_screen)
 
       departure = %Departure{
         prediction: %Prediction{
           trip: %Trip{
-            headsign: "Alewife (Express Shuttle)"
+            headsign: "Lowell (Express Shuttle)"
           },
-          route: route(id: "AlewifeExpressShuttle", line_id: "line-Red")
+          route: route(id: "Lowell Express Shuttle (shuttle)", line_id: "line-CR-Lowell")
         }
       }
 
-      assert %{headsigns: ["Alewife"], variation: "(Express)"} ==
+      assert %{variation: "(Express)", headsigns: ["Lowell"]} ==
                Departures.serialize_headsign([departure], bus_shelter_screen)
 
-      assert %{
-               headsigns: ["Alewife (Express)"],
-               variation: nil
-             } ==
+      assert %{headsigns: ["Lowell (Express)"], variation: nil} ==
                Departures.serialize_headsign([departure], dup_screen)
     end
 

--- a/test/screens/v2/widget_instance/serializer/route_pill_test.exs
+++ b/test/screens/v2/widget_instance/serializer/route_pill_test.exs
@@ -146,42 +146,6 @@ defmodule Screens.V2.WidgetInstance.Serializer.RoutePillTest do
                )
     end
 
-    test "Returns dual pill for Red Line shuttle", %{pre_fare_screen: screen} do
-      route =
-        route(
-          id: "Shuttle-BoylstonKenmore (shuttle)",
-          type: :bus,
-          line_id: "line-Red"
-        )
-
-      assert %{type: :dual, text: "RL", icon: :bus, color: :red, secondary_color: :yellow} ==
-               serialize_for_departure(route, nil, screen)
-    end
-
-    test "Returns dual pill for Blue Line shuttle", %{pre_fare_screen: screen} do
-      route =
-        route(
-          id: "Blue Line Shuttle (shuttle)",
-          type: :bus,
-          line_id: "line-Blue"
-        )
-
-      assert %{type: :dual, text: "BL", icon: :bus, color: :blue, secondary_color: :yellow} ==
-               serialize_for_departure(route, nil, screen)
-    end
-
-    test "Returns dual pill for Orange Line shuttle", %{pre_fare_screen: screen} do
-      route =
-        route(
-          id: "Orange Line Shuttle (shuttle)",
-          type: :bus,
-          line_id: "line-Orange"
-        )
-
-      assert %{type: :dual, text: "OL", icon: :bus, color: :orange, secondary_color: :yellow} ==
-               serialize_for_departure(route, nil, screen)
-    end
-
     test "Returns dual pill for Commuter Rail shuttle", %{pre_fare_screen: screen} do
       route =
         route(


### PR DESCRIPTION
Description
- with RDS, we now show schedules for buses but because of this, we are now displaying shuttle schedule times for Subway lines
- filter out subway shuttles because they aren't particularly useful information and we would prefer showing other information if we can

Before: 
<img width="961" height="544" alt="Screenshot 2026-07-22 at 10 54 55 AM" src="https://github.com/user-attachments/assets/4b92523b-129c-4569-9b33-21b755fbd79d" />

After:
<img width="964" height="550" alt="Screenshot 2026-07-22 at 10 54 31 AM" src="https://github.com/user-attachments/assets/64f653ec-55e7-4bd3-9c26-f7b24d640d8a" />

(Disregard the visual bug, that will be fixed in an upcoming PR that handles Dual Pill routes for CR)

- [x] Tests modified?
