### PR TITLE
refactor: Cast config from Postgres as `Screen` type

### DIFF
--- a/lib/screens/config/screen_config.ex
+++ b/lib/screens/config/screen_config.ex
@@ -1,7 +1,8 @@
 defmodule Screens.Config.ScreenConfig do
   use Ecto.Schema
 
-  alias ScreensConfig.Config
+  alias Screens.Config.ScreenConfigType
+  alias ScreensConfig.Screen
 
   import Ecto.Changeset
 
@@ -9,12 +10,12 @@ defmodule Screens.Config.ScreenConfig do
 
   @type t() :: %__MODULE__{
           id: String.t(),
-          config: Config.t()
+          config: Screen.t()
         }
 
   @primary_key {:id, :string, autogenerate: false}
   schema "screen_configs" do
-    field :config, :map
+    field :config, ScreenConfigType
 
     timestamps(type: :utc_datetime)
   end
@@ -23,5 +24,12 @@ defmodule Screens.Config.ScreenConfig do
     screen_config
     |> cast(attrs, [:id, :config])
     |> validate_required([:id, :config])
+  end
+
+  @spec from_attrs(map()) :: {:ok, t()} | {:error, Ecto.Changeset.t()}
+  def from_attrs(attrs) do
+    %__MODULE__{}
+    |> changeset(attrs)
+    |> apply_action(:insert)
   end
 end

--- a/lib/screens/config/screen_config_type.ex
+++ b/lib/screens/config/screen_config_type.ex
@@ -1,0 +1,45 @@
+defmodule Screens.Config.ScreenConfigType do
+  @moduledoc """
+  Custom `Ecto.Type` for screen configuration payloads.
+
+  This type stores config data as a map in the database while supporting
+  `%ScreensConfig.Screen{}` structs at the application boundary.
+
+  On load, it hydrates persisted maps into `%ScreensConfig.Screen{}`.
+  """
+
+  @behaviour Ecto.Type
+
+  alias ScreensConfig.Screen
+
+  @impl true
+  def type, do: :map
+
+  @impl true
+  def cast(%Screen{} = screen), do: {:ok, screen}
+
+  def cast(%{} = map), do: {:ok, Screen.from_json(map)}
+
+  def cast(_), do: :error
+
+  @impl true
+  def load(config) when is_map(config) do
+    case Screen.from_json(config) do
+      %Screen{} = screen -> {:ok, screen}
+      nil -> {:ok, config}
+    end
+  end
+
+  def load(_), do: :error
+
+  @impl true
+  def dump(%Screen{} = screen), do: {:ok, Screen.to_json(screen)}
+
+  def dump(_), do: :error
+
+  @impl true
+  def embed_as(_format), do: :self
+
+  @impl true
+  def equal?(left, right), do: left == right
+end

--- a/lib/screens/screen_configs.ex
+++ b/lib/screens/screen_configs.ex
@@ -8,6 +8,7 @@ defmodule Screens.ScreenConfigs do
 
   alias Screens.Config.ScreenConfig
   alias Screens.Repo
+  alias ScreensConfig.Screen
 
   @config_fetcher injected(Screens.Config.Fetch)
 
@@ -49,7 +50,7 @@ defmodule Screens.ScreenConfigs do
   end
 
   @doc """
-  Returns all Configs as JSON to be used by Screens Admin
+  Returns all Configs as JSON with the ID as a key and the configuration as the value.
   """
   @spec list_all() :: String.t() | :error
   def list_all do
@@ -57,34 +58,14 @@ defmodule Screens.ScreenConfigs do
       screens =
         ScreenConfig
         |> Repo.all()
-        |> Map.new(fn %ScreenConfig{id: id, config: config} -> {id, config} end)
+        |> Map.new(fn %ScreenConfig{id: id, config: config} ->
+          {id, Screen.to_json(config)}
+        end)
 
       Jason.encode!(%{screens: screens})
     else
       with {:ok, config, _version} <- @config_fetcher.fetch_config() do
         config
-      end
-    end
-  end
-
-  @doc """
-  Returns all configs as a list of ScreenConfig structs to be used by Screens Admin
-  The API controller handles the JSON encoding and formatting for the response.
-  As part of post_config_migration_cleanup, this and list_all can be cleaned up and restructured
-  """
-  @spec list_screen_configs() :: [ScreenConfig.t()]
-  def list_screen_configs do
-    if config_migration_enabled?() do
-      Repo.all(ScreenConfig)
-    else
-      with {:ok, config_json, _version} <- @config_fetcher.fetch_config(),
-           {:ok, decoded_config} <- Jason.decode(config_json),
-           screens when is_map(screens) <- Map.get(decoded_config, "screens", %{}) do
-        Enum.map(screens, fn {id, config} ->
-          %ScreenConfig{id: id, config: config}
-        end)
-      else
-        _ -> []
       end
     end
   end

