### PR TITLE
feat: Recurring job to backup Screen Configs in S3

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -472,6 +472,11 @@ config :screens, :screens_by_alert,
 
 config :screens, Screens.ScreensByAlert.SelfRefreshRunner, batch_size: 20, concurrency: 1
 
+config :screens, Screens.Config.Backup,
+  enabled: true,
+  interval_ms: :timer.seconds(10),
+  store: Screens.Config.Backup.Store.S3
+
 config :screens, Screens.DeviceMonitor.Store, backend: Screens.DeviceMonitor.Store.Local
 
 # Memory limits for V3 API response caches are based on stats measured in a deployed environment.

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -40,9 +40,10 @@ config :ueberauth_oidcc,
     ]
   ]
 
-config :screens, Screens.Config.Backup,
-  local_backup_path: "local/config_backups/screens_local.json",
-  store: Screens.Config.Backup.Store.Mixed
+config :screens, Screens.Config.Backup, store: Screens.Config.Backup.Store.Mixed
+
+config :screens, Screens.Config.Backup.Store.Local,
+  local_backup_path: "local/config_backups/screens_local.json"
 
 # ## SSL Support
 #

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -40,6 +40,10 @@ config :ueberauth_oidcc,
     ]
   ]
 
+config :screens, Screens.Config.Backup,
+  local_backup_path: "local/config_backups/screens_local.json",
+  store: Screens.Config.Backup.Store.Mixed
+
 # ## SSL Support
 #
 # In order to use HTTPS in development, a self-signed

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -41,6 +41,8 @@ config :screens, Screens.Repo,
   show_sensitive_data_on_connection_error: false,
   configure: {Screens.Repo, :add_prod_credentials, []}
 
+config :screens, Screens.Config.Backup, store: Screens.Config.Backup.Store.S3
+
 # ## SSL Support
 #
 # To get SSL working, you will need to add the `https` key

--- a/config/test.exs
+++ b/config/test.exs
@@ -11,6 +11,12 @@ config :screens, Screens.Repo,
   database: "screens_test",
   pool: Ecto.Adapters.SQL.Sandbox
 
+config :screens, Screens.Config.Backup,
+  enabled: false,
+  interval_ms: 10,
+  local_backup_path: "local/config_backups/screens_test.json",
+  store: Screens.Config.Backup.Store.Local
+
 config :screens,
   config_fetcher: Screens.Config.Fetch.Local,
   local_config_file_spec: {:test, "config.json"},

--- a/config/test.exs
+++ b/config/test.exs
@@ -13,9 +13,10 @@ config :screens, Screens.Repo,
 
 config :screens, Screens.Config.Backup,
   enabled: false,
-  interval_ms: 10,
-  local_backup_path: "local/config_backups/screens_test.json",
   store: Screens.Config.Backup.Store.Local
+
+config :screens, Screens.Config.Backup.Store.Local,
+  local_backup_path: "local/config_backups/screens_test.json"
 
 config :screens,
   config_fetcher: Screens.Config.Fetch.Local,

--- a/lib/screens/application.ex
+++ b/lib/screens/application.ex
@@ -28,6 +28,7 @@ defmodule Screens.Application do
         {Task.Supervisor, name: Screens.ScreensByAlert.SelfRefreshRunner.TaskSupervisor},
         # ScreensByAlert self-refresh job runner
         self_refresh_runner_child(),
+        backup_runner_task_supervisor_child(),
         {Task.Supervisor, name: Screens.DeviceMonitor.Supervisor},
         Screens.DeviceMonitor,
         Screens.Telemetry,
@@ -59,5 +60,10 @@ defmodule Screens.Application do
     defp self_refresh_runner_child do
       {Screens.ScreensByAlert.SelfRefreshRunner, name: Screens.ScreensByAlert.SelfRefreshRunner}
     end
+  end
+
+  defp backup_runner_task_supervisor_child do
+    if Application.get_env(:screens, Screens.Config.Backup)[:enabled],
+      do: Screens.Config.Backup.Runner
   end
 end

