### PR TITLE
fix: add countdown to gl-eink linemaps

### DIFF
--- a/assets/src/components/departures/departure_time.tsx
+++ b/assets/src/components/departures/departure_time.tsx
@@ -1,6 +1,7 @@
-import { ComponentType, useEffect, useState } from "react";
+import { ComponentType } from "react";
 
 import { useCurrentPage } from "Context/dup_page";
+import { useCurrentTime } from "Hooks/use_current_time";
 import MoonIcon from "Images/moon.svg";
 import LiveDataSvg from "Images/live-data-small.svg";
 import { classWithModifier, classWithModifiers } from "Util/utils";
@@ -24,14 +25,8 @@ const DepartureTimePart: ComponentType<DepartureTimePartProps> = ({
   timeInEpoch,
   currentPage,
 }) => {
-  const [currentDateTime, setCurrentDateTime] = useState(new Date());
-  useEffect(() => {
-    const intervalTimer = setInterval(() => {
-      setCurrentDateTime(new Date());
-    }, 1000);
+  const { currentDateTime } = useCurrentTime();
 
-    return () => clearInterval(intervalTimer);
-  }, []);
   switch (time.type) {
     case "text":
       return <div className="departure-time__text">{time.text}</div>;

--- a/assets/src/components/departures/departure_time.tsx
+++ b/assets/src/components/departures/departure_time.tsx
@@ -4,6 +4,7 @@ import { useCurrentPage } from "Context/dup_page";
 import MoonIcon from "Images/moon.svg";
 import LiveDataSvg from "Images/live-data-small.svg";
 import { classWithModifier, classWithModifiers } from "Util/utils";
+import { adjustMinute } from "Util/timing";
 
 type DepartureTime =
   | { type: "text"; text: string }
@@ -17,30 +18,6 @@ interface DepartureTimePartProps {
   timeInEpoch: number;
   currentPage: number;
 }
-
-/**
- * Given two dates, compute the difference in minutes between `departureTimeSeconds`
- * and `currentDateTime`.
- *
- * If the difference between the two values in minutes results in a float,
- * round the result (rounding method is considered an implementation detail).
- * This function will always return a value of 1 or greater - the system relies
- * on the backend to provide the appropriate text ("ARR", "BRD", etc.) in lieu
- * of showing '0 min'.
- *
- * @param departureTimeSeconds A datetime provided by the backend, representing
- * the departure time of a route at a stop.
- * @param currentDateTime The current datetime of the browser
- */
-const adjustMinute = (
-  departureTimeSeconds: Date,
-  currentDateTime: Date,
-): number => {
-  const timeDifferenceSeconds =
-    departureTimeSeconds.getTime() - currentDateTime.getTime() / 1000;
-  const timeDifferenceMin = Math.floor(timeDifferenceSeconds / 60);
-  return Math.max(timeDifferenceMin, 1);
-};
 
 const DepartureTimePart: ComponentType<DepartureTimePartProps> = ({
   time,

--- a/assets/src/components/gl_eink/line_map.tsx
+++ b/assets/src/components/gl_eink/line_map.tsx
@@ -483,7 +483,7 @@ type Stop = {
 type Vehicle = {
   id: string;
   index: number;
-  label: { type: string; minutes: number } | { type: string, text: string}
+  label: { type: string; minutes: number } | { type: string; text: string };
   time_in_epoch: number;
 };
 

--- a/assets/src/components/gl_eink/line_map.tsx
+++ b/assets/src/components/gl_eink/line_map.tsx
@@ -483,7 +483,7 @@ type Stop = {
 type Vehicle = {
   id: string;
   index: number;
-  label: { type: string; minutes: number }; // TODO: Double check
+  label: { type: string; minutes: number } | { type: string, text: string}
   time_in_epoch: number;
 };
 

--- a/assets/src/components/gl_eink/line_map.tsx
+++ b/assets/src/components/gl_eink/line_map.tsx
@@ -1,6 +1,8 @@
-import { Fragment, type JSX } from "react";
+import { ComponentType, Fragment, type JSX } from "react";
 
+import { adjustMinute } from "Util/timing";
 import { classWithModifier } from "Util/utils";
+import { useCurrentTime } from "Hooks/use_current_time";
 
 const WIDTH = 374;
 const HEIGHT = 1312;
@@ -394,17 +396,25 @@ const VehicleMinutesLabel = ({ cx, cy, minutes }) => {
   );
 };
 
-const VehicleLabel = ({ cx, cy, label }) => {
+const VehicleLabel = ({ cx, cy, label, timeInEpoch }) => {
+  const { currentDateTime } = useCurrentTime();
+
   if (label.type === "text") {
     return <VehicleTextLabel cx={cx} cy={cy} text={label.text} />;
   } else if (label.type === "minutes") {
-    return <VehicleMinutesLabel cx={cx} cy={cy} minutes={label.minutes} />;
+    return (
+      <VehicleMinutesLabel
+        cx={cx}
+        cy={cy}
+        minutes={adjustMinute(new Date(timeInEpoch), currentDateTime)}
+      />
+    );
   }
 
   return null;
 };
 
-const Vehicle = ({ index, label }) => {
+const Vehicle: ComponentType<Vehicle> = ({ index, label, time_in_epoch }) => {
   const cx = LEFT_MARGIN + LINE_WIDTH / 2;
   const cy = TOP_MARGIN + index * STOP_SPACING;
 
@@ -412,7 +422,14 @@ const Vehicle = ({ index, label }) => {
     <>
       <VehicleDroplet cx={cx} cy={cy} />
       <VehicleIcon cx={cx} cy={cy} iconSize={VEHICLE_ICON_SIZE} />
-      {label && <VehicleLabel cx={cx} cy={cy} label={label} />}
+      {label && (
+        <VehicleLabel
+          cx={cx}
+          cy={cy}
+          label={label}
+          timeInEpoch={time_in_epoch}
+        />
+      )}
     </>
   );
 };
@@ -429,8 +446,8 @@ const Vehicles = ({
 
   return (
     <>
-      {vehicles.map(({ id, ...data }) => (
-        <Vehicle {...data} key={id} />
+      {vehicles.map((vehicle) => (
+        <Vehicle {...vehicle} key={vehicle.id} />
       ))}
     </>
   );
@@ -466,7 +483,8 @@ type Stop = {
 type Vehicle = {
   id: string;
   index: number;
-  label: string;
+  label: { type: string; minutes: number }; // TODO: Double check
+  time_in_epoch: number;
 };
 
 type ScheduledDeparture = {

--- a/assets/src/hooks/use_current_time.ts
+++ b/assets/src/hooks/use_current_time.ts
@@ -1,0 +1,17 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Creates a one-second timer, returning the current `Date`.
+ */
+export const useCurrentTime = (): { currentDateTime: Date } => {
+  const [currentDateTime, setCurrentDateTime] = useState(new Date());
+  useEffect(() => {
+    const intervalTimer = setInterval(() => {
+      setCurrentDateTime(new Date());
+    }, 1000);
+
+    return () => clearInterval(intervalTimer);
+  }, []);
+
+  return { currentDateTime };
+};

--- a/assets/src/util/timing.tsx
+++ b/assets/src/util/timing.tsx
@@ -1,0 +1,23 @@
+/**
+ * Given two dates, compute the difference in minutes between `departureTimeSeconds`
+ * and `currentDateTime`.
+ *
+ * If the difference between the two values in minutes results in a float,
+ * round the result (rounding method is considered an implementation detail).
+ * This function will always return a value of 1 or greater - the system relies
+ * on the backend to provide the appropriate text ("ARR", "BRD", etc.) in lieu
+ * of showing '0 min'.
+ *
+ * @param departureTimeSeconds A datetime provided by the backend, representing
+ * the departure time of a route at a stop.
+ * @param currentDateTime The current datetime of the browser
+ */
+export const adjustMinute = (
+  departureTimeSeconds: Date,
+  currentDateTime: Date,
+): number => {
+  const timeDifferenceSeconds =
+    departureTimeSeconds.getTime() - currentDateTime.getTime() / 1000;
+  const timeDifferenceMin = Math.floor(timeDifferenceSeconds / 60);
+  return Math.max(timeDifferenceMin, 1);
+};

--- a/assets/tests/util/timing.test.ts
+++ b/assets/tests/util/timing.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "@jest/globals";
+import { adjustMinute } from "Util/timing";
+
+describe("adjustMinute", () => {
+  test("returns the difference between two datetimes, in minutes", () => {
+    const departureTimeSeconds = new Date(
+      new Date(2026, 7, 27, 13, 30, 45, 0).getTime() / 1000,
+    );
+    const currentDateTime = new Date(2026, 7, 27, 13, 25, 45, 0);
+
+    const actual = adjustMinute(departureTimeSeconds, currentDateTime);
+
+    expect(actual).toBe(5);
+  });
+
+  test("returns 1 when the two datetimes are the same", () => {
+    const departureTimeSeconds = new Date(
+      new Date(2026, 7, 27, 13, 30, 45, 0).getTime() / 1000,
+    );
+    const currentDateTime = new Date(2026, 7, 27, 13, 30, 45, 0);
+
+    const actual = adjustMinute(departureTimeSeconds, currentDateTime);
+
+    expect(actual).toBe(1);
+  });
+
+  test("returns 1 when the the current datetime is after the departure time are the same", () => {
+    const departureTimeSeconds = new Date(
+      new Date(2026, 7, 27, 13, 30, 45, 0).getTime() / 1000,
+    );
+    const currentDateTime = new Date(2026, 7, 27, 13, 35, 45, 0);
+
+    const actual = adjustMinute(departureTimeSeconds, currentDateTime);
+
+    expect(actual).toBe(1);
+  });
+});

--- a/assets/tests/util/timing.test.ts
+++ b/assets/tests/util/timing.test.ts
@@ -24,7 +24,7 @@ describe("adjustMinute", () => {
     expect(actual).toBe(1);
   });
 
-  test("returns 1 when the the current datetime is after the departure time are the same", () => {
+  test("returns 1 when the the current datetime is after the departure time", () => {
     const departureTimeSeconds = new Date(
       new Date(2026, 7, 27, 13, 30, 45, 0).getTime() / 1000,
     );


### PR DESCRIPTION

**Asana task**: [Screens client-side countdowns](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1216571034745361?focus=true)

Description

- [x] Tests added?

Add countdowns to the gl-eink linemaps, similar to the departure times as was done in b55b90ab. Common code has been extracted into a separate react hook and utility function.
