### PR TITLE
fix: dropped log messages when Device Monitor runs

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -23,7 +23,10 @@ config :screens, Screens.Repo,
 
 config :screens, ecto_repos: [Screens.Repo]
 
-# Configures Elixir's Logger
+# Increase drop mode threshold from the default to accommodate periodic "bursts" of >200 log
+# messages at once from the Device Monitor.
+config :logger, :default_handler, config: [drop_mode_qlen: 500]
+
 config :logger, :default_formatter,
   format: "$time [$level] $message $metadata\n",
   metadata: ~w[


### PR DESCRIPTION
The Device Monitor periodically produces "bursts" of a few hundred log messages in nearly the same instant, which can exceed the default drop mode threshold of 200 and cause some messages (including those from unrelated processes that happen to be logging something at the same time) to be dropped. Increasing this threshold uses more memory during those instants but allows all messages to be logged.

The configuration is [documented here](https://www.erlang.org/doc/apps/kernel/logger_chapter.html#overload_protection). Tested in dev; [example search](https://mbta.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dscreens-dev-application%20handler%20switched&display.page.search.mode=verbose&dispatch.sample_ratio=1&workload_pool=&earliest=-4h%40m&latest=now&sid=1787067230.61682) showing the logger is no longer switching to `drop` mode since the deploy at 11:00am.