### PR TITLE
feat: update departure times independent of screen refresh

### DIFF
--- a/assets/src/components/departures/departure_time.tsx
+++ b/assets/src/components/departures/departure_time.tsx
@@ -1,4 +1,4 @@
-import type { ComponentType } from "react";
+import { ComponentType, useEffect, useState } from "react";
 
 import { useCurrentPage } from "Context/dup_page";
 import MoonIcon from "Images/moon.svg";
@@ -14,13 +14,47 @@ type DepartureTime =
 
 interface DepartureTimePartProps {
   time: DepartureTime;
+  timeInEpochMinutes: number;
   currentPage: number;
 }
 
+/**
+ * Given two dates, compute the difference in seconds between `departureTimeSeconds`
+ * and `currentDateTime`.
+ *
+ * If the difference between the two values in minutes results in a float,
+ * round the result (rounding method is considered an implementation detail).
+ * This function will always return a value of 1 or greater - the system relies
+ * on the backend to provide the appropriate text ("ARR", "BRD", etc.) in lieu
+ * of showing '0 min'.
+ *
+ * @param departureTimeSeconds A datetime provided by the backend, representing
+ * the departure time of a route at a stop.
+ * @param currentDateTime The current datetime of the browser
+ */
+const adjustMinute = (
+  departureTimeSeconds: Date,
+  currentDateTime: Date,
+): number => {
+  const timeDifferenceMin =
+    departureTimeSeconds.getTime() - currentDateTime.getTime() / 1000;
+  const timeDifferenceSeconds = Math.floor(timeDifferenceMin / 60);
+  return Math.max(timeDifferenceSeconds, 1);
+};
+
 const DepartureTimePart: ComponentType<DepartureTimePartProps> = ({
   time,
+  timeInEpochMinutes,
   currentPage,
 }) => {
+  const [currentDateTime, setCurrentDateTime] = useState(new Date());
+  useEffect(() => {
+    const intervalTimer = setInterval(() => {
+      setCurrentDateTime(new Date());
+    }, 1000);
+
+    return () => clearInterval(intervalTimer);
+  }, []);
   switch (time.type) {
     case "text":
       return <div className="departure-time__text">{time.text}</div>;
@@ -28,7 +62,9 @@ const DepartureTimePart: ComponentType<DepartureTimePartProps> = ({
     case "minutes":
       return (
         <>
-          <div className="departure-time__minutes">{time.minutes}</div>
+          <div className="departure-time__minutes">
+            {adjustMinute(new Date(timeInEpochMinutes), currentDateTime)}
+          </div>
           <div className="departure-time__minutes-label">m</div>
         </>
       );
@@ -58,12 +94,14 @@ const DepartureTimePart: ComponentType<DepartureTimePartProps> = ({
 
 interface Props {
   time?: DepartureTime;
+  time_in_epoch: number;
   scheduled_time?: DepartureTime;
   is_live: boolean;
 }
 
 const DepartureTime: ComponentType<Props> = ({
   time,
+  time_in_epoch: timeInEpoch,
   scheduled_time,
   is_live: isLive,
 }) => {
@@ -80,7 +118,11 @@ const DepartureTime: ComponentType<Props> = ({
             className="departure-time__live-icon"
           />
         )}
-        <DepartureTimePart currentPage={currentPage} time={time} />
+        <DepartureTimePart
+          currentPage={currentPage}
+          time={time}
+          timeInEpochMinutes={timeInEpoch}
+        />
       </div>
     );
   } else if (scheduled_time && (currentPage === 1 || !time)) {
@@ -91,7 +133,13 @@ const DepartureTime: ComponentType<Props> = ({
           time ? "delayed" : "cancelled",
         ])}
       >
-        <DepartureTimePart {...{ time: scheduled_time, currentPage }} />
+        <DepartureTimePart
+          {...{
+            time: scheduled_time,
+            timeInEpochMinutes: timeInEpoch,
+            currentPage,
+          }}
+        />
       </div>
     );
   } else {

--- a/assets/src/components/departures/departure_time.tsx
+++ b/assets/src/components/departures/departure_time.tsx
@@ -19,7 +19,7 @@ interface DepartureTimePartProps {
 }
 
 /**
- * Given two dates, compute the difference in seconds between `departureTimeSeconds`
+ * Given two dates, compute the difference in minutes between `departureTimeSeconds`
  * and `currentDateTime`.
  *
  * If the difference between the two values in minutes results in a float,
@@ -36,10 +36,10 @@ const adjustMinute = (
   departureTimeSeconds: Date,
   currentDateTime: Date,
 ): number => {
-  const timeDifferenceMin =
+  const timeDifferenceSeconds =
     departureTimeSeconds.getTime() - currentDateTime.getTime() / 1000;
-  const timeDifferenceSeconds = Math.floor(timeDifferenceMin / 60);
-  return Math.max(timeDifferenceSeconds, 1);
+  const timeDifferenceMin = Math.floor(timeDifferenceSeconds / 60);
+  return Math.max(timeDifferenceMin, 1);
 };
 
 const DepartureTimePart: ComponentType<DepartureTimePartProps> = ({

--- a/assets/src/components/departures/departure_time.tsx
+++ b/assets/src/components/departures/departure_time.tsx
@@ -14,7 +14,7 @@ type DepartureTime =
 
 interface DepartureTimePartProps {
   time: DepartureTime;
-  timeInEpochMinutes: number;
+  timeInEpochSeconds: number;
   currentPage: number;
 }
 
@@ -44,7 +44,7 @@ const adjustMinute = (
 
 const DepartureTimePart: ComponentType<DepartureTimePartProps> = ({
   time,
-  timeInEpochMinutes,
+  timeInEpochSeconds,
   currentPage,
 }) => {
   const [currentDateTime, setCurrentDateTime] = useState(new Date());
@@ -63,7 +63,7 @@ const DepartureTimePart: ComponentType<DepartureTimePartProps> = ({
       return (
         <>
           <div className="departure-time__minutes">
-            {adjustMinute(new Date(timeInEpochMinutes), currentDateTime)}
+            {adjustMinute(new Date(timeInEpochSeconds), currentDateTime)}
           </div>
           <div className="departure-time__minutes-label">m</div>
         </>
@@ -121,7 +121,7 @@ const DepartureTime: ComponentType<Props> = ({
         <DepartureTimePart
           currentPage={currentPage}
           time={time}
-          timeInEpochMinutes={timeInEpoch}
+          timeInEpochSeconds={timeInEpoch}
         />
       </div>
     );
@@ -136,7 +136,7 @@ const DepartureTime: ComponentType<Props> = ({
         <DepartureTimePart
           {...{
             time: scheduled_time,
-            timeInEpochMinutes: timeInEpoch,
+            timeInEpochSeconds: timeInEpoch,
             currentPage,
           }}
         />

--- a/assets/src/components/departures/departure_time.tsx
+++ b/assets/src/components/departures/departure_time.tsx
@@ -49,11 +49,21 @@ const DepartureTimePart: ComponentType<DepartureTimePartProps> = ({
 }) => {
   const [currentDateTime, setCurrentDateTime] = useState(new Date());
   useEffect(() => {
-    const intervalTimer = setInterval(() => {
+    const timeDifferenceSeconds =
+      new Date(timeInEpoch).getTime() - currentDateTime.getTime() / 1000;
+    const timeUntilDeptWithoutMin = Math.floor(timeDifferenceSeconds % 60);
+    // Ensure that if the number of seconds is greater than or equal to 30, we
+    // refresh when there are 29 seconds left in the minute. Otherwise, refresh
+    // when the minute changes (and there are 59 seconds left)
+    const timerDelaySeconds =
+      timeUntilDeptWithoutMin >= 30
+        ? timeUntilDeptWithoutMin - 29
+        : timeUntilDeptWithoutMin + 1;
+    const minuteAdjustTimer = setTimeout(() => {
       setCurrentDateTime(new Date());
-    }, 1000);
+    }, timerDelaySeconds * 1000);
 
-    return () => clearInterval(intervalTimer);
+    return () => clearTimeout(minuteAdjustTimer);
   }, []);
   switch (time.type) {
     case "text":

--- a/assets/src/components/departures/departure_time.tsx
+++ b/assets/src/components/departures/departure_time.tsx
@@ -49,21 +49,11 @@ const DepartureTimePart: ComponentType<DepartureTimePartProps> = ({
 }) => {
   const [currentDateTime, setCurrentDateTime] = useState(new Date());
   useEffect(() => {
-    const timeDifferenceSeconds =
-      new Date(timeInEpoch).getTime() - currentDateTime.getTime() / 1000;
-    const timeUntilDeptWithoutMin = Math.floor(timeDifferenceSeconds % 60);
-    // Ensure that if the number of seconds is greater than or equal to 30, we
-    // refresh when there are 29 seconds left in the minute. Otherwise, refresh
-    // when the minute changes (and there are 59 seconds left)
-    const timerDelaySeconds =
-      timeUntilDeptWithoutMin >= 30
-        ? timeUntilDeptWithoutMin - 29
-        : timeUntilDeptWithoutMin + 1;
-    const minuteAdjustTimer = setTimeout(() => {
+    const intervalTimer = setInterval(() => {
       setCurrentDateTime(new Date());
-    }, timerDelaySeconds * 1000);
+    }, 1000);
 
-    return () => clearTimeout(minuteAdjustTimer);
+    return () => clearInterval(intervalTimer);
   }, []);
   switch (time.type) {
     case "text":

--- a/assets/src/components/departures/departure_time.tsx
+++ b/assets/src/components/departures/departure_time.tsx
@@ -14,7 +14,7 @@ type DepartureTime =
 
 interface DepartureTimePartProps {
   time: DepartureTime;
-  timeInEpochSeconds: number;
+  timeInEpoch: number;
   currentPage: number;
 }
 
@@ -44,7 +44,7 @@ const adjustMinute = (
 
 const DepartureTimePart: ComponentType<DepartureTimePartProps> = ({
   time,
-  timeInEpochSeconds,
+  timeInEpoch,
   currentPage,
 }) => {
   const [currentDateTime, setCurrentDateTime] = useState(new Date());
@@ -63,7 +63,7 @@ const DepartureTimePart: ComponentType<DepartureTimePartProps> = ({
       return (
         <>
           <div className="departure-time__minutes">
-            {adjustMinute(new Date(timeInEpochSeconds), currentDateTime)}
+            {adjustMinute(new Date(timeInEpoch), currentDateTime)}
           </div>
           <div className="departure-time__minutes-label">m</div>
         </>
@@ -121,7 +121,7 @@ const DepartureTime: ComponentType<Props> = ({
         <DepartureTimePart
           currentPage={currentPage}
           time={time}
-          timeInEpochSeconds={timeInEpoch}
+          timeInEpoch={timeInEpoch}
         />
       </div>
     );
@@ -136,7 +136,7 @@ const DepartureTime: ComponentType<Props> = ({
         <DepartureTimePart
           {...{
             time: scheduled_time,
-            timeInEpochSeconds: timeInEpoch,
+            timeInEpoch: timeInEpoch,
             currentPage,
           }}
         />

--- a/assets/src/components/departures/departure_times.tsx
+++ b/assets/src/components/departures/departure_times.tsx
@@ -6,6 +6,7 @@ import DepartureCrowding, { CrowdingLevel } from "./departure_crowding";
 export type TimeWithCrowding = {
   id: string;
   time?: DepartureTime;
+  time_in_epoch: number;
   scheduled_time?: DepartureTime;
   is_live: boolean;
   crowding: CrowdingLevel | null;
@@ -19,11 +20,12 @@ const DepartureTimes: ComponentType<Props> = ({ timesWithCrowding }) => {
   return (
     <div className="departure-times-with-crowding">
       {timesWithCrowding.map(
-        ({ id, time, scheduled_time, is_live, crowding }) => (
+        ({ id, time, time_in_epoch, scheduled_time, is_live, crowding }) => (
           <div className="departure-time-with-crowding" key={id}>
             {crowding && <DepartureCrowding crowdingLevel={crowding} />}
             <DepartureTime
               time={time}
+              time_in_epoch={time_in_epoch}
               scheduled_time={scheduled_time}
               is_live={is_live}
             />

--- a/assets/tests/components/departures/factories.ts
+++ b/assets/tests/components/departures/factories.ts
@@ -36,6 +36,7 @@ export const timeWithCrowding = Factory.define<TimeWithCrowding>(
   ({ sequence }) => ({
     id: sequence.toString(),
     time: { type: "minutes", minutes: sequence },
+    time_in_epoch: new Date(2026, 7, 20, 16, sequence).getTime() / 60_000,
     crowding: null,
     is_live: true,
   }),

--- a/lib/screens/v2/widget_instance/departures.ex
+++ b/lib/screens/v2/widget_instance/departures.ex
@@ -114,7 +114,7 @@ defmodule Screens.V2.WidgetInstance.Departures do
            required(:scheduled_time) => serialized_timestamp() | nil,
            required(:crowding) => pos_integer() | nil,
            required(:is_live) => boolean(),
-           optional(:time_in_epoch) => integer()
+           required(:time_in_epoch) => integer()
          }
 
   @type serialized_headsign_lcd :: %{
@@ -618,7 +618,7 @@ defmodule Screens.V2.WidgetInstance.Departures do
   @spec serialize_time(Departure.t(), Screen.t(), DateTime.t()) ::
           %{
             :time => serialized_time() | nil,
-            optional(:time_in_epoch) => integer(),
+            :time_in_epoch => integer(),
             optional(:scheduled_time) => serialized_timestamp() | nil,
             :is_live => boolean()
           }
@@ -669,6 +669,7 @@ defmodule Screens.V2.WidgetInstance.Departures do
 
     %{
       time: serialized_predicted_time,
+      time_in_epoch: departure |> Departure.time() |> DateTime.to_unix(),
       scheduled_time: serialized_scheduled_time,
       is_live: predicted?
     }


### PR DESCRIPTION


**Asana task**: [Screens client-side countdowns](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1216571034745361?focus=true)

Description


This commit allows departure times to "count down" on screens, without the need for updated data from the server.

This is accomplished by serializing the departure time in the payload sent to the client, using the `time_in_epoch` field similar to responses to Mercury. Note that `time_in_epoch` serializes using a granularity of minutes for Mercury. To keep the data consistent, the same is done for non-Mercury responses.

When the client renders, it maintains a record of the current time that is updated on a one second interval. This triggers rerenders of the `DepartureTimePart` component on a ~1 second interval, rather than the existing screen refresh rate. The difference between the timestamp sent in our last response from the server and "now" is calculated, which informs the client if we can "count down" from the last provided departure time.

- [ ] Tests added?
