### PR TITLE
fix: Check fonts are loaded before measuring headsign overflow on DUPs

### DIFF
--- a/assets/src/components/dup/departures/destination.tsx
+++ b/assets/src/components/dup/departures/destination.tsx
@@ -147,41 +147,44 @@ const Destination: ComponentType<DupDestination> = ({
    * cause infinite update loops, so we don't need to be warned that it might.
    */
   useLayoutEffect(() => {
-    // First attempt to fit headsign on a single line. Prefer fitting an abbreviated
-    // headsign on a single line than the full headsign across 2 pages.
-    // If that doesn't work, try to fit it on two lines by adjusting
-    // between which words we paginate. Move through abbreviations until we find fit.
-    if (
-      firstLineRef.current &&
-      secondLineRef.current &&
-      phase !== PHASES.Done
-    ) {
-      const next = nextSizingState({
-        phase,
-        headsignIndex,
-        partsIndex1,
-        partsIndex2,
-        partsLength: parts.length,
-        headsigns: headsigns,
-        firstLineFits: !hasOverflowX(firstLineRef.current),
-        secondLineFits: !hasOverflowX(secondLineRef.current),
-      });
-      if (next) {
-        // Update the state so we can re-attempt sizing with updated values
-        if ("headsignIndex" in next && next.headsignIndex !== undefined) {
-          setHeadsignIndex(next.headsignIndex);
-        }
-        if ("phase" in next && next.phase !== undefined) {
-          setPhase(next.phase);
-        }
-        if ("partsIndex1" in next && next.partsIndex1 !== undefined) {
-          setPartsIndex1(next.partsIndex1);
-        }
-        if ("partsIndex2" in next && next.partsIndex2 !== undefined) {
-          setPartsIndex2(next.partsIndex2);
+    // Wait for fonts to load before measuring text width
+    document.fonts.ready.then(() => {
+      // First attempt to fit headsign on a single line. Prefer fitting an abbreviated
+      // headsign on a single line than the full headsign across 2 pages.
+      // If that doesn't work, try to fit it on two lines by adjusting
+      // between which words we paginate. Move through abbreviations until we find fit.
+      if (
+        firstLineRef.current &&
+        secondLineRef.current &&
+        phase !== PHASES.Done
+      ) {
+        const next = nextSizingState({
+          phase,
+          headsignIndex,
+          partsIndex1,
+          partsIndex2,
+          partsLength: parts.length,
+          headsigns: headsigns,
+          firstLineFits: !hasOverflowX(firstLineRef.current),
+          secondLineFits: !hasOverflowX(secondLineRef.current),
+        });
+        if (next) {
+          // Update the state so we can re-attempt sizing with updated values
+          if ("headsignIndex" in next && next.headsignIndex !== undefined) {
+            setHeadsignIndex(next.headsignIndex);
+          }
+          if ("phase" in next && next.phase !== undefined) {
+            setPhase(next.phase);
+          }
+          if ("partsIndex1" in next && next.partsIndex1 !== undefined) {
+            setPartsIndex1(next.partsIndex1);
+          }
+          if ("partsIndex2" in next && next.partsIndex2 !== undefined) {
+            setPartsIndex2(next.partsIndex2);
+          }
         }
       }
-    }
+    });
   });
 
   // Render paged version when done determining breaks


### PR DESCRIPTION
See [Slack thread ](https://mbta.slack.com/archives/C02SXM166N8/p1785770961563189).

On initial rendering of the page, the overflow calculation is sometimes done before the font is loaded onto the page. This caused issues with `Heath Street`, which just barely overflows with Inter font, but not with the default font. Adding this check before doing the headsign sizing prevents this issue from occurring.

This behavior is available starting on Chrome 31, and so will work on DUP hardware: https://developer.mozilla.org/en-US/docs/Web/API/Document/fonts