### PR TITLE
fix: Long URL should not overflow on alert takeover

### DIFF
--- a/assets/src/components/pre_fare_single_screen_alert.tsx
+++ b/assets/src/components/pre_fare_single_screen_alert.tsx
@@ -2,7 +2,12 @@ import type { ComponentType } from "react";
 
 import useAutoSize from "Hooks/use_auto_size";
 import { getHexColor, STRING_TO_SVG } from "Util/svg_utils";
-import { classWithModifier, classWithModifiers, formatCause } from "Util/utils";
+import {
+  addUrlBreaksAfterSlashes,
+  classWithModifier,
+  classWithModifiers,
+  formatCause,
+} from "Util/utils";
 import { QRCodeSVG as QRCode } from "qrcode.react";
 
 import DisruptionDiagram, {
@@ -311,7 +316,9 @@ const RemedySection: ComponentType<RemedySectionProps> = ({
             <span className="alert-card__remedy__text--alternate-route">
               Find alternate route at{" "}
             </span>
-            {alternateRouteURL}
+            <span className="alert-card__remedy__text--alternate-route-url">
+              {addUrlBreaksAfterSlashes(alternateRouteURL)}
+            </span>
           </h5>
         ) : (
           <h5 className="alert-card__remedy__text">{remedy}</h5>

--- a/assets/src/components/reconstructed_takeover.tsx
+++ b/assets/src/components/reconstructed_takeover.tsx
@@ -1,5 +1,9 @@
 import type { ComponentType } from "react";
-import { classWithModifiers, imagePath } from "Util/utils";
+import {
+  addUrlBreaksAfterSlashes,
+  classWithModifiers,
+  imagePath,
+} from "Util/utils";
 import DisruptionDiagram, {
   DisruptionDiagramData,
 } from "./disruption_diagram/disruption_diagram";
@@ -118,8 +122,7 @@ const ReconstructedTakeover: ComponentType<ReconAlertProps> = (alert) => {
                     <span className="alert-card__body__remedy--alternate-route">
                       Find alternate route at{" "}
                     </span>
-                    {alternateRouteURL}
-
+                    {addUrlBreaksAfterSlashes(alternateRouteURL)}
                     <div className="alert-card__body__remedy--alternate-route-qrcode">
                       <QRCode marginSize={1} size={128} value={qrCodeURL} />
                     </div>

--- a/assets/src/util/utils.ts
+++ b/assets/src/util/utils.ts
@@ -71,6 +71,9 @@ export const firstWord = (str: string): string => str.split(" ")[0];
 export const formatCause = (cause: string) =>
   (cause.charAt(0).toUpperCase() + cause.substring(1)).replace("_", " ");
 
+export const addUrlBreaksAfterSlashes = (url: string): string =>
+  url.replace(/\//g, "/\u200B");
+
 export const extensionForAsset = (assetPath: string) => {
   const parts = assetPath.split(".");
   return parts[parts.length - 1].toLowerCase();


### PR DESCRIPTION
See Slack thread: https://mbta.slack.com/archives/C039ARUM48H/p1787254963874569

Use the zero-width space character to handle long URLs. See two screenshots of the logic working. 

<img width="865" height="931" alt="image" src="https://github.com/user-attachments/assets/c1c140ae-050e-4405-ad93-921de00c1786" />

<img width="865" height="620" alt="image" src="https://github.com/user-attachments/assets/fa850133-0373-4406-9823-5bd28b6b3b45" />