--- a/lib/screens_web/controllers/screen_configs_api_controller.ex
+++ b/lib/screens_web/controllers/screen_configs_api_controller.ex
@@ -4,9 +4,7 @@ defmodule ScreensWeb.ScreenConfigsApiController do
   alias Screens.ScreenConfigs
 
   def index(conn, _params) do
-    screen_configs = ScreenConfigs.list_screen_configs()
-
-    json(conn, %{screen_configs: screen_configs})
+    json(conn, %{config: ScreenConfigs.list_all()})
   end
 
   def update(conn, %{"screen_configs" => screen_configs}) when is_list(screen_configs) do

--- a/test/screens_web/controllers/admin_api_controller_test.exs
+++ b/test/screens_web/controllers/admin_api_controller_test.exs
@@ -3,13 +3,10 @@ defmodule ScreensWeb.AdminApiControllerTest do
 
   import ExUnit.CaptureLog
   import Mox
+  import Screens.TestSupport.ScreenConfigBuilder
 
   alias Screens.Config.ScreenConfig
   alias Screens.Repo
-
-  # Test config constants
-  @screen_dup_config %{"app_id" => "dup_v2"}
-  @screen_busway_config %{"app_id" => "busway_v2"}
 
   setup do
     :ok = Ecto.Adapters.SQL.Sandbox.checkout(Repo)
@@ -30,24 +27,29 @@ defmodule ScreensWeb.AdminApiControllerTest do
     test "updates screen configs in Postgres when migration flag is true", %{conn: conn} do
       Application.put_env(:screens, :config_migration, true)
 
-      Repo.insert!(%ScreenConfig{id: "screen-1", config: @screen_busway_config})
+      screen_dup_config = screen_config(:dup_v2)
+      screen_busway_config = screen_config(:busway_v2)
+
+      Repo.insert!(%ScreenConfig{id: "screen-1", config: screen_busway_config})
 
       conn =
         post(conn, "/api/admin/screen_configs/update", %{
           screen_configs: [
-            %{id: "screen-1", config: @screen_dup_config}
+            %{id: "screen-1", config: screen_dup_config}
           ]
         })
 
       assert json_response(conn, 200) == %{"success" => true}
 
       updated = Repo.get!(ScreenConfig, "screen-1")
-      assert updated.config == @screen_dup_config
+      assert updated.config == screen_dup_config
     end
 
     @tag :authenticated
     test "updates full config when migration flag is false", %{conn: conn} do
       Application.put_env(:screens, :config_migration, false)