--- a/lib/screens/config/backup.ex
+++ b/lib/screens/config/backup.ex
@@ -1,0 +1,58 @@
+defmodule Screens.Config.Backup do
+  @moduledoc """
+  Exports all screen configs to JSON, so that any environment's configs can be used as a source
+  when syncing another environment.
+  """
+
+  import Screens.Inject
+
+  alias Screens.Config.Backup
+  alias Screens.Config.ScreenConfig
+  alias Screens.Repo.AdvisoryLock
+  alias Screens.ScreenConfigs
+  alias ScreensConfig.Screen
+
+  @store injected(Screens.Config.Backup.Store)
+
+  @type result :: %{count: non_neg_integer()}
+
+  @cron_lock_key 1
+  @interval Application.compile_env!(:screens, [Backup, :interval_ms])
+
+  @doc """
+  Writes a backup of the current screen configs. Returns `:locked` if another instance is already
+  running a backup.
+  """
+  @spec run(DateTime.t()) :: {:ok, result()} | :locked | {:error, term()}
+  def run(now \\ DateTime.utc_now()) do
+    AdvisoryLock.with_lock(
+      @cron_lock_key,
+      @interval,
+      fn -> export(DateTime.truncate(now, :second)) end
+    )
+  end
+
+  @spec export(DateTime.t()) :: {:ok, result()} | {:error, term()}
+  defp export(now) do
+    configs = ScreenConfigs.all()
+
+    payload = %{
+      meta: %{
+        environment: Application.get_env(:screens, :environment_name),
+        exported_at: DateTime.to_iso8601(now)
+      },
+      screens:
+        Map.new(configs, fn %ScreenConfig{id: id, config: config} ->
+          {id, Screen.to_json(config)}
+        end)
+    }
+
+    with {:ok, json} <- Jason.encode(payload, pretty: true),
+         :ok <- @store.put_backup(json) do
+      {:ok, %{count: length(configs)}}
+    else
+      :error -> {:error, :backup_write_failed}
+      {:error, error} -> {:error, error}
+    end
+  end
+end

--- a/lib/screens/config/backup.ex
+++ b/lib/screens/config/backup.ex
@@ -14,7 +14,7 @@ defmodule Screens.Config.Backup do
 
   @store injected(Screens.Config.Backup.Store)
 
-  @type result :: %{count: non_neg_integer()}
+  @type result :: %{count: non_neg_integer()} | :skipped
 
   @cron_lock_key 1
   @interval Application.compile_env!(:screens, [Backup, :interval_ms])
@@ -36,6 +36,32 @@ defmodule Screens.Config.Backup do
   defp export(now) do
     configs = ScreenConfigs.all()
 
