### PR TITLE
fix: Render departures audio properly for headsigns

### DIFF
--- a/lib/screens_web/views/v2/audio/departures_view.ex
+++ b/lib/screens_web/views/v2/audio/departures_view.ex
@@ -137,11 +137,11 @@ defmodule ScreensWeb.V2.Audio.DeparturesView do
     end
   end
 
-  defp render_headsign(%{headsign: headsign, variation: nil}) do
+  defp render_headsign(%{headsigns: [headsign | _], variation: nil}) do
     ~E|<%= headsign %>|
   end
 
-  defp render_headsign(%{headsign: headsign, variation: variation}) do
+  defp render_headsign(%{headsigns: [headsign | _], variation: variation}) do
     ~E|<%= headsign %> <%= variation %>|
   end
 

--- a/test/screens_web/views/v2/audio/departures_view_test.exs
+++ b/test/screens_web/views/v2/audio/departures_view_test.exs
@@ -25,7 +25,7 @@ defmodule ScreensWeb.V2.Audio.DeparturesViewTest do
             track_number: nil,
             route_text: "Red Line"
           },
-          headsign: %{headsign: "Ashmont", variation: nil}
+          headsign: %{headsigns: ["Ashmont"], variation: nil}
         }
       ]
     }
@@ -96,7 +96,7 @@ defmodule ScreensWeb.V2.Audio.DeparturesViewTest do
                   track_number: nil,
                   route_text: "Green Line B"
                 },
-                headsign: %{headsign: "Boston College", variation: nil}
+                headsign: %{headsigns: ["Boston College", "Boston Col"], variation: nil}
               },
               normal: %{
                 type: :departure_row,
@@ -118,7 +118,7 @@ defmodule ScreensWeb.V2.Audio.DeparturesViewTest do
                   track_number: nil,
                   route_text: "Red Line"
                 },
-                headsign: %{headsign: "Alewife", variation: nil}
+                headsign: %{headsigns: ["Alewife"], variation: nil}
               }
             ]
           }
@@ -156,7 +156,7 @@ defmodule ScreensWeb.V2.Audio.DeparturesViewTest do
                   }
                 ],
                 route: %{id: "73", vehicle_type: :bus, track_number: "E", route_text: "73"},
-                headsign: %{headsign: "Waverley", variation: nil}
+                headsign: %{headsigns: ["Waverley"], variation: nil}
               },
               normal: %{
                 type: :departure_row,
@@ -173,7 +173,7 @@ defmodule ScreensWeb.V2.Audio.DeparturesViewTest do
                   track_number: "5",
                   route_text: "Needham Line"
                 },
-                headsign: %{headsign: "South Station", variation: nil}
+                headsign: %{headsigns: ["South Station"], variation: nil}
               }
             ]
           }


### PR DESCRIPTION
A fix for Sentry issue: https://mbtace.sentry.io/issues/7629292553/

Fix tested and working locally