### PR TITLE
fix: use build identifier to detect deployments

### DIFF
--- a/assets/src/hooks/use_api_response.ts
+++ b/assets/src/hooks/use_api_response.ts
@@ -111,7 +111,9 @@ const useApiPath = (screenId: string, appendPath?: string): string => {
 
     const params: Record<string, string | null | undefined> = {
       is_real_screen: isRealScreen() ? "true" : null,
+      // TODO: Remove this following a complete rollout of build_identifier code
       last_refresh: getDatasetValue("lastRefresh"),
+      build_identifier: getDatasetValue("buildIdentifier"),
       requestor: getDatasetValue("requestor"),
       rotation_index: getRotationIndex(),
       screen_side: getScreenSide(),

--- a/config/config.exs
+++ b/config/config.exs
@@ -95,6 +95,7 @@ config :ex_cldr,
 config :screens,
   config_fetcher: Screens.Config.Fetch.S3,
   config_s3_bucket: "mbta-ctd-config",
+  # TODO: Remove this following a complete rollout of build_identifier code
   last_deploy_fetcher: Screens.Util.LastDeploy.S3Fetch,
   signs_ui_config_fetcher: Screens.SignsUiConfig.Fetch.S3,
   signs_ui_s3_path: "config.json"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -15,6 +15,7 @@ config :screens, ScreensWeb.Endpoint,
 
 config :screens,
   config_fetcher: Screens.Config.Fetch.Local,
+  # TODO: Remove this following a complete rollout of build_identifier code
   last_deploy_fetcher: Screens.Util.LastDeploy.LocalFetch,
   local_config_file_spec: {:priv, "local.json"},
   local_signs_ui_config_file_spec: {:priv, "signs_ui_config.json"},

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -57,6 +57,14 @@ if config_env() == :prod do
     ]
 end
 
+build_identifier =
+  case System.cmd("git", ["rev-parse", "--short", "HEAD"]) do
+    {build_id, 0} -> String.trim(build_id)
+    {_, exit_code} -> raise "Failed with exit code: " <> Integer.to_string(exit_code)
+  end
+
+config :screens, :build_identifier, build_identifier
+
 # ## Using releases (Elixir v1.9+)
 #
 # If you are doing OTP releases, you need to instruct Phoenix

--- a/config/test.exs
+++ b/config/test.exs
@@ -13,6 +13,7 @@ config :screens, Screens.Repo,
 
 config :screens,
   config_fetcher: Screens.Config.Fetch.Local,
+  # TODO: Remove this following a complete rollout of build_identifier code
   last_deploy_fetcher: Screens.Util.LastDeploy.LocalFetch,
   local_config_file_spec: {:test, "config.json"},
   local_signs_ui_config_file_spec: {:test, "signs_ui_config.json"},

--- a/docs/mercury_api.md
+++ b/docs/mercury_api.md
@@ -53,6 +53,9 @@ we include the following additional fields:
 * `last_deploy_timestamp` *(string)* — The datetime the app was last deployed,
   in ISO8601 format. [[#1909]]
 
+* `build_identifier` *(string)* — A string identifying when the app was last 
+  deployed, expressed as a short git SHA. [[#3258]]
+
 
 ## `Departures` widget
 
@@ -83,3 +86,4 @@ add its own clock independent of data fetching and widget rendering. [[#1943]]
 [#1970]: https://github.com/mbta/screens/pull/1970
 [#2317]: https://github.com/mbta/screens/pull/2317
 [#3180]: https://github.com/mbta/screens/pull/3180/
+[#3258]: https://github.com/mbta/screens/pull/3258/

--- a/lib/screens/util/build_info.ex
+++ b/lib/screens/util/build_info.ex
@@ -1,0 +1,14 @@
+defmodule Screens.Util.BuildInfo do
+  @moduledoc """
+  A utility for retrieving a build information for the running
+  application.
+  """
+
+  @doc """
+  Return an identifier that uniquely identifies a build of the project.
+  """
+  @callback build_identifier() :: String.t()
+  def build_identifier() do
+    Application.fetch_env!(:screens, :build_identifier)
+  end
+end

--- a/lib/screens_web/controllers/v2/screen_api_controller.ex
+++ b/lib/screens_web/controllers/v2/screen_api_controller.ex
@@ -7,6 +7,7 @@ defmodule ScreensWeb.V2.ScreenApiController do
   alias ScreensWeb.Plug.ScreenRequest
 
   import Screens.Inject
+  @build_info injected(Screens.Util.BuildInfo)
   @cache injected(Screens.Config.Cache)
 
   @base_response %{data: nil, disabled: false, force_reload: false}
@@ -79,6 +80,7 @@ defmodule ScreensWeb.V2.ScreenApiController do
     response
     |> Map.put(:audio_data, fetch_ssml(screen))
     |> Map.put(:last_deploy_timestamp, @cache.last_deploy_timestamp())
+    |> Map.put(:build_identifier, @build_info.build_identifier())
   end
 
   defp put_extra_fields(response, _screen), do: response
@@ -103,8 +105,28 @@ defmodule ScreensWeb.V2.ScreenApiController do
   # The packaged client can't reload the page to update itself; this would just reload the local
   # copy of the code, resulting in an infinite loop. Compatibility and versioning of the packaged
   # client is handled manually.
+  # credo:disable-for-next-line
+  # TODO: Remove this following a complete rollout of build_identifier code
   defp outdated_response(%{params: %{"last_refresh" => "packaged"}} = conn, _), do: conn
+  defp outdated_response(%{params: %{"build_identifier" => "packaged"}} = conn, _), do: conn
 
+  defp outdated_response(%{params: %{"build_identifier" => build_identifier}} = conn, _) do
+    latest_build_identifier = @build_info.build_identifier()
+    # TODO(NOW): RM
+    IO.inspect(latest_build_identifier, label: "LATEST")
+    IO.inspect(build_identifier, label: "REC")
+
+    if is_binary(build_identifier) &&
+         String.trim(build_identifier) != String.trim(latest_build_identifier) do
+      Logger.metadata(response_type: :outdated)
+      conn |> json(%{@base_response | force_reload: true}) |> halt()
+    else
+      conn
+    end
+  end
+
+  # credo:disable-for-next-line
+  # TODO: Remove this following a complete rollout of build_identifier code
   defp outdated_response(
          %{
            assigns: %{screen: %Screen{refresh_if_loaded_before: refresh_if_loaded_before}},

--- a/lib/screens_web/controllers/v2/screen_controller.ex
+++ b/lib/screens_web/controllers/v2/screen_controller.ex
@@ -7,20 +7,30 @@ defmodule ScreensWeb.V2.ScreenController do
   alias ScreensConfig.Screen
   alias ScreensWeb.Plug.ScreenRequest
 
+  import Screens.Inject
+  @build_info injected(Screens.Util.BuildInfo)
+
   plug ScreenRequest, [type: :page] when action in [:index, :simulation]
 
   plug :environment_name
   plug :last_refresh
+  plug :build_identifier
 
   defp environment_name(conn, _) do
     environment_name = Application.get_env(:screens, :environment_name)
     assign(conn, :environment_name, environment_name)
   end
 
+  # credo:disable-for-next-line
+  # TODO: Remove this following a complete rollout of build_identifier code
   defp last_refresh(conn, _) do
     # credo:disable-for-next-line Screens.Checks.UntestableDateTime
     now = DateTime.utc_now() |> DateTime.to_iso8601()
     assign(conn, :last_refresh, now)
+  end
+
+  defp build_identifier(conn, _) do
+    assign(conn, :build_identifier, @build_info.build_identifier())
   end
 
   def index(conn, params) do

--- a/lib/screens_web/templates/v2/screen/index.html.eex
+++ b/lib/screens_web/templates/v2/screen/index.html.eex
@@ -5,6 +5,7 @@
   data-environment-name="<%= @environment_name %>"
   data-is-real-screen="<%= @is_real_screen %>"
   data-last-refresh="<%= @last_refresh %>"
+  data-build-identifier="<%= @build_identifier %>"
   data-refresh-rate-offset="<%= @refresh_rate_offset %>"
   data-refresh-rate="<%= @refresh_rate %>"
   <%= if assigns[:requestor] do %>

--- a/lib/screens_web/templates/v2/screen/index_multi.html.eex
+++ b/lib/screens_web/templates/v2/screen/index_multi.html.eex
@@ -1,6 +1,7 @@
 <div
   id="app"
   data-last-refresh="<%= @last_refresh %>"
+  data-build-identifier="<%= @build_identifier %>"
   data-environment-name="<%= @environment_name %>"
   data-refresh-rate="<%= @refresh_rate %>"
   data-screen-ids-with-offset-map="<%= Jason.encode!(@screen_ids_with_offset_map) %>"

--- a/priv/dup-app.html
+++ b/priv/dup-app.html
@@ -16,6 +16,7 @@
       data-is-outfront="true"
       data-is-real-screen="true"
       data-last-refresh="packaged"
+      data-build-identifier="packaged"
       data-packaged-version="%version%"
       data-refresh-rate="0"
       data-rotation-index="%rotation%"

--- a/test/screens_web/controllers/v2/screen_api_controller_test.exs
+++ b/test/screens_web/controllers/v2/screen_api_controller_test.exs
@@ -9,6 +9,7 @@ defmodule ScreensWeb.V2.ScreenApiControllerTest do
   setup :verify_on_exit!
 
   import Screens.Inject
+  @build_info injected(Screens.Util.BuildInfo)
   @cache injected(Screens.Config.Cache)
   @parameters injected(Screens.V2.ScreenData.Parameters)
 
@@ -17,6 +18,7 @@ defmodule ScreensWeb.V2.ScreenApiControllerTest do
   Stub.candidate_generator(StubGenerator, fn _ -> [placeholder(:blue)] end)
 
   setup do
+    stub(@build_info, :build_identifier, fn -> "eae8fa35" end)
     stub(@cache, :last_deploy_timestamp, fn -> ~U[2020-01-01 00:00:00Z] end)
     stub(@cache, :screen, fn _id -> struct(Screen) end)
     stub(@parameters, :candidate_generator, fn _screen -> StubGenerator end)
@@ -26,6 +28,29 @@ defmodule ScreensWeb.V2.ScreenApiControllerTest do
   end
 
   describe "show/2" do
+    test "does not tell the client to reload when its code is up to date by the build identifier",
+         %{conn: conn} do
+      conn = get(conn, "/v2/api/screen/1?build_identifier=eae8fa35")
+
+      assert %{"force_reload" => false} = json_response(conn, 200)
+    end
+
+    test "tells client to reload when its code is outdated by the build identifier", %{conn: conn} do
+      conn = get(conn, "/v2/api/screen/1?build_identifier=123456a")
+
+      assert %{"force_reload" => true} = json_response(conn, 200)
+    end
+
+    test "tells client to reload when its code is outdated by the build identifier over last_refresh",
+         %{conn: conn} do
+      expect(@cache, :last_deploy_timestamp, 0, fn -> ~U[2026-01-01 12:00:00Z] end)
+
+      conn =
+        get(conn, "/v2/api/screen/1?build_identifier=123456a&last_refresh=2026-01-01T11:00:00Z")
+
+      assert %{"force_reload" => true} = json_response(conn, 200)
+    end
+
     test "tells client to reload when its code is outdated", %{conn: conn} do
       expect(@cache, :last_deploy_timestamp, fn -> ~U[2026-01-01 12:00:00Z] end)
 
@@ -74,7 +99,8 @@ defmodule ScreensWeb.V2.ScreenApiControllerTest do
                "disabled" => false,
                "flex_zone" => [],
                "force_reload" => false,
-               "last_deploy_timestamp" => "2020-01-01T00:00:00Z"
+               "last_deploy_timestamp" => "2020-01-01T00:00:00Z",
+               "build_identifier" => "eae8fa35"
              } == json_response(conn, 200)
     end
 

--- a/test/screens_web/controllers/v2/screen_controller_test.exs
+++ b/test/screens_web/controllers/v2/screen_controller_test.exs
@@ -5,7 +5,13 @@ defmodule ScreensWeb.V2.ScreenControllerTest do
   setup :verify_on_exit!
 
   import Screens.Inject
+  @build_info injected(Screens.Util.BuildInfo)
   @cache injected(Screens.Config.Cache)
+
+  setup do
+    stub(@build_info, :build_identifier, fn -> "eae8fa35" end)
+    :ok
+  end
 
   describe "index/2" do
     test "returns 200", %{conn: conn} do

--- a/test/support/mocks.ex
+++ b/test/support/mocks.ex
@@ -11,6 +11,7 @@ injected_modules = [
   Screens.Routes.Route,
   Screens.Schedules.Schedule,
   Screens.Stops.Stop,
+  Screens.Util.BuildInfo,
   Screens.V2.Departure,
   Screens.V2.RDS,
   Screens.V2.ScreenData,


### PR DESCRIPTION


**Asana task**: [Fix gaps in Screens client "deploy detection"](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1217249394771512?focus=true)

Description

- [X] Tests added?


This commit introduces a new value, a build identifier, to detect when a new version of the backend service has been deployed.

The changes in this commit are intended to replace the existing last_deploy_timestamp mechanism. The existing mechanism has the following issues that we intend to remedy with this change:
1. Reliance on a file pushed to AWS S3 to retrieve the last_deploy_timestamp, which can be brittle if we fail to retrieve the file from S3 or fail to push it to S3 as a part of CI
2. There's additional overhead required to fetch and cache the timestamp from S3
3. There can be a gap in time between the update of the last deploy timestamp in S3 and when the application accepts connections, causing a mismatch in the understanding of the "latest" version of the app.

The mechanism for determining if the frontend's client is stale is similar to the existing last_deploy_timestamp mechanism in place today. The build identifier is sent to the server as a query string parameter, and if the value does not match the server's a reload is forced. A short git SHA is used as the build identifier.

This commit does not remove the existing last_timestamp checks in the code, as we will require deploys to devices such as DUPs to complete the transition.