+    if any_updated_since_last_backup?(configs) do
+      write_backup(now, configs)
+    else
+      {:ok, :skipped}
+    end
+  end
+
+  # Skips writing a new backup if nothing has changed since the last one was exported, to avoid
+  # needless S3 writes. Any error reading the existing backup is treated as if it's out of date.
+  @spec any_updated_since_last_backup?([ScreenConfig.t()]) :: boolean()
+  defp any_updated_since_last_backup?(configs) do
+    environment = Application.get_env(:screens, :environment_name)
+
+    with {:ok, backup_json} <- @store.fetch_backup(environment),
+         {:ok, %{"meta" => %{"exported_at" => exported_at}}} <- Jason.decode(backup_json),
+         {:ok, exported_at, _offset} <- DateTime.from_iso8601(exported_at) do
+      Enum.any?(configs, fn %ScreenConfig{updated_at: updated_at} ->
+        DateTime.compare(updated_at, exported_at) == :gt
+      end)
+    else
+      _ -> true
+    end
+  end
+
+  @spec write_backup(DateTime.t(), [ScreenConfig.t()]) :: {:ok, result()} | {:error, term()}
+  defp write_backup(now, configs) do
     payload = %{
       meta: %{
         environment: Application.get_env(:screens, :environment_name),

--- a/lib/screens/config/backup/runner.ex
+++ b/lib/screens/config/backup/runner.ex
@@ -1,0 +1,39 @@
+defmodule Screens.Config.Backup.Runner do
+  @moduledoc """
+  Periodically runs a screen config backup. This runs on every instance, but the backup itself is
+  guarded by an advisory lock so only one instance does the work for a given interval.
+
+  Since we never need to maintain any state between runs, this is a task supervised by a
+  `Task.Supervisor` rather than a `GenServer`.
+  """
+
+  alias __MODULE__.TaskSupervisor
+  alias Screens.Config.Backup
+
+  @interval Application.compile_env!(:screens, [Backup, :interval_ms])
+
+  def child_spec(opts) do
+    %{
+      id: TaskSupervisor,
+      start: {__MODULE__, :start_link, [opts]}
+    }
+  end
+
+  def start_link(_opts) do
+    with {:ok, task_supervisor} <- Task.Supervisor.start_link(name: TaskSupervisor),
+         {:ok, _task} <- Task.Supervisor.start_child(task_supervisor, &run/0, restart: :permanent) do
+      {:ok, task_supervisor}
+    end
+  end
+
+  defp run do
+    Process.sleep(@interval)
+
+    case Backup.run() do
+      {:error, reason} -> Logster.error(["screen_configs_backup_error", error: inspect(reason)])
+      _ -> :ok
+    end
+
+    run()
+  end
+end

--- a/lib/screens/config/backup/store.ex
+++ b/lib/screens/config/backup/store.ex
@@ -1,0 +1,15 @@
+defmodule Screens.Config.Backup.Store do
+  @moduledoc """
+  Defines a behaviour for, and delegates to, a module that provides access to backups of the
+  screen configs. Backups can be fetched for any environment, but are only ever written for the
+  environment the app is running in.
+  """
+
+  @callback fetch_backup(environment :: String.t()) :: {:ok, String.t()} | :error
+  @callback put_backup(file_contents :: String.t()) :: :ok | :error
+
+  @store Application.compile_env!(:screens, [Screens.Config.Backup, :store])
+
+  defdelegate fetch_backup(environment), to: @store
+  defdelegate put_backup(file_contents), to: @store
+end

--- a/lib/screens/config/backup/store/local.ex
+++ b/lib/screens/config/backup/store/local.ex
@@ -3,11 +3,7 @@ defmodule Screens.Config.Backup.Store.Local do
   Functions to work with a local copy of the screen configs backup.
   """
 
-  alias Screens.Config.Backup
-
   @behaviour Screens.Config.Backup.Store
-
-  @backup_path Application.compile_env!(:screens, [Backup, :local_backup_path])
 
   @impl true
   def fetch_backup(_environment_name) do
@@ -30,6 +26,9 @@ defmodule Screens.Config.Backup.Store.Local do
   end
 
   defp backup_path do
-    Path.join([:code.priv_dir(:screens), @backup_path])
+    Path.join([
+      :code.priv_dir(:screens),
+      Application.get_env(:screens, __MODULE__)[:local_backup_path]
+    ])
   end
 end

--- a/lib/screens/config/backup/store/local.ex
+++ b/lib/screens/config/backup/store/local.ex
@@ -1,0 +1,35 @@
+defmodule Screens.Config.Backup.Store.Local do
+  @moduledoc """
+  Functions to work with a local copy of the screen configs backup.
+  """
+
+  alias Screens.Config.Backup
+
+  @behaviour Screens.Config.Backup.Store
+
+  @backup_path Application.compile_env!(:screens, [Backup, :local_backup_path])
+
+  @impl true
+  def fetch_backup(_environment_name) do
+    case File.read(backup_path()) do
+      {:ok, contents} -> {:ok, contents}
+      {:error, _} -> :error
+    end
+  end
+
+  @impl true
+  def put_backup(file_contents) do
+    path = backup_path()
+
+    with :ok <- File.mkdir_p(Path.dirname(path)),
+         :ok <- File.write(path, file_contents) do
+      :ok
+    else
+      {:error, _} -> :error
+    end
+  end
+
+  defp backup_path do
+    Path.join([:code.priv_dir(:screens), @backup_path])
+  end
+end

--- a/lib/screens/config/backup/store/mixed.ex
+++ b/lib/screens/config/backup/store/mixed.ex
@@ -1,0 +1,19 @@
+defmodule Screens.Config.Backup.Store.Mixed do
+  @moduledoc """
+  A store for local development: always writes backups to the local file, but fetches backups
+  from the local file for the "local" environment and from S3 for any other (real) environment.
+  This allows pulling down a real environment's configs while never writing backups to S3.
+  """
+
+  @behaviour Screens.Config.Backup.Store
+
+  alias Screens.Config.Backup.Store.Local
+  alias Screens.Config.Backup.Store.S3
+
+  @impl true
+  def fetch_backup("local"), do: Local.fetch_backup("local")
+  def fetch_backup(environment), do: S3.fetch_backup(environment)
+
+  @impl true
+  def put_backup(file_contents), do: Local.put_backup(file_contents)
+end

--- a/lib/screens/config/backup/store/s3.ex
+++ b/lib/screens/config/backup/store/s3.ex
@@ -1,0 +1,40 @@
+defmodule Screens.Config.Backup.Store.S3 do
+  @moduledoc """
+  Functions to work with S3-hosted backups of the screen configs.
+  """
+
+  @behaviour Screens.Config.Backup.Store
+
+  @impl true
+  def fetch_backup(environment) do
+    get_operation = ExAws.S3.get_object(bucket(), backup_path(environment))
+
+    case ExAws.request(get_operation) do
+      {:ok, %{body: body, status_code: 200}} ->
+        {:ok, body}
+
+      err ->
+        Logster.warning(["s3_screen_configs_backup_fetch_error", inspect(err)])
+        :error
+    end
+  end
+
+  @impl true
+  def put_backup(file_contents) do
+    path = backup_path(Application.get_env(:screens, :environment_name))
+    put_operation = ExAws.S3.put_object(bucket(), path, file_contents)
+
+    case ExAws.request(put_operation) do
+      {:ok, %{status_code: 200}} ->
+        :ok
+
+      err ->
+        Logster.warning(["s3_screen_configs_backup_put_error", inspect(err)])
+        :error
+    end
+  end
+
+  defp bucket, do: Application.get_env(:screens, :config_s3_bucket)
+
+  defp backup_path(environment), do: "screens/latest/#{environment}.json"
+end

--- a/lib/screens/config/backup/store/s3.ex
+++ b/lib/screens/config/backup/store/s3.ex
@@ -2,6 +2,7 @@ defmodule Screens.Config.Backup.Store.S3 do
   @moduledoc """
   Functions to work with S3-hosted backups of the screen configs.
   """
+  alias Screens.Report
 
   @behaviour Screens.Config.Backup.Store
 
@@ -29,7 +30,7 @@ defmodule Screens.Config.Backup.Store.S3 do
         :ok
 
       err ->
-        Logster.warning(["s3_screen_configs_backup_put_error", inspect(err)])
+        Report.error("s3_screen_configs_backup_put_error", error: inspect(err))
         :error
     end
   end

--- a/lib/screens/repo/advisory_lock.ex
+++ b/lib/screens/repo/advisory_lock.ex
@@ -1,0 +1,45 @@
+defmodule Screens.Repo.AdvisoryLock do
+  @moduledoc """
+  Runs a function while holding a Postgres session-level advisory lock, so that work scheduled on
+  every app instance only runs on one of them at a time.
+
+  Can be reused for any recurring cron job type functions that only needs to run once across all tasks.
+  New uses of this locking mechanism just need to pass an  application-wide unique cron_lock_key
+  and an interval for how frequently the job should run.
+  """
+
+  alias Screens.Repo
+
+  @doc """
+  Runs `func` if the lock identified by `cron_lock_key` can be acquired immediately, returning `:locked` otherwise.
+  `cron_lock_key` must be a unique-per-job 64-bit integer. The lock is held for `interval` ms
+  regardless of how quickly `func` completes, so that another instance can't acquire it early.
+  """
+  @spec with_lock(integer(), non_neg_integer(), (-> result)) :: result
+        when result: term()
+  def with_lock(cron_lock_key, interval, func) do
+    Repo.transact(
+      fn ->
+        started_at = System.monotonic_time(:millisecond)
+
+        case Repo.query!("SELECT pg_try_advisory_xact_lock($1)", [cron_lock_key]) do
+          %{rows: [[true]]} ->
+            result = func.()
+            hold_lock_until(started_at, interval)
+            result
+
+          %{rows: [[false]]} ->
+            {:ok, :locked}
+        end
+      end,
+      timeout: interval
+    )
+  end
+
+  defp hold_lock_until(started_at, interval) do
+    # Sleep for 15 seconds less than the interval for running the locking function
+    # This makes sure that the lock is held for slightly less than the full interval
+    remaining = interval - (System.monotonic_time(:millisecond) - started_at) - :timer.seconds(15)
+    if remaining > 0, do: Process.sleep(remaining)
+  end
+end

--- a/lib/screens/repo/advisory_lock.ex
+++ b/lib/screens/repo/advisory_lock.ex
@@ -4,11 +4,15 @@ defmodule Screens.Repo.AdvisoryLock do
   every app instance only runs on one of them at a time.
 
   Can be reused for any recurring cron job type functions that only needs to run once across all tasks.
-  New uses of this locking mechanism just need to pass an  application-wide unique cron_lock_key
+  New uses of this locking mechanism just need to pass an application-wide unique cron_lock_key
   and an interval for how frequently the job should run.
   """
 
+  import Screens.Inject
+
   alias Screens.Repo
+
+  @sleeper injected(Screens.Repo.AdvisoryLock.Sleeper)
 
   @doc """
   Runs `func` if the lock identified by `cron_lock_key` can be acquired immediately, returning `:locked` otherwise.
@@ -37,9 +41,8 @@ defmodule Screens.Repo.AdvisoryLock do
   end
 
   defp hold_lock_until(started_at, interval) do
-    # Sleep for 15 seconds less than the interval for running the locking function
-    # This makes sure that the lock is held for slightly less than the full interval
-    remaining = interval - (System.monotonic_time(:millisecond) - started_at) - :timer.seconds(15)
-    if remaining > 0, do: Process.sleep(remaining)
+    # Ensure the lock is held for the full interval. It's released when the transaction ends.
+    remaining = interval - (System.monotonic_time(:millisecond) - started_at)
+    if remaining > 0, do: @sleeper.sleep(remaining)
   end
 end

--- a/lib/screens/repo/advisory_lock.ex
+++ b/lib/screens/repo/advisory_lock.ex
@@ -28,6 +28,9 @@ defmodule Screens.Repo.AdvisoryLock do
 
         case Repo.query!("SELECT pg_try_advisory_xact_lock($1)", [cron_lock_key]) do
           %{rows: [[true]]} ->
+            # Lock successfully acquired; run the function and hold lock for the full interval.
+            Logster.info(["advisory_lock_acquired", "lock_key=#{cron_lock_key}"])
+
             result = func.()
             hold_lock_until(started_at, interval)
             result

--- a/lib/screens/repo/advisory_lock/sleeper.ex
+++ b/lib/screens/repo/advisory_lock/sleeper.ex
@@ -1,0 +1,6 @@
+defmodule Screens.Repo.AdvisoryLock.Sleeper do
+  @moduledoc "Injectable wrapper around `Process.sleep/1`, so tests don't need to wait in real time."
+
+  @callback sleep(non_neg_integer()) :: :ok
+  def sleep(ms), do: Process.sleep(ms)
+end

--- a/test/screens/screen_configs/backup_test.exs
+++ b/test/screens/screen_configs/backup_test.exs
@@ -1,0 +1,79 @@
+defmodule Screens.ScreenConfigs.BackupTest do
+  use ExUnit.Case
+
+  import Mox
+  import Screens.TestSupport.ScreenConfigBuilder
+
+  alias Screens.Config.Backup
+  alias Screens.Config.Backup.Store
+  alias Screens.Config.ScreenConfig
+  alias Screens.Repo
+  alias ScreensConfig.Screen
+
+  setup do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(Repo)
+    :ok
+  end
+
+  setup :verify_on_exit!
+
+  describe "run/1" do
+    test "writes the current configs to the backup store" do
+      config_json = :dup_v2 |> screen_config_json() |> normalize_json()
+      config = Screen.from_json(config_json)
+
+      {:ok, _} = Repo.insert(%ScreenConfig{id: "dup_1", config: config})
+
+      now = ~U[2026-09-02 15:30:45Z]
+
+      expect(Store.Mock, :put_backup, fn contents ->
+        send(self(), {:put_backup, contents})
+        :ok
+      end)
+
+      assert {:ok, %{count: 1}} = Backup.run(now)
+
+      assert_received {:put_backup, contents}
+
+      assert %{
+               "meta" => %{"exported_at" => "2026-09-02T15:30:45Z"},
+               "screens" => %{"dup_1" => ^config_json}
+             } = Jason.decode!(contents)
+    end
+
+    test "does nothing and returns :locked when another instance is already running a backup" do
+      test_pid = self()
+
+      # Run test async so that other tests don't run while it's holding the lock.
+      task =
+        Task.async(fn ->
+          :ok = Ecto.Adapters.SQL.Sandbox.checkout(Repo)
+
+          Repo.transaction(fn ->
+            # `1` is the same cron lock key `Backup.run/1` uses internally
+            Repo.query!("SELECT pg_advisory_xact_lock($1)", [1])
+            send(test_pid, :locked)
+
+            receive do
+              :release -> :ok
+            end
+          end)
+
+          Ecto.Adapters.SQL.Sandbox.checkin(Repo)
+        end)
+
+      assert_receive :locked
+
+      assert {:ok, :locked} = Backup.run(~U[2026-09-02 15:30:45Z])
+
+      send(task.pid, :release)
+      Task.await(task)
+    end
+
+    test "returns an error when the write fails" do
+      expect(Store.Mock, :put_backup, fn _contents -> :error end)
+
+      assert {:error, :backup_write_failed} = Backup.run(~U[2026-09-02 15:30:45Z])
+    end
+  end
+end

--- a/test/screens/screen_configs/backup_test.exs
+++ b/test/screens/screen_configs/backup_test.exs
@@ -22,21 +22,37 @@ defmodule Screens.ScreenConfigs.BackupTest do
       config_json = :dup_v2 |> screen_config_json() |> normalize_json()
       config = Screen.from_json(config_json)
 
-      {:ok, _} = Repo.insert(%ScreenConfig{id: "dup_1", config: config})
+      {:ok, %ScreenConfig{updated_at: updated_at}} =
+        Repo.insert(%ScreenConfig{id: "dup_1", config: config})
 
-      now = ~U[2026-09-02 15:30:45Z]
+      # Set export time to just before the last update time, so that the backup is considered out of date.
+      last_export_iso =
+        updated_at
+        |> DateTime.from_naive!("Etc/UTC")
+        |> DateTime.add(-1, :second)
+        |> DateTime.to_iso8601()
+
+      updated_at_iso = DateTime.to_iso8601(updated_at)
+
+      backup_json =
+        Jason.encode!(%{
+          meta: %{environment: "test", exported_at: last_export_iso},
+          screens: config_json
+        })
+
+      expect(Store.Mock, :fetch_backup, fn _environment -> {:ok, backup_json} end)
 
       expect(Store.Mock, :put_backup, fn contents ->
         send(self(), {:put_backup, contents})
         :ok
       end)
 
-      assert {:ok, %{count: 1}} = Backup.run(now)
+      assert {:ok, %{count: 1}} = Backup.run(updated_at)
 
       assert_received {:put_backup, contents}
 
       assert %{
-               "meta" => %{"exported_at" => "2026-09-02T15:30:45Z"},
+               "meta" => %{"exported_at" => ^updated_at_iso},
                "screens" => %{"dup_1" => ^config_json}
              } = Jason.decode!(contents)
     end
@@ -71,9 +87,30 @@ defmodule Screens.ScreenConfigs.BackupTest do
     end
 
     test "returns an error when the write fails" do
+      expect(Store.Mock, :fetch_backup, fn _environment -> :error end)
       expect(Store.Mock, :put_backup, fn _contents -> :error end)
 
       assert {:error, :backup_write_failed} = Backup.run(~U[2026-09-02 15:30:45Z])
+    end
+
+    test "skips writing a backup when no config has changed since the last export" do
+      config_json = :dup_v2 |> screen_config_json() |> normalize_json()
+      config = Screen.from_json(config_json)
+
+      {:ok, %ScreenConfig{updated_at: updated_at}} =
+        Repo.insert(%ScreenConfig{id: "dup_1", config: config})
+
+      exported_at = DateTime.add(DateTime.from_naive!(updated_at, "Etc/UTC"), 1, :second)
+
+      backup_json =
+        Jason.encode!(%{
+          meta: %{environment: "test", exported_at: DateTime.to_iso8601(exported_at)},
+          screens: %{"dup_1" => config_json}
+        })
+
+      expect(Store.Mock, :fetch_backup, fn _environment -> {:ok, backup_json} end)
+
+      assert {:ok, :skipped} = Backup.run(~U[2026-09-02 15:30:45Z])
     end
   end
 end

--- a/test/support/mocks.ex
+++ b/test/support/mocks.ex
@@ -26,3 +26,11 @@ end
 
 Mox.defmock(Screens.DeviceMonitor.MockVendor, for: Screens.DeviceMonitor.Vendor)
 Mox.defmock(Screens.ScreensByAlert.Mock, for: Screens.ScreensByAlert.Behaviour)
+
+defmodule Screens.Repo.AdvisoryLock.Sleeper.Mock do
+  @moduledoc "No-op sleeper so tests don't have to wait out `AdvisoryLock`'s hold interval."
+  @behaviour Screens.Repo.AdvisoryLock.Sleeper
+
+  @impl true
+  def sleep(_ms), do: :ok
+end

--- a/test/support/mocks.ex
+++ b/test/support/mocks.ex
@@ -1,5 +1,6 @@
 injected_modules = [
   Screens.Alerts.Alert,
+  Screens.Config.Backup.Store,
   Screens.Config.Cache,
   Screens.Config.Fetch,
   Screens.Elevator,


### PR DESCRIPTION
**Asana task**: [Routinely backup Screen Configs in S3](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1218058354689661?focus=true)

### Summary
Writes Screen Configurations from Postgres into S3 every minutes using a Postgres advisory lock to ensure that only one task will write a backup at a time.

### Notes for Reviewer
- Since this is slightly different than what’s implemented in `Screens.Config.Fetch`, I implemented this separately so that after migration, we can just delete the old module. This approach was simpler than mixing them together and then needing to untangle during cleanup.
- The advisory lock module (Screens.Repo.AdvisoryLock) is implemented generically so that we can use it again in the future for any jobs like this that we would want to run.
- This has been running in dev-blue with good results. See the JSON uploaded [here in S3](https://us-east-1.console.aws.amazon.com/s3/buckets/mbta-ctd-config?region=us-east-1&prefix=screens/latest/&tab=objects), and the image below showing logs that indicate

<img width="586" height="380" alt="lock for key 1" src="https://github.com/user-attachments/assets/a0d0c961-fdad-49fb-b90b-8a10c15b9881" />

### AI Disclosure 
I used Copilot with Claude for this work more generally than I had in months, since the AI pilot began. For transparency of the reviewer, here’s a summary of how that went. 

I gave a general overview of what I was looking for, and it created the general structure. Some things were only slightly modified from the original AI implementation:
- `Screens.Config.Backup.Store` and its associated implementations in `Local`, `S3`, and `Mixed` only had minor changes. This implementation was very effective because I pointed it directly to this existing pattern elsewhere and specified what I wanted different with local being able to specify either a local or S3 environment backup to fetch from, but only write locally. 
- `Screens.Config.Backup` only had slight changes, but the general structure stayed the same. Changes were mainly simplification of the JSON and removing edge cases that weren’t necessary.

Some pieces were completely scrapped and redone:
- Completely rewrote the advisory locking mechanism since it ignored my specifications and overcomplicated it. 
- `Screens.Config.Backup.Runner` was completely rewritten from what was first done. I initially specified this as a GenServer, but then once I realized it was completely stateless, I converted it into a `TaskSupervisor` using AI. I made many general edits after the fact,
- Redid the general naming and scheme of how configuration values were passed around 
- I actually rewrote most of the happy path test