+
+      screen_busway_config = screen_config_json(:busway_v2)
 
       # Mock the fetch and put to prevent writing to the fixture file
       expect(Screens.Config.Fetch.Mock, :fetch_config, fn ->
@@ -59,7 +61,7 @@ defmodule ScreensWeb.AdminApiControllerTest do
       conn =
         post(conn, "/api/admin/screen_configs/update", %{
           screen_configs: [
-            %{"id" => "screen-2", "config" => @screen_busway_config}
+            %{"id" => "screen-2", "config" => screen_busway_config}
           ]
         })
 
@@ -78,8 +80,11 @@ defmodule ScreensWeb.AdminApiControllerTest do
     test "deletes screen configs in Postgres when migration flag is true", %{conn: conn} do
       Application.put_env(:screens, :config_migration, true)
 
-      Repo.insert!(%ScreenConfig{id: "screen-1", config: @screen_dup_config})
-      Repo.insert!(%ScreenConfig{id: "screen-2", config: @screen_busway_config})
+      screen_dup_config = screen_config(:dup_v2)
+      screen_busway_config = screen_config(:busway_v2)
+
+      Repo.insert!(%ScreenConfig{id: "screen-1", config: screen_dup_config})
+      Repo.insert!(%ScreenConfig{id: "screen-2", config: screen_busway_config})
 
       conn =
         post(conn, "/api/admin/screen_configs/delete", %{

--- a/test/screens_web/controllers/screen_configs_api_controller_test.exs
+++ b/test/screens_web/controllers/screen_configs_api_controller_test.exs
@@ -3,29 +3,13 @@ defmodule ScreensWeb.ScreenConfigsApiControllerTest do
 
   import ExUnit.CaptureLog
   import Mox
+  import Screens.TestSupport.ScreenConfigBuilder
 
   alias Screens.Config.ScreenConfig
   alias Screens.Repo
+  alias ScreensConfig.Screen
 
   @env_var "SCREENS_API_CLIENT_KEY"
-
-  # Test config constants
-  @screen_dup_config %{"app_id" => "dup_v2"}
-  @screen_busway_config %{"app_id" => "busway_v2"}
-  @screen_dup_old_config %{"app_id" => "dup_old"}
-
-  @legacy_config %{
-    "screens" => %{
-      "dup_1" => @screen_dup_config,
-      "busway_1" => @screen_busway_config
-    }
-  }
-
-  @legacy_config_dup_only %{
-    "screens" => %{
-      "dup_1" => @screen_dup_old_config
-    }
-  }
 
   setup do
     :ok = Ecto.Adapters.SQL.Sandbox.checkout(Repo)
@@ -59,8 +43,11 @@ defmodule ScreensWeb.ScreenConfigsApiControllerTest do
       System.put_env(@env_var, "shared-secret")
       Application.put_env(:screens, :config_migration, true)
 
-      Repo.insert!(%ScreenConfig{id: "screen-1", config: @screen_dup_config})
-      Repo.insert!(%ScreenConfig{id: "screen-2", config: @screen_busway_config})
+      screen_dup_config = screen_config(:dup_v2)
+      screen_busway_config = screen_config(:busway_v2)
+
+      Repo.insert!(%ScreenConfig{id: "screen-1", config: screen_dup_config})
+      Repo.insert!(%ScreenConfig{id: "screen-2", config: screen_busway_config})
 
       conn =
         conn
@@ -69,12 +56,11 @@ defmodule ScreensWeb.ScreenConfigsApiControllerTest do
 
       assert conn.status == 200
 
-      %{"screen_configs" => screen_configs} = json_response(conn, 200)
+      %{"config" => config_json} = json_response(conn, 200)
+      config = Jason.decode!(config_json)
 
-      assert length(screen_configs) == 2
-      configs_by_id = Map.new(screen_configs, &{&1["id"], &1["config"]})
-      assert configs_by_id["screen-1"] == @screen_dup_config
-      assert configs_by_id["screen-2"] == @screen_busway_config
+      assert config["screens"]["screen-1"] == normalize_json(Screen.to_json(screen_dup_config))
+      assert config["screens"]["screen-2"] == normalize_json(Screen.to_json(screen_busway_config))
     end
 
     test "returns screen configs from legacy config source when migration flag is false", %{
@@ -83,9 +69,12 @@ defmodule ScreensWeb.ScreenConfigsApiControllerTest do
       System.put_env(@env_var, "shared-secret")
       Application.put_env(:screens, :config_migration, false)
 
+      screen_dup_config = screen_config_json(:dup_v2)
+      screen_busway_config = screen_config_json(:busway_v2)
+
       # Mock fetch_config to return our test config
       expect(Screens.Config.Fetch.Mock, :fetch_config, fn ->
-        {:ok, Jason.encode!(@legacy_config), 1}
+        {:ok, Jason.encode!(legacy_config(screen_dup_config, screen_busway_config)), 1}
       end)
 
       conn =
@@ -95,12 +84,11 @@ defmodule ScreensWeb.ScreenConfigsApiControllerTest do
 
       assert conn.status == 200
 
-      %{"screen_configs" => screen_configs} = json_response(conn, 200)
+      %{"config" => config_json} = json_response(conn, 200)
+      config = Jason.decode!(config_json)
 
-      # Verify configs match our constants
-      configs_by_id = Map.new(screen_configs, &{&1["id"], &1["config"]})
-      assert configs_by_id["dup_1"] == @screen_dup_config
-      assert configs_by_id["busway_1"] == @screen_busway_config
+      assert config["screens"]["dup_1"] == normalize_json(screen_dup_config)
+      assert config["screens"]["busway_1"] == normalize_json(screen_busway_config)
     end
   end
 
@@ -123,37 +111,45 @@ defmodule ScreensWeb.ScreenConfigsApiControllerTest do
       System.put_env(@env_var, "shared-secret")
       Application.put_env(:screens, :config_migration, true)
 
-      Repo.insert!(%ScreenConfig{id: "screen-1", config: @screen_dup_config})
+      screen_dup_config = screen_config(:dup_v2)
+      screen_busway_config = screen_config(:busway_v2)
+
+      Repo.insert!(%ScreenConfig{id: "screen-1", config: screen_dup_config})
 
       conn =
         conn
         |> put_req_header("authorization", "Bearer shared-secret")
         |> post("/api/screen_configs", %{
           screen_configs: [
-            %{id: "screen-1", config: @screen_busway_config}
+            %{id: "screen-1", config: screen_busway_config}
           ]
         })
 
       assert json_response(conn, 200) == %{"success" => true}
 
       updated = Repo.get!(ScreenConfig, "screen-1")
-      assert updated.config == @screen_busway_config
+      assert updated.config == screen_busway_config
     end
 
     test "updates full config when migration flag is false", %{conn: conn} do
       System.put_env(@env_var, "shared-secret")
       Application.put_env(:screens, :config_migration, false)
 
+      screen_dup_config = screen_config_json(:dup_v2)
+
       # Mock the fetch and put to prevent writing to the fixture file
       expect(Screens.Config.Fetch.Mock, :fetch_config, fn ->
-        {:ok, Jason.encode!(@legacy_config_dup_only), 1}
+        {:ok, Jason.encode!(legacy_config_dup_only()), 1}
       end)
 
       expect(Screens.Config.Fetch.Mock, :put_config, fn config ->
         # Verify the updated config has the new screen 1001 config
         {:ok, decoded} = Jason.decode(config)
         screens = Map.get(decoded, "screens", %{})
-        assert screens["dup_1"] == @screen_dup_config
+
+        assert Screen.to_json(Screen.from_json(screens["dup_1"])) ==
+                 Screen.to_json(screen_config(:dup_v2))
+
         :ok
       end)
 
@@ -162,7 +158,7 @@ defmodule ScreensWeb.ScreenConfigsApiControllerTest do
         |> put_req_header("authorization", "Bearer shared-secret")
         |> post("/api/screen_configs", %{
           screen_configs: [
-            %{"id" => "dup_1", "config" => @screen_dup_config}
+            %{"id" => "dup_1", "config" => screen_dup_config}
           ]
         })
 

--- a/test/support/screen_config_builder.ex
+++ b/test/support/screen_config_builder.ex
@@ -1,0 +1,64 @@
+defmodule Screens.TestSupport.ScreenConfigBuilder do
+  @moduledoc """
+  Helpers for building screen config fixtures in tests.
+
+  Provides normalized and legacy-shaped config payloads used by tests that
+  exercise screen config parsing, loading, and compatibility behavior.
+
+  During post_config_migration_cleanup, this file can be simplified to remove the legacy config helpers.
+  """
+
+  alias ScreensConfig.Screen
+
+  def screen_config_json(app_id), do: app_id |> screen_config() |> Screen.to_json()
+
+  def screen_config(app_id) do
+    %{
+      "app_id" => Atom.to_string(app_id),
+      "app_params" => minimal_app_params(app_id),
+      "device_id" => "test-device",
+      "name" => "test-screen",
+      "vendor" => "gds"
+    }
+    |> Screen.from_json()
+  end
+
+  defp minimal_app_params(:dup_v2) do
+    %{
+      "header" => %{"stop_name" => "Test Stop"},
+      "primary_departures" => %{"sections" => []},
+      "secondary_departures" => %{"sections" => []},
+      "alerts" => %{"stop_id" => "place-test"}
+    }
+  end
+
+  defp minimal_app_params(:busway_v2) do
+    %{
+      "header" => %{"stop_name" => "Test Stop"},
+      "departures" => %{"sections" => []}
+    }
+  end
+
+  def legacy_config(screen_dup_config, screen_busway_config) do
+    %{
+      "screens" => %{
+        "dup_1" => screen_dup_config,
+        "busway_1" => screen_busway_config
+      }
+    }
+  end
+
+  def legacy_config_dup_only do
+    dup_old_config =
+      screen_config_json(:dup_v2)
+      |> Map.put("app_id", "dup_old")
+
+    %{
+      "screens" => %{
+        "dup_1" => dup_old_config
+      }
+    }
+  end
+
+  def normalize_json(map), do: map |> Jason.encode!() |> Jason.decode!()
+end


### PR DESCRIPTION
This refactor will be very helpful for my upcoming PR to use Postgres for configs throughout the application. 

- Adds `ScreenConfigType` module that handles casting the column as a `ScreenConfig.Screen` type. 
- Consolidates the external API to use the same `list_all` method that the Admin API controller does. This just returns a the configs as JSON.
- Adds a test helper to build configs and integrates into the existing controller tests. 