### PR TITLE
fix: multiple green line routes causing unexpected_platform_closure_dup

### DIFF
--- a/lib/screens/v2/widget_instance/dup_alert/serialize.ex
+++ b/lib/screens/v2/widget_instance/dup_alert/serialize.ex
@@ -305,6 +305,7 @@ defmodule Screens.V2.WidgetInstance.DupAlert.Serialize do
       t.alert.informed_entities
       |> Enum.filter(&(&1.stop.id in child_stop_ids and &1.stop.platform_name))
       |> Enum.map(& &1.stop.platform_name)
+      |> Enum.uniq()
 
     case platform_names do
       [platform_name] ->


### PR DESCRIPTION
**Asana task**: [DUP single platform closure bug](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1217246407080159?focus=true)

Description
- because `Green Line` was selected for the alert, we have IEs for all of the Green Line routes associated with that platform get mapped to multiple of the same platform name and therefore become "multiple platforms closed".
- added a `Enum.uniq` to filter out repeating platform names if we have the same platform name for multiple routes
