### PR TITLE
chore: remove candidate generator variants

### DIFF
--- a/assets/src/components/admin/inspector.tsx
+++ b/assets/src/components/admin/inspector.tsx
@@ -32,23 +32,13 @@ const APP_IDS = new Set(Object.keys(SCREEN_APPS));
 const MAX_SSML_BILLED_CHARS = 3000;
 const MAX_SSML_TOTAL_CHARS = 6000;
 
-const anyVariantsExist = Object.values(SCREEN_APPS).some(
-  ({ variants }) => variants.length > 0,
-);
-
-const buildIframeUrl = (
-  screen: ScreenWithId | null,
-  isSimulation: boolean,
-  isVariantEnabled: boolean,
-) => {
+const buildIframeUrl = (screen: ScreenWithId | null, isSimulation: boolean) => {
   if (screen) {
     const pathSuffix = isSimulation ? "/simulation" : "";
     const url = new URL(
       `/v2/screen/${screen.id}${pathSuffix}`,
       location.origin.toString(),
     );
-
-    if (isVariantEnabled) url.searchParams.append("variant", "all");
 
     return url.toString();
   } else {
@@ -86,9 +76,8 @@ const Inspector: ComponentType = () => {
       : null;
 
   const [isSimulation, setIsSimulation] = useState(false);
-  const [isVariantEnabled, setIsVariantEnabled] = useState(false);
 
-  const iframeUrl = buildIframeUrl(screen, isSimulation, isVariantEnabled);
+  const iframeUrl = buildIframeUrl(screen, isSimulation);
 
   const frameRef = useRef<HTMLIFrameElement>(null);
 
@@ -116,8 +105,6 @@ const Inspector: ComponentType = () => {
               reloadFrame={reloadFrame}
               isSimulation={isSimulation}
               setIsSimulation={setIsSimulation}
-              isVariantEnabled={isVariantEnabled}
-              setIsVariantEnabled={setIsVariantEnabled}
             />
 
             {screen && (
@@ -135,8 +122,6 @@ const Inspector: ComponentType = () => {
                   // Reset when the iframe reloads, since the screen will no
                   // longer be aware of previously-sent inspector messages
                   key={"data-controls-" + frameLoadedAt}
-                  isVariantEnabled={isVariantEnabled}
-                  screen={screen}
                   sendToFrame={sendToFrame}
                 />
                 <AudioControls
@@ -174,17 +159,7 @@ const ScreenSelector: ComponentType<{
   reloadFrame: () => void;
   isSimulation: boolean;
   setIsSimulation: (value: boolean) => void;
-  isVariantEnabled: boolean;
-  setIsVariantEnabled: (value: boolean) => void;
-}> = ({
-  config,
-  screen,
-  reloadFrame,
-  isSimulation,
-  setIsSimulation,
-  isVariantEnabled,
-  setIsVariantEnabled,
-}) => {
+}> = ({ config, screen, reloadFrame, isSimulation, setIsSimulation }) => {
   const navigate = useNavigate();
   const { pathname, search } = useLocation();
 
@@ -238,17 +213,6 @@ const ScreenSelector: ComponentType<{
         />
         Screenplay simulation
       </label>
-
-      {anyVariantsExist && (
-        <label>
-          <input
-            type="checkbox"
-            checked={isVariantEnabled}
-            onChange={() => setIsVariantEnabled(!isVariantEnabled)}
-          />
-          Enable variant switcher
-        </label>
-      )}
 
       <button onClick={reloadFrame}>🔄 Reload Screen</button>
     </fieldset>
@@ -350,14 +314,11 @@ const ViewControls: ComponentType<{
 };
 
 const DataControls: ComponentType<{
-  isVariantEnabled: boolean;
-  screen: ScreenWithId;
   sendToFrame: (message: Message) => void;
-}> = ({ isVariantEnabled, screen, sendToFrame }) => {
+}> = ({ sendToFrame }) => {
   const [dataTimestamp, setDataTimestamp] = useState<number | null>(null);
   const [dataSecondsOld, setDataSecondsOld] = useState<number | null>(null);
   const [isRefreshEnabled, setIsRefreshEnabled] = useState(true);
-  const [variant, setVariant] = useState<string | null>(null);
 
   useReceiveMessage((message) => {
     if (message.type === "data_refreshed") {
@@ -378,11 +339,6 @@ const DataControls: ComponentType<{
   const updateIsRefreshEnabled = (isEnabled) => {
     setIsRefreshEnabled(isEnabled);
     sendToFrame({ type: "set_refresh_rate", ms: isEnabled ? null : 0 });
-  };
-
-  const updateVariant = (newVariant) => {
-    setVariant(newVariant);
-    sendToFrame({ type: "set_data_variant", variant: newVariant });
   };
 
   return (
@@ -409,34 +365,6 @@ const DataControls: ComponentType<{
           Enable refresh interval
         </label>
       </fieldset>
-
-      {isVariantEnabled && (
-        <fieldset>
-          <legend>Variants</legend>
-
-          <label>
-            <input
-              type="radio"
-              name="variant"
-              checked={variant === null}
-              onChange={() => updateVariant(null)}
-            />
-            Default
-          </label>
-
-          {SCREEN_APPS[screen.config.app_id].variants.map((v) => (
-            <label key={v}>
-              <input
-                type="radio"
-                name="variant"
-                checked={variant === v}
-                onChange={() => updateVariant(v)}
-              />
-              <code>{v}</code>
-            </label>
-          ))}
-        </fieldset>
-      )}
     </>
   );
 };

--- a/assets/src/hooks/use_api_response.ts
+++ b/assets/src/hooks/use_api_response.ts
@@ -21,12 +21,7 @@ const BASE_PATH = "/v2/api/screen";
 const MINUTE_IN_MS = 60_000;
 
 type SimulationResponse = { full_page: WidgetData; flex_zone: WidgetData[] };
-
-type DataResponse<T extends SimulationResponse | WidgetData> = {
-  data: T;
-  variants?: Record<string, T>;
-};
-
+type DataResponse<T extends SimulationResponse | WidgetData> = { data: T };
 type SimulationData = { fullPage: WidgetData; flexZone: WidgetData[] };
 
 type Success = { state: "success"; data: WidgetData };
@@ -44,34 +39,23 @@ type NonSuccess =
 
 type ApiResponse = Success | SimulationSuccess | NonSuccess;
 
-type ApiResponseWithVariants =
-  | (Success & { variants?: Record<string, WidgetData> })
-  | (SimulationSuccess & { variants?: Record<string, SimulationData> })
-  | NonSuccess;
-
 const FAILURE_RESPONSE: ApiResponse = { state: "failure" };
 const LOADING_RESPONSE: ApiResponse = { state: "loading" };
 
-const parseRawResponse = (json): ApiResponseWithVariants => {
+const parseRawResponse = (json): ApiResponse => {
   if (json.disabled) {
     return { state: "disabled" };
   } else if (json.data) {
     if ("full_page" in json.data) {
-      const { data, variants } = json as DataResponse<SimulationResponse>;
+      const { data } = json as DataResponse<SimulationResponse>;
 
       return {
         state: "simulation_success",
         data: parseSimulationResponse(data),
-        variants: Object.fromEntries(
-          Object.entries(variants ?? {}).map(([variant, data]) => [
-            variant,
-            parseSimulationResponse(data),
-          ]),
-        ),
       };
     } else {
-      const { data, variants } = json as DataResponse<WidgetData>;
-      return { state: "success", data, variants };
+      const { data } = json as DataResponse<WidgetData>;
+      return { state: "success", data };
     }
   } else {
     return { state: "failure" };
@@ -138,7 +122,6 @@ const useApiPath = (screenId: string, appendPath?: string): string => {
       requestor: getDatasetValue("requestor"),
       rotation_index: getRotationIndex(),
       screen_side: getScreenSide(),
-      variant: getDatasetValue("variant"),
       version: getVersion(),
     };
 
@@ -219,36 +202,9 @@ const useBaseApiResponse = ({
     refreshRateOffsetMs,
   );
 
-  const variant = useInspectorVariant();
   useInspectorControls(fetchData, lastSuccess);
 
-  return {
-    apiResponse: selectVariant(apiResponse, variant),
-    requestCount,
-    lastSuccess,
-  };
-};
-
-const selectVariant = (
-  response: ApiResponseWithVariants,
-  variant: string | null,
-): ApiResponse => {
-  if (variant && isSuccess(response) && response.variants) {
-    if (variant in response.variants) {
-      // This seems like it should be replacable with a less "mutable" approach
-      // such as `return { ...response, data: response.variants[variant] }`, but
-      // the compiler can't work out that the types are compatible. Maybe check
-      // this again once we upgrade to TypeScript 5.
-      const copy = { ...response };
-      copy.data = response.variants[variant];
-      delete copy.variants;
-      return copy;
-    } else {
-      return FAILURE_RESPONSE;
-    }
-  } else {
-    return response;
-  }
+  return { apiResponse, requestCount, lastSuccess };
 };
 
 const useInspectorRateOverride = (): number | null => {
@@ -259,16 +215,6 @@ const useInspectorRateOverride = (): number | null => {
   });
 
   return override;
-};
-
-const useInspectorVariant = (): string | null => {
-  const [variant, setVariant] = useState<string | null>(null);
-
-  useReceiveFromInspector((message) => {
-    if (message.type === "set_data_variant") setVariant(message.variant);
-  });
-
-  return variant;
 };
 
 const useInspectorControls = (

--- a/assets/src/util/admin.tsx
+++ b/assets/src/util/admin.tsx
@@ -31,15 +31,15 @@ export type AppId =
   | "gl_eink_v2"
   | "pre_fare_v2";
 
-type AppInfo = { name: string; hasAudio: boolean; variants: string[] };
+type AppInfo = { name: string; hasAudio: boolean };
 
 export const SCREEN_APPS: { [key in AppId]: AppInfo } = {
-  bus_eink_v2: { name: "Bus E-ink", hasAudio: true, variants: [] },
-  bus_shelter_v2: { name: "Bus Shelter", hasAudio: true, variants: [] },
-  busway_v2: { name: "Sectional", hasAudio: true, variants: [] },
-  dup_v2: { name: "DUP", hasAudio: false, variants: [] },
-  gl_eink_v2: { name: "GL E-ink", hasAudio: true, variants: [] },
-  pre_fare_v2: { name: "Pre-Fare", hasAudio: true, variants: [] },
+  bus_eink_v2: { name: "Bus E-ink", hasAudio: true },
+  bus_shelter_v2: { name: "Bus Shelter", hasAudio: true },
+  busway_v2: { name: "Sectional", hasAudio: true },
+  dup_v2: { name: "DUP", hasAudio: false },
+  gl_eink_v2: { name: "GL E-ink", hasAudio: true },
+  pre_fare_v2: { name: "Pre-Fare", hasAudio: true },
 };
 
 export const SCREEN_APP_ENTRIES = (

--- a/assets/src/util/inspector.ts
+++ b/assets/src/util/inspector.ts
@@ -15,7 +15,6 @@ export type Message =
   | { type: "audio_config"; config: AudioConfig | null }
   | { type: "data_refreshed"; timestamp: number }
   | { type: "refresh_data" }
-  | { type: "set_data_variant"; variant: string | null }
   | { type: "set_refresh_rate"; ms: number | null };
 
 export const INSPECTOR_FRAME_NAME = "screen-inspector-frame";

--- a/config/config.exs
+++ b/config/config.exs
@@ -35,7 +35,6 @@ config :logger, :console,
     rotation_index
     screen_id
     screen_side
-    variant
     vendor
   ]a
 

--- a/lib/screens/application.ex
+++ b/lib/screens/application.ex
@@ -25,8 +25,6 @@ defmodule Screens.Application do
         {Task.Supervisor, name: Screens.ScreensByAlert.SelfRefreshRunner.TaskSupervisor},
         # ScreensByAlert self-refresh job runner
         self_refresh_runner_child(),
-        # Task supervisor for parallel running of candidate generator variants
-        {Task.Supervisor, name: Screens.V2.ScreenData.ParallelRunSupervisor},
         {Task.Supervisor, name: Screens.DeviceMonitor.Supervisor},
         Screens.DeviceMonitor,
         Screens.Telemetry,

--- a/lib/screens/v2/screen_data.ex
+++ b/lib/screens/v2/screen_data.ex
@@ -6,7 +6,8 @@ defmodule Screens.V2.ScreenData do
   alias Screens.V2.Template
   alias Screens.V2.WidgetInstance
   alias ScreensConfig.Screen
-  alias __MODULE__.{ParallelRunSupervisor, Layout}
+
+  alias __MODULE__.Layout
 
   import Screens.Inject
   import Screens.V2.Template.Guards, only: [is_slot_id: 1, is_paged_slot_id: 1]
@@ -15,64 +16,27 @@ defmodule Screens.V2.ScreenData do
 
   @type t :: %{type: atom()}
   @type simulation_data :: %{full_page: t(), flex_zone: [t()]}
-  @type variants(data) :: {data, %{String.t() => data}}
   @type options :: [
-          generator_variant: String.t() | nil,
-          run_all_variants?: boolean(),
           update_visible_alerts_for_screen_id: String.t()
         ]
 
   @callback get(Screen.t()) :: t()
   @callback get(Screen.t(), options()) :: t()
-  def get(screen, opts \\ []), do: select_variant(screen, opts, &layout_to_data/2)
+  def get(screen, opts \\ []), do: generate(screen, opts, &layout_to_data/2)
 
   @spec simulation(Screen.t()) :: simulation_data()
   @spec simulation(Screen.t(), options()) :: simulation_data()
-  def simulation(screen, opts \\ []),
-    do: select_variant(screen, opts, &layout_to_simulation_data/2)
+  def simulation(screen, opts \\ []), do: generate(screen, opts, &layout_to_simulation_data/2)
 
-  @spec variants(Screen.t()) :: variants(t())
-  def variants(screen), do: all_variants(screen, &layout_to_data/2)
-
-  @spec simulation_variants(Screen.t()) :: variants(simulation_data())
-  def simulation_variants(screen), do: all_variants(screen, &layout_to_simulation_data/2)
-
-  @spec select_variant(Screen.t(), options(), (Layout.t(), Screen.t() -> data)) :: data
+  @spec generate(Screen.t(), options(), (Layout.t(), Screen.t() -> data)) :: data
         when data: t() | simulation_data()
-  defp select_variant(screen, opts, then_fn) do
+  defp generate(screen, opts, then_fn) do
     update_visible_alerts_in_progress(screen, opts)
-    selected_variant = Keyword.get(opts, :generator_variant)
-
-    if Keyword.get(opts, :run_all_variants?, false) do
-      other_variants = List.delete([nil | @parameters.variants(screen)], selected_variant)
-
-      Enum.each(other_variants, fn variant ->
-        {:ok, _pid} =
-          Task.Supervisor.start_child(ParallelRunSupervisor, fn ->
-            screen |> Layout.generate(variant) |> then_fn.(screen)
-          end)
-      end)
-    end
 
     screen
-    |> Layout.generate(selected_variant)
+    |> Layout.generate()
     |> tap(&update_visible_alerts(&1, screen, opts))
     |> then_fn.(screen)
-  end
-
-  @spec all_variants(Screen.t(), (Layout.t(), Screen.t() -> data)) :: {data, %{atom() => data}}
-        when data: t() | simulation_data()
-  defp all_variants(screen, then_fn) do
-    ParallelRunSupervisor
-    |> Task.Supervisor.async_stream(
-      [nil | @parameters.variants(screen)],
-      fn variant ->
-        {variant, screen |> Layout.generate(variant) |> then_fn.(screen)}
-      end
-    )
-    |> Enum.map(fn {:ok, result} -> result end)
-    |> Enum.split(1)
-    |> then(fn {[{nil, default}], variants} -> {default, Map.new(variants)} end)
   end
 
   @spec layout_to_data(Layout.t(), Screen.t()) :: t()

--- a/lib/screens/v2/screen_data/layout.ex
+++ b/lib/screens/v2/screen_data/layout.ex
@@ -26,9 +26,8 @@ defmodule Screens.V2.ScreenData.Layout do
         }
 
   @spec generate(Screen.t()) :: t()
-  @spec generate(Screen.t(), String.t() | nil) :: t()
-  def generate(config, variant \\ nil) do
-    candidate_generator = @parameters.candidate_generator(config, variant)
+  def generate(config) do
+    candidate_generator = @parameters.candidate_generator(config)
     screen_template = candidate_generator.screen_template(config)
 
     config

--- a/lib/screens/v2/screen_data/parameters.ex
+++ b/lib/screens/v2/screen_data/parameters.ex
@@ -117,17 +117,10 @@ defmodule Screens.V2.ScreenData.Parameters do
   end
 
   @callback candidate_generator(Screen.t()) :: module()
-  @callback candidate_generator(Screen.t(), String.t() | nil) :: module()
-  @callback candidate_generator(Screen.t(), String.t() | nil, static_params()) :: module()
-  def candidate_generator(
-        %Screen{app_id: app_id},
-        variant \\ nil,
-        static_params \\ @static_params
-      ) do
-    case Map.fetch!(static_params, app_id) do
-      %Static{candidate_generator: default} when is_nil(variant) -> default
-      %Static{variants: %{^variant => variant}} -> variant
-    end
+  @callback candidate_generator(Screen.t(), static_params()) :: module()
+  def candidate_generator(%Screen{app_id: app_id}, static_params \\ @static_params) do
+    %Static{candidate_generator: generator} = Map.fetch!(static_params, app_id)
+    generator
   end
 
   @callback refresh_rate(Screen.t() | Screen.app_id()) :: pos_integer() | nil
@@ -140,12 +133,5 @@ defmodule Screens.V2.ScreenData.Parameters do
   def refresh_rate(app_id, static_params) do
     %Static{refresh_rate: refresh_rate} = Map.fetch!(static_params, app_id)
     refresh_rate
-  end
-
-  @callback variants(Screen.t()) :: [String.t()]
-  @callback variants(Screen.t(), static_params()) :: [String.t()]
-  def variants(%Screen{app_id: app_id}, static_params \\ @static_params) do
-    %Static{variants: variants} = Map.fetch!(static_params, app_id)
-    Map.keys(variants)
   end
 end

--- a/lib/screens/v2/screen_data/static.ex
+++ b/lib/screens/v2/screen_data/static.ex
@@ -28,10 +28,9 @@ defmodule Screens.V2.ScreenData.Static do
           audio_active_time: time_range() | nil,
           candidate_generator: module(),
           periodic_audio: PeriodicAudio.t() | nil,
-          refresh_rate: pos_integer(),
-          variants: %{String.t() => module()}
+          refresh_rate: pos_integer()
         }
 
   @enforce_keys ~w[candidate_generator refresh_rate]a
-  defstruct @enforce_keys ++ [audio_active_time: nil, periodic_audio: nil, variants: %{}]
+  defstruct @enforce_keys ++ [audio_active_time: nil, periodic_audio: nil]
 end

--- a/lib/screens_web/controllers/v2/screen_api_controller.ex
+++ b/lib/screens_web/controllers/v2/screen_api_controller.ex
@@ -20,10 +20,10 @@ defmodule ScreensWeb.V2.ScreenApiController do
   plug :disabled_response when action in @non_pending_show_actions
   plug :outdated_response when action in @non_pending_show_actions
 
-  def show(%{assigns: %{screen_id: screen_id, screen: screen, variant: variant}} = conn, _params) do
+  def show(%{assigns: %{screen_id: screen_id, screen: screen}} = conn, _params) do
     response =
       screen
-      |> screen_response(variant, update_visible_alerts_for_screen_id: screen_id)
+      |> screen_response(update_visible_alerts_for_screen_id: screen_id)
       |> put_extra_fields(screen)
 
     json(conn, response)
@@ -31,14 +31,9 @@ defmodule ScreensWeb.V2.ScreenApiController do
 
   def show_dup(conn, params), do: show(conn, params)
 
-  def simulation(
-        %{assigns: %{screen_id: screen_id, screen: screen, variant: variant}} = conn,
-        _params
-      ) do
-    json(
-      conn,
-      simulation_response(screen, variant, update_visible_alerts_for_screen_id: screen_id)
-    )
+  def simulation(%{assigns: %{screen_id: screen_id, screen: screen}} = conn, _params) do
+    data = ScreenData.simulation(screen, update_visible_alerts_for_screen_id: screen_id)
+    json(conn, %{@base_response | data: data})
   end
 
   def show_pending(%{assigns: %{screen: screen}} = conn, _params) do
@@ -85,22 +80,14 @@ defmodule ScreensWeb.V2.ScreenApiController do
     )
   end
 
-  defp screen_response(screen, "all", _opts) do
-    {default, variants} = ScreenData.variants(screen)
-    Map.put(%{@base_response | data: default}, :variants, variants)
-  end
-
   # See `docs/mercury_api.md`
-  defp screen_response(%Screen{vendor: :mercury} = screen, variant, opts) do
-    %{full_page: data, flex_zone: flex_zone} =
-      ScreenData.simulation(screen, merge_options(variant, opts))
-
+  defp screen_response(%Screen{vendor: :mercury} = screen, opts) do
+    %{full_page: data, flex_zone: flex_zone} = ScreenData.simulation(screen, opts)
     Map.merge(%{@base_response | data: data}, %{flex_zone: flex_zone})
   end
 
-  defp screen_response(screen, variant, opts) do
-    data = ScreenData.get(screen, merge_options(variant, opts))
-    %{@base_response | data: data}
+  defp screen_response(screen, opts) do
+    %{@base_response | data: ScreenData.get(screen, opts)}
   end
 
   # See `docs/mercury_api.md`
@@ -120,19 +107,6 @@ defmodule ScreensWeb.V2.ScreenApiController do
       data ->
         View.render_to_string(ScreensWeb.V2.AudioView, "index.ssml", widget_audio_data: data)
     end
-  end
-
-  defp simulation_response(screen, "all", _opts) do
-    {default, variants} = ScreenData.simulation_variants(screen)
-    Map.put(%{@base_response | data: default}, :variants, variants)
-  end
-
-  defp simulation_response(screen, variant, opts) do
-    %{@base_response | data: ScreenData.simulation(screen, merge_options(variant, opts))}
-  end
-
-  defp merge_options(variant, opts) do
-    Keyword.put(opts, :generator_variant, variant)
   end
 
   defp disabled_response(%{assigns: %{screen: %Screen{disabled: true}}} = conn, _) do

--- a/lib/screens_web/plug/screen_request.ex
+++ b/lib/screens_web/plug/screen_request.ex
@@ -75,8 +75,7 @@ defmodule ScreensWeb.Plug.ScreenRequest do
       requestor: params["requestor"],
       rotation_index: params["rotation_index"],
       screen_id: screen_id,
-      screen_side: screen_side(app_params, params),
-      variant: params["variant"]
+      screen_side: screen_side(app_params, params)
     ]
 
     Logger.metadata(meta_base ++ meta_assigns)

--- a/lib/screens_web/templates/v2/screen/index.html.eex
+++ b/lib/screens_web/templates/v2/screen/index.html.eex
@@ -21,7 +21,4 @@
     data-screenplay-fullstory-org-id="<%= assigns[:screenplay_fullstory_org_id] %>"
   <% end %>
   data-sentry="<%= @sentry_dsn %>"
-  <%= if assigns[:variant] do %>
-    data-variant="<%= @variant %>"
-  <% end %>
 ></div>

--- a/test/screens/v2/screen_data/parameters_test.exs
+++ b/test/screens/v2/screen_data/parameters_test.exs
@@ -131,12 +131,7 @@ defmodule Screens.V2.ScreenData.ParametersTest do
   describe "candidate_generator/2" do
     test "returns the candidate generator for a screen type" do
       static_params = build_params(candidate_generator: :default)
-      assert Parameters.candidate_generator(build_screen(), nil, static_params) == :default
-    end
-
-    test "returns a variant candidate generator" do
-      static_params = build_params(candidate_generator: :default, variants: %{"test" => :variant})
-      assert Parameters.candidate_generator(build_screen(), "test", static_params) == :variant
+      assert Parameters.candidate_generator(build_screen(), static_params) == :default
     end
   end
 
@@ -144,13 +139,6 @@ defmodule Screens.V2.ScreenData.ParametersTest do
     test "returns the configured refresh rate for a screen type" do
       static_params = build_params(refresh_rate: 25)
       assert Parameters.refresh_rate(build_screen(), static_params) == 25
-    end
-  end
-
-  describe "variants/1" do
-    test "returns the list of variants for a screen type" do
-      static_params = build_params(variants: %{"one" => :test1, "two" => :test2})
-      assert Parameters.variants(build_screen(), static_params) == ["one", "two"]
     end
   end
 end

--- a/test/screens/v2/screen_data_test.exs
+++ b/test/screens/v2/screen_data_test.exs
@@ -6,7 +6,6 @@ defmodule Screens.V2.ScreenDataTest do
   alias Screens.V2.WidgetInstance.{MockWidget, Placeholder}
   alias ScreensConfig.Screen
 
-  import ExUnit.CaptureLog
   import Screens.Inject
   import Mox
   setup :verify_on_exit!
@@ -16,7 +15,6 @@ defmodule Screens.V2.ScreenDataTest do
   require Stub
 
   Stub.candidate_generator(GrayGenerator, fn _ -> [placeholder(:gray)] end)
-  Stub.candidate_generator(GreenGenerator, fn _ -> [placeholder(:green)] end)
 
   Stub.candidate_generator(CrashGenerator, fn %Screen{app_params: %{test_pid: pid}} ->
     send(pid, {:crash_running, self()})
@@ -39,76 +37,10 @@ defmodule Screens.V2.ScreenDataTest do
     test "gets widget data for a screen" do
       screen = build_screen(%{app_id: :test_app})
 
-      expect(
-        @parameters,
-        :candidate_generator,
-        fn %Screen{app_id: :test_app}, nil -> GrayGenerator end
-      )
+      expect(@parameters, :candidate_generator, fn %Screen{app_id: :test_app} -> GrayGenerator end)
 
       assert ScreenData.get(screen) ==
                %{type: :normal, main: %{type: :placeholder, color: :gray, text: ""}}
-    end
-
-    test "selects a variant candidate generator" do
-      screen = build_screen(%{app_id: :test_app})
-
-      expect(
-        @parameters,
-        :candidate_generator,
-        fn %Screen{app_id: :test_app}, "test_variant" -> GrayGenerator end
-      )
-
-      assert ScreenData.get(screen, generator_variant: "test_variant") ==
-               %{type: :normal, main: %{type: :placeholder, color: :gray, text: ""}}
-    end
-
-    test "runs all variant generators in the background" do
-      screen = build_screen(%{app_id: :test_app, app_params: %{test_pid: self()}})
-      expect(@parameters, :variants, fn %Screen{app_id: :test_app} -> ["crash"] end)
-
-      stub(
-        @parameters,
-        :candidate_generator,
-        fn
-          %Screen{app_id: :test_app}, nil -> GrayGenerator
-          %Screen{app_id: :test_app}, "crash" -> CrashGenerator
-        end
-      )
-
-      capture_log(fn ->
-        assert %{type: :normal} = ScreenData.get(screen, run_all_variants?: true)
-
-        receive do
-          {:crash_running, pid} ->
-            ref = Process.monitor(pid)
-            # Wait a bit longer than the default 100ms to avoid occasional timeouts
-            assert_receive({:DOWN, ^ref, :process, _pid, _reason}, 200)
-        end
-      end)
-    end
-  end
-
-  describe "variants/2" do
-    setup do
-      stub(@parameters, :refresh_rate, fn _app_id -> 0 end)
-      :ok
-    end
-
-    test "gets widget data for all variants" do
-      screen = build_screen(%{app_id: :test_app})
-      expect(@parameters, :variants, fn %Screen{app_id: :test_app} -> ["green"] end)
-
-      stub(
-        @parameters,
-        :candidate_generator,
-        fn
-          %Screen{app_id: :test_app}, nil -> GrayGenerator
-          %Screen{app_id: :test_app}, "green" -> GreenGenerator
-        end
-      )
-
-      assert {%{main: %{color: :gray}}, %{"green" => %{main: %{color: :green}}}} =
-               ScreenData.variants(screen)
     end
   end
 

--- a/test/screens_web/controllers/v2/screen_api_controller_test.exs
+++ b/test/screens_web/controllers/v2/screen_api_controller_test.exs
@@ -19,9 +19,8 @@ defmodule ScreensWeb.V2.ScreenApiControllerTest do
   setup do
     stub(@cache, :last_deploy_timestamp, fn -> ~U[2020-01-01 00:00:00Z] end)
     stub(@cache, :screen, fn _id -> struct(Screen) end)
-    stub(@parameters, :candidate_generator, fn _screen, _variant -> StubGenerator end)
+    stub(@parameters, :candidate_generator, fn _screen -> StubGenerator end)
     stub(@parameters, :refresh_rate, fn _app_id -> 0 end)
-    stub(@parameters, :variants, fn _screen -> [nil] end)
     stub(ScreensByAlert.Mock, :put_data, fn _screen_id, _alert_ids -> :ok end)
     :ok
   end

--- a/test/screens_web/plug/screen_request_test.exs
+++ b/test/screens_web/plug/screen_request_test.exs
@@ -104,10 +104,10 @@ defmodule ScreensWeb.Plug.ScreenRequestTest do
       %Conn{assigns: assigns} =
         conn
         |> make_successful()
-        |> struct!(query_string: "requestor=test&rotation_index=2&variant=abc")
+        |> struct!(query_string: "requestor=test&rotation_index=2")
         |> ScreenRequest.call(%Options{})
 
-      assert %{requestor: "test", rotation_index: "2", variant: "abc"} = assigns
+      assert %{requestor: "test", rotation_index: "2"} = assigns
     end
 
     test "assigns is_real_screen from param", %{conn: conn} do


### PR DESCRIPTION
We built this feature to enable a development approach that was essentially a "long-lived feature branch" but with the work merged incrementally and with the ability to run and compare the live and work-in-progress systems in parallel, in production.

In retrospect we agreed it was undesirable to develop future features this way, in favor of normal incremental shipping. So far "variants" have not been used for anything else, and we have no future plans to use them.

Accordingly, banish them from the code to streamline maintenance.

**Asana task**: https://app.asana.com/1/15492006741476/project/1185117109217413/task/1216930065867971?focus=true