### PR TITLE
feat: Add Screens Admin tool to backfill Configs in Postgres

### DIFF
--- a/assets/src/components/admin/tools.tsx
+++ b/assets/src/components/admin/tools.tsx
@@ -88,9 +88,12 @@ const ImportConfigs = () => {
 
     setIsImporting(true);
 
-    const { success, upserted, deleted, error } = await fetch.post(IMPORT_PATH, {});
+    const { status, upserted, deleted, error } = await fetch.post(
+      IMPORT_PATH,
+      {},
+    );
 
-    if (success) {
+    if (status === 200) {
       window.alert(`Imported ${upserted} configurations. Deleted ${deleted}.`);
     } else {
       window.alert(`Import failed: ${error || "Unknown error"}`);

--- a/assets/src/components/admin/tools.tsx
+++ b/assets/src/components/admin/tools.tsx
@@ -93,12 +93,13 @@ const ImportConfigs = () => {
       {},
     );
 
+    setIsImporting(false);
+
     if (status === 200) {
       window.alert(`Imported ${upserted} configurations. Deleted ${deleted}.`);
     } else {
       window.alert(`Import failed: ${error || "Unknown error"}`);
     }
-    setIsImporting(false);
   };
 
   return (

--- a/assets/src/components/admin/tools.tsx
+++ b/assets/src/components/admin/tools.tsx
@@ -2,11 +2,13 @@ import { useMemo, useState } from "react";
 import { fetch } from "Util/admin";
 
 const API_PATH = "/api/admin/maintenance";
+const IMPORT_PATH = "/api/admin/import_configs";
 
 const Tools = () => {
   return (
     <main className="admin-page">
       <EvergreenContentCleanup />
+      <ImportConfigs />
     </main>
   );
 };
@@ -64,6 +66,37 @@ const EvergreenContentCleanup = () => {
         />
         <button type="submit">Cleanup</button>
       </form>
+    </section>
+  );
+};
+
+// This section should be a part of post_config_migration_cleanup
+const ImportConfigs = () => {
+  const importConfigs = async () => {
+    const { success, upserted, deleted, error } = await fetch.post(
+      IMPORT_PATH,
+      {},
+    );
+
+    if (success) {
+      window.alert(
+        `Imported ${upserted} screen configurations. Deleted ${deleted}.`,
+      );
+    } else {
+      window.alert(`Import failed: ${error || "Unknown error"}`);
+    }
+  };
+
+  return (
+    <section>
+      <h2>Import Screen Configurations</h2>
+      <p>
+        Load screen configurations from the JSON file into the DB. This will
+        overwrite any existing configurations in Postgres.
+      </p>
+      <button type="button" onClick={importConfigs}>
+        Import
+      </button>
     </section>
   );
 };

--- a/assets/src/components/admin/tools.tsx
+++ b/assets/src/components/admin/tools.tsx
@@ -72,29 +72,40 @@ const EvergreenContentCleanup = () => {
 
 // This section should be a part of post_config_migration_cleanup
 const ImportConfigs = () => {
+  const [isImporting, setIsImporting] = useState(false);
+
   const importConfigs = async () => {
-    const { success, upserted, deleted, error } = await fetch.post(
-      IMPORT_PATH,
-      {},
-    );
+    // Shouldn't happen, but just in case the button is clicked multiple times
+    if (isImporting) return;
+
+    if (
+      !window.confirm(
+        "Are you sure? This will overwrite existing configurations in Postgres with the JSON file in S3.",
+      )
+    ) {
+      return;
+    }
+
+    setIsImporting(true);
+
+    const { success, upserted, deleted, error } = await fetch.post(IMPORT_PATH, {});
 
     if (success) {
-      window.alert(
-        `Imported ${upserted} screen configurations. Deleted ${deleted}.`,
-      );
+      window.alert(`Imported ${upserted} configurations. Deleted ${deleted}.`);
     } else {
       window.alert(`Import failed: ${error || "Unknown error"}`);
     }
+    setIsImporting(false);
   };
 
   return (
     <section>
-      <h2>Import Screen Configurations</h2>
+      <h2>Import Screen Configurations to Postgres</h2>
       <p>
-        Load screen configurations from the JSON file into the DB. This will
+        Load screen configurations from the JSON file into our DB. This will
         overwrite any existing configurations in Postgres.
       </p>
-      <button type="button" onClick={importConfigs}>
+      <button type="button" onClick={importConfigs} disabled={isImporting}>
         Import
       </button>
     </section>

--- a/assets/src/util/admin.tsx
+++ b/assets/src/util/admin.tsx
@@ -174,14 +174,21 @@ export const fetch = {
   get: (path) => doFetch(path, {}),
 
   post: (path, data) => {
-    return doFetch(path, {
-      body: JSON.stringify(data),
-      headers: {
-        "content-type": "application/json",
-        "x-csrf-token": getCsrfToken(),
+    return doFetch(
+      path,
+      {
+        body: JSON.stringify(data),
+        headers: {
+          "content-type": "application/json",
+          "x-csrf-token": getCsrfToken(),
+        },
+        method: "POST",
       },
-      method: "POST",
-    });
+      async (response) => {
+        const json = await response.json();
+        return { status: response.status, ...json };
+      },
+    );
   },
 
   delete: (path) =>

--- a/lib/screens/config/screen_config.ex
+++ b/lib/screens/config/screen_config.ex
@@ -1,0 +1,25 @@
+defmodule Screens.Config.ScreenConfig do
+  use Ecto.Schema
+
+  alias ScreensConfig.Config
+
+  import Ecto.Changeset
+
+  @type t() :: %__MODULE__{
+          id: String.t(),
+          config: Config.t()
+        }
+
+  @primary_key {:id, :string, autogenerate: false}
+  schema "screen_configs" do
+    field :config, :map
+
+    timestamps(type: :utc_datetime)
+  end
+
+  def changeset(screen_config, attrs) do
+    screen_config
+    |> cast(attrs, [:id, :config])
+    |> validate_required([:id, :config])
+  end
+end

--- a/lib/screens/screen_configs.ex
+++ b/lib/screens/screen_configs.ex
@@ -1,0 +1,49 @@
+defmodule Screens.ScreenConfigs do
+  @moduledoc """
+  Context for managing screen configuration records persisted to Postgres.
+  """
+
+  import Ecto.Query
+
+  alias Screens.Config.Fetch, as: ConfigFetch
+  alias Screens.Config.ScreenConfig
+  alias Screens.Repo
+
+  @spec import_from_file() :: {:ok, %{upserted: integer(), deleted: integer()}} | {:error, any()}
+  def import_from_file do
+    # This should be a part of post_config_migration_cleanup
+    with {:ok, config, _version} <- ConfigFetch.fetch_config(),
+         config = Jason.decode!(config),
+         screens when is_map(screens) <- Map.get(config, "screens", %{}) do
+      screen_ids = Map.keys(screens)
+
+      Enum.each(screens, fn {id, config} ->
+        upsert_screen_config(%{id: id, config: config})
+      end)
+
+      {deleted, _} =
+        Repo.delete_all(from s in ScreenConfig, where: s.id not in ^screen_ids)
+
+      {:ok, %{upserted: Enum.count(screen_ids), deleted: deleted}}
+    end
+  end
+
+  def list do
+    Repo.all(ScreenConfig)
+  end
+
+  @doc """
+  Creates a screen configuration.
+  Upserts so an existing config with the same ID will be overwritten.
+  """
+  @spec upsert_screen_config(params :: map()) ::
+          {:ok, ScreenConfig.t()} | {:error, Ecto.Changeset.t()}
+  def upsert_screen_config(params) do
+    %ScreenConfig{}
+    |> ScreenConfig.changeset(params)
+    |> Repo.insert(
+      on_conflict: {:replace, [:config, :updated_at]},
+      conflict_target: :id
+    )
+  end
+end

--- a/lib/screens_web/controllers/admin_api_controller.ex
+++ b/lib/screens_web/controllers/admin_api_controller.ex
@@ -3,6 +3,7 @@ defmodule ScreensWeb.AdminApiController do
 
   alias Screens.Config.Fetch, as: ConfigFetch
   alias Screens.{Image, Util}
+  alias Screens.ScreenConfigs
   alias ScreensConfig.{Config, Screen}
 
   plug :accepts, ["multipart/form-data"] when action == :upload_image
@@ -44,6 +45,20 @@ defmodule ScreensWeb.AdminApiController do
 
   def list_images(conn, _params) do
     json(conn, %{images: Image.list()})
+  end
+
+  @spec import_configs(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  # This should be a part of post_config_migration_cleanup
+  def import_configs(conn, _params) do
+    case ScreenConfigs.import_from_file() do
+      {:ok, %{upserted: upserted, deleted: deleted}} ->
+        json(conn, %{success: true, upserted: upserted, deleted: deleted})
+
+      {:error, reason} ->
+        conn
+        |> put_status(500)
+        |> json(%{success: false, error: inspect(reason)})
+    end
   end
 
   def upload_image(conn, %{"image" => %Plug.Upload{} = upload, "key" => key}) do

--- a/lib/screens_web/controllers/admin_api_controller.ex
+++ b/lib/screens_web/controllers/admin_api_controller.ex
@@ -52,7 +52,7 @@ defmodule ScreensWeb.AdminApiController do
   def import_configs(conn, _params) do
     case ScreenConfigs.import_from_file() do
       {:ok, %{upserted: upserted, deleted: deleted}} ->
-        json(conn, %{success: true, upserted: upserted, deleted: deleted})
+        json(conn, %{upserted: upserted, deleted: deleted})
 
       {:error, reason} ->
         conn

--- a/lib/screens_web/router.ex
+++ b/lib/screens_web/router.ex
@@ -71,6 +71,7 @@ defmodule ScreensWeb.Router do
     post "/screens/confirm/:id", AdminApiController, :confirm
     post "/refresh", AdminApiController, :refresh
     post "/maintenance", AdminApiController, :maintenance
+    post "/import_configs", AdminApiController, :import_configs
     get "/images", AdminApiController, :list_images
     post "/images", AdminApiController, :upload_image
     delete "/images/:key", AdminApiController, :delete_image


### PR DESCRIPTION
**Asana task**: [DB Backfill Script for Screen Configs](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1216318458240936?focus=true)

- Add a section to the Tools section of Screens Admin to backfill Postgres from the JSON config