### PR TITLE
fix: incorrect audio content summary behavior

### DIFF
--- a/lib/screens/v2/screen_audio_data.ex
+++ b/lib/screens/v2/screen_audio_data.ex
@@ -14,19 +14,11 @@ defmodule Screens.V2.ScreenAudioData do
         now \\ DateTime.utc_now()
       ) do
     if Parameters.audio_enabled?(screen, now) do
-      visual_widgets_with_audio_equivalence =
-        screen
-        |> generate_layout_fn.()
-        |> elem(1)
-        |> Map.values()
-        |> Enum.filter(&WidgetInstance.audio_valid_candidate?/1)
+      visual_widgets = screen |> generate_layout_fn.() |> elem(1) |> Map.values()
+      audio_only_widgets = get_audio_only_instances_fn.(visual_widgets, screen)
 
-      audio_only_widgets =
-        visual_widgets_with_audio_equivalence
-        |> get_audio_only_instances_fn.(screen)
-        |> Enum.filter(&WidgetInstance.audio_valid_candidate?/1)
-
-      (visual_widgets_with_audio_equivalence ++ audio_only_widgets)
+      (visual_widgets ++ audio_only_widgets)
+      |> Enum.filter(&WidgetInstance.audio_valid_candidate?/1)
       |> Enum.sort_by(&WidgetInstance.audio_sort_key/1)
       |> Enum.map(&{WidgetInstance.audio_view(&1), WidgetInstance.audio_serialize(&1)})
     else

--- a/test/screens/v2/screen_audio_data_test.exs
+++ b/test/screens/v2/screen_audio_data_test.exs
@@ -62,7 +62,14 @@ defmodule Screens.V2.ScreenAudioDataTest do
       }
 
       generate_layout_fn = fn _config_valid_audio -> {:layout, selected_instances} end
-      get_audio_only_instances_fn = fn _widgets, _config -> [] end
+
+      get_audio_only_instances_fn = fn widgets, _config ->
+        # All selected instances should be passed to `audio_only_instances` in the snapshot, even
+        # those without audio equivalence
+        assert Enum.sort(widgets) == selected_instances |> Map.values() |> Enum.sort()
+        []
+      end
+
       audio_view = ScreensWeb.V2.Audio.MockWidgetView
       expected_data = [{audio_view, %{content: "Header"}}, {audio_view, %{content: "Departures"}}]
 


### PR DESCRIPTION
The Content Summary widget generator function checks whether there are any "takeover" widgets in the snapshot it's given, and doesn't generate the summary widget if so. However, this snapshot only included widgets with audio equivalence, which is not true of (say) an evergreen content takeover without any "audio text" configured. Screens in this state would thus incorrectly read out a content summary (and nothing else), and report a warning due to not finding the header widget.

Fix this by passing the full list of widgets to `audio_only_instances`. Only those that are valid audio candidates are included in the readout, as before.

**Asana task**: https://app.asana.com/1/15492006741476/project/1185117109217413/task/1217246407080153?focus=true