### PR TITLE
refactor: simplify ScreenData screen ID handling

### DIFF
--- a/lib/screens/screens_by_alert/self_refresh_runner.ex
+++ b/lib/screens/screens_by_alert/self_refresh_runner.ex
@@ -99,7 +99,7 @@ defmodule Screens.ScreensByAlert.SelfRefreshRunner do
         |> Task.Supervisor.async_stream_nolink(
           ids,
           fn id ->
-            id |> Cache.screen() |> @screen_data.get(update_visible_alerts_for_screen_id: id)
+            @screen_data.get(id, Cache.screen(id))
             id
           end,
           max_concurrency: @max_concurrency,

--- a/lib/screens/v2/screen_data.ex
+++ b/lib/screens/v2/screen_data.ex
@@ -16,26 +16,20 @@ defmodule Screens.V2.ScreenData do
 
   @type t :: %{type: atom()}
   @type simulation_data :: %{full_page: t(), flex_zone: [t()]}
-  @type options :: [
-          update_visible_alerts_for_screen_id: String.t()
-        ]
 
-  @callback get(Screen.t()) :: t()
-  @callback get(Screen.t(), options()) :: t()
-  def get(screen, opts \\ []), do: generate(screen, opts, &layout_to_data/2)
+  @callback get(String.t(), Screen.t()) :: t()
+  def get(id, screen), do: generate(id, screen, &layout_to_data/2)
 
-  @spec simulation(Screen.t()) :: simulation_data()
-  @spec simulation(Screen.t(), options()) :: simulation_data()
-  def simulation(screen, opts \\ []), do: generate(screen, opts, &layout_to_simulation_data/2)
+  @spec simulation(String.t(), Screen.t()) :: simulation_data()
+  def simulation(id, screen), do: generate(id, screen, &layout_to_simulation_data/2)
 
-  @spec generate(Screen.t(), options(), (Layout.t(), Screen.t() -> data)) :: data
+  @spec generate(String.t(), Screen.t(), (Layout.t(), Screen.t() -> data)) :: data
         when data: t() | simulation_data()
-  defp generate(screen, opts, then_fn) do
-    update_visible_alerts_in_progress(screen, opts)
-
+  defp generate(id, screen, then_fn) do
     screen
+    |> tap(&update_visible_alerts_in_progress(id, &1))
     |> Layout.generate()
-    |> tap(&update_visible_alerts(&1, screen, opts))
+    |> tap(&update_visible_alerts(&1, id, screen))
     |> then_fn.(screen)
   end
 
@@ -131,29 +125,18 @@ defmodule Screens.V2.ScreenData do
     end
   end
 
-  defp update_visible_alerts_in_progress(%Screen{hidden_from_screenplay: true}, _opts), do: :ok
+  defp update_visible_alerts_in_progress(_id, %Screen{hidden_from_screenplay: true}), do: :ok
+  defp update_visible_alerts_in_progress(id, _screen), do: ScreensByAlert.put_in_progress([id])
 
-  defp update_visible_alerts_in_progress(_screen, opts) do
-    screen_id = Keyword.get(opts, :update_visible_alerts_for_screen_id, nil)
-    if not is_nil(screen_id), do: ScreensByAlert.put_in_progress([screen_id])
-    :ok
-  end
+  defp update_visible_alerts(_, _id, %Screen{hidden_from_screenplay: true}), do: :ok
 
-  defp update_visible_alerts(_, %Screen{hidden_from_screenplay: true}, _opts), do: :ok
+  defp update_visible_alerts({_layout, instance_map}, id, _screen) do
+    alert_ids =
+      instance_map
+      |> Map.values()
+      |> Enum.flat_map(&AlertsWidget.alert_ids/1)
 
-  defp update_visible_alerts({_layout, instance_map}, _screen, opts) do
-    screen_id = Keyword.get(opts, :update_visible_alerts_for_screen_id, nil)
-
-    if not is_nil(screen_id) do
-      alert_ids =
-        instance_map
-        |> Map.values()
-        |> Enum.flat_map(&AlertsWidget.alert_ids/1)
-
-      ScreensByAlert.put_data(screen_id, alert_ids)
-    end
-
-    :ok
+    ScreensByAlert.put_data(id, alert_ids)
   end
 
   defp paged_slot_key({paged_slot_id, _}, :pre_fare_v2), do: Template.get_slot_id(paged_slot_id)

--- a/lib/screens_web/controllers/v2/screen_api_controller.ex
+++ b/lib/screens_web/controllers/v2/screen_api_controller.ex
@@ -18,20 +18,14 @@ defmodule ScreensWeb.V2.ScreenApiController do
   plug :disabled_response when action in @show_actions
   plug :outdated_response when action in @show_actions
 
-  def show(%{assigns: %{screen_id: screen_id, screen: screen}} = conn, _params) do
-    response =
-      screen
-      |> screen_response(update_visible_alerts_for_screen_id: screen_id)
-      |> put_extra_fields(screen)
-
-    json(conn, response)
+  def show(%{assigns: %{screen_id: id, screen: screen}} = conn, _params) do
+    json(conn, screen_response(id, screen) |> put_extra_fields(screen))
   end
 
   def show_dup(conn, params), do: show(conn, params)
 
-  def simulation(%{assigns: %{screen_id: screen_id, screen: screen}} = conn, _params) do
-    data = ScreenData.simulation(screen, update_visible_alerts_for_screen_id: screen_id)
-    json(conn, %{@base_response | data: data})
+  def simulation(%{assigns: %{screen_id: id, screen: screen}} = conn, _params) do
+    json(conn, %{@base_response | data: ScreenData.simulation(id, screen)})
   end
 
   def log_frontend_error(conn, params) do
@@ -71,13 +65,13 @@ defmodule ScreensWeb.V2.ScreenApiController do
   end
 
   # See `docs/mercury_api.md`
-  defp screen_response(%Screen{vendor: :mercury} = screen, opts) do
-    %{full_page: data, flex_zone: flex_zone} = ScreenData.simulation(screen, opts)
+  defp screen_response(id, %Screen{vendor: :mercury} = screen) do
+    %{full_page: data, flex_zone: flex_zone} = ScreenData.simulation(id, screen)
     Map.merge(%{@base_response | data: data}, %{flex_zone: flex_zone})
   end
 
-  defp screen_response(screen, opts) do
-    %{@base_response | data: ScreenData.get(screen, opts)}
+  defp screen_response(id, screen) do
+    %{@base_response | data: ScreenData.get(id, screen)}
   end
 
   # See `docs/mercury_api.md`

--- a/test/screens/screens_by_alert/self_refresh_runner_test.exs
+++ b/test/screens/screens_by_alert/self_refresh_runner_test.exs
@@ -24,15 +24,8 @@ defmodule Screens.ScreensByAlert.SelfRefreshRunnerTest do
     expect(ScreensByAlert.Mock, :get_in_progress, fn _screen_ids -> ["1301"] end)
     expect(ScreensByAlert.Mock, :put_in_progress, fn ~w[1401 1002] -> :ok end)
 
-    expect(ScreenData.Mock, :get, fn %Screen{app_id: :bus_shelter_v2},
-                                     [update_visible_alerts_for_screen_id: "1401"] ->
-      %{type: :x}
-    end)
-
-    expect(ScreenData.Mock, :get, fn %Screen{app_id: :bus_eink_v2},
-                                     [update_visible_alerts_for_screen_id: "1002"] ->
-      raise "oops"
-    end)
+    expect(ScreenData.Mock, :get, fn "1401", %Screen{app_id: :bus_shelter_v2} -> %{type: :x} end)
+    expect(ScreenData.Mock, :get, fn "1002", %Screen{app_id: :bus_eink_v2} -> raise "oops" end)
 
     screen_ids = MapSet.new(~w[1002 1401])
     assert {:noreply, ^screen_ids} = SelfRefreshRunner.handle_info(:check, MapSet.new())

--- a/test/screens/v2/screen_data_test.exs
+++ b/test/screens/v2/screen_data_test.exs
@@ -39,7 +39,7 @@ defmodule Screens.V2.ScreenDataTest do
 
       expect(@parameters, :candidate_generator, fn %Screen{app_id: :test_app} -> GrayGenerator end)
 
-      assert ScreenData.get(screen) ==
+      assert ScreenData.get("test", screen) ==
                %{type: :normal, main: %{type: :placeholder, color: :gray, text: ""}}
     end
   end


### PR DESCRIPTION
422269c removed all code paths that *didn't* provide the `update_visible_alerts_for_screen_id` option to `ScreenData` functions, so this can be made a required argument. This also:

* simplifies implementation of the upcoming widget cache.
* should reduce the changes needed to support database-backed config, where the ID and config struct will travel together.