### PR TITLE
fix: encoding string mode instead of atom mode causing crashes

### DIFF
--- a/lib/screens/v2/candidate_generator/gl_eink/line_map.ex
+++ b/lib/screens/v2/candidate_generator/gl_eink/line_map.ex
@@ -40,7 +40,7 @@ defmodule Screens.V2.CandidateGenerator.GlEink.LineMap do
 
   defp fetch_departures(station_id, now) do
     @departure.fetch(
-      %{stop_ids: [station_id], mode: "gl"},
+      %{stop_ids: [station_id], mode: :gl},
       now: DateTime.add(now, -@scheduled_terminal_departure_lookback_seconds)
     )
   end

--- a/lib/screens/v2/departure.ex
+++ b/lib/screens/v2/departure.ex
@@ -74,7 +74,7 @@ defmodule Screens.V2.Departure do
     if route_type in option_types do
       fetch_fn.(params)
     else
-      Report.warning("departure_mode_unknown", Map.to_list(params))
+      Report.warning("departure_mode_unknown_for_schedule", Map.to_list(params))
       {:ok, []}
     end
   end


### PR DESCRIPTION
- incorrect usage of the String mode instead of the atom mode is causing crashes when fetching GL EInk