### PR TITLE
chore: Add new abbreviation for Newton Highlands headsign

### DIFF
--- a/lib/screens/headsigns/data.ex
+++ b/lib/screens/headsigns/data.ex
@@ -69,7 +69,7 @@ defmodule Screens.Headsigns.Data do
     "Museum of Fine Arts" => ["Museum of Fine Arts", "MFA"],
     "Needham Heights" => ["Needham Heights", "Needham Hts"],
     "Newton Centre" => ["Newton Centre", "Newton Ctr"],
-    "Newton Highlands" => ["Newton Highlands", "Newton Hlnd"],
+    "Newton Highlands" => ["Newton Highlands", "Nwtn Highlands", "Newton Hlnd"],
     "North Quincy" => ["North Quincy", "N Quincy"],
     "North Station" => ["North Station", "North Sta"],
     "Northeastern" => ["Northeastern University", "Northeastern", "Northeast'n"],


### PR DESCRIPTION
See [this Slack thread ](https://mbta.slack.com/archives/C039ARUM48H/p1785437974468899)


TLDR: The below looks better on prefares.
<img width="430" height="255" alt="image" src="https://github.com/user-attachments/assets/1400686e-2c08-4cac-a651-5025b161660b" />
