### PR TITLE
feat: Screen Configs API to list by IDs

### DIFF
--- a/lib/screens/screen_configs.ex
+++ b/lib/screens/screen_configs.ex
@@ -77,6 +77,35 @@ defmodule Screens.ScreenConfigs do
   end
 
   @doc """
+  Returns Configs filtered by a list of screen IDs as JSON with the ID as a key and the configuration as the value.
+  When config_migration_enabled? is true, filters in the Postgres query.
+  When false, filters after fetching the config.
+  """
+  @spec list_by_ids(ids :: [screen_id()]) :: String.t() | :error
+  def list_by_ids(ids) when is_list(ids) do
+    if config_migration_enabled?() do
+      screens =
+        ScreenConfig
+        |> where([screen_config], screen_config.id in ^ids)
+        |> Repo.all()
+        |> Map.new(fn %ScreenConfig{id: id, config: config} ->
+          {id, Screen.to_json(config)}
+        end)
+
+      Jason.encode!(%{screens: screens})
+    else
+      with {:ok, config, _version} <- @config_fetcher.fetch_config() do
+        config_map = Jason.decode!(config)
+        screens = Map.get(config_map, "screens", %{})
+
+        filtered_screens = Map.take(screens, ids)
+
+        Jason.encode!(%{screens: filtered_screens})
+      end
+    end
+  end
+
+  @doc """
   Creates a screen configuration.
   Upserts so an existing config with the same ID will be overwritten.
   """

--- a/lib/screens_web/controllers/screen_configs_api_controller.ex
+++ b/lib/screens_web/controllers/screen_configs_api_controller.ex
@@ -32,6 +32,6 @@ defmodule ScreensWeb.ScreenConfigsApiController do
   end
 
   defp parse_query_param_list(param) do
-    param |> String.split(",") |> Enum.map(&String.trim/1)
+    param |> String.split(",") |> Enum.map(&String.trim/1) |> Enum.reject(&(&1 == ""))
   end
 end

--- a/lib/screens_web/controllers/screen_configs_api_controller.ex
+++ b/lib/screens_web/controllers/screen_configs_api_controller.ex
@@ -3,6 +3,12 @@ defmodule ScreensWeb.ScreenConfigsApiController do
 
   alias Screens.ScreenConfigs
 
+  def index(conn, %{"ids" => ids}) do
+    config = ids |> parse_query_param_list() |> ScreenConfigs.list_by_ids()
+
+    json(conn, %{config: config})
+  end
+
   def index(conn, _params) do
     json(conn, %{config: ScreenConfigs.list_all()})
   end
@@ -23,5 +29,9 @@ defmodule ScreensWeb.ScreenConfigsApiController do
     conn
     |> put_status(400)
     |> json(%{success: false, error: "screen_configs parameter is required"})
+  end
+
+  defp parse_query_param_list(param) do
+    param |> String.split(",") |> Enum.map(&String.trim/1)
   end
 end

--- a/lib/screens_web/router.ex
+++ b/lib/screens_web/router.ex
@@ -19,6 +19,12 @@ defmodule ScreensWeb.Router do
     plug :protect_from_forgery
   end
 
+  pipeline :api_client_auth do
+    plug :accepts, ["json"]
+    plug :fetch_session
+    plug(ScreensWeb.Plug.EnsureBearerToken, env_var: "SCREENS_API_CLIENT_KEY")
+  end
+
   pipeline :redirect_prod_http do
     if Application.compile_env(:screens, :redirect_http?) do
       plug(Plug.SSL, rewrite_on: [:x_forwarded_proto])
@@ -35,10 +41,6 @@ defmodule ScreensWeb.Router do
 
   pipeline :ensure_screens_group do
     plug(ScreensWeb.Plug.EnsureScreensGroup)
-  end
-
-  pipeline :screens_api_client_auth do
-    plug(ScreensWeb.Plug.EnsureBearerToken, env_var: "SCREENS_API_CLIENT_KEY")
   end
 
   scope "/", ScreensWeb do
@@ -133,7 +135,7 @@ defmodule ScreensWeb.Router do
   end
 
   scope "/api", ScreensWeb do
-    pipe_through [:redirect_prod_http, :api, :screens_api_client_auth]
+    pipe_through [:redirect_prod_http, :api_client_auth]
 
     get "/screen_configs", ScreenConfigsApiController, :index
     post "/screen_configs", ScreenConfigsApiController, :update

--- a/test/screens_web/controllers/screen_configs_api_controller_test.exs
+++ b/test/screens_web/controllers/screen_configs_api_controller_test.exs
@@ -27,6 +27,21 @@ defmodule ScreensWeb.ScreenConfigsApiControllerTest do
 
   setup :verify_on_exit!
 
