### PR TITLE
fix: Crash in RDS caused by String direction_id

### DIFF
--- a/lib/screens/v2/candidate_generator/widgets/realtime_departures.ex
+++ b/lib/screens/v2/candidate_generator/widgets/realtime_departures.ex
@@ -3,7 +3,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.RealtimeDepartures do
   Candidate generator for LCD RDS Items
   Takes in the generated sections from Screens.V2.CandidateGenerator.Widgets.RdsDepartures and
   handles the roll-up and creation of the actual widget that will be serialized and used on
-  the screen itself. 
+  the screen itself.
   """
 
   alias Screens.Routes.Route
@@ -191,6 +191,9 @@ defmodule Screens.V2.CandidateGenerator.Widgets.RealtimeDepartures do
   end
 
   defp no_data_text(%Route{direction_names: direction_names} = route, direction_id) do
+    direction_index =
+      if is_binary(direction_id), do: String.to_integer(direction_id), else: direction_id
+
     %FreeTextLine{
       icon: Route.icon(route),
       text: [
@@ -201,7 +204,7 @@ defmodule Screens.V2.CandidateGenerator.Widgets.RealtimeDepartures do
         else
           route
           |> Route.normalized_direction_names()
-          |> Enum.at(direction_id, "")
+          |> Enum.at(direction_index, "")
           |> no_departures_message()
         end
       ]


### PR DESCRIPTION
For this [Sentry failure](https://mbtace.sentry.io/issues/7696007428/?alert_rule_id=9523677&alert_timestamp=1787854733911&alert_type=email&environment=screens-prod&notification_uuid=06bd755d-a826-4eb2-9471-91a55dc2b689&project=6061747&referrer=alert_email) 
that's caused by direction_id being a String. 

```
no function clause matching in Enum.at/3.
arg0:["Southbound", "Northbound"], arg1: "1" arg2:""
```



Ideally, this would be fixed in `screens_config_lib` with the below, but I think that might have downstream effects that shouldn't be pushed out at the end of a Friday. 

```ex
  defp value_from_json("direction_id", direction_id) when is_binary(direction_id) do
    String.to_integer(direction_id)
  end
```