### PR TITLE
fix: fixed cancelled prediction with schedules for RDS LCD

### DIFF
--- a/lib/screens/v2/widget_instance/departures.ex
+++ b/lib/screens/v2/widget_instance/departures.ex
@@ -599,7 +599,18 @@ defmodule Screens.V2.WidgetInstance.Departures do
   end
 
   def serialize_times_with_crowding(departures, screen, now) do
-    Enum.map(departures, &serialize_time_with_crowding(&1, screen, now))
+    departures
+    # Quick fix for cancelled scheduled departures, remove once we
+    # have a presentation for this
+    |> Enum.reject(&cancelled_prediction_on_lcd?(&1, screen))
+    |> Enum.map(&serialize_time_with_crowding(&1, screen, now))
+  end
+
+  @spec cancelled_prediction_on_lcd?(Departure.t(), Screen.t()) :: boolean()
+  defp cancelled_prediction_on_lcd?(_departure, %Screen{app_id: :dup_v2}), do: false
+
+  defp cancelled_prediction_on_lcd?(departure, _screen) do
+    Departure.cancelled?(departure) and departure.schedule != nil
   end
 
   @spec serialize_time_with_crowding(Departure.t(), Screen.t(), DateTime.t()) ::


### PR DESCRIPTION
Description
- we get a %{time: nil, scheduled_time: nil} when we have a cancelled prediction along with a valid schedule
- we currently don't have a way to display that for LCDs like we do DUPs, so for now just filter them

I think this introduce some edge case problems (e.g. what happens if it's the only departure in the list) but putting this up right now for the crash fix while we discuss what the presentation of the actual cancelled departure should be (maybe just don't show it?)
