### PR TITLE
fix: Set env variables for DB in setup action

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,6 +1,11 @@
 name: Setup
 description: Installs tools and dependencies
 
+env:
+  # Placeholder values for database credentials
+  DATABASE_PASSWORD: postgres
+  DATABASE_USER: postgres
+
 runs:
   using: composite
   steps:


### PR DESCRIPTION
A fix for the setup action since these env variables are now required in `config.exs`. See [successful run](https://github.com/mbta/screens/actions/runs/30855101442) 