### PR TITLE
fix: adjust DUPs headsign content pagination

### DIFF
--- a/assets/src/components/dup/departures/destination.tsx
+++ b/assets/src/components/dup/departures/destination.tsx
@@ -141,7 +141,7 @@ export const buildPageContent = ({
     if (secondPage === "") {
       return [firstPage];
     } else {
-      return [firstPage + "…", "…" + secondPage];
+      return [`${firstPage}…`, `…${secondPage}`];
     }
   }
 };

--- a/assets/src/components/dup/departures/destination.tsx
+++ b/assets/src/components/dup/departures/destination.tsx
@@ -107,24 +107,79 @@ export const nextSizingState = (
   }
 };
 
-const RenderedDestination = ({ parts, index1, index2, classModifier }) => {
+type PageContentAndSplitIndices = {
+  entireMessageByWord: string[];
+  firstLineEndIndex: number;
+  secondLineEndIndex: number;
+};
+
+/**
+ * For single headsign's content, chunk it into one or two pages.
+ *
+ * When two pages of content are returned, an ellipsis will be added to:
+ * 1. The end of the first page
+ * 2. The start of the second page
+ * 3. The end of the second page, if the message does not wholly fit on 2 pages
+ */
+export const buildPageContent = ({
+  entireMessageByWord,
+  firstLineEndIndex,
+  secondLineEndIndex,
+}: PageContentAndSplitIndices): ReadonlyArray<string> => {
+  if (firstLineEndIndex === entireMessageByWord.length) {
+    return [entireMessageByWord.join(" ")];
+  } else {
+    const firstPage = entireMessageByWord.slice(0, firstLineEndIndex).join(" ");
+
+    let secondPage = entireMessageByWord
+      .slice(firstLineEndIndex, secondLineEndIndex)
+      .join(" ")
+      .trimEnd();
+
+    let lastUsedSecondPageIndex = secondLineEndIndex;
+    if (
+      secondPage.trim() === "v/" &&
+      lastUsedSecondPageIndex <= entireMessageByWord.length - 1
+    ) {
+      // Pull the next word into the second page, allow CSS to handle overflow
+      secondPage += ` ${entireMessageByWord[lastUsedSecondPageIndex].trim()}`;
+      lastUsedSecondPageIndex += 1;
+    }
+
+    if (secondPage === "") {
+      return [firstPage];
+    } else {
+      secondPage =
+        lastUsedSecondPageIndex === entireMessageByWord.length
+          ? secondPage
+          : secondPage + "…";
+      return [firstPage + "…", "…" + secondPage];
+    }
+  }
+};
+
+type RenderedDestinationProps = {
+  pageContent: ReadonlyArray<string>;
+  classModifier: string;
+};
+
+const RenderedDestination: ComponentType<RenderedDestinationProps> = ({
+  pageContent,
+  classModifier,
+}) => {
   const currentPage = useCurrentPage();
 
-  let pageContent: string;
+  let currentContent: string;
 
-  if (index1 === parts.length) {
-    pageContent = parts.join(" ");
+  if (pageContent.length === 1) {
+    currentContent = pageContent[0];
   } else {
-    const pages = [
-      parts.slice(0, index1).join(" ") + "…",
-      "…" + parts.slice(index1, index2).join(" "),
-    ];
-    pageContent = pages[currentPage];
+    currentContent = pageContent[currentPage];
   }
 
   return (
     <div className={classWithModifier("departure-destination", classModifier)}>
-      <div className="departure-destination__headsign">{pageContent}</div>
+      <div className="departure-destination__headsign">{currentContent}</div>
     </div>
   );
 };
@@ -186,11 +241,14 @@ const Destination: ComponentType<DupDestination> = ({
 
   // Render paged version when done determining breaks
   if (phase === PHASES.Done) {
+    const pageContent = buildPageContent({
+      entireMessageByWord: parts,
+      firstLineEndIndex: partsIndex1,
+      secondLineEndIndex: partsIndex2,
+    });
     return (
       <RenderedDestination
-        index1={partsIndex1}
-        index2={partsIndex2}
-        parts={parts}
+        pageContent={pageContent}
         classModifier={classModifier}
       />
     );

--- a/assets/src/components/dup/departures/destination.tsx
+++ b/assets/src/components/dup/departures/destination.tsx
@@ -110,7 +110,6 @@ export const nextSizingState = (
 type PageContentAndSplitIndices = {
   entireMessageByWord: string[];
   firstLineEndIndex: number;
-  secondLineEndIndex: number;
 };
 
 /**
@@ -119,40 +118,29 @@ type PageContentAndSplitIndices = {
  * When two pages of content are returned, an ellipsis will be added to:
  * 1. The end of the first page
  * 2. The start of the second page
- * 3. The end of the second page, if the message does not wholly fit on 2 pages
+ *
+ * For DUPs, the second page consists of "…" + the portion of the message that
+ * did not fit on the first page. It is not guaranteed that all text will fit
+ * when actually displayed. We rely on CSS rules on text-overflow to ellipsize
+ * the end of the second page for us.
  */
 export const buildPageContent = ({
   entireMessageByWord,
   firstLineEndIndex,
-  secondLineEndIndex,
 }: PageContentAndSplitIndices): ReadonlyArray<string> => {
   if (firstLineEndIndex === entireMessageByWord.length) {
     return [entireMessageByWord.join(" ")];
   } else {
     const firstPage = entireMessageByWord.slice(0, firstLineEndIndex).join(" ");
 
-    let secondPage = entireMessageByWord
-      .slice(firstLineEndIndex, secondLineEndIndex)
+    const secondPage = entireMessageByWord
+      .slice(firstLineEndIndex, entireMessageByWord.length)
       .join(" ")
       .trimEnd();
-
-    let lastUsedSecondPageIndex = secondLineEndIndex;
-    if (
-      secondPage.trim() === "v/" &&
-      lastUsedSecondPageIndex <= entireMessageByWord.length - 1
-    ) {
-      // Pull the next word into the second page, allow CSS to handle overflow
-      secondPage += ` ${entireMessageByWord[lastUsedSecondPageIndex].trim()}`;
-      lastUsedSecondPageIndex += 1;
-    }
 
     if (secondPage === "") {
       return [firstPage];
     } else {
-      secondPage =
-        lastUsedSecondPageIndex === entireMessageByWord.length
-          ? secondPage
-          : secondPage + "…";
       return [firstPage + "…", "…" + secondPage];
     }
   }
@@ -244,7 +232,6 @@ const Destination: ComponentType<DupDestination> = ({
     const pageContent = buildPageContent({
       entireMessageByWord: parts,
       firstLineEndIndex: partsIndex1,
-      secondLineEndIndex: partsIndex2,
     });
     return (
       <RenderedDestination

--- a/assets/tests/components/dup/departures/destination.test.ts
+++ b/assets/tests/components/dup/departures/destination.test.ts
@@ -1,31 +1,35 @@
 import { describe, expect, test } from "@jest/globals";
-import { nextSizingState, PHASES } from "Components/dup/departures/destination";
-
-// Helper constants for different line fit scenarios
-const fits = { firstLineFits: true, secondLineFits: true };
-const firstOverflows = { firstLineFits: false, secondLineFits: true };
-const secondOverflows = { firstLineFits: true, secondLineFits: false };
-const bothOverflow = { firstLineFits: false, secondLineFits: false };
-
-const oneLineBase = {
-  phase: PHASES.OneLine,
-  headsignIndex: 0,
-  partsIndex1: 3,
-  partsIndex2: 3,
-  partsLength: 3,
-  headsigns: ["Wonderland"],
-};
-
-const twoLinesBase = {
-  phase: PHASES.TwoLines,
-  headsignIndex: 0,
-  partsIndex1: 3,
-  partsIndex2: 3,
-  partsLength: 3,
-  headsigns: ["Wonderland"],
-};
+import {
+  buildPageContent,
+  nextSizingState,
+  PHASES,
+} from "Components/dup/departures/destination";
 
 describe("nextSizingState", () => {
+  // Helper constants for different line fit scenarios
+  const fits = { firstLineFits: true, secondLineFits: true };
+  const firstOverflows = { firstLineFits: false, secondLineFits: true };
+  const secondOverflows = { firstLineFits: true, secondLineFits: false };
+  const bothOverflow = { firstLineFits: false, secondLineFits: false };
+
+  const oneLineBase = {
+    phase: PHASES.OneLine,
+    headsignIndex: 0,
+    partsIndex1: 3,
+    partsIndex2: 3,
+    partsLength: 3,
+    headsigns: ["Wonderland"],
+  };
+
+  const twoLinesBase = {
+    phase: PHASES.TwoLines,
+    headsignIndex: 0,
+    partsIndex1: 3,
+    partsIndex2: 3,
+    partsLength: 3,
+    headsigns: ["Wonderland"],
+  };
+
   describe("PHASES.OneLine", () => {
     test("transitions to DONE and resets indices when first line fits", () => {
       expect(nextSizingState({ ...oneLineBase, ...fits })).toEqual({
@@ -107,6 +111,75 @@ describe("nextSizingState", () => {
         ...bothOverflow,
       };
       expect(nextSizingState(state)).toEqual({ phase: PHASES.Done });
+    });
+  });
+});
+
+describe("buildPageContent", () => {
+  describe("message fits on the first line", () => {
+    test("places all content in a single page", () => {
+      const messageContent = ["Framingham"];
+
+      const actual = buildPageContent({
+        entireMessageByWord: messageContent,
+        firstLineEndIndex: messageContent.length,
+        secondLineEndIndex: messageContent.length, // fit the entire message
+      });
+
+      expect(actual).toEqual(messageContent);
+    });
+  });
+
+  describe("message fits on both lines", () => {
+    test("paginates the content", () => {
+      const messageContent = "Readville v/ Fairmount".split(" ");
+
+      const actual = buildPageContent({
+        entireMessageByWord: messageContent,
+        firstLineEndIndex: messageContent.length - 1, // "Readville v/"
+        secondLineEndIndex: messageContent.length, // "Fairmount"
+      });
+
+      expect(actual).toEqual(["Readville v/…", "…Fairmount"]);
+    });
+  });
+
+  describe("message doesn't fit on both lines", () => {
+    test("paginates and truncates the content", () => {
+      const messageContent =
+        "Wickford Junction (Express to Sharon after Ruggles)".split(" ");
+
+      const actual = buildPageContent({
+        entireMessageByWord: messageContent,
+        firstLineEndIndex: 3, // "Wickford Junction (Express"
+        secondLineEndIndex: 5, // "to Sharon"
+      });
+
+      expect(actual).toEqual(["Wickford Junction (Express…", "…to Sharon…"]);
+    });
+
+    test("does not remove trailing 'via' shorthand on the second page", () => {
+      const messageContent = "Forge Park/495 v/ Back Bay".split(" ");
+
+      const actual = buildPageContent({
+        entireMessageByWord: messageContent,
+        firstLineEndIndex: 1, // "Forge"
+        secondLineEndIndex: 3, // "Park/495 v/"
+      });
+
+      expect(actual).toEqual(["Forge…", "…Park/495 v/…"]);
+    });
+
+    test("pulls in the next word when the second page is only 'via' shorthand", () => {
+      const messageContent = "Readville v/ Fairmount".split(" ");
+
+      const actual = buildPageContent({
+        entireMessageByWord: messageContent,
+        firstLineEndIndex: 1, // "Readville"
+        secondLineEndIndex: 2, // "v/"
+      });
+
+      expect(actual).toEqual(["Readville…", "…v/ Fairmount"]);
     });
   });
 });

--- a/assets/tests/components/dup/departures/destination.test.ts
+++ b/assets/tests/components/dup/departures/destination.test.ts
@@ -122,76 +122,56 @@ describe("buildPageContent", () => {
 
       const actual = buildPageContent({
         entireMessageByWord: messageContent,
-        firstLineEndIndex: messageContent.length,
-        secondLineEndIndex: messageContent.length, // fit the entire message
+        firstLineEndIndex: messageContent.length, // fit the entire message
       });
 
       expect(actual).toEqual(messageContent);
     });
   });
 
-  describe("message fits on both lines", () => {
+  describe("message extends to two lines", () => {
     test("paginates the content", () => {
       const messageContent = "Readville v/ Fairmount".split(" ");
 
       const actual = buildPageContent({
         entireMessageByWord: messageContent,
         firstLineEndIndex: messageContent.length - 1, // "Readville v/"
-        secondLineEndIndex: messageContent.length, // "Fairmount"
       });
 
       expect(actual).toEqual(["Readville v/…", "…Fairmount"]);
     });
-  });
 
-  describe("message doesn't fit on both lines", () => {
-    test("paginates and truncates the content", () => {
+    test("paginates particularly long content", () => {
       const messageContent =
         "Wickford Junction (Express to Sharon after Ruggles)".split(" ");
 
       const actual = buildPageContent({
         entireMessageByWord: messageContent,
         firstLineEndIndex: 3, // "Wickford Junction (Express"
-        secondLineEndIndex: 5, // "to Sharon"
       });
 
-      expect(actual).toEqual(["Wickford Junction (Express…", "…to Sharon…"]);
+      expect(actual).toEqual([
+        "Wickford Junction (Express…",
+        "…to Sharon after Ruggles)",
+      ]);
     });
 
-    test("paginates and truncates the content with 'via' shorthand", () => {
-      const messageContent = "Wickford Junction v/ Park Street".split(" ");
+    test.each([{ preposition: "v/" }, { preposition: "via" }])(
+      "paginates the content with the preposition '$preposition'",
+      ({ preposition }) => {
+        const messageContent =
+          `Wickford Junction ${preposition} Park Street`.split(" ");
 
-      const actual = buildPageContent({
-        entireMessageByWord: messageContent,
-        firstLineEndIndex: 2, // "Wickford Junction"
-        secondLineEndIndex: 4, // "v/ Park"
-      });
+        const actual = buildPageContent({
+          entireMessageByWord: messageContent,
+          firstLineEndIndex: 2, // "Wickford Junction"
+        });
 
-      expect(actual).toEqual(["Wickford Junction…", "…v/ Park…"]);
-    });
-
-    test("does not remove trailing 'via' shorthand on the second page", () => {
-      const messageContent = "Forge Park/495 v/ Back Bay".split(" ");
-
-      const actual = buildPageContent({
-        entireMessageByWord: messageContent,
-        firstLineEndIndex: 1, // "Forge"
-        secondLineEndIndex: 3, // "Park/495 v/"
-      });
-
-      expect(actual).toEqual(["Forge…", "…Park/495 v/…"]);
-    });
-
-    test("pulls in the next word when the second page is only 'via' shorthand", () => {
-      const messageContent = "Readville v/ Fairmount".split(" ");
-
-      const actual = buildPageContent({
-        entireMessageByWord: messageContent,
-        firstLineEndIndex: 1, // "Readville"
-        secondLineEndIndex: 2, // "v/"
-      });
-
-      expect(actual).toEqual(["Readville…", "…v/ Fairmount"]);
-    });
+        expect(actual).toEqual([
+          "Wickford Junction…",
+          `…${preposition} Park Street`,
+        ]);
+      },
+    );
   });
 });

--- a/assets/tests/components/dup/departures/destination.test.ts
+++ b/assets/tests/components/dup/departures/destination.test.ts
@@ -158,6 +158,18 @@ describe("buildPageContent", () => {
       expect(actual).toEqual(["Wickford Junction (Express…", "…to Sharon…"]);
     });
 
+    test("paginates and truncates the content with 'via' shorthand", () => {
+      const messageContent = "Wickford Junction v/ Park Street".split(" ");
+
+      const actual = buildPageContent({
+        entireMessageByWord: messageContent,
+        firstLineEndIndex: 2, // "Wickford Junction"
+        secondLineEndIndex: 4, // "v/ Park"
+      });
+
+      expect(actual).toEqual(["Wickford Junction…", "…v/ Park…"]);
+    });
+
     test("does not remove trailing 'via' shorthand on the second page", () => {
       const messageContent = "Forge Park/495 v/ Back Bay".split(" ");
 

--- a/lib/screens/headsigns/data.ex
+++ b/lib/screens/headsigns/data.ex
@@ -11,6 +11,7 @@ defmodule Screens.Headsigns.Data do
   See the generate_headsign_abbreviations.exs script to see how to generate this data in bulk.
   """
 
+  # TODO(NOW): Update the Notion document with the changes here
   @headsign_abbreviations %{
     "Allston Street" => ["Allston Street", "Allston St"],
     "Babcock Street" => ["Babcock Street", "Babcock St"],
@@ -54,15 +55,21 @@ defmodule Screens.Headsigns.Data do
     "Harvard Avenue" => ["Harvard Avenue", "Harvard Ave"],
     "Hawes Street" => ["Hawes Street", "Hawes St"],
     "Heath Street" => ["Heath Street", "Heath St"],
-    "Houghs Neck via Germantown" => ["Houghs Neck via Germntwn"],
-    "Houghs Neck via McGrath & Germantown" => ["Houghs Neck via McGth & Gtwn"],
+    "Houghs Neck via Germantown" => ["Houghs Neck via Germntwn", "Houghs Neck v/ Germntwn"],
+    "Houghs Neck via McGrath & Germantown" => [
+      "Houghs Neck via McGth & Gtwn",
+      "Houghs Neck v/ McGth & Gtwn"
+    ],
     "Hynes Convention Center" => ["Hynes Convention Center", "Hynes"],
     "Jackson Square" => ["Jackson Sq"],
     "Kent Street" => ["Kent Street", "Kent St"],
     "Longwood Medical Area" => ["Longwood Medical Area", "Longwood Med", "Lngwd Med"],
     "Magoun Square" => ["Magoun Square", "Magoun Sq"],
     "Malden Center" => ["Malden Center", "Malden Ctr"],
-    "Malden via Square One Mall & Kennedy Dr" => ["Malden via Square One Mall & Kndy Dr"],
+    "Malden via Square One Mall & Kennedy Dr" => [
+      "Malden via Square One Mall & Kndy Dr",
+      "Malden v/ Square One Mall & Kndy Dr"
+    ],
     "Massachusetts Avenue" => ["Mass Ave"],
     "Medford/Tufts" => ["Medford/Tufts", "Medfd/Tufts"],
     "Mission Park" => ["Mission Park", "Mission Pk"],
@@ -82,7 +89,10 @@ defmodule Screens.Headsigns.Data do
     "Roxbury Crossing" => ["Roxbury Crossing", "Roxbury Xng"],
     "Saint Mary's Street" => ["St. Mary's Street", "St. Mary's St", "St. Mary's"],
     "Saint Paul Street" => ["St. Paul Street", "St. Paul St"],
-    "Saugus Center via Kennedy Dr & Square One Mall" => ["Saugus Center via Kndy Dr & Square One"],
+    "Saugus Center via Kennedy Dr & Square One Mall" => [
+      "Saugus Center via Kndy Dr & Square One",
+      "Saugus Center v/ Kndy Dr & Square One"
+    ],
     "Science Park/West End" => ["Science Park/West End", "Science Park", "Science Pk"],
     "Silver Line Way" => ["Silver Line Way"],
     "South Station" => ["South Station", "South Sta"],
@@ -100,7 +110,10 @@ defmodule Screens.Headsigns.Data do
     "Washington Street" => ["Washington Street", "Washington St", "Wshngtn St"],
     "Washington St & Pleasant St Weymouth" => ["Washington St & Plsnt St Weymouth"],
     "Wickford Junction" => ["Wickford Junction", "Wickford Jct"],
-    "Woodland Rd via Gateway Center" => ["Woodland Rd via Gatew'y Center"],
+    "Woodland Rd via Gateway Center" => [
+      "Woodland Rd via Gatew'y Center",
+      "Woodland Rd v/ Gatew'y Center"
+    ],
     "Worcester Square" => ["Worcester Square", "Worcester Sq"],
     "World Trade Center" => ["World Trade Center", "World Trade Ctr"]
   }
@@ -114,6 +127,7 @@ defmodule Screens.Headsigns.Data do
     "College" => "Coll",
     "Corner" => "Cn",
     "Court" => "Ct",
+    "Depot" => "Dpt",
     "Drive" => "Dr",
     "East" => "E",
     "Express" => "Exp",
@@ -134,6 +148,7 @@ defmodule Screens.Headsigns.Data do
     "Station" => "Stn",
     "Street" => "St",
     "Terrace" => "Ter",
+    "via" => "v/",
     "Village" => "Vill",
     "Washington" => "Wash",
     "Way" => "Wy",

--- a/lib/screens/headsigns/data.ex
+++ b/lib/screens/headsigns/data.ex
@@ -11,7 +11,6 @@ defmodule Screens.Headsigns.Data do
   See the generate_headsign_abbreviations.exs script to see how to generate this data in bulk.
   """
 
-  # TODO(NOW): Update the Notion document with the changes here
   @headsign_abbreviations %{
     "Allston Street" => ["Allston Street", "Allston St"],
     "Babcock Street" => ["Babcock Street", "Babcock St"],

--- a/test/screens/v2/widget_instance/departures_test.exs
+++ b/test/screens/v2/widget_instance/departures_test.exs
@@ -740,7 +740,7 @@ defmodule Screens.V2.WidgetInstance.DeparturesTest do
     test "does not handle via on DUPs", %{dup_screen: dup_screen} do
       departure = %Departure{prediction: %Prediction{trip: %Trip{headsign: "Nubian via Allston"}}}
 
-      assert %{headsigns: ["Nubian via Allston"], variation: nil} ==
+      assert %{headsigns: ["Nubian via Allston", "Nubian v/ Allston"], variation: nil} ==
                Departures.serialize_headsign([departure], dup_screen)
     end
 


### PR DESCRIPTION


**Asana task**: [[DUP] Fallback for when headsigns are still too long after abbreviation](https://app.asana.com/1/15492006741476/project/1185117109217422/task/1216176829234397?focus=true)

Description

- [x] Tests added?


Add the "via" -> "v/" and "depot" -> "dpt" single word abbreviations
to the word abbreviation dictionary. Update the headsign abbreviations
list to include these transformations where applicable. Note: These
abbreviations apply to all non eink screens.

For DUPs, update the pagination of headsigns on DUPs when content
spans two pages:
1. An ellipsis will be added to the end of the first page and the start
   of the second page
2. The second page consists of "…" + the portion of the message that
   did not fit on the first page. It is not guaranteed that all text
   will fit when actually displayed. We rely on CSS rules on
   text-overflow to ellipsize the end of the second page for us.

The logic for single page content remains unchanged.

A new function, `buildPageContent` is introduced to keep the new logic
out of the `RenderedDestination` component. This move was made to:
1. Make `RenderedDestination` more presentational
2. Remove `RenderedDestination`'s need to understand the semantics
of message parts and indices set by `useLayoutEffect` and
`nextSizingState`
3. Extract the logic to make it testable


https://github.com/user-attachments/assets/8dc5cbb6-0196-416a-a3b4-05ab09f50171