+  setup do
+    screen_dup_config = screen_config(:dup_v2)
+    screen_busway_config = screen_config(:busway_v2)
+    screen_bus_eink_config = screen_config(:bus_eink_v2)
+    screen_dup_config_json = screen_config_json(:dup_v2)
+    screen_busway_config_json = screen_config_json(:busway_v2)
+
+    {:ok,
+     screen_dup_config: screen_dup_config,
+     screen_busway_config: screen_busway_config,
+     screen_bus_eink_config: screen_bus_eink_config,
+     screen_dup_config_json: screen_dup_config_json,
+     screen_busway_config_json: screen_busway_config_json}
+  end
+
   describe "index/2" do
     test "returns 401 when bearer token is missing", %{conn: conn} do
       System.put_env(@env_var, "shared-secret")
@@ -39,12 +54,13 @@ defmodule ScreensWeb.ScreenConfigsApiControllerTest do
       end)
     end
 
-    test "returns all screen configs as JSON when bearer token is valid", %{conn: conn} do
+    test "returns all screen configs as JSON when bearer token is valid", %{
+      conn: conn,
+      screen_dup_config: screen_dup_config,
+      screen_busway_config: screen_busway_config
+    } do
       System.put_env(@env_var, "shared-secret")
       Application.put_env(:screens, :config_migration, true)
-
-      screen_dup_config = screen_config(:dup_v2)
-      screen_busway_config = screen_config(:busway_v2)
 
       Repo.insert!(%ScreenConfig{id: "screen-1", config: screen_dup_config})
       Repo.insert!(%ScreenConfig{id: "screen-2", config: screen_busway_config})
@@ -64,17 +80,16 @@ defmodule ScreensWeb.ScreenConfigsApiControllerTest do
     end
 
     test "returns screen configs from legacy config source when migration flag is false", %{
-      conn: conn
+      conn: conn,
+      screen_dup_config_json: screen_dup_config_json,
+      screen_busway_config_json: screen_busway_config_json
     } do
       System.put_env(@env_var, "shared-secret")
       Application.put_env(:screens, :config_migration, false)
 
-      screen_dup_config = screen_config_json(:dup_v2)
-      screen_busway_config = screen_config_json(:busway_v2)
-
       # Mock fetch_config to return our test config
       expect(Screens.Config.Fetch.Mock, :fetch_config, fn ->
-        {:ok, Jason.encode!(legacy_config(screen_dup_config, screen_busway_config)), 1}
+        {:ok, Jason.encode!(legacy_config(screen_dup_config_json, screen_busway_config_json)), 1}
       end)
 
       conn =
@@ -87,8 +102,88 @@ defmodule ScreensWeb.ScreenConfigsApiControllerTest do
       %{"config" => config_json} = json_response(conn, 200)
       config = Jason.decode!(config_json)
 
-      assert config["screens"]["dup_1"] == normalize_json(screen_dup_config)
-      assert config["screens"]["busway_1"] == normalize_json(screen_busway_config)
+      assert config["screens"]["dup_1"] == normalize_json(screen_dup_config_json)
+      assert config["screens"]["busway_1"] == normalize_json(screen_busway_config_json)
+    end
+
+    test "filters screen configs by ids when migration flag is true", %{
+      conn: conn,
+      screen_dup_config: screen_dup_config,
+      screen_busway_config: screen_busway_config,
+      screen_bus_eink_config: screen_bus_eink_config
+    } do
+      System.put_env(@env_var, "shared-secret")
+      Application.put_env(:screens, :config_migration, true)
+
+      Repo.insert!(%ScreenConfig{id: "screen-1", config: screen_dup_config})
+      Repo.insert!(%ScreenConfig{id: "screen-2", config: screen_busway_config})
+      Repo.insert!(%ScreenConfig{id: "screen-3", config: screen_bus_eink_config})
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer shared-secret")
+        |> get("/api/screen_configs", %{"ids" => "screen-1,screen-3"})
+
+      assert conn.status == 200
+
+      %{"config" => config_json} = json_response(conn, 200)
+      config = Jason.decode!(config_json)
+
+      assert config["screens"]["screen-1"] == normalize_json(Screen.to_json(screen_dup_config))
+      assert config["screens"]["screen-2"] == nil
+
+      assert config["screens"]["screen-3"] ==
+               normalize_json(Screen.to_json(screen_bus_eink_config))
+    end
+
+    test "filters screen configs by ids from legacy config when migration flag is false",
+         %{
+           conn: conn,
+           screen_dup_config_json: screen_dup_config_json,
+           screen_busway_config_json: screen_busway_config_json
+         } do
+      System.put_env(@env_var, "shared-secret")
+      Application.put_env(:screens, :config_migration, false)
+
+      # Mock fetch_config to return our test config with both screens
+      expect(Screens.Config.Fetch.Mock, :fetch_config, fn ->
+        {:ok, Jason.encode!(legacy_config(screen_dup_config_json, screen_busway_config_json)), 1}
+      end)
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer shared-secret")
+        |> get("/api/screen_configs", %{"ids" => "dup_1"})
+
+      assert conn.status == 200
+
+      %{"config" => config_json} = json_response(conn, 200)
+      config = Jason.decode!(config_json)
+
+      assert config["screens"]["dup_1"] == normalize_json(screen_dup_config_json)
+      assert config["screens"]["busway_1"] == nil
+    end
+
+    test "returns empty screens object when filtering by non-existent ids", %{
+      conn: conn,
+      screen_dup_config: screen_dup_config
+    } do
+      System.put_env(@env_var, "shared-secret")
+      Application.put_env(:screens, :config_migration, true)
+
+      Repo.insert!(%ScreenConfig{id: "screen-1", config: screen_dup_config})
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer shared-secret")
+        |> get("/api/screen_configs", %{"ids" => "screen-nonexistent"})
+
+      assert conn.status == 200
+
+      %{"config" => config_json} = json_response(conn, 200)
+      config = Jason.decode!(config_json)
+
+      assert config["screens"] == %{}
     end
   end
 
