### PR TITLE
feat(admin): minor enhancements

### DIFF
--- a/assets/css/admin/editor.scss
+++ b/assets/css/admin/editor.scss
@@ -25,6 +25,12 @@
         margin-right: 0.5em;
       }
     }
+
+    tbody {
+      input[type="checkbox"] {
+        width: 100%;
+      }
+    }
   }
 
   &__footer {

--- a/assets/css/admin/inspector.scss
+++ b/assets/css/admin/inspector.scss
@@ -71,6 +71,15 @@
   gap: 0.5em;
   margin-top: 0.5em;
 
+  &__toolbar {
+    display: flex;
+    gap: 0.5em;
+
+    input {
+      flex-grow: 1;
+    }
+  }
+
   iframe {
     width: 100%;
     border: 0;

--- a/assets/src/components/admin/editor.tsx
+++ b/assets/src/components/admin/editor.tsx
@@ -9,6 +9,7 @@ import {
   fetch,
   useModalDialog,
   useResetKey,
+  withInFlight,
 } from "Util/admin";
 
 import EditDialog from "./editor/edit_dialog";
@@ -109,19 +110,8 @@ const Editor = () => {
     resetKeyFn();
   };
 
-  const withInFlight = async (func: () => Promise<void>) => {
-    setIsLoading(true);
-    try {
-      await func();
-    } catch {
-      window.alert("Error: Request failed.");
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
   const reloadConfig = () => {
-    withInFlight(async () => {
+    withInFlight(setIsLoading, async () => {
       const response = await fetch.get("/api/admin");
       const config: Config = JSON.parse(response.config);
       setLocalConfig(config);
@@ -133,7 +123,7 @@ const Editor = () => {
   };
 
   const validateConfig = () => {
-    withInFlight(async () => {
+    withInFlight(setIsLoading, async () => {
       const { config } = await fetch.post("/api/admin/screens/validate", {
         config: JSON.stringify(localConfig),
       });
@@ -144,7 +134,7 @@ const Editor = () => {
   };
 
   const commitConfig = () => {
-    withInFlight(async () => {
+    withInFlight(setIsLoading, async () => {
       const { success } = await fetch.post("/api/admin/screens/confirm", {
         config: JSON.stringify(localConfig),
       });

--- a/assets/src/components/admin/editor/edit_dialog.tsx
+++ b/assets/src/components/admin/editor/edit_dialog.tsx
@@ -27,7 +27,8 @@ const EditDialog: ComponentType<{
   return (
     <dialog className="admin-editor__dialog" onClose={onClose} ref={ref}>
       <h2>
-        Editing {entries.length} screen{entries.length === 1 ? "" : "s"}
+        Editing{" "}
+        {entries.length === 1 ? entries[0][0] : `${entries.length} screens`}
       </h2>
 
       {entries.length > 0 && (

--- a/assets/src/components/admin/inspector.tsx
+++ b/assets/src/components/admin/inspector.tsx
@@ -14,6 +14,7 @@ import { type AudioConfig } from "Components/screen_container";
 
 import {
   fetch,
+  withInFlight,
   SCREEN_APPS,
   type Config,
   type Screen,
@@ -49,13 +50,17 @@ const buildIframeUrl = (screen: ScreenWithId | null, isSimulation: boolean) => {
 const Inspector: ComponentType = () => {
   const [config, setConfig] = useState<Config | null>(null);
   const [frameLoadedAt, setFrameLoadedAt] = useState(0);
+  const [isLoading, setIsLoading] = useState(false);
 
-  useEffect(() => {
-    fetch
-      .get("/api/admin")
-      .then((response) => JSON.parse(response.config))
-      .then((config) => setConfig(config));
-  }, []);
+  const reloadConfig = () => {
+    withInFlight(setIsLoading, async () => {
+      const response = await fetch.get("/api/admin");
+      const config: Config = JSON.parse(response.config);
+      setConfig(config);
+    });
+  };
+
+  useEffect(reloadConfig, []);
 
   const onScreenUpdated = (screenId, newConfig) => {
     if (config) {
@@ -97,12 +102,17 @@ const Inspector: ComponentType = () => {
       <div className="inspector__controls">
         <h1>Inspector</h1>
 
+        <div>
+          <button disabled={isLoading} onClick={reloadConfig}>
+            🔄 Reload Configuration
+          </button>
+        </div>
+
         {config && (
           <>
             <ScreenSelector
               config={config}
               screen={screen}
-              reloadFrame={reloadFrame}
               isSimulation={isSimulation}
               setIsSimulation={setIsSimulation}
             />
@@ -111,6 +121,7 @@ const Inspector: ComponentType = () => {
               <>
                 <ConfigControls
                   screen={screen}
+                  isLoading={isLoading}
                   onUpdated={(config) => onScreenUpdated(screen.id, config)}
                 />
                 <ViewControls
@@ -136,7 +147,10 @@ const Inspector: ComponentType = () => {
       </div>
 
       <div className="inspector__screen">
-        <input disabled value={iframeUrl} />
+        <div className="inspector__screen__toolbar">
+          <button onClick={reloadFrame}>🔄</button>
+          <input disabled value={iframeUrl} />
+        </div>
 
         <iframe
           className={isSimulation ? "simulation" : undefined}
@@ -156,10 +170,9 @@ const Inspector: ComponentType = () => {
 const ScreenSelector: ComponentType<{
   config: Config;
   screen: ScreenWithId | null;
-  reloadFrame: () => void;
   isSimulation: boolean;
   setIsSimulation: (value: boolean) => void;
-}> = ({ config, screen, reloadFrame, isSimulation, setIsSimulation }) => {
+}> = ({ config, screen, isSimulation, setIsSimulation }) => {
   const navigate = useNavigate();
   const { pathname, search } = useLocation();
 
@@ -213,16 +226,15 @@ const ScreenSelector: ComponentType<{
         />
         Screenplay simulation
       </label>
-
-      <button onClick={reloadFrame}>🔄 Reload Screen</button>
     </fieldset>
   );
 };
 
 const ConfigControls: ComponentType<{
   screen: ScreenWithId;
+  isLoading: boolean;
   onUpdated: (newConfig: Screen) => void;
-}> = ({ screen, onUpdated }) => {
+}> = ({ screen, isLoading, onUpdated }) => {
   const [editableConfig, setEditableConfig] = useState<Screen | null>(null);
   const [isRequestingReload, setIsRequestingReload] = useState(false);
   const dialogRef = useRef<HTMLDialogElement>(null);
@@ -232,12 +244,15 @@ const ConfigControls: ComponentType<{
     setEditableConfig(null);
   };
 
+  const isDisabled = isLoading || isRequestingReload;
+
   return (
     <fieldset>
       <legend>Configuration</legend>
 
       <div>
         <button
+          disabled={isDisabled}
           onClick={() => {
             setEditableConfig(screen.config);
             dialogRef.current?.showModal();
@@ -247,7 +262,7 @@ const ConfigControls: ComponentType<{
         </button>
 
         <button
-          disabled={isRequestingReload}
+          disabled={isDisabled}
           onClick={() => {
             setIsRequestingReload(true);
             fetch

--- a/assets/src/util/admin.tsx
+++ b/assets/src/util/admin.tsx
@@ -144,6 +144,22 @@ export const useResetKey = (): [Key, () => void] => {
 };
 
 /**
+ * Calls an async function and sets a state value according to whether the
+ * function is "in flight" (has not yet resolved).
+ */
+export const withInFlight = async (
+  setFn: (isInFlight: boolean) => void,
+  requestFn: () => Promise<void>,
+) => {
+  setFn(true);
+  try {
+    await requestFn();
+  } finally {
+    setFn(false);
+  }
+};
+
+/**
  * Set of attributes for forms and form elements which disable "auto" browser
  * behaviors like autocomplete and spell check.
  */


### PR DESCRIPTION
* Improve initialization/in-flight request handling in the Inspector, extracting some code to share with the table editor.

* Add a button to the Inspector to reload the configuration, as in the table editor.

* Put the Inspector's "reload screen page" button next to the "address bar" where it might be more expected to find it.

* When editing only one screen in the table editor, show its ID in the dialog title, instead of "Editing 1 screen".

* Center checkboxes in their columns in the main table view. This also makes them easier to click as the target is expanded to the entire cell horizontally (not vertically, which would be nice but seems more complicated to achieve).

* Fix duplicate "request failed" error dialog in the table editor when e.g. the user needs to reauthenticate.