### PR TITLE
chore: add exhaustive switch lint check

### DIFF
--- a/assets/eslint.config.mjs
+++ b/assets/eslint.config.mjs
@@ -7,7 +7,21 @@ import eslintConfigPrettier from "eslint-config-prettier";
 import jestPlugin from "eslint-plugin-jest";
 
 export default [
-  { languageOptions: { globals: globals.browser } },
+  {
+    languageOptions: {
+      globals: globals.browser,
+      parserOptions: {
+        projectService: {
+          allowDefaultProject: [
+            "eslint.config.mjs",
+            "jest.config.js",
+            "stylelint.config.mjs",
+            "webpack.config.js",
+          ],
+        },
+      },
+    },
+  },
   pluginJs.configs.recommended,
   ...tseslint.configs.recommended,
   pluginReact.configs.flat.recommended,
@@ -50,6 +64,14 @@ export default [
           caughtErrorsIgnorePattern: "^_",
           destructuredArrayIgnorePattern: "^_",
           varsIgnorePattern: "^_",
+        },
+      ],
+      "@typescript-eslint/switch-exhaustiveness-check": [
+        "error",
+        {
+          allowDefaultCaseForExhaustiveSwitch: false,
+          requireDefaultForNonUnion: true,
+          considerDefaultExhaustiveForUnions: true,
         },
       ],
     },

--- a/assets/src/components/dup/departures/destination.tsx
+++ b/assets/src/components/dup/departures/destination.tsx
@@ -46,9 +46,7 @@ export type SizingStateUpdate =
   | TwoLinesPhaseUpdate;
 
 // Returns changes to make to the state given the current line-fit measurements
-export const nextSizingState = (
-  state: SizingState,
-): SizingStateUpdate | null => {
+export const nextSizingState = (state: SizingState): SizingStateUpdate => {
   const {
     phase,
     headsignIndex,
@@ -101,9 +99,8 @@ export const nextSizingState = (
           return { phase: PHASES.Done };
         }
       }
-    default:
-      // Must return default fallback, but we'll never reach this case
-      return null;
+    case PHASES.Done:
+      return { phase: PHASES.Done };
   }
 };
 
@@ -211,20 +208,18 @@ const Destination: ComponentType<DupDestination> = ({
           firstLineFits: !hasOverflowX(firstLineRef.current),
           secondLineFits: !hasOverflowX(secondLineRef.current),
         });
-        if (next) {
-          // Update the state so we can re-attempt sizing with updated values
-          if ("headsignIndex" in next && next.headsignIndex !== undefined) {
-            setHeadsignIndex(next.headsignIndex);
-          }
-          if ("phase" in next && next.phase !== undefined) {
-            setPhase(next.phase);
-          }
-          if ("partsIndex1" in next && next.partsIndex1 !== undefined) {
-            setPartsIndex1(next.partsIndex1);
-          }
-          if ("partsIndex2" in next && next.partsIndex2 !== undefined) {
-            setPartsIndex2(next.partsIndex2);
-          }
+        // Update the state so we can re-attempt sizing with updated values
+        if ("headsignIndex" in next && next.headsignIndex !== undefined) {
+          setHeadsignIndex(next.headsignIndex);
+        }
+        if ("phase" in next && next.phase !== undefined) {
+          setPhase(next.phase);
+        }
+        if ("partsIndex1" in next && next.partsIndex1 !== undefined) {
+          setPartsIndex1(next.partsIndex1);
+        }
+        if ("partsIndex2" in next && next.partsIndex2 !== undefined) {
+          setPartsIndex2(next.partsIndex2);
         }
       }
     });

--- a/assets/src/components/dup/viewport.tsx
+++ b/assets/src/components/dup/viewport.tsx
@@ -20,8 +20,9 @@ const Viewport: ComponentType<PropsWithChildren> = ({ children }) => {
     case "2":
       shifterClassName += " dup-shifter--rotation-two";
       break;
-    default:
+    case null:
       viewportClassName += " dup-screen-viewport--all";
+      break;
   }
 
   return (

--- a/assets/src/components/eink/alert.tsx
+++ b/assets/src/components/eink/alert.tsx
@@ -120,8 +120,6 @@ const filenameForFullBodyTopScreenIcon = (icon: AlertIcon) => {
       return "alert-black.svg";
     case "snowflake":
       return "alert-widget-icon-snowflake--eink.svg";
-    default:
-      return "alert-black.svg";
   }
 };
 

