### PR TITLE
chore: change Report to Logster for mode schedule fetching

### DIFF
--- a/lib/screens/v2/departure.ex
+++ b/lib/screens/v2/departure.ex
@@ -2,7 +2,6 @@ defmodule Screens.V2.Departure do
   @moduledoc false
 
   alias Screens.Predictions.Prediction
-  alias Screens.Report
   alias Screens.Routes.Route
   alias Screens.RouteType
   alias Screens.Schedules.Schedule
@@ -74,7 +73,7 @@ defmodule Screens.V2.Departure do
     if route_type in option_types do
       fetch_fn.(params)
     else
-      Report.warning("departure_mode_unknown_for_schedule", Map.to_list(params))
+      Logster.info(["departure_mode_unknown_for_schedule" | Map.to_list(params)])
       {:ok, []}
     end
   end


### PR DESCRIPTION
- we initially used `Report.warning/2` for logging cases where we are trying to fetch scheduled departures for modes that don't work, but it's causing Sentry reports
- this doesn't quite warrant a Sentry report, so change this to use `Logster` instead, this is currently only for GL EInk and Bus EInk which is using the old non RDS departures along with the old `schedule_route_type_filter`.