@@ -107,12 +202,13 @@ defmodule ScreensWeb.ScreenConfigsApiControllerTest do
       end)
     end
 
-    test "updates screen configs in Postgres when migration flag is true", %{conn: conn} do
+    test "updates screen configs in Postgres when migration flag is true", %{
+      conn: conn,
+      screen_dup_config: screen_dup_config,
+      screen_busway_config: screen_busway_config
+    } do
       System.put_env(@env_var, "shared-secret")
       Application.put_env(:screens, :config_migration, true)
-
-      screen_dup_config = screen_config(:dup_v2)
-      screen_busway_config = screen_config(:busway_v2)
 
       Repo.insert!(%ScreenConfig{id: "screen-1", config: screen_dup_config})
 
@@ -131,11 +227,12 @@ defmodule ScreensWeb.ScreenConfigsApiControllerTest do
       assert updated.config == screen_busway_config
     end
 
-    test "updates full config when migration flag is false", %{conn: conn} do
+    test "updates full config when migration flag is false", %{
+      conn: conn,
+      screen_dup_config_json: screen_dup_config_json
+    } do
       System.put_env(@env_var, "shared-secret")
       Application.put_env(:screens, :config_migration, false)
-
-      screen_dup_config = screen_config_json(:dup_v2)
 
       # Mock the fetch and put to prevent writing to the fixture file
       expect(Screens.Config.Fetch.Mock, :fetch_config, fn ->
@@ -158,7 +255,7 @@ defmodule ScreensWeb.ScreenConfigsApiControllerTest do
         |> put_req_header("authorization", "Bearer shared-secret")
         |> post("/api/screen_configs", %{
           screen_configs: [
-            %{"id" => "dup_1", "config" => screen_dup_config}
+            %{"id" => "dup_1", "config" => screen_dup_config_json}
           ]
         })
 

--- a/test/support/screen_config_builder.ex
+++ b/test/support/screen_config_builder.ex
@@ -39,6 +39,15 @@ defmodule Screens.TestSupport.ScreenConfigBuilder do
     }
   end
 
+  defp minimal_app_params(:bus_eink_v2) do
+    %{
+      "alerts" => %{"stop_ids" => ["place-test"]},
+      "departures" => %{"sections" => []},
+      "footer" => %{"stop_id" => "place-test"},
+      "header" => %{"stop_name" => "Test Stop"}
+    }
+  end
+
   def legacy_config(screen_dup_config, screen_busway_config) do
     %{
       "screens" => %{


### PR DESCRIPTION
**Asana task**: [Screenplay: Use shared Screen Config APIs](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1216329820920791?focus=true)

Adds an option to the `api/screen_configs` for `ids` to filter and return a list of configs for the given screen IDs. 

While implementing the linked work for Screenplay, I realized that it would be simpler to just filter down to the screens we want on the API side rather than requesting the entire list of configs when we're modifying a single screen. 

Note that the tests for this were generated using Copilot, reviewed by myself, refactored by Copilot based on my suggestions, and then slightly modified by myself again. 