### PR TITLE
feat(admin): ability to delete screens

### DIFF
--- a/assets/src/components/admin/editor.tsx
+++ b/assets/src/components/admin/editor.tsx
@@ -22,6 +22,18 @@ const appIdFilters: { id: AppId | null; name: string }[] = [
   ...SCREEN_APP_ENTRIES.map(([id, { name }]) => ({ id, name })),
 ];
 
+const confirmScreenDeletion = (ids: Set<string>): boolean =>
+  window.confirm(
+    `This will permanently delete the following screens:
+
+${Array.from(ids)
+  .sort()
+  .map((id) => `❌ ${id}`)
+  .join("\n")}
+
+This is not easily undone and may break live screens if done in production. Really commit this change?`.trim(),
+  );
+
 const Editor = () => {
   const [didInitialize, setDidInitialize] = useState(false);
   const [isAddingScreen, setIsAddingScreen] = useState(false);
@@ -51,6 +63,14 @@ const Editor = () => {
     [remoteConfig, localConfig],
   );
 
+  const deletedIDs = useMemo(
+    () =>
+      new Set(Object.keys(remoteConfig.screens)).difference(
+        new Set(Object.keys(localConfig.screens)),
+      ),
+    [remoteConfig, localConfig],
+  );
+
   const changedIDs = useMemo(
     () =>
       new Set(
@@ -64,7 +84,7 @@ const Editor = () => {
     [localConfig, remoteConfig, newIDs],
   );
 
-  const isChanged = changedIDs.size > 0 || newIDs.size > 0;
+  const isChanged = changedIDs.size + newIDs.size + deletedIDs.size > 0;
 
   const navBlocker = useBlocker(isChanged);
 
@@ -75,6 +95,15 @@ const Editor = () => {
     setLocalConfig({
       ...localConfig,
       screens: { ...localConfig.screens, ...screens },
+    });
+    setIsCommitReady(false);
+    resetKeyFn();
+  };
+
+  const deleteScreens = (ids: string[], resetKeyFn: () => void = () => {}) => {
+    setLocalConfig({
+      ...localConfig,
+      screens: _.omit(ids, localConfig.screens),
     });
     setIsCommitReady(false);
     resetKeyFn();
@@ -191,6 +220,7 @@ const Editor = () => {
           appIdFilter={appIdFilter}
           changedIDs={changedIDs}
           dataKey={tableDataKey}
+          deletedIDs={deletedIDs}
           isLoading={isLoading}
           localConfig={localConfig}
           newIDs={newIDs}
@@ -211,8 +241,25 @@ const Editor = () => {
           🔹 Edit selected
         </button>
 
+        <button
+          disabled={selectedIDs.size === 0}
+          onClick={() => {
+            deleteScreens(Array.from(selectedIDs), resetTableDataKey);
+            setSelectedIDs(new Set());
+          }}
+        >
+          ❌ Delete selected
+        </button>
+
         {isCommitReady ? (
-          <button disabled={isLoading} onClick={commitConfig}>
+          <button
+            disabled={isLoading}
+            onClick={() => {
+              if (deletedIDs.size === 0 || confirmScreenDeletion(deletedIDs)) {
+                commitConfig();
+              }
+            }}
+          >
             ✅ Commit changes
           </button>
         ) : (

--- a/assets/src/components/admin/editor/table.tsx
+++ b/assets/src/components/admin/editor/table.tsx
@@ -27,6 +27,7 @@ const Table: ComponentType<{
   appIdFilter: AppId | null;
   changedIDs: Set<string>;
   dataKey: Key;
+  deletedIDs: Set<string>;
   isLoading: boolean;
   localConfig: Config;
   newIDs: Set<string>;
@@ -38,6 +39,7 @@ const Table: ComponentType<{
   appIdFilter,
   changedIDs,
   dataKey,
+  deletedIDs,
   isLoading,
   localConfig,
   newIDs,
@@ -96,12 +98,13 @@ const Table: ComponentType<{
       visible: visibleIDs.size,
       changed: changedIDs.size,
       new: newIDs.size,
+      deleted: deletedIDs.size,
       selected: selectedIDs.size,
       visibleChanged: visibleIDs.intersection(changedIDs).size,
       visibleNew: visibleIDs.intersection(newIDs).size,
       visibleSelected: visibleIDs.intersection(selectedIDs).size,
     };
-  }, [localConfig, changedIDs, newIDs, selectedIDs, visibleIDs]);
+  }, [localConfig, changedIDs, newIDs, deletedIDs, selectedIDs, visibleIDs]);
 
   return (
     <table>
@@ -160,10 +163,15 @@ const Table: ComponentType<{
 
                   {counts.new > 0 && (
                     <span>
+                      ✴️
                       {counts.new !== counts.visibleNew &&
                         `${counts.visibleNew} of`}{" "}
                       {counts.new} new
                     </span>
+                  )}
+
+                  {counts.deleted > 0 && (
+                    <span>❌ {counts.deleted} deleted</span>
                   )}
 
                   {isFiltered && (


### PR DESCRIPTION
This was already possible by deleting entries from the raw JSON Editor, but since this will likely be removed soon as a consequence of moving to database storage, there should be at least a basic UI to perform this function.

Committing a config change that will delete one or more screens gets an extra confirmation with some attention-grabbing emoji.

<img width="397" height="249" alt="Screenshot 2026-07-31 at 2 36 11 PM" src="https://github.com/user-attachments/assets/4221b3e1-b61f-46bb-b27a-501e839d54db" />

**Asana task**: https://app.asana.com/1/15492006741476/project/1185117109217413/task/1216571034745371?focus=true

Note: I think the original idea of this task was that we'd do this alongside/somewhere in the middle of the database changes, but it seemed reasonable to get out of the way now since nothing about it really "depended on" those changes. Once we migrate the admin UI to be able to use the database in general, this feature would naturally be included.

Open to suggestions on UI wording here while remaining concise; I'd like to somehow make it clearer that you don't have to be super careful around the "Delete selected" button since it just "marks for deletion" or "sends to trash" or some similar concept, and it's the separate Validate/Commit action that *really* deletes screens.