--- a/assets/src/components/elevator_status.tsx
+++ b/assets/src/components/elevator_status.tsx
@@ -1,6 +1,6 @@
 import cx from "classnames";
 import { QRCodeSVG as QRCode } from "qrcode.react";
-import { type ComponentType, type JSX } from "react";
+import { type ComponentType } from "react";
 
 import FreeText, { type FreeTextType } from "./free_text";
 
@@ -27,9 +27,7 @@ type Props = {
   qr_code_url: string;
 };
 
-const StatusIcon: ComponentType<{ status: ElevatorStatus }> = ({
-  status,
-}): JSX.Element => {
+const StatusIcon: ComponentType<{ status: ElevatorStatus }> = ({ status }) => {
   switch (status) {
     case "alert":
       return <ElevatorAlertIcon width={280} height={160} />;

--- a/assets/src/components/pre_fare_single_screen_alert.tsx
+++ b/assets/src/components/pre_fare_single_screen_alert.tsx
@@ -368,7 +368,7 @@ const PreFareSingleScreenAlert: ComponentType<PreFareSingleScreenAlertProps> = (
   } = alert;
 
   /**
-   * This switch statement picks the alert layout
+   * This series of if/else statements picks the alert layout:
    * - fallback: icon, followed by a summary & pio text, or just the pio text
    * - partial closure: icon + route pill + text explaining the lines that are closed at the station
    *                    and then icon + route pill + text explaining normal service. Finally, the map section
@@ -376,81 +376,78 @@ const PreFareSingleScreenAlert: ComponentType<PreFareSingleScreenAlertProps> = (
    * - downstream: map, issue without icon, then icon + remedy
    **/
   let layout;
-  switch (true) {
-    case effect === "delay" || !disruption_diagram:
-      layout = <FallbackLayout issue={issue} remedy={remedy} effect={effect} />;
-      break;
-    case isPartialClosure(alert):
-      // By definition if `isPartialClosure` is true then `unaffected_routes` is
-      // present, so it's okay to use a non-null assertion here.
-      layout = (
-        <PartialClosureLayout
-          routes={routes}
-          unaffected_routes={unaffected_routes!}
-          disruptionDiagram={disruption_diagram}
-        />
-      );
-      break;
-    case effect === "station_closure" && region === "here":
-      layout = (
-        <StandardLayout
-          issue={issue}
-          remedy={remedy}
-          effect={effect}
-          location={location}
-          disruptionDiagram={disruption_diagram}
-          show_alternate_route_text={show_alternate_route_text}
-          alternateRouteURL={alternateRouteURL}
-          qrCodeURL={qrCodeURL}
-        />
-      );
-      break;
-    case effect === "station_closure":
-      layout = (
-        <StandardLayout
-          issue={issue}
-          remedy={remedy}
-          effect={effect}
-          location={location}
-          disruptionDiagram={disruption_diagram}
-          show_alternate_route_text={show_alternate_route_text}
-          alternateRouteURL={alternateRouteURL}
-          qrCodeURL={qrCodeURL}
-        />
-      );
-      break;
-    case (region === "boundary" || region === "here") &&
-      (effect === "shuttle" || effect === "suspension"):
-      layout = (
-        <StandardLayout
-          issue={issue}
-          remedy={remedy}
-          effect={effect}
-          location={location}
-          disruptionDiagram={disruption_diagram}
-          show_alternate_route_text={show_alternate_route_text}
-          alternateRouteURL={alternateRouteURL}
-          qrCodeURL={qrCodeURL}
-        />
-      );
-      break;
-    case region === "outside" &&
-      endpoints &&
-      (effect === "shuttle" || effect === "suspension"):
-      layout = (
-        <DownstreamLayout
-          endpoints={endpoints}
-          effect={effect}
-          remedy={remedy}
-          disruptionDiagram={disruption_diagram}
-          show_alternate_route_text={show_alternate_route_text}
-          alternateRouteURL={alternateRouteURL}
-          qrCodeURL={qrCodeURL}
-        />
-      );
-      break;
-    default:
-      layout = <FallbackLayout issue={issue} remedy={remedy} effect={effect} />;
+  if (effect === "delay" || !disruption_diagram) {
+    layout = <FallbackLayout issue={issue} remedy={remedy} effect={effect} />;
+  } else if (isPartialClosure(alert)) {
+    // By definition if `isPartialClosure` is true then `unaffected_routes` is
+    // present, so it's okay to use a non-null assertion here.
+    layout = (
+      <PartialClosureLayout
+        routes={routes}
+        unaffected_routes={unaffected_routes!}
+        disruptionDiagram={disruption_diagram}
+      />
+    );
+  } else if (effect === "station_closure" && region === "here") {
+    layout = (
+      <StandardLayout
+        issue={issue}
+        remedy={remedy}
+        effect={effect}
+        location={location}
+        disruptionDiagram={disruption_diagram}
+        show_alternate_route_text={show_alternate_route_text}
+        alternateRouteURL={alternateRouteURL}
+        qrCodeURL={qrCodeURL}
+      />
+    );
+  } else if (effect === "station_closure") {
+    layout = (
+      <StandardLayout
+        issue={issue}
+        remedy={remedy}
+        effect={effect}
+        location={location}
+        disruptionDiagram={disruption_diagram}
+        show_alternate_route_text={show_alternate_route_text}
+        alternateRouteURL={alternateRouteURL}
+        qrCodeURL={qrCodeURL}
+      />
+    );
+  } else if (
+    (region === "boundary" || region === "here") &&
+    (effect === "shuttle" || effect === "suspension")
+  ) {
+    layout = (
+      <StandardLayout
+        issue={issue}
+        remedy={remedy}
+        effect={effect}
+        location={location}
+        disruptionDiagram={disruption_diagram}
+        show_alternate_route_text={show_alternate_route_text}
+        alternateRouteURL={alternateRouteURL}
+        qrCodeURL={qrCodeURL}
+      />
+    );
+  } else if (
+    region === "outside" &&
+    endpoints &&
+    (effect === "shuttle" || effect === "suspension")
+  ) {
+    layout = (
+      <DownstreamLayout
+        endpoints={endpoints}
+        effect={effect}
+        remedy={remedy}
+        disruptionDiagram={disruption_diagram}
+        show_alternate_route_text={show_alternate_route_text}
+        alternateRouteURL={alternateRouteURL}
+        qrCodeURL={qrCodeURL}
+      />
+    );
+  } else {
+    layout = <FallbackLayout issue={issue} remedy={remedy} effect={effect} />;
   }
 
   const showBanner = !isPartialClosure(alert);


### PR DESCRIPTION
**Asana task**: [Screens: Type-Aware Linting](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1216828252543714?focus=true)

Description


Enable `@typescript-eslint/switch-exhaustiveness-check` in the project
to evaluate `switch` statements for completeness with the following
options set:
- `allowDefaultCaseForExhaustiveSwitch` - disabled to detect cases
where `default:` is used in a `switch` that would otherwise be
exhaustive, preventing dead code
- `requireDefaultForNonUnion` - enabled to enforce a `default` when
switching over a type that is not a union/necessarily exhaustive, such
as a `number` or `string`
- `considerDefaultExhaustiveForUnions` - enabled to allow for a single
case in the codebase where a "base" component accepts a wider range of
unioned strings than we provide in practice

Doing so required expanding the `languageOptions` in the eslint config.
`projectService` was used to add type semantics to linting, per the
recommendation of typescript-eslint. A handful of files are not
connected to the project's `tsconfig.json`, which resulted in errors
when linting. They've been added under the `allowDefaultProject`
property to be able to lint them moving forward.



- [ ] Tests added